### PR TITLE
feat(mcp): support VS Code object serialization in execute_command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -885,6 +885,8 @@ CodeHydra runs an MCP (Model Context Protocol) server that exposes workspace API
 
 **Note**: MCP tools mirror the Public API workspace methods. See `docs/API.md` for detailed documentation.
 
+**VS Code Object Serialization**: Commands requiring VS Code objects (Uri, Position, Range, Selection, Location) use the `$vscode` wrapper format. Example: `{ "$vscode": "Uri", "value": "file:///path/to/file.ts" }`. See [docs/API.md#vs-code-object-serialization](docs/API.md#vs-code-object-serialization) for full format documentation.
+
 ## Development Workflow
 
 - **Features**: Efficient coverage - implement with tests, batch validate at end

--- a/planning/VSCODE_OBJECT_SERIALIZATION.md
+++ b/planning/VSCODE_OBJECT_SERIALIZATION.md
@@ -1,0 +1,289 @@
+---
+status: COMPLETED
+last_updated: 2026-01-04
+reviewers: [review-arch, review-quality, review-testing]
+---
+
+# VSCODE_OBJECT_SERIALIZATION
+
+## Overview
+
+- **Problem**: VS Code commands often require class instances (Uri, Position, Range, etc.) that cannot be serialized through JSON. When using CodeHydra's MCP `workspace_execute_command` tool or IPC interface, these objects lose their prototypes and methods, causing commands to fail silently or error.
+
+- **Solution**: Introduce a convention where VS Code objects are wrapped with a `$vscode` type marker. A pure TypeScript reconstruction utility (in `src/shared/`) recognizes these markers and reconstructs the actual VS Code objects using injected factory functions. The sidekick extension wires in the real `vscode` constructors.
+
+- **Risks**:
+  - **Collision risk**: Using `$vscode` as a key could theoretically collide with legitimate data. Mitigation: `$vscode` is an unlikely key in normal usage. If a command genuinely needs to pass `{ "$vscode": "literal" }` as data, wrap it in another object: `{ "data": { "$vscode": "literal" } }`.
+  - **Incomplete reconstruction**: Missing support for a VS Code object type. Mitigation: Start with the most common types, document supported types clearly, and provide clear error messages for unsupported types.
+  - **Nested objects**: Deep nesting with mixed VS Code and plain objects. Mitigation: Recursive transformation handles arbitrary depth.
+  - **Circular references**: Circular object references would cause infinite recursion. Mitigation: Not supported - will cause stack overflow. Document this limitation.
+
+- **Alternatives Considered**:
+  1. **Schema-based transformation**: Define which arguments need transformation per command. Rejected: Would require maintaining a database of all VS Code commands and their signatures.
+  2. **MCP-side reconstruction**: Reconstruct objects in the MCP server. Rejected: The `vscode` module is only available in the extension context, not in the main process.
+  3. **String-based DSL**: Use strings like `"Uri:file:///path"`. Rejected: Less flexible and harder to represent complex nested objects like Location (which contains both Uri and Range).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ AI Agent (Claude)                                                           │
+│                                                                             │
+│  vscode.open requires Uri, so I'll use:                                     │
+│  { "$vscode": "Uri", "value": "file:///path/to/file.ts" }                   │
+└──────────────────────────────┬──────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ MCP Server (workspace_execute_command)                                      │
+│                                                                             │
+│  args: [{ "$vscode": "Uri", "value": "file:///path/to/file.ts" }]          │
+│                                                                             │
+│  → Passes through as-is (JSON-serializable)                                 │
+└──────────────────────────────┬──────────────────────────────────────────────┘
+                               │ Socket.IO
+                               ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Sidekick Extension                                                          │
+│                                                                             │
+│  import { reconstructVscodeObjects } from "shared/vscode-serialization";    │
+│  import * as vscode from "vscode";                                          │
+│                                                                             │
+│  const factories = {                                                        │
+│    Uri: (v) => vscode.Uri.parse(v.value),                                   │
+│    Position: (v) => new vscode.Position(v.line, v.character),               │
+│    // ...                                                                   │
+│  };                                                                         │
+│                                                                             │
+│  socket.on("command", (request, ack) => {                                   │
+│    const args = reconstructVscodeObjects(request.args ?? [], factories);    │
+│    vscode.commands.executeCommand(request.command, ...args);                │
+│  });                                                                        │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Supported VS Code Object Types
+
+| Type      | `$vscode` Value | Required Fields     | Field Types            | Reconstruction                  |
+| --------- | --------------- | ------------------- | ---------------------- | ------------------------------- |
+| Uri       | `"Uri"`         | `value`             | `string`               | `Uri.parse(value)`              |
+| Position  | `"Position"`    | `line`, `character` | `number`, `number`     | `new Position(line, character)` |
+| Range     | `"Range"`       | `start`, `end`      | `Position`, `Position` | `new Range(start, end)`         |
+| Selection | `"Selection"`   | `anchor`, `active`  | `Position`, `Position` | `new Selection(anchor, active)` |
+| Location  | `"Location"`    | `uri`, `range`      | `Uri`, `Range`         | `new Location(uri, range)`      |
+
+**Supported types constant**: `SUPPORTED_VSCODE_TYPES = new Set(["Uri", "Position", "Range", "Selection", "Location"])`
+
+**Future additions**: `TextEdit` (requires Range + newText) may be added if needed for refactoring commands.
+
+### JSON Format Examples
+
+**Uri**:
+
+```json
+{ "$vscode": "Uri", "value": "file:///path/to/file.ts" }
+```
+
+**Position**:
+
+```json
+{ "$vscode": "Position", "line": 10, "character": 5 }
+```
+
+**Range**:
+
+```json
+{
+  "$vscode": "Range",
+  "start": { "$vscode": "Position", "line": 10, "character": 5 },
+  "end": { "$vscode": "Position", "line": 10, "character": 20 }
+}
+```
+
+**Location** (fully nested):
+
+```json
+{
+  "$vscode": "Location",
+  "uri": { "$vscode": "Uri", "value": "file:///path/to/file.ts" },
+  "range": {
+    "$vscode": "Range",
+    "start": { "$vscode": "Position", "line": 10, "character": 5 },
+    "end": { "$vscode": "Position", "line": 10, "character": 20 }
+  }
+}
+```
+
+### Nested Object Handling
+
+The reconstruction is recursive, processing:
+
+- Arrays: each element is recursively processed
+- Objects: each property value is recursively processed
+- `$vscode` markers: validated and reconstructed using factory functions
+
+Plain objects and primitives pass through unchanged. Mixed objects work correctly:
+
+```json
+{
+  "label": "Go to definition",
+  "location": { "$vscode": "Location", "uri": {...}, "range": {...} }
+}
+```
+
+Result: `{ label: "Go to definition", location: <Location instance> }`
+
+### Error Handling
+
+**Unknown type error format**:
+
+```
+Unknown VS Code object type: "Unknown". Supported types: Uri, Position, Range, Selection, Location
+```
+
+**Missing field error format**:
+
+```
+Invalid VS Code Position: missing required field "line"
+```
+
+**Invalid field type error format**:
+
+```
+Invalid VS Code Position: field "line" must be a number, got string
+```
+
+## Implementation Steps
+
+- [x] **Step 1: Create VS Code object reconstruction utility**
+  - Create `src/shared/vscode-serialization.ts` with:
+    - `SUPPORTED_VSCODE_TYPES` constant (Set of type names)
+    - `VscodeWrapper` discriminated union type
+    - `VscodeFactories` interface for factory function injection
+    - `reconstructVscodeObjects(value: unknown, factories: VscodeFactories): unknown` function
+  - Implement type-safe validation for each object type's required fields
+  - Handle recursive transformation for nested objects and arrays
+  - Return clear error messages with exact format specified above
+  - **Files affected**: `src/shared/vscode-serialization.ts` (new)
+  - **Test criteria**: All focused tests pass in vitest
+
+- [x] **Step 2: Integrate reconstruction into sidekick extension**
+  - Import `reconstructVscodeObjects` and types from shared module
+  - Create `vscodeFactories` object mapping type names to real `vscode` constructors
+  - Apply transformation in command handler before `executeCommand`
+  - **Files affected**: `extensions/sidekick/src/extension.ts`
+  - **Test criteria**: Commands with VS Code objects work through Socket.IO
+
+- [x] **Step 3: Update MCP tool description**
+  - Update `workspace_execute_command` tool's `description` field to mention `$vscode` wrapper support
+  - Update `args` parameter's `.describe()` with examples for each supported type
+  - Include the fully nested Location example
+  - **Files affected**: `src/services/mcp-server/mcp-server.ts`
+  - **Test criteria**: Tool description includes complete serialization format documentation
+
+- [x] **Step 4: Update documentation**
+  - Add "VS Code Object Serialization" section to `docs/API.md` with:
+    - Supported types table
+    - JSON format examples for each type
+    - Nested object example (Location)
+    - Error message formats
+  - Update AGENTS.md MCP Server section to note `$vscode` wrapper support with reference to API.md
+  - **Files affected**: `docs/API.md`, `AGENTS.md`
+  - **Test criteria**: Documentation is clear and complete
+
+## Testing Strategy
+
+### Focused Tests (pure utility function in src/shared/)
+
+The `reconstructVscodeObjects` function is pure TypeScript with injected factories, testable in vitest.
+
+| #   | Test Case                              | Function                   | Input/Output                                                                                   |
+| --- | -------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | Uri wrapper reconstruction             | `reconstructVscodeObjects` | `{ "$vscode": "Uri", "value": "file:///test" }` → factory called with value                    |
+| 2   | Position wrapper reconstruction        | `reconstructVscodeObjects` | `{ "$vscode": "Position", "line": 0, "character": 5 }` → factory called                        |
+| 3   | Range wrapper reconstruction           | `reconstructVscodeObjects` | `{ "$vscode": "Range", "start": {...}, "end": {...} }` → nested positions reconstructed first  |
+| 4   | Selection wrapper reconstruction       | `reconstructVscodeObjects` | `{ "$vscode": "Selection", "anchor": {...}, "active": {...} }` → factory called                |
+| 5   | Location wrapper reconstruction        | `reconstructVscodeObjects` | `{ "$vscode": "Location", "uri": {...}, "range": {...} }` → nested uri/range reconstructed     |
+| 6   | Nested wrappers in plain object        | `reconstructVscodeObjects` | `{ label: "foo", uri: { "$vscode": "Uri", ... } }` → label unchanged, uri reconstructed        |
+| 7   | Nested wrappers in array               | `reconstructVscodeObjects` | `[{ "$vscode": "Uri", ... }, "plain"]` → first reconstructed, second unchanged                 |
+| 8   | Plain object passthrough               | `reconstructVscodeObjects` | `{ foo: "bar" }` → unchanged, no factory calls                                                 |
+| 9   | Plain array passthrough                | `reconstructVscodeObjects` | `[1, 2, 3]` → unchanged                                                                        |
+| 10  | Primitives passthrough                 | `reconstructVscodeObjects` | `"string"`, `42`, `true`, `null` → unchanged                                                   |
+| 11  | Unknown $vscode type error             | `reconstructVscodeObjects` | `{ "$vscode": "Unknown" }` → throws with message containing "Unknown" and supported types      |
+| 12  | Uri missing value error                | `reconstructVscodeObjects` | `{ "$vscode": "Uri" }` → throws "missing required field \"value\""                             |
+| 13  | Position missing line error            | `reconstructVscodeObjects` | `{ "$vscode": "Position", "character": 0 }` → throws "missing required field \"line\""         |
+| 14  | Position missing character error       | `reconstructVscodeObjects` | `{ "$vscode": "Position", "line": 0 }` → throws "missing required field \"character\""         |
+| 15  | Position invalid line type error       | `reconstructVscodeObjects` | `{ "$vscode": "Position", "line": "0", "character": 0 }` → throws "must be a number"           |
+| 16  | Range with invalid nested Position     | `reconstructVscodeObjects` | `{ "$vscode": "Range", "start": { "$vscode": "Position" }, "end": {...} }` → throws for nested |
+| 17  | Mixed object with primitives preserved | `reconstructVscodeObjects` | `{ label: "test", count: 5, uri: { "$vscode": "Uri", ... } }` → label/count unchanged          |
+
+### Integration Tests
+
+| #   | Test Case                                    | Entry Point            | Boundary Mocks | Behavior Verified                                        |
+| --- | -------------------------------------------- | ---------------------- | -------------- | -------------------------------------------------------- |
+| 1   | Args with $vscode pass through MCP unchanged | `McpServer.handleTool` | API mock       | Args array passed to executeCommand without modification |
+
+### Manual Testing Checklist
+
+- [ ] Open file via MCP:
+  ```json
+  {
+    "command": "vscode.open",
+    "args": [{ "$vscode": "Uri", "value": "file:///c:/path/to/file.ts" }]
+  }
+  ```
+- [ ] Go to location via MCP:
+  ```json
+  {
+    "command": "editor.action.goToLocations",
+    "args": [
+      { "$vscode": "Uri", "value": "file:///c:/path/to/file.ts" },
+      { "$vscode": "Position", "line": 10, "character": 0 },
+      [
+        {
+          "$vscode": "Location",
+          "uri": { "$vscode": "Uri", "value": "file:///..." },
+          "range": {
+            "$vscode": "Range",
+            "start": { "$vscode": "Position", "line": 5, "character": 0 },
+            "end": { "$vscode": "Position", "line": 5, "character": 10 }
+          }
+        }
+      ]
+    ]
+  }
+  ```
+- [ ] Verify error message when using unknown `$vscode` type shows supported types
+- [ ] Verify error message when wrapper is malformed shows which field is missing/invalid
+
+## Dependencies
+
+No new dependencies required. Uses only the `vscode` module which is already available in the extension context.
+
+| Package | Purpose | Approved |
+| ------- | ------- | -------- |
+| (none)  | -       | -        |
+
+## Documentation Updates
+
+### Files to Update
+
+| File          | Changes Required                                                                                                                                                          |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/API.md` | Add "VS Code Object Serialization" section with supported types, JSON formats, examples, error messages                                                                   |
+| `AGENTS.md`   | Add note to MCP Server section: "Commands requiring VS Code objects (Uri, Position, Range, etc.) use `$vscode` wrapper format. See docs/API.md for serialization format." |
+
+### New Documentation Required
+
+| File   | Purpose |
+| ------ | ------- |
+| (none) | -       |
+
+## Definition of Done
+
+- [ ] All implementation steps complete
+- [ ] `pnpm validate:fix` passes
+- [ ] Documentation updated
+- [ ] User acceptance testing passed
+- [ ] CI passed
+- [ ] Merged to main

--- a/src/services/mcp-server/mcp-server.ts
+++ b/src/services/mcp-server/mcp-server.ts
@@ -467,14 +467,26 @@ export class McpServer implements IMcpServer {
         "workspace_execute_command",
         {
           description:
-            "Execute a VS Code command in the current workspace. Most commands return undefined.",
+            "Execute a VS Code command in the current workspace. Most commands return undefined. " +
+            "Commands requiring VS Code objects (Uri, Position, Range, Selection, Location) can use " +
+            'the $vscode wrapper format. Example: { "$vscode": "Uri", "value": "file:///path/to/file.ts" }',
           inputSchema: z.object({
             command: z
               .string()
               .min(1)
               .max(256)
               .describe("VS Code command identifier (e.g., 'workbench.action.files.save')"),
-            args: z.array(z.unknown()).optional().describe("Optional command arguments"),
+            args: z
+              .array(z.unknown())
+              .optional()
+              .describe(
+                "Optional command arguments. Supports $vscode wrapper format for VS Code objects:\n" +
+                  '- Uri: { "$vscode": "Uri", "value": "file:///path/to/file.ts" }\n' +
+                  '- Position: { "$vscode": "Position", "line": 10, "character": 5 }\n' +
+                  '- Range: { "$vscode": "Range", "start": <Position>, "end": <Position> }\n' +
+                  '- Selection: { "$vscode": "Selection", "anchor": <Position>, "active": <Position> }\n' +
+                  '- Location: { "$vscode": "Location", "uri": <Uri>, "range": <Range> }'
+              ),
           }),
         },
         this.createWorkspaceHandler(

--- a/src/shared/vscode-serialization.test.ts
+++ b/src/shared/vscode-serialization.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  reconstructVscodeObjects,
+  SUPPORTED_VSCODE_TYPES,
+  type VscodeFactories,
+} from "./vscode-serialization";
+
+/**
+ * Create mock factories that record calls and return identifiable mock objects.
+ */
+function createMockFactories() {
+  const calls = {
+    Uri: [] as Array<{ value: string }>,
+    Position: [] as Array<{ line: number; character: number }>,
+    Range: [] as Array<{ start: unknown; end: unknown }>,
+    Selection: [] as Array<{ anchor: unknown; active: unknown }>,
+    Location: [] as Array<{ uri: unknown; range: unknown }>,
+  };
+
+  const factories: VscodeFactories = {
+    Uri: vi.fn((value: string) => {
+      calls.Uri.push({ value });
+      return { __mock: "Uri", value };
+    }),
+    Position: vi.fn((line: number, character: number) => {
+      calls.Position.push({ line, character });
+      return { __mock: "Position", line, character };
+    }),
+    Range: vi.fn((start: unknown, end: unknown) => {
+      calls.Range.push({ start, end });
+      return { __mock: "Range", start, end };
+    }),
+    Selection: vi.fn((anchor: unknown, active: unknown) => {
+      calls.Selection.push({ anchor, active });
+      return { __mock: "Selection", anchor, active };
+    }),
+    Location: vi.fn((uri: unknown, range: unknown) => {
+      calls.Location.push({ uri, range });
+      return { __mock: "Location", uri, range };
+    }),
+  };
+
+  return { factories, calls };
+}
+
+describe("SUPPORTED_VSCODE_TYPES", () => {
+  it("contains expected types", () => {
+    expect(SUPPORTED_VSCODE_TYPES.has("Uri")).toBe(true);
+    expect(SUPPORTED_VSCODE_TYPES.has("Position")).toBe(true);
+    expect(SUPPORTED_VSCODE_TYPES.has("Range")).toBe(true);
+    expect(SUPPORTED_VSCODE_TYPES.has("Selection")).toBe(true);
+    expect(SUPPORTED_VSCODE_TYPES.has("Location")).toBe(true);
+    expect(SUPPORTED_VSCODE_TYPES.size).toBe(5);
+  });
+});
+
+describe("reconstructVscodeObjects", () => {
+  // Test 1: Uri wrapper reconstruction
+  it("reconstructs Uri wrapper", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects({ $vscode: "Uri", value: "file:///test" }, factories);
+
+    expect(factories.Uri).toHaveBeenCalledWith("file:///test");
+    expect(result).toEqual({ __mock: "Uri", value: "file:///test" });
+  });
+
+  // Test 2: Position wrapper reconstruction
+  it("reconstructs Position wrapper", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      { $vscode: "Position", line: 0, character: 5 },
+      factories
+    );
+
+    expect(factories.Position).toHaveBeenCalledWith(0, 5);
+    expect(result).toEqual({ __mock: "Position", line: 0, character: 5 });
+  });
+
+  // Test 3: Range wrapper reconstruction
+  it("reconstructs Range wrapper with nested Positions", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        $vscode: "Range",
+        start: { $vscode: "Position", line: 10, character: 5 },
+        end: { $vscode: "Position", line: 10, character: 20 },
+      },
+      factories
+    );
+
+    expect(factories.Position).toHaveBeenCalledTimes(2);
+    expect(factories.Position).toHaveBeenCalledWith(10, 5);
+    expect(factories.Position).toHaveBeenCalledWith(10, 20);
+    expect(factories.Range).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ __mock: "Range" });
+  });
+
+  // Test 4: Selection wrapper reconstruction
+  it("reconstructs Selection wrapper with nested Positions", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        $vscode: "Selection",
+        anchor: { $vscode: "Position", line: 5, character: 0 },
+        active: { $vscode: "Position", line: 10, character: 15 },
+      },
+      factories
+    );
+
+    expect(factories.Position).toHaveBeenCalledTimes(2);
+    expect(factories.Selection).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ __mock: "Selection" });
+  });
+
+  // Test 5: Location wrapper reconstruction
+  it("reconstructs Location wrapper with nested Uri and Range", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        $vscode: "Location",
+        uri: { $vscode: "Uri", value: "file:///path/to/file.ts" },
+        range: {
+          $vscode: "Range",
+          start: { $vscode: "Position", line: 10, character: 5 },
+          end: { $vscode: "Position", line: 10, character: 20 },
+        },
+      },
+      factories
+    );
+
+    expect(factories.Uri).toHaveBeenCalledWith("file:///path/to/file.ts");
+    expect(factories.Position).toHaveBeenCalledTimes(2);
+    expect(factories.Range).toHaveBeenCalledTimes(1);
+    expect(factories.Location).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ __mock: "Location" });
+  });
+
+  // Test 6: Nested wrappers in plain object
+  it("reconstructs wrappers nested in plain objects", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        label: "foo",
+        uri: { $vscode: "Uri", value: "file:///test.ts" },
+      },
+      factories
+    );
+
+    expect(factories.Uri).toHaveBeenCalledWith("file:///test.ts");
+    expect(result).toEqual({
+      label: "foo",
+      uri: { __mock: "Uri", value: "file:///test.ts" },
+    });
+  });
+
+  // Test 7: Nested wrappers in array
+  it("reconstructs wrappers nested in arrays", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      [{ $vscode: "Uri", value: "file:///test.ts" }, "plain"],
+      factories
+    );
+
+    expect(factories.Uri).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([{ __mock: "Uri", value: "file:///test.ts" }, "plain"]);
+  });
+
+  // Test 8: Plain object passthrough
+  it("passes through plain objects unchanged", () => {
+    const { factories } = createMockFactories();
+    const input = { foo: "bar", nested: { baz: 123 } };
+    const result = reconstructVscodeObjects(input, factories);
+
+    expect(factories.Uri).not.toHaveBeenCalled();
+    expect(factories.Position).not.toHaveBeenCalled();
+    expect(result).toEqual(input);
+  });
+
+  // Test 9: Plain array passthrough
+  it("passes through plain arrays unchanged", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects([1, 2, 3], factories);
+
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  // Test 10: Primitives passthrough
+  it("passes through primitives unchanged", () => {
+    const { factories } = createMockFactories();
+
+    expect(reconstructVscodeObjects("string", factories)).toBe("string");
+    expect(reconstructVscodeObjects(42, factories)).toBe(42);
+    expect(reconstructVscodeObjects(true, factories)).toBe(true);
+    expect(reconstructVscodeObjects(null, factories)).toBe(null);
+    expect(reconstructVscodeObjects(undefined, factories)).toBe(undefined);
+  });
+
+  // Test 11: Unknown $vscode type error
+  it("throws error for unknown $vscode type", () => {
+    const { factories } = createMockFactories();
+
+    expect(() => reconstructVscodeObjects({ $vscode: "Unknown" }, factories)).toThrow(
+      'Unknown VS Code object type: "Unknown". Supported types: Uri, Position, Range, Selection, Location'
+    );
+  });
+
+  // Test 12: Uri missing value error
+  it("throws error when Uri missing value field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() => reconstructVscodeObjects({ $vscode: "Uri" }, factories)).toThrow(
+      'Invalid VS Code Uri: missing required field "value"'
+    );
+  });
+
+  // Test 13: Position missing line error
+  it("throws error when Position missing line field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects({ $vscode: "Position", character: 0 }, factories)
+    ).toThrow('Invalid VS Code Position: missing required field "line"');
+  });
+
+  // Test 14: Position missing character error
+  it("throws error when Position missing character field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() => reconstructVscodeObjects({ $vscode: "Position", line: 0 }, factories)).toThrow(
+      'Invalid VS Code Position: missing required field "character"'
+    );
+  });
+
+  // Test 15: Position invalid line type error
+  it("throws error when Position line is not a number", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects({ $vscode: "Position", line: "0", character: 0 }, factories)
+    ).toThrow('Invalid VS Code Position: field "line" must be a number, got string');
+  });
+
+  // Test 16: Range with invalid nested Position
+  it("throws error for Range with invalid nested Position", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects(
+        {
+          $vscode: "Range",
+          start: { $vscode: "Position" }, // Missing fields
+          end: { $vscode: "Position", line: 0, character: 0 },
+        },
+        factories
+      )
+    ).toThrow('Invalid VS Code Position: missing required field "line"');
+  });
+
+  // Test 17: Mixed object with primitives preserved
+  it("preserves primitives in mixed objects", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        label: "test",
+        count: 5,
+        enabled: true,
+        uri: { $vscode: "Uri", value: "file:///test.ts" },
+      },
+      factories
+    );
+
+    expect(result).toEqual({
+      label: "test",
+      count: 5,
+      enabled: true,
+      uri: { __mock: "Uri", value: "file:///test.ts" },
+    });
+  });
+
+  // Additional tests for completeness
+
+  it("handles deeply nested arrays and objects", () => {
+    const { factories } = createMockFactories();
+    const result = reconstructVscodeObjects(
+      {
+        items: [
+          {
+            locations: [
+              {
+                $vscode: "Location",
+                uri: { $vscode: "Uri", value: "file:///a.ts" },
+                range: {
+                  $vscode: "Range",
+                  start: { $vscode: "Position", line: 1, character: 0 },
+                  end: { $vscode: "Position", line: 1, character: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      factories
+    );
+
+    expect(factories.Uri).toHaveBeenCalledTimes(1);
+    expect(factories.Position).toHaveBeenCalledTimes(2);
+    expect(factories.Range).toHaveBeenCalledTimes(1);
+    expect(factories.Location).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      items: [{ locations: [{ __mock: "Location" }] }],
+    });
+  });
+
+  it("handles empty objects and arrays", () => {
+    const { factories } = createMockFactories();
+
+    expect(reconstructVscodeObjects({}, factories)).toEqual({});
+    expect(reconstructVscodeObjects([], factories)).toEqual([]);
+  });
+
+  it("throws error for Range missing start field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects(
+        { $vscode: "Range", end: { $vscode: "Position", line: 0, character: 0 } },
+        factories
+      )
+    ).toThrow('Invalid VS Code Range: missing required field "start"');
+  });
+
+  it("throws error for Location missing uri field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects(
+        {
+          $vscode: "Location",
+          range: {
+            $vscode: "Range",
+            start: { $vscode: "Position", line: 0, character: 0 },
+            end: { $vscode: "Position", line: 0, character: 0 },
+          },
+        },
+        factories
+      )
+    ).toThrow('Invalid VS Code Location: missing required field "uri"');
+  });
+
+  it("throws error for Selection missing anchor field", () => {
+    const { factories } = createMockFactories();
+
+    expect(() =>
+      reconstructVscodeObjects(
+        {
+          $vscode: "Selection",
+          active: { $vscode: "Position", line: 0, character: 0 },
+        },
+        factories
+      )
+    ).toThrow('Invalid VS Code Selection: missing required field "anchor"');
+  });
+
+  it("throws error for Uri with non-string value", () => {
+    const { factories } = createMockFactories();
+
+    expect(() => reconstructVscodeObjects({ $vscode: "Uri", value: 123 }, factories)).toThrow(
+      'Invalid VS Code Uri: field "value" must be a string, got number'
+    );
+  });
+});

--- a/src/shared/vscode-serialization.ts
+++ b/src/shared/vscode-serialization.ts
@@ -1,0 +1,301 @@
+/**
+ * VS Code Object Serialization Utilities
+ *
+ * Provides serialization/deserialization for VS Code objects (Uri, Position, Range, etc.)
+ * that cannot be transmitted directly through JSON. Objects are wrapped with a `$vscode`
+ * type marker that identifies how to reconstruct them.
+ *
+ * The reconstruction function is pure TypeScript with injected factories, making it
+ * testable without VS Code dependencies.
+ */
+
+/**
+ * Supported VS Code object types.
+ */
+export const SUPPORTED_VSCODE_TYPES = new Set([
+  "Uri",
+  "Position",
+  "Range",
+  "Selection",
+  "Location",
+] as const);
+
+/**
+ * Type name for a supported VS Code object.
+ */
+export type VscodeTypeName = "Uri" | "Position" | "Range" | "Selection" | "Location";
+
+/**
+ * Wrapper format for Uri objects.
+ */
+export interface VscodeUriWrapper {
+  readonly $vscode: "Uri";
+  readonly value: string;
+}
+
+/**
+ * Wrapper format for Position objects.
+ */
+export interface VscodePositionWrapper {
+  readonly $vscode: "Position";
+  readonly line: number;
+  readonly character: number;
+}
+
+/**
+ * Wrapper format for Range objects.
+ */
+export interface VscodeRangeWrapper {
+  readonly $vscode: "Range";
+  readonly start: VscodePositionWrapper;
+  readonly end: VscodePositionWrapper;
+}
+
+/**
+ * Wrapper format for Selection objects.
+ */
+export interface VscodeSelectionWrapper {
+  readonly $vscode: "Selection";
+  readonly anchor: VscodePositionWrapper;
+  readonly active: VscodePositionWrapper;
+}
+
+/**
+ * Wrapper format for Location objects.
+ */
+export interface VscodeLocationWrapper {
+  readonly $vscode: "Location";
+  readonly uri: VscodeUriWrapper;
+  readonly range: VscodeRangeWrapper;
+}
+
+/**
+ * Discriminated union of all VS Code wrapper types.
+ */
+export type VscodeWrapper =
+  | VscodeUriWrapper
+  | VscodePositionWrapper
+  | VscodeRangeWrapper
+  | VscodeSelectionWrapper
+  | VscodeLocationWrapper;
+
+/**
+ * Factory functions for creating VS Code objects.
+ *
+ * Each factory receives the validated wrapper data and returns the actual VS Code object.
+ * The Position/Range/Selection/Location factories receive already-reconstructed nested objects.
+ */
+export interface VscodeFactories {
+  /**
+   * Create a Uri from a string value.
+   */
+  Uri: (value: string) => unknown;
+
+  /**
+   * Create a Position from line and character numbers.
+   */
+  Position: (line: number, character: number) => unknown;
+
+  /**
+   * Create a Range from start and end Position objects.
+   */
+  Range: (start: unknown, end: unknown) => unknown;
+
+  /**
+   * Create a Selection from anchor and active Position objects.
+   */
+  Selection: (anchor: unknown, active: unknown) => unknown;
+
+  /**
+   * Create a Location from a Uri and Range object.
+   */
+  Location: (uri: unknown, range: unknown) => unknown;
+}
+
+/**
+ * Check if a value is a VS Code wrapper object (has $vscode property).
+ */
+function isVscodeWrapper(value: unknown): value is { $vscode: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "$vscode" in value &&
+    typeof (value as { $vscode: unknown }).$vscode === "string"
+  );
+}
+
+/**
+ * Validate that a required field exists on the wrapper.
+ */
+function validateRequiredField(
+  wrapper: Record<string, unknown>,
+  typeName: string,
+  fieldName: string
+): void {
+  if (!(fieldName in wrapper)) {
+    throw new Error(`Invalid VS Code ${typeName}: missing required field "${fieldName}"`);
+  }
+}
+
+/**
+ * Validate that a field is a number.
+ */
+function validateNumberField(
+  wrapper: Record<string, unknown>,
+  typeName: string,
+  fieldName: string
+): void {
+  const value = wrapper[fieldName];
+  if (typeof value !== "number") {
+    throw new Error(
+      `Invalid VS Code ${typeName}: field "${fieldName}" must be a number, got ${typeof value}`
+    );
+  }
+}
+
+/**
+ * Reconstruct VS Code objects from their JSON wrapper format.
+ *
+ * This function recursively processes a value, transforming any objects with a `$vscode`
+ * marker into actual VS Code objects using the provided factory functions.
+ *
+ * @param value - The value to transform (may be nested objects/arrays)
+ * @param factories - Factory functions for creating VS Code objects
+ * @returns The value with all $vscode wrappers replaced with actual objects
+ * @throws Error if an unknown $vscode type is encountered or required fields are missing
+ */
+export function reconstructVscodeObjects(value: unknown, factories: VscodeFactories): unknown {
+  // Handle null/undefined/primitives - pass through unchanged
+  if (value === null || value === undefined || typeof value !== "object") {
+    return value;
+  }
+
+  // Handle arrays - recursively process each element
+  if (Array.isArray(value)) {
+    return value.map((item) => reconstructVscodeObjects(item, factories));
+  }
+
+  // Handle objects
+  const obj = value as Record<string, unknown>;
+
+  // Check for $vscode marker
+  if (isVscodeWrapper(obj)) {
+    return reconstructSingleWrapper(obj, factories);
+  }
+
+  // Plain object - recursively process each property
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    result[key] = reconstructVscodeObjects(obj[key], factories);
+  }
+  return result;
+}
+
+/**
+ * Reconstruct a single VS Code wrapper object.
+ */
+function reconstructSingleWrapper(
+  wrapper: { $vscode: string } & Record<string, unknown>,
+  factories: VscodeFactories
+): unknown {
+  const typeName = wrapper.$vscode;
+
+  // Check for supported type
+  if (!SUPPORTED_VSCODE_TYPES.has(typeName as VscodeTypeName)) {
+    const supportedList = Array.from(SUPPORTED_VSCODE_TYPES).join(", ");
+    throw new Error(
+      `Unknown VS Code object type: "${typeName}". Supported types: ${supportedList}`
+    );
+  }
+
+  switch (typeName) {
+    case "Uri":
+      return reconstructUri(wrapper, factories);
+    case "Position":
+      return reconstructPosition(wrapper, factories);
+    case "Range":
+      return reconstructRange(wrapper, factories);
+    case "Selection":
+      return reconstructSelection(wrapper, factories);
+    case "Location":
+      return reconstructLocation(wrapper, factories);
+    default:
+      // This should never happen due to the SUPPORTED_VSCODE_TYPES check above
+      throw new Error(`Unhandled VS Code type: ${typeName}`);
+  }
+}
+
+/**
+ * Reconstruct a Uri wrapper.
+ */
+function reconstructUri(wrapper: Record<string, unknown>, factories: VscodeFactories): unknown {
+  validateRequiredField(wrapper, "Uri", "value");
+  const value = wrapper.value;
+  if (typeof value !== "string") {
+    throw new Error(`Invalid VS Code Uri: field "value" must be a string, got ${typeof value}`);
+  }
+  return factories.Uri(value);
+}
+
+/**
+ * Reconstruct a Position wrapper.
+ */
+function reconstructPosition(
+  wrapper: Record<string, unknown>,
+  factories: VscodeFactories
+): unknown {
+  validateRequiredField(wrapper, "Position", "line");
+  validateRequiredField(wrapper, "Position", "character");
+  validateNumberField(wrapper, "Position", "line");
+  validateNumberField(wrapper, "Position", "character");
+
+  return factories.Position(wrapper.line as number, wrapper.character as number);
+}
+
+/**
+ * Reconstruct a Range wrapper.
+ */
+function reconstructRange(wrapper: Record<string, unknown>, factories: VscodeFactories): unknown {
+  validateRequiredField(wrapper, "Range", "start");
+  validateRequiredField(wrapper, "Range", "end");
+
+  // Recursively reconstruct nested Position objects
+  const start = reconstructVscodeObjects(wrapper.start, factories);
+  const end = reconstructVscodeObjects(wrapper.end, factories);
+
+  return factories.Range(start, end);
+}
+
+/**
+ * Reconstruct a Selection wrapper.
+ */
+function reconstructSelection(
+  wrapper: Record<string, unknown>,
+  factories: VscodeFactories
+): unknown {
+  validateRequiredField(wrapper, "Selection", "anchor");
+  validateRequiredField(wrapper, "Selection", "active");
+
+  // Recursively reconstruct nested Position objects
+  const anchor = reconstructVscodeObjects(wrapper.anchor, factories);
+  const active = reconstructVscodeObjects(wrapper.active, factories);
+
+  return factories.Selection(anchor, active);
+}
+
+/**
+ * Reconstruct a Location wrapper.
+ */
+function reconstructLocation(
+  wrapper: Record<string, unknown>,
+  factories: VscodeFactories
+): unknown {
+  validateRequiredField(wrapper, "Location", "uri");
+  validateRequiredField(wrapper, "Location", "range");
+
+  // Recursively reconstruct nested Uri and Range objects
+  const uri = reconstructVscodeObjects(wrapper.uri, factories);
+  const range = reconstructVscodeObjects(wrapper.range, factories);
+
+  return factories.Location(uri, range);
+}


### PR DESCRIPTION
Implements VSCODE_OBJECT_SERIALIZATION plan.

- Add $vscode wrapper format for Uri, Position, Range, Selection, Location
- Create shared reconstruction utility with type-safe validation
- Integrate into sidekick extension command handler
- Update MCP tool description with serialization format docs

Plan: planning/VSCODE_OBJECT_SERIALIZATION.md