### PR TITLE
infra(release): consolidate build workflow and simplify release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,24 +8,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - run: |
-          CONCLUSION=$(gh run list --workflow=ci.yaml --commit=$(git rev-parse HEAD) --json conclusion --jq '.[0].conclusion')
-          if [[ "$CONCLUSION" != "success" ]]; then
-            echo "::error::CI has not passed (status: ${CONCLUSION:-not found})"
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   build:
-    needs: check
     uses: ./.github/workflows/build.yaml
     with:
       release: true

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -12,13 +12,21 @@ Extension versions use valid SemVer format (required by VS Code).
 
 The `-dirty` suffix only appears in local dev builds when there are uncommitted changes.
 
-## Triggering a Build
+## Triggering a Release
 
 1. Go to **Actions** > **Release**
 2. Click **Run workflow**
-3. Optionally check "Skip CI status check" to bypass CI gate
 
 Summary and artifacts appear on the workflow run page.
+
+### Prerequisites
+
+Releases can only be triggered from commits on the `main` branch. Branch protection ensures all commits have passed CI before merge, so no additional CI check is performed during release.
+
+**Required branch protection settings for `main`:**
+
+- Require status checks to pass before merging
+- Required checks: `validate (ubuntu-24.04)`, `validate (windows-2025)`, `build`
 
 ## Artifacts
 


### PR DESCRIPTION
- Consolidate build workflow to single Ubuntu runner with Wine for Windows cross-compilation
- Add reusable build.yaml workflow with matrix for all 5 platforms (linux-x64, win-installer-x64, win-portable-x64, darwin-x64, darwin-arm64)
- Add NSIS installer config for Windows
- Enable macOS builds with x64 and arm64 support
- Remove CI status check from release workflow in favor of branch protection
- Update docs/RELEASE.md with branch protection prerequisites