### PR TITLE
fix: resolve ASAR-incompatible external script paths

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -18,17 +18,30 @@ files:
   - "!out/**/*.map"
   - "!out/**/*.test.*"
 
-# Copy icons outside ASAR for runtime access (app badge, etc.)
+# Copy files outside ASAR for external process access
+# (ASAR contents not accessible by child_process.spawn/exec)
 extraResources:
   - from: resources/icon.png
     to: icon.png
   - from: resources/icon.ico
     to: icon.ico
+  # CLI wrapper scripts and hook handler (executed by Claude Code)
+  - from: out/main/assets/bin
+    to: bin
+  # PowerShell scripts (executed by PowerShell)
+  - from: out/main/assets/scripts
+    to: scripts
+  # VSIX files (installed by code-server)
+  # Note: glob patterns require filter syntax
+  - from: out/main/assets
+    to: extensions
+    filter:
+      - "*.vsix"
 
 # ASAR archive settings
 asar: true
-# Note: No asarUnpack needed - simple-git is pure JS (spawns git CLI),
-# and socket.io's optional native deps are already externalized in vite config
+# Note: No asarUnpack needed - external process files use extraResources above,
+# simple-git is pure JS, socket.io deps externalized in vite config
 
 # Use normal compression for faster CI builds (default is maximum)
 compression: normal

--- a/src/agents/claude-code/server-manager.ts
+++ b/src/agents/claude-code/server-manager.ts
@@ -127,10 +127,9 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     this.fileSystem = deps.fileSystem;
     this.logger = deps.logger;
 
-    // Default hook handler path is in the bin assets directory
+    // Default hook handler path uses runtime dir (outside ASAR in production)
     this.hookHandlerPath =
-      deps.config?.hookHandlerPath ??
-      new Path(this.pathProvider.binAssetsDir, "claude-code-hook-handler.cjs").toNative();
+      deps.config?.hookHandlerPath ?? this.pathProvider.claudeCodeHookHandlerPath.toNative();
   }
 
   /**

--- a/src/main/build-info.ts
+++ b/src/main/build-info.ts
@@ -40,6 +40,7 @@ export class ElectronBuildInfo implements BuildInfo {
   readonly isDevelopment: boolean;
   readonly gitBranch?: string;
   readonly appPath: string;
+  readonly resourcesPath?: string;
 
   constructor(gitBranchFn: () => string = getGitBranch) {
     // Cache at construction time - these values should never change during runtime
@@ -55,5 +56,11 @@ export class ElectronBuildInfo implements BuildInfo {
     // In dev: returns project root (same as process.cwd())
     // In prod: returns path inside ASAR archive
     this.appPath = app.getAppPath();
+
+    // Resources path for external process access (outside ASAR)
+    // Only set in production - dev mode accesses files directly from appPath
+    if (!this.isDevelopment) {
+      this.resourcesPath = process.resourcesPath;
+    }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -772,13 +772,13 @@ async function bootstrap(): Promise<void> {
 
       // Create WorkspaceLockHandler for Windows file handle detection
       // Uses "process" logger since blocking process detection is process management
-      // Script path is resolved from pathProvider.scriptsDir
+      // Script path is resolved from pathProvider.scriptsRuntimeDir (outside ASAR)
       // Returns undefined on non-Windows platforms (no file locking issues)
       const workspaceLockHandler = createWorkspaceLockHandler(
         processRunner,
         platformInfo,
         loggingService.createLogger("process"),
-        nodePath.join(pathProvider.scriptsDir.toNative(), "blocking-processes.ps1")
+        nodePath.join(pathProvider.scriptsRuntimeDir.toNative(), "blocking-processes.ps1")
       );
 
       const baseDeps = {

--- a/src/services/platform/build-info.test-utils.ts
+++ b/src/services/platform/build-info.test-utils.ts
@@ -6,6 +6,7 @@ import type { BuildInfo } from "./build-info";
 /**
  * Create a mock BuildInfo with controllable behavior.
  * Defaults to development mode (isDevelopment: true, gitBranch: "test-branch", appPath: "/test/app", version: "1.0.0-test").
+ * In production mode (isDevelopment: false), resourcesPath defaults to "/test/resources".
  *
  * @param overrides - Optional overrides for BuildInfo properties
  * @returns Mock BuildInfo object
@@ -15,10 +16,18 @@ export function createMockBuildInfo(overrides?: Partial<BuildInfo>): BuildInfo {
   const isDevelopment = overrides?.isDevelopment ?? true;
   const gitBranch = overrides?.gitBranch ?? (isDevelopment ? "test-branch" : undefined);
   const appPath = overrides?.appPath ?? "/test/app";
+  // resourcesPath is only set in production mode (mirrors ElectronBuildInfo behavior)
+  const resourcesPath = overrides?.resourcesPath ?? (isDevelopment ? undefined : "/test/resources");
 
   // Build object conditionally to satisfy exactOptionalPropertyTypes
+  const result: BuildInfo = { version, isDevelopment, appPath };
+
   if (gitBranch !== undefined) {
-    return { version, isDevelopment, gitBranch, appPath };
+    (result as { gitBranch: string }).gitBranch = gitBranch;
   }
-  return { version, isDevelopment, appPath };
+  if (resourcesPath !== undefined) {
+    (result as { resourcesPath: string }).resourcesPath = resourcesPath;
+  }
+
+  return result;
 }

--- a/src/services/platform/build-info.ts
+++ b/src/services/platform/build-info.ts
@@ -29,4 +29,12 @@ export interface BuildInfo {
    * - In prod mode: app.getAppPath() (inside ASAR archive)
    */
   readonly appPath: string;
+
+  /**
+   * Path to application resources directory (outside ASAR).
+   * Used for files that need external process access (scripts, extensions).
+   * - In dev mode: undefined (use appPath-relative paths directly)
+   * - In prod mode: process.resourcesPath (extraResources destination)
+   */
+  readonly resourcesPath?: string;
 }

--- a/src/services/platform/path-provider.test-utils.ts
+++ b/src/services/platform/path-provider.test-utils.ts
@@ -36,6 +36,9 @@ export interface MockPathProviderOptions {
   scriptsDir?: Path | string;
   appIconPath?: Path | string;
   binAssetsDir?: Path | string;
+  binRuntimeDir?: Path | string;
+  scriptsRuntimeDir?: Path | string;
+  extensionsRuntimeDir?: Path | string;
   claudeCodeConfigDir?: Path | string;
   claudeCodeHookHandlerPath?: Path | string;
   claudeCodeWrapperPath?: Path | string;
@@ -122,6 +125,12 @@ export function createMockPathProvider(overrides?: MockPathProviderOptions): Pat
     scriptsDir: ensurePath(overrides?.scriptsDir, "/mock/assets/scripts"),
     appIconPath: ensurePath(overrides?.appIconPath, "/test/resources/icon.png"),
     binAssetsDir: ensurePath(overrides?.binAssetsDir, "/mock/assets/bin"),
+
+    // Runtime paths (same as assets in dev mode, resourcesPath in prod)
+    binRuntimeDir: ensurePath(overrides?.binRuntimeDir, "/mock/assets/bin"),
+    scriptsRuntimeDir: ensurePath(overrides?.scriptsRuntimeDir, "/mock/assets/scripts"),
+    extensionsRuntimeDir: ensurePath(overrides?.extensionsRuntimeDir, "/mock/assets"),
+
     claudeCodeConfigDir: ensurePath(overrides?.claudeCodeConfigDir, "/test/app-data/claude-code"),
     claudeCodeHookHandlerPath: ensurePath(
       overrides?.claudeCodeHookHandlerPath,

--- a/src/services/vscode-setup/vscode-setup-service.integration.test.ts
+++ b/src/services/vscode-setup/vscode-setup-service.integration.test.ts
@@ -139,6 +139,9 @@ describe("VscodeSetupService Integration", () => {
       vscodeAssetsDir: mockPaths.assetsDir,
       binDir: mockPaths.binDir,
       binAssetsDir: join(mockPaths.assetsDir, "bin"),
+      binRuntimeDir: join(mockPaths.assetsDir, "bin"), // Same as assets in dev mode
+      extensionsRuntimeDir: mockPaths.assetsDir, // Same as assets in dev mode
+      scriptsRuntimeDir: join(mockPaths.assetsDir, "scripts"), // Same as assets in dev mode
       opencodeConfig: join(tempDir, "opencode", "opencode.codehydra.json"),
     });
   });
@@ -159,8 +162,8 @@ describe("VscodeSetupService Integration", () => {
 
       expect(result.success).toBe(true);
 
-      // Verify vsix was copied to vscodeDir
-      const vsixPath = join(mockPaths.vscodeDir, "codehydra-sidekick-0.0.3.vsix");
+      // Verify vsix exists in extensionsRuntimeDir (no copy - installed directly)
+      const vsixPath = join(mockPaths.assetsDir, "codehydra-sidekick-0.0.3.vsix");
       const vsixContent = await readFile(vsixPath, "utf-8");
       expect(vsixContent).toBe("mock-vsix-content");
 
@@ -223,15 +226,16 @@ describe("VscodeSetupService Integration", () => {
       await expect(access(mockPaths.markerPath)).rejects.toThrow();
     });
 
-    it("bundled vsix is copied before extension install is attempted", async () => {
+    it("bundled vsix exists in extensionsRuntimeDir for install", async () => {
       const processRunner = createTestProcessRunner(1, "Failed");
       const service = new VscodeSetupService(processRunner, testPathProvider, fsLayer);
       const preflight = createFullSetupPreflightResult();
 
       await service.setup(preflight);
 
-      // Vsix file should be copied (happens before install command)
-      const vsixPath = join(mockPaths.vscodeDir, "codehydra-sidekick-0.0.3.vsix");
+      // Vsix file should exist in extensionsRuntimeDir (created by createMockAssets)
+      // No copy needed - code-server reads directly from this location
+      const vsixPath = join(mockPaths.assetsDir, "codehydra-sidekick-0.0.3.vsix");
       const vsixContent = await readFile(vsixPath, "utf-8");
       expect(vsixContent).toBe("mock-vsix-content");
     });
@@ -360,6 +364,9 @@ describe("VscodeSetupService Integration", () => {
         vscodeAssetsDir: mockPaths.assetsDir,
         binDir,
         binAssetsDir: join(mockPaths.assetsDir, "bin"),
+        binRuntimeDir: join(mockPaths.assetsDir, "bin"),
+        extensionsRuntimeDir: mockPaths.assetsDir,
+        scriptsRuntimeDir: join(mockPaths.assetsDir, "scripts"),
         opencodeConfig: join(tempDir, "opencode", "opencode.codehydra.json"),
       });
 
@@ -392,6 +399,9 @@ describe("VscodeSetupService Integration", () => {
         vscodeAssetsDir: mockPaths.assetsDir,
         binDir,
         binAssetsDir: join(mockPaths.assetsDir, "bin"),
+        binRuntimeDir: join(mockPaths.assetsDir, "bin"),
+        extensionsRuntimeDir: mockPaths.assetsDir,
+        scriptsRuntimeDir: join(mockPaths.assetsDir, "scripts"),
         opencodeConfig: join(tempDir, "opencode", "opencode.codehydra.json"),
       });
 


### PR DESCRIPTION
External processes (Claude Code, PowerShell, code-server) cannot access files inside ASAR archives. Use electron-builder's extraResources to copy bin/, scripts/, and extensions/ directories outside ASAR at build time, and add runtime path properties that resolve to process.resourcesPath in production.

- Add extraResources config for bin, scripts, extensions directories
- Add resourcesPath to BuildInfo (set in production from process.resourcesPath)
- Add binRuntimeDir, scriptsRuntimeDir, extensionsRuntimeDir to PathProvider
- Update ClaudeCodeServerManager to use claudeCodeHookHandlerPath
- Update vscode-setup to install extensions from extensionsRuntimeDir