### PR TITLE
fix(ship-wait): convert to async/await to prevent system freeze under memory pressure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ node_modules/
 out/
 pnpm-lock.yaml
 .vite/
-.opencode/
+.opencode/*
+!.opencode/scripts/


### PR DESCRIPTION
## Summary

- Replace `Atomics.wait` + `SharedArrayBuffer` with Promise-based `setTimeout` to prevent memory pressure issues
- Replace `execSync` with async spawn wrapper with 60s timeout per command
- Convert all functions to async/await pattern for proper event loop handling
- Add graceful shutdown handlers for SIGINT/SIGTERM
- Include `.opencode/scripts/` in Prettier coverage