### PR TITLE
fix(agents): deny write/edit permissions for plan agent

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -37,6 +37,10 @@
     },
     "plan": {
       "color": "#3B82F6", // blue
+      "permission": {
+        "edit": "deny",
+        "write": "deny",
+      },
     },
   },
 }


### PR DESCRIPTION
## Summary
- Explicitly deny `write` and `edit` permissions for the `plan` agent in `opencode.jsonc`.
- This ensures the plan agent cannot modify files during the planning phase, adhering to the principle of separation of concerns and preventing accidental modifications.