### PR TITLE
fix(release): add explicit --tag latest for npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,7 @@ jobs:
       - run: npm version $VERSION --no-git-tag-version
         working-directory: packages/npm
 
-      - run: npm publish --access public
+      - run: npm publish --access public --tag latest
         working-directory: packages/npm
 
   publish-pypi:


### PR DESCRIPTION
- Add `--tag latest` to npm publish command to fix 4-part version publishing

npm requires --tag flag for versions like YYYY.MM.DD.BUILD which it misinterprets as prereleases.