### PR TITLE
fix: status indicator shows incorrect busy state for existing sessions

### DIFF
--- a/src/services/opencode/agent-status-manager.ts
+++ b/src/services/opencode/agent-status-manager.ts
@@ -180,6 +180,7 @@ export class OpenCodeProvider implements IDisposable {
         const matchingSession = findMatchingSession(sessionsResult.value, this.workspacePath);
         if (matchingSession) {
           this._primarySessionId = matchingSession.id;
+          client.addRootSession(matchingSession.id);
           this.logger.info("Found existing session", {
             workspacePath: this.workspacePath,
             sessionId: matchingSession.id,

--- a/src/services/opencode/opencode-client.ts
+++ b/src/services/opencode/opencode-client.ts
@@ -224,6 +224,14 @@ export class OpenCodeClient implements IDisposable {
   }
 
   /**
+   * Add a session to the root sessions set (for existing sessions found via listSessions).
+   * This ensures status events for existing sessions are properly processed.
+   */
+  addRootSession(sessionId: string): void {
+    this.rootSessionIds.add(sessionId);
+  }
+
+  /**
    * Get current status from the API.
    * Fetches session status and aggregates to a single ClientStatus.
    * Empty or all idle → "idle", any busy/retry → "busy"


### PR DESCRIPTION
## Summary
- Add addRootSession() method to OpenCodeClient for registering existing sessions
- Register existing sessions found via listSessions() in AgentStatusManager.initializeClient()
- Fix bug where status events were ignored for existing sessions, causing UI to stay 'busy'
- Fixes incorrect status display when using /ship command with existing OpenCode sessions