### PR TITLE
fix(build): correct Claude Code hook handler output filename

### DIFF
--- a/vite.config.bin.ts
+++ b/vite.config.bin.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         {
           src: "out/main/agents/hook-handler.cjs",
           dest: "../../../dist/bin",
-          rename: "claude-hook-handler.cjs",
+          rename: "claude-code-hook-handler.cjs",
         },
       ],
       hook: "closeBundle",


### PR DESCRIPTION
- Fix hook handler being renamed to `claude-hook-handler.cjs` when `path-provider.ts` expects `claude-code-hook-handler.cjs`