### PR TITLE
fix(release): skip npm/PyPI for same-day releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,12 +11,16 @@ on:
       version:
         description: "The computed version string"
         value: ${{ jobs.prepare.outputs.version }}
+      is_base_version:
+        description: "Whether this is a base version (no .N suffix) for npm/PyPI"
+        value: ${{ jobs.prepare.outputs.is_base_version }}
 
 jobs:
   prepare:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
+      is_base_version: ${{ steps.version.outputs.is_base_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,6 +62,13 @@ jobs:
               VERSION="${BASE_VERSION}.${MAX_SUFFIX}"
             fi
             echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+            # Check if this is a base version (no .N suffix)
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "is_base_version=true" >> $GITHUB_OUTPUT
+            else
+              echo "is_base_version=false" >> $GITHUB_OUTPUT
+            fi
           else
             DATE=$(git log -1 --format=%cs | tr '-' '.')
             HASH=$(git rev-parse --short=8 HEAD)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,7 @@ jobs:
 
   publish-npm:
     needs: [build, release]
+    if: needs.build.outputs.is_base_version == 'true'
     runs-on: ubuntu-24.04
     env:
       VERSION: ${{ needs.build.outputs.version }}
@@ -83,6 +84,7 @@ jobs:
 
   publish-pypi:
     needs: [build, release]
+    if: needs.build.outputs.is_base_version == 'true'
     runs-on: ubuntu-24.04
     env:
       VERSION: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
- Skip npm/PyPI publishing for same-day releases (4-part versions like 2026.1.19.1)
- Only first release of each day publishes to npm/PyPI (3-part versions like 2026.1.19)
- Added `is_base_version` output to build workflow to detect version format