### PR TITLE
feat(agents): switch Claude Code to terminal mode with improved startup

### DIFF
--- a/src/agents/claude-code/provider.integration.test.ts
+++ b/src/agents/claude-code/provider.integration.test.ts
@@ -329,8 +329,8 @@ describe("ClaudeCodeProvider integration", () => {
   });
 
   describe("startupCommands", () => {
-    it("returns claude-vscode editor.open command", () => {
-      expect(provider.startupCommands).toEqual(["claude-vscode.editor.open"]);
+    it("returns claude-vscode terminal.open command", () => {
+      expect(provider.startupCommands).toEqual(["claude-vscode.terminal.open"]);
     });
   });
 });

--- a/src/agents/claude-code/provider.ts
+++ b/src/agents/claude-code/provider.ts
@@ -35,9 +35,9 @@ export interface ClaudeCodeProviderDeps {
 export class ClaudeCodeProvider implements AgentProvider {
   /**
    * VS Code commands to execute on workspace activation.
-   * Uses the Claude Code VS Code extension's editor.open command to open the panel.
+   * Uses the Claude Code VS Code extension's terminal.open command to open the terminal.
    */
-  readonly startupCommands: readonly string[] = ["claude-vscode.editor.open"] as const;
+  readonly startupCommands: readonly string[] = ["claude-vscode.terminal.open"] as const;
 
   private readonly serverManager: ClaudeCodeServerManager;
   private readonly workspacePath: string;

--- a/src/agents/claude-code/types.ts
+++ b/src/agents/claude-code/types.ts
@@ -60,6 +60,9 @@ export type HookStatusChange = AgentStatus | null;
  * - none: No session active
  * - idle: Waiting for user (submit prompt, answer permission, etc.)
  * - busy: Agent is working, no action needed
+ *
+ * Note: PreToolUse is handled specially in server-manager.ts
+ * to only transition to busy after a PermissionRequest (flag-based).
  */
 export const HOOK_STATUS_MAP: Readonly<Record<ClaudeCodeHookName, HookStatusChange>> = {
   // Session started, waiting for user prompt
@@ -74,8 +77,8 @@ export const HOOK_STATUS_MAP: Readonly<Record<ClaudeCodeHookName, HookStatusChan
   Stop: "idle",
   // Subagent done, main agent continues (no change)
   SubagentStop: null,
-  // Tool starting, back to busy (handles return from PermissionRequest idle state)
-  PreToolUse: "busy",
+  // Tool starting - handled specially with flag (see server-manager.ts)
+  PreToolUse: null,
   // Tool done, back to busy (handles return from PermissionRequest idle state)
   PostToolUse: "busy",
   // Informational only (no change)

--- a/src/main/app-state.integration.test.ts
+++ b/src/main/app-state.integration.test.ts
@@ -153,6 +153,7 @@ function createMockWorkspaceFileService() {
     ensureWorkspaceFile: vi.fn().mockResolvedValue(new Path("/test/workspace.code-workspace")),
     createWorkspaceFile: vi.fn().mockResolvedValue(new Path("/test/workspace.code-workspace")),
     getWorkspaceFilePath: vi.fn().mockReturnValue(new Path("/test/workspace.code-workspace")),
+    deleteWorkspaceFile: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/src/main/app-state.test.ts
+++ b/src/main/app-state.test.ts
@@ -95,6 +95,7 @@ const {
     ensureWorkspaceFile: vi.fn(),
     createWorkspaceFile: vi.fn(),
     getWorkspaceFilePath: vi.fn(),
+    deleteWorkspaceFile: vi.fn(),
   };
 
   return {
@@ -704,6 +705,7 @@ describe("AppState", () => {
         expect.any(Path), // workspacePath
         expect.any(Path), // projectWorkspacesDir
         expect.objectContaining({
+          "claudeCode.useTerminal": true,
           "claudeCode.claudeProcessWrapper": MOCK_WRAPPER_PATH,
           // Env vars are converted to {name, value}[] format for Claude extension
           "claudeCode.environmentVariables": [{ name: "ANTHROPIC_API_KEY", value: "test-key" }],

--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -545,6 +545,7 @@ export class AppState {
       // Convert env vars from Record<string, string> to {name, value}[] format expected by Claude extension
       const envVarsArray = Object.entries(agentEnvVars).map(([name, value]) => ({ name, value }));
       const agentSettings: Record<string, unknown> = {
+        "claudeCode.useTerminal": true,
         "claudeCode.claudeProcessWrapper": this.wrapperPath,
         "claudeCode.environmentVariables": envVarsArray,
       };
@@ -717,6 +718,11 @@ export class AppState {
 
     // Destroy the workspace view
     await this.viewManager.destroyWorkspaceView(workspacePathStr);
+
+    // Delete the .code-workspace file
+    const workspaceName = workspacePath.basename;
+    const projectWorkspacesDir = workspacePath.dirname;
+    await this.workspaceFileService.deleteWorkspaceFile(workspaceName, projectWorkspacesDir);
 
     // Update internal project state using Path.equals() for comparison
     const updatedProject: OpenProject = {

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -565,7 +565,7 @@ export class ViewManager implements IViewManager {
     state.urlLoaded = true;
 
     const workspaceName = basename(workspacePath);
-    this.logger.debug("Loading URL", { workspace: workspaceName });
+    this.logger.info("Loading URL", { workspace: workspaceName, url: state.url });
 
     // Load the URL (fire-and-forget)
     void this.viewLayer.loadURL(state.handle, state.url);

--- a/src/main/modules/core/index.ts
+++ b/src/main/modules/core/index.ts
@@ -281,7 +281,8 @@ export class CoreModule implements IApiModule {
       : undefined;
 
     // Add workspace and start server (with optional initial prompt)
-    this.deps.appState.addWorkspace(
+    // Must await to ensure view is created before setActiveWorkspace is called
+    await this.deps.appState.addWorkspace(
       projectPath,
       internalWorkspace,
       normalizedPrompt ? { initialPrompt: normalizedPrompt } : undefined

--- a/src/main/shortcut-controller.ts
+++ b/src/main/shortcut-controller.ts
@@ -165,8 +165,8 @@ export class ShortcutController {
     const isAltKey = input.key === SHORTCUT_MODIFIER_KEY;
     const currentMode = this.getCurrentMode();
 
-    // Log all input events for debugging
-    this.logger?.debug("Input received", {
+    // Log all input events for debugging (silly level to avoid noise)
+    this.logger?.silly("Input received", {
       type: input.type,
       key: input.key,
       isAutoRepeat: input.isAutoRepeat,

--- a/src/services/plugin-server/plugin-server.ts
+++ b/src/services/plugin-server/plugin-server.ts
@@ -162,23 +162,25 @@ const DEFAULT_AGENT_COMMAND = "opencode.openTerminal";
  *
  * These commands configure the workspace layout:
  * - Close sidebars to maximize editor space
- * - Open agent terminal for AI workflow (OpenCode or Claude Code)
- * - Unlock editor groups for flexible tab management
+ * - Open agent tab for AI workflow (OpenCode or Claude Code)
+ * - Close all other editors to show only the agent
+ * - Hide the terminal panel
  * - Open dictation panel in background (no-op if not configured)
- * - Focus terminal to ensure agent input is ready for typing
  *
- * @param agentCommand - The VS Code command to open the agent terminal
+ * @param agentCommand - The VS Code command to open the agent tab
  * @returns Array of VS Code commands to execute
  */
 function getStartupCommands(agentCommand: string = DEFAULT_AGENT_COMMAND): readonly string[] {
   return [
     "workbench.action.closeSidebar", // Hide left sidebar to maximize editor
     "workbench.action.closeAuxiliaryBar", // Hide right sidebar (auxiliary bar)
-    agentCommand, // Open agent terminal (dynamic: OpenCode or Claude Code)
+    agentCommand,
+    "workbench.action.closeOtherEditors", // Close other editors in current group
+    "workbench.action.closeEditorsInOtherGroups", // Close editors in other groups
     "workbench.action.unlockEditorGroup", // Unlock editor group for tab reuse
-    "workbench.action.closeEditorsInOtherGroups", // Clean up empty editor groups
+    "workbench.action.editorLayoutSingle",
     "codehydra.dictation.openPanel", // Open dictation tab in background (no-op if no API key)
-    "workbench.action.terminal.focus", // Ensure terminal input is focused
+    "workbench.action.terminal.focus",
   ];
 }
 

--- a/src/services/vscode-workspace/types.ts
+++ b/src/services/vscode-workspace/types.ts
@@ -88,4 +88,12 @@ export interface IWorkspaceFileService {
    * @returns Path to the .code-workspace file
    */
   getWorkspaceFilePath(workspaceName: string, projectWorkspacesDir: Path): Path;
+
+  /**
+   * Delete a workspace file if it exists.
+   *
+   * @param workspaceName - Name of the workspace
+   * @param projectWorkspacesDir - Directory containing all workspace folders and files
+   */
+  deleteWorkspaceFile(workspaceName: string, projectWorkspacesDir: Path): Promise<void>;
 }

--- a/src/services/vscode-workspace/workspace-file-service.ts
+++ b/src/services/vscode-workspace/workspace-file-service.ts
@@ -41,8 +41,8 @@ export class WorkspaceFileService implements IWorkspaceFileService {
     const content: CodeWorkspaceFile = {
       folders: [
         {
-          // Use relative path from workspace file to folder
-          path: `./${workspaceName}`,
+          // Use absolute path for the folder
+          path: workspacePath.toString(),
         },
       ],
       settings: {
@@ -70,5 +70,24 @@ export class WorkspaceFileService implements IWorkspaceFileService {
 
   getWorkspaceFilePath(workspaceName: string, projectWorkspacesDir: Path): Path {
     return new Path(projectWorkspacesDir, `${workspaceName}.code-workspace`);
+  }
+
+  async deleteWorkspaceFile(workspaceName: string, projectWorkspacesDir: Path): Promise<void> {
+    const workspaceFilePath = this.getWorkspaceFilePath(workspaceName, projectWorkspacesDir);
+
+    try {
+      await this.fileSystem.rm(workspaceFilePath, { force: true });
+      this.logger.debug("Deleted workspace file", {
+        workspaceName,
+        path: workspaceFilePath.toString(),
+      });
+    } catch (error) {
+      // Log but don't throw - file might not exist or be already deleted
+      this.logger.debug("Failed to delete workspace file", {
+        workspaceName,
+        path: workspaceFilePath.toString(),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }


### PR DESCRIPTION
- Switch from claude-vscode.editor.open to claude-vscode.terminal.open
- Add claudeCode.useTerminal setting for terminal-based workflow
- Execute startup commands sequentially to preserve execution order
- Improve status detection with flag-based PreToolUse handling after PermissionRequest
- Add deleteWorkspaceFile method for workspace cleanup on deletion
- Use absolute paths in .code-workspace files for reliability
- Add window reload workaround for VS Code workspace race condition
- Reduce input logging noise by using silly level
- Await addWorkspace in core module to ensure view creation order