### PR TITLE
chore: allow CodeHydra MCP tools by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["mcp__codehydra__*"]
+  }
+}


### PR DESCRIPTION
- Add `.claude/settings.json` with permission rule `mcp__codehydra__*` to allow all CodeHydra MCP tools without prompts