### PR TITLE
feat: add Claude Code permission settings for pnpm scripts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,14 @@
 {
   "permissions": {
-    "allow": ["mcp__codehydra__*"]
+    "allow": [
+      "mcp__codehydra__*",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm validate:*)",
+      "Bash(pnpm build:*)",
+      "Bash(node --version:*)",
+      "Bash(npm --version:*)",
+      "Bash(pnpm --version:*)",
+      "Bash(tsc --version:*)"
+    ]
   }
 }


### PR DESCRIPTION
- Add `.claude/settings.json` with permission allowlist
- Allow `pnpm test`, `pnpm validate`, and `pnpm build` commands without prompts
- Allow version check commands (`node/npm/pnpm/tsc --version`)