### PR TITLE
ci: trigger workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
- Enable CI to run on pull requests from forks (fixes missing checks on external PRs like #10)