### PR TITLE
feat(claude-code): add WrapperStart/WrapperEnd hooks to clear loading screen early

### DIFF
--- a/src/agents/claude-code/types.ts
+++ b/src/agents/claude-code/types.ts
@@ -8,8 +8,13 @@ import type { AgentStatus } from "../types";
 /**
  * All Claude Code hook names.
  * These are the lifecycle events that Claude Code emits.
+ *
+ * WrapperStart/WrapperEnd are CodeHydra-specific hooks sent by the wrapper script
+ * before/after spawning the Claude binary. They are not part of Claude's hook system.
  */
 export type ClaudeCodeHookName =
+  | "WrapperStart"
+  | "WrapperEnd"
   | "SessionStart"
   | "SessionEnd"
   | "UserPromptSubmit"
@@ -65,6 +70,10 @@ export type HookStatusChange = AgentStatus | null;
  * to only transition to busy after a PermissionRequest (flag-based).
  */
 export const HOOK_STATUS_MAP: Readonly<Record<ClaudeCodeHookName, HookStatusChange>> = {
+  // Wrapper started, Claude about to be spawned
+  WrapperStart: "idle",
+  // Wrapper exited, Claude has closed
+  WrapperEnd: "none",
   // Session started, waiting for user prompt
   SessionStart: "idle",
   // Session ended


### PR DESCRIPTION
- Add WrapperStart and WrapperEnd hook types (WrapperStart sets status to idle)
- Add onWorkspaceReady callback that fires when status changes to idle
- Wire onWorkspaceReady to setWorkspaceLoaded in main
- Add notifyHook function in wrapper.ts that awaits HTTP request completion
- Call notifyHook before/after spawnSync in wrapper

When Claude starts, it may show user dialogs before SessionStart is emitted, causing the loading screen timeout to always fire. This adds wrapper hooks that fire before/after spawning Claude, allowing the loading screen to clear immediately when the wrapper starts.