### PR TITLE
chore(build): reduce verbosity of build output

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -30,6 +30,7 @@ const appVersion = getAppVersion();
 export default defineConfig({
   main: {
     build: {
+      reportCompressedSize: false,
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/main/index.ts"),
@@ -55,6 +56,7 @@ export default defineConfig({
   preload: {
     plugins: [codehydraDefaults()],
     build: {
+      reportCompressedSize: false,
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/preload/index.ts"),
@@ -69,6 +71,7 @@ export default defineConfig({
   renderer: {
     root: resolve(__dirname, "src/renderer"),
     build: {
+      reportCompressedSize: false,
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/renderer/index.html"),

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    reportCompressedSize: false,
   },
 });

--- a/vite.config.bin.ts
+++ b/vite.config.bin.ts
@@ -56,5 +56,7 @@ export default defineConfig({
     outDir: "dist/bin",
     // Clear dist/bin on each build
     emptyOutDir: true,
+    // Don't report gzip sizes (not relevant for CLI scripts)
+    reportCompressedSize: false,
   },
 });


### PR DESCRIPTION
## Summary

- Add verbose mode to extension build script (`--verbose` flag or `CI` env var)
- Remove redundant `pnpm install` from extension builds (workspace dependencies already installed)
- Disable gzip size reporting in all Vite configs
- Extension build output now shows simple progress: `Building X... done`