### PR TITLE
fix(windows): normalize paths for OpenCode server startup

### DIFF
--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -341,8 +341,22 @@ export class AppState {
    * @returns The Project containing the workspace, or undefined
    */
   findProjectForWorkspace(workspacePath: string): Project | undefined {
+    // Normalize the input path for comparison:
+    // - Use path.normalize to handle forward/backslashes
+    // - On Windows, use case-insensitive comparison (filesystem is case-insensitive)
+    // - On Linux/macOS, use case-sensitive comparison (filesystem is case-sensitive)
+    const isWindows = process.platform === "win32";
+    const normalizePath = (p: string) => {
+      const normalized = path.normalize(p);
+      return isWindows ? normalized.toLowerCase() : normalized;
+    };
+
+    const normalizedInput = normalizePath(workspacePath);
+
     for (const openProject of this.openProjects.values()) {
-      const found = openProject.project.workspaces.find((w) => w.path === workspacePath);
+      const found = openProject.project.workspaces.find(
+        (w) => normalizePath(w.path) === normalizedInput
+      );
       if (found) {
         return openProject.project;
       }

--- a/src/services/opencode/opencode-server-manager.ts
+++ b/src/services/opencode/opencode-server-manager.ts
@@ -146,17 +146,16 @@ export class OpenCodeServerManager implements IDisposable {
     // Build environment variables with MCP config if available
     let env: NodeJS.ProcessEnv | undefined;
     if (this.mcpConfig) {
+      // Convert Windows backslashes to forward slashes for the workspace path.
+      // OpenCode substitutes {env:CODEHYDRA_WORKSPACE_PATH} directly into JSON,
+      // so backslashes would become invalid escape sequences and cause JSON parsing errors.
+      const normalizedWorkspacePath = workspacePath.replace(/\\/g, "/");
       env = {
         ...process.env,
         OPENCODE_CONFIG: this.mcpConfig.configPath,
-        CODEHYDRA_WORKSPACE_PATH: workspacePath,
+        CODEHYDRA_WORKSPACE_PATH: normalizedWorkspacePath,
         CODEHYDRA_MCP_PORT: String(this.mcpConfig.port),
       };
-      this.logger.debug("Starting with MCP env", {
-        workspacePath,
-        mcpPort: this.mcpConfig.port,
-        configPath: this.mcpConfig.configPath,
-      });
     }
 
     // Spawn opencode serve


### PR DESCRIPTION
- Normalize CODEHYDRA_WORKSPACE_PATH to forward slashes to prevent JSON parsing errors when OpenCode substitutes the env var into its config
- Use platform-aware path comparison in findProjectForWorkspace(): case-insensitive on Windows, case-sensitive on Linux/macOS