### PR TITLE
fix(extension): disable markdown-review-editor by default

### DIFF
--- a/extensions/markdown-review-editor/package.json
+++ b/extensions/markdown-review-editor/package.json
@@ -34,7 +34,7 @@
 						"filenamePattern": "*.md"
 					}
 				],
-				"priority": "default"
+				"priority": "option"
 			}
 		]
 	},


### PR DESCRIPTION
- Change custom editor priority from "default" to "option" so markdown files open in the standard text editor
- Users can still access the Markdown Review Editor via "Open With..." menu

cc @mrh1997