### PR TITLE
feat(build): centralize Vite defaults with warning-as-error enforcement

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,6 +3,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { resolve } from "path";
 import { execSync } from "node:child_process";
+import { codehydraDefaults } from "./vite.defaults";
 
 /**
  * Gets the application version.
@@ -33,14 +34,14 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, "src/main/index.ts"),
         },
-        // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)
-        external: ["bufferutil", "utf-8-validate"],
       },
     },
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },
     plugins: [
+      // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)
+      codehydraDefaults({ external: ["bufferutil", "utf-8-validate"] }),
       viteStaticCopy({
         targets: [
           { src: "dist/extensions/*", dest: "assets" },
@@ -52,6 +53,7 @@ export default defineConfig({
     ],
   },
   preload: {
+    plugins: [codehydraDefaults()],
     build: {
       rollupOptions: {
         input: {
@@ -76,7 +78,7 @@ export default defineConfig({
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },
-    plugins: [svelte()],
+    plugins: [codehydraDefaults(), svelte()],
     resolve: {
       alias: {
         $lib: resolve(__dirname, "src/renderer/lib"),

--- a/extensions/markdown-review-editor/src/extension/webview-manager.ts
+++ b/extensions/markdown-review-editor/src/extension/webview-manager.ts
@@ -14,6 +14,7 @@ import type {
 	AnnotationContent
 } from './message-types';
 import { logger } from './logger';
+import { serializeDocument } from '../lib/utils/document-storage';
 
 // Track active prompt requests for cancellation support
 const activeRequests = new Map<string, AbortController>();
@@ -302,7 +303,6 @@ export async function handleSaveAs(
 
 		if (uri) {
 			logger.info(`Saving document: path=${uri.fsPath}`);
-			const { serializeDocument } = await import('../lib/utils/document-storage');
 			const serialized = serializeDocument(content, annotations);
 			await vscode.workspace.fs.writeFile(uri, Buffer.from(serialized, 'utf-8'));
 			logger.info('Document saved successfully');

--- a/extensions/markdown-review-editor/vite.config.ts
+++ b/extensions/markdown-review-editor/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, mergeConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { resolve } from 'path';
 import baseConfig from '../vite.config.ext';
+import { codehydraDefaults, createSvelteOnWarn } from '../../vite.defaults';
 
 /**
  * Markdown Review Editor extension Vite config.
@@ -25,17 +26,12 @@ export default mergeConfig(
 					await build({
 						configFile: false,
 						plugins: [
+							codehydraDefaults(),
 							svelte({
-								onwarn(warning) {
-									// Allow specific a11y warnings for intentional UI patterns:
-									// - CommentEditor container uses click/mousedown for activation convenience
-									// - Discussion thread uses mouseup for copy-on-select behavior
-									if (warning.code?.startsWith('a11y_')) {
-										return; // Suppress a11y warnings
-									}
-									// Treat all other Svelte warnings as errors
-									throw new Error(`Svelte warning: ${warning.message}`);
-								}
+								// Allow a11y warnings for intentional UI patterns:
+								// - CommentEditor container uses click/mousedown for activation convenience
+								// - Discussion thread uses mouseup for copy-on-select behavior
+								onwarn: createSvelteOnWarn({ allowA11y: true })
 							})
 						],
 						build: {
@@ -47,9 +43,7 @@ export default mergeConfig(
 									entryFileNames: 'index.js',
 									assetFileNames: 'index.[ext]'
 								}
-							},
-							minify: false,
-							sourcemap: false
+							}
 						},
 						resolve: {
 							alias: {

--- a/extensions/vite.config.ext.ts
+++ b/extensions/vite.config.ext.ts
@@ -1,5 +1,5 @@
-import { builtinModules } from "node:module";
 import { defineConfig, type UserConfig } from "vite";
+import { codehydraDefaults } from "../vite.defaults";
 
 /**
  * Base Vite configuration for VS Code extensions.
@@ -13,20 +13,13 @@ import { defineConfig, type UserConfig } from "vite";
  * additional SSR settings - see sidekick/vite.config.ts for an example.
  */
 const baseConfig: UserConfig = {
+  plugins: [codehydraDefaults({ nodeBuiltins: true, external: ["vscode"] })],
   build: {
     lib: {
       entry: "", // Must be overridden by each extension
       formats: ["cjs"],
       fileName: () => "extension.cjs",
     },
-    rollupOptions: {
-      // Externalize:
-      // - vscode: VS Code API (provided at runtime)
-      // - Node.js built-ins: path, fs, etc. (available in VS Code extension host)
-      external: ["vscode", ...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
-    },
-    minify: false,
-    sourcemap: false,
     emptyOutDir: true,
   },
 };

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "../vite.defaults.ts"]
 }

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { resolve } from "path";
+import { codehydraDefaults } from "../vite.defaults";
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [codehydraDefaults({ minify: true, sourcemap: true }), svelte()],
   root: resolve(__dirname),
   base: "./", // Relative paths work for custom domain, GitHub Pages subdirectory, and dev server
   build: {

--- a/vite.config.bin.ts
+++ b/vite.config.bin.ts
@@ -7,14 +7,15 @@
  * Also copies wrapper scripts to ./app-data/bin/ for development use.
  */
 
-import { builtinModules } from "node:module";
 import { defineConfig } from "vite";
 import { resolve } from "path";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { chmod } from "node:fs/promises";
+import { codehydraDefaults } from "./vite.defaults";
 
 export default defineConfig({
   plugins: [
+    codehydraDefaults({ nodeBuiltins: true }),
     // Copy wrapper scripts to app-data/bin/ for development
     viteStaticCopy({
       targets: [
@@ -53,14 +54,6 @@ export default defineConfig({
       fileName: () => "opencode.cjs",
     },
     outDir: "dist/bin",
-    rollupOptions: {
-      // Externalize all Node.js built-in modules
-      external: [...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
-    },
-    // Don't minify - makes debugging easier
-    minify: false,
-    // No sourcemaps for CLI scripts
-    sourcemap: false,
     // Clear dist/bin on each build
     emptyOutDir: true,
   },

--- a/vite.defaults.ts
+++ b/vite.defaults.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared Vite defaults for consistent build behavior across all configs.
+ *
+ * Features:
+ * - Fails build on Rollup warnings (always enabled)
+ * - Configurable Node.js built-ins externalization
+ * - Sensible defaults for minify/sourcemap
+ *
+ * Usage:
+ *   import { codehydraDefaults } from "./vite.defaults";
+ *   export default defineConfig({
+ *     plugins: [codehydraDefaults({ nodeBuiltins: true })],
+ *   });
+ */
+
+import { builtinModules } from "node:module";
+
+/**
+ * Minimal Vite plugin interface compatible with multiple Vite versions.
+ * Using a minimal interface avoids type conflicts between vite 6 and vite 7
+ * in the monorepo (root uses vite 7, some extensions use vite 6).
+ */
+interface VitePluginCompat {
+  name: string;
+  config?: () => Record<string, unknown>;
+}
+
+export interface CodehydraDefaultsOptions {
+  /**
+   * Include Node.js built-in modules in rollupOptions.external.
+   * Includes both bare (fs) and prefixed (node:fs) forms.
+   * @default false
+   */
+  nodeBuiltins?: boolean;
+
+  /**
+   * Additional modules to externalize.
+   * Merged with nodeBuiltins if enabled.
+   */
+  external?: string[];
+
+  /**
+   * Enable minification.
+   * @default false
+   */
+  minify?: boolean;
+
+  /**
+   * Enable sourcemaps.
+   * @default false
+   */
+  sourcemap?: boolean;
+}
+
+const nodeBuiltins = [...builtinModules, ...builtinModules.map((m) => `node:${m}`)];
+
+/**
+ * Shared Vite plugin for consistent build behavior across all configs.
+ *
+ * Always fails build on Rollup warnings to catch issues early.
+ */
+export function codehydraDefaults(options: CodehydraDefaultsOptions = {}): VitePluginCompat {
+  const {
+    nodeBuiltins: includeNodeBuiltins = false,
+    external = [],
+    minify = false,
+    sourcemap = false,
+  } = options;
+
+  const externalModules = [...external, ...(includeNodeBuiltins ? nodeBuiltins : [])];
+
+  return {
+    name: "codehydra-defaults",
+    config() {
+      return {
+        build: {
+          minify,
+          sourcemap,
+          rollupOptions: {
+            ...(externalModules.length > 0 && { external: externalModules }),
+            onLog(
+              level: string,
+              log: { message?: string; code?: string },
+              handler: (level: string, log: { message?: string }) => void
+            ) {
+              if (level === "warn") {
+                // Allow circular dependency warnings from node_modules (e.g., Svelte internals)
+                if (log.code === "CIRCULAR_DEPENDENCY" && log.message?.includes("node_modules")) {
+                  return;
+                }
+                throw new Error(`Rollup warning: ${log.message}`);
+              }
+              handler(level, log);
+            },
+          },
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Create Svelte onwarn handler with configurable a11y behavior.
+ *
+ * Usage:
+ *   svelte({ onwarn: createSvelteOnWarn({ allowA11y: true }) })
+ */
+export function createSvelteOnWarn(options: { allowA11y?: boolean } = {}) {
+  const { allowA11y = false } = options;
+
+  return (warning: { code?: string; message: string }) => {
+    if (allowA11y && warning.code?.startsWith("a11y_")) {
+      return;
+    }
+    throw new Error(`Svelte warning: ${warning.message}`);
+  };
+}


### PR DESCRIPTION
## Summary

- Add `vite.defaults.ts` plugin that centralizes build configuration with fail-on-warning enforcement for Rollup
- Update all Vite configs to use `codehydraDefaults()` plugin for consistent build behavior
- Fix dynamic import warning in webview-manager.ts by converting to static import