### PR TITLE
fix(claude): use POSIX-style paths in hooks JSON config

### DIFF
--- a/src/agents/claude/server-manager.ts
+++ b/src/agents/claude/server-manager.ts
@@ -128,8 +128,9 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     this.logger = deps.logger;
 
     // Default hook handler path uses runtime dir (outside ASAR in production)
+    // Use toString() for POSIX-style paths - works on all platforms including Windows
     this.hookHandlerPath =
-      deps.config?.hookHandlerPath ?? this.pathProvider.claudeCodeHookHandlerPath.toNative();
+      deps.config?.hookHandlerPath ?? this.pathProvider.claudeCodeHookHandlerPath.toString();
   }
 
   /**


### PR DESCRIPTION
- Use toString() instead of toNative() for hook handler path to ensure forward slashes on all platforms
- Node.js handles POSIX paths correctly on Windows, avoiding backslash issues in JSON config files