### PR TITLE
chore: add file watcher excludes and fix preview script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,15 @@
 {
-  "task.allowAutomaticTasks": "on"
+  "task.allowAutomaticTasks": "on",
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.pnpm-store/**": true,
+    "**/.vite/**": true,
+    "**/app-data/**": true,
+    "**/coverage/**": true,
+    "**/dist/**": true,
+    "**/node_modules/**": true,
+    "**/out/**": true,
+    "**/pnpm-lock.yaml": true,
+    "**/site/dist/**": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:wrappers": "vite build --config vite.config.bin.ts",
     "build:extensions": "tsx scripts/build-extensions.ts",
     "build": "pnpm build:wrappers && pnpm build:extensions && electron-vite build",
-    "preview": "electron-vite preview",
+    "preview": "pnpm build && electron-vite preview",
     "test": "vitest run --no-color",
     "test:legacy": "vitest run --no-color --exclude '**/*.integration.test.ts' --exclude '**/*.boundary.test.ts'",
     "test:integration": "vitest run --no-color integration",


### PR DESCRIPTION
## Summary
- Add `files.watcherExclude` settings to reduce VS Code file watcher load on large/generated directories (node_modules, out, dist, app-data, etc.)
- Fix `pnpm preview` to run build first, matching `pnpm dev` behavior