### PR TITLE
feat(opencode): allow read-only gh commands for plan agent

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -37,6 +37,29 @@
     },
     "plan": {
       "color": "#3B82F6", // blue
+      "permission": {
+        "bash": {
+          "*": "deny",
+          // Standard read-only commands
+          "git log*": "allow",
+          "git diff*": "allow",
+          "git show*": "allow",
+          "git status": "allow",
+          "ls*": "allow",
+          "tree*": "allow",
+          "cat*": "allow",
+          "head*": "allow",
+          "tail*": "allow",
+          "wc*": "allow",
+          "pwd": "allow",
+          // Plan-specific GH allowed commands
+          "gh workflow list*": "allow",
+          "gh workflow view*": "allow",
+          "gh run list*": "allow",
+          "gh run view*": "allow",
+          "gh run watch*": "allow",
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
## Summary
Enable the `plan` agent to inspect GitHub Actions workflows and runs by whitelisting specific read-only `gh` commands.

## Details
- Explicitly configured `agent.plan` permissions in `opencode.jsonc`.
- Whitelisted commands:
  - `gh workflow list`, `gh workflow view`
  - `gh run list`, `gh run view`, `gh run watch`
- Denied by default (wildcard `*` deny).
- Re-added standard read-only tools (`git log`, `ls`, `cat`, etc.) to the plan agent to ensure no functionality is lost due to override.
- `gh api` is explicitly excluded to prevent broad access.