### PR TITLE
refactor(agents): replace vendor extensions with terminal-based CLI launching

### DIFF
--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -28,10 +28,13 @@ export interface CommandRequest {
   readonly args?: readonly unknown[];
 }
 
+/** Agent type for terminal launching */
+export type AgentType = "opencode" | "claude";
+
 export interface PluginConfig {
   readonly isDevelopment: boolean;
   readonly env: Record<string, string> | null;
-  readonly startupCommands: readonly string[];
+  readonly agentType: AgentType | null;
 }
 
 export interface SetMetadataRequest {

--- a/resources/bin/ch-claude
+++ b/resources/bin/ch-claude
@@ -4,4 +4,4 @@ if [ -z "$CODEHYDRA_CODE_SERVER_DIR" ]; then
   exit 1
 fi
 BINDIR="$(dirname "$0")"
-exec "$CODEHYDRA_CODE_SERVER_DIR/lib/node" "$BINDIR/claude.cjs" "$@"
+exec "$CODEHYDRA_CODE_SERVER_DIR/lib/node" "$BINDIR/ch-claude.cjs" "$@"

--- a/resources/bin/ch-claude.cmd
+++ b/resources/bin/ch-claude.cmd
@@ -3,4 +3,4 @@ if "%CODEHYDRA_CODE_SERVER_DIR%"=="" (
   echo Error: CODEHYDRA_CODE_SERVER_DIR not set. >&2
   exit /b 1
 )
-"%CODEHYDRA_CODE_SERVER_DIR%\lib\node.exe" "%~dp0claude.cjs" %*
+"%CODEHYDRA_CODE_SERVER_DIR%\lib\node.exe" "%~dp0ch-claude.cjs" %*

--- a/resources/bin/ch-opencode
+++ b/resources/bin/ch-opencode
@@ -4,4 +4,4 @@ if [ -z "$CODEHYDRA_CODE_SERVER_DIR" ]; then
   exit 1
 fi
 BINDIR="$(dirname "$0")"
-exec "$CODEHYDRA_CODE_SERVER_DIR/lib/node" "$BINDIR/opencode.cjs" "$@"
+exec "$CODEHYDRA_CODE_SERVER_DIR/lib/node" "$BINDIR/ch-opencode.cjs" "$@"

--- a/resources/bin/ch-opencode.cmd
+++ b/resources/bin/ch-opencode.cmd
@@ -3,4 +3,4 @@ if "%CODEHYDRA_CODE_SERVER_DIR%"=="" (
   echo Error: CODEHYDRA_CODE_SERVER_DIR not set. >&2
   exit /b 1
 )
-"%CODEHYDRA_CODE_SERVER_DIR%\lib\node.exe" "%~dp0opencode.cjs" %*
+"%CODEHYDRA_CODE_SERVER_DIR%\lib\node.exe" "%~dp0ch-opencode.cjs" %*

--- a/src/agents/claude/provider.integration.test.ts
+++ b/src/agents/claude/provider.integration.test.ts
@@ -327,10 +327,4 @@ describe("ClaudeCodeProvider integration", () => {
       // Should not throw
     });
   });
-
-  describe("startupCommands", () => {
-    it("returns claude-vscode terminal.open command", () => {
-      expect(provider.startupCommands).toEqual(["claude-vscode.terminal.open"]);
-    });
-  });
 });

--- a/src/agents/claude/provider.ts
+++ b/src/agents/claude/provider.ts
@@ -33,12 +33,6 @@ export interface ClaudeCodeProviderDeps {
  * - Environment variables tell sidekick how to configure Claude CLI
  */
 export class ClaudeCodeProvider implements AgentProvider {
-  /**
-   * VS Code commands to execute on workspace activation.
-   * Uses the Claude Code VS Code extension's terminal.open command to open the terminal.
-   */
-  readonly startupCommands: readonly string[] = ["claude-vscode.terminal.open"] as const;
-
   private readonly serverManager: ClaudeCodeServerManager;
   private readonly workspacePath: string;
   private readonly logger: Logger;

--- a/src/agents/claude/setup-info.ts
+++ b/src/agents/claude/setup-info.ts
@@ -112,11 +112,6 @@ export class ClaudeSetupInfo implements AgentSetupInfo {
    */
   readonly wrapperEntryPoint = "agents/claude-wrapper.cjs";
 
-  /**
-   * VS Code marketplace extension ID for Claude Code.
-   */
-  readonly extensionId = "anthropic.claude-code";
-
   private readonly fileSystem: FileSystemLayer;
   private readonly httpClient: HttpClient;
   private readonly platform: SupportedPlatform;

--- a/src/agents/opencode/provider.ts
+++ b/src/agents/opencode/provider.ts
@@ -23,11 +23,6 @@ import type { Logger } from "../../services/logging";
  * Implements AgentProvider interface for use in the agent abstraction layer.
  */
 export class OpenCodeProvider implements AgentProvider, IDisposable {
-  /**
-   * VS Code commands to execute on workspace activation.
-   */
-  readonly startupCommands = ["opencode.openTerminal"] as const;
-
   private client: OpenCodeClient | null = null;
   private clientStatus: ClientStatus = "idle";
   private readonly sdkFactory: SdkClientFactory | undefined;

--- a/src/agents/opencode/setup-info.ts
+++ b/src/agents/opencode/setup-info.ts
@@ -87,7 +87,6 @@ export interface OpenCodeSetupInfoDeps {
 export class OpenCodeSetupInfo implements AgentSetupInfo {
   readonly version = OPENCODE_VERSION;
   readonly wrapperEntryPoint = "agents/opencode-wrapper.cjs";
-  readonly extensionId = "sst-dev.opencode";
 
   private readonly fileSystem: FileSystemLayer;
   private readonly platform: SupportedPlatform;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -48,9 +48,6 @@ export interface AgentSetupInfo {
   /** Entry point for wrapper script (e.g., "agents/opencode-wrapper.cjs") */
   readonly wrapperEntryPoint: string;
 
-  /** VS Code marketplace extension ID (e.g., "sst-dev.opencode", "anthropic.claude") */
-  readonly extensionId?: string;
-
   /** Get download URL for the binary for current platform (uses instance's version) */
   getBinaryUrl(): string;
 
@@ -148,9 +145,6 @@ export interface AgentSessionInfo {
  * to the agent server and tracks status.
  */
 export interface AgentProvider {
-  /** VS Code commands to execute on workspace activation */
-  readonly startupCommands: readonly string[];
-
   /** Connect to agent server at given port */
   connect(port: number): Promise<void>;
 

--- a/src/main/app-state.test.ts
+++ b/src/main/app-state.test.ts
@@ -1115,8 +1115,8 @@ describe("AppState", () => {
     });
   });
 
-  describe("getAgentStartupCommand", () => {
-    it("returns default command when agentStatusManager is not set", async () => {
+  describe("getAgentType", () => {
+    it("returns configured agent type for claude", () => {
       const appState = new AppState(
         mockProjectStore as unknown as ProjectStore,
         mockViewManager as unknown as IViewManager,
@@ -1129,14 +1129,10 @@ describe("AppState", () => {
         MOCK_WRAPPER_PATH
       );
 
-      // Without agentStatusManager set, should return default
-      const command = appState.getAgentStartupCommand(
-        "/project/.worktrees/feature-1" as import("../shared/ipc").WorkspacePath
-      );
-      expect(command).toBe("opencode.openTerminal");
+      expect(appState.getAgentType()).toBe("claude");
     });
 
-    it("returns default command when provider not found", async () => {
+    it("returns configured agent type for opencode", () => {
       const appState = new AppState(
         mockProjectStore as unknown as ProjectStore,
         mockViewManager as unknown as IViewManager,
@@ -1144,87 +1140,12 @@ describe("AppState", () => {
         8080,
         mockFileSystemLayer,
         mockLoggingService,
-        "claude",
+        "opencode",
         mockWorkspaceFileService,
         MOCK_WRAPPER_PATH
       );
 
-      // Create a mock AgentStatusManager
-      const mockAgentStatusManager = {
-        getProvider: vi.fn().mockReturnValue(undefined),
-        addProvider: vi.fn(),
-        hasProvider: vi.fn(),
-        removeWorkspace: vi.fn(),
-        disconnectWorkspace: vi.fn(),
-        reconnectWorkspace: vi.fn(),
-        markActive: vi.fn(),
-        clearTuiTracking: vi.fn(),
-        onStatusChanged: vi.fn(),
-        dispose: vi.fn(),
-        getLogger: vi.fn(),
-        getSdkFactory: vi.fn(),
-      };
-      appState.setAgentStatusManager(
-        mockAgentStatusManager as unknown as import("../agents").AgentStatusManager
-      );
-
-      // Provider not found, should return default
-      const command = appState.getAgentStartupCommand(
-        "/project/.worktrees/feature-1" as import("../shared/ipc").WorkspacePath
-      );
-      expect(command).toBe("opencode.openTerminal");
-    });
-
-    it("returns provider startup command when provider found", async () => {
-      const appState = new AppState(
-        mockProjectStore as unknown as ProjectStore,
-        mockViewManager as unknown as IViewManager,
-        mockPathProvider,
-        8080,
-        mockFileSystemLayer,
-        mockLoggingService,
-        "claude",
-        mockWorkspaceFileService,
-        MOCK_WRAPPER_PATH
-      );
-
-      // Create a mock provider with startupCommands
-      const mockProvider = {
-        startupCommands: ["claude-vscode.terminal.open"] as readonly string[],
-        connect: vi.fn(),
-        disconnect: vi.fn(),
-        reconnect: vi.fn(),
-        onStatusChange: vi.fn(),
-        getSession: vi.fn(),
-        getEnvironmentVariables: vi.fn(),
-        markActive: vi.fn(),
-        dispose: vi.fn(),
-      };
-
-      // Create a mock AgentStatusManager that returns the provider
-      const mockAgentStatusManager = {
-        getProvider: vi.fn().mockReturnValue(mockProvider),
-        addProvider: vi.fn(),
-        hasProvider: vi.fn(),
-        removeWorkspace: vi.fn(),
-        disconnectWorkspace: vi.fn(),
-        reconnectWorkspace: vi.fn(),
-        markActive: vi.fn(),
-        clearTuiTracking: vi.fn(),
-        onStatusChanged: vi.fn(),
-        dispose: vi.fn(),
-        getLogger: vi.fn(),
-        getSdkFactory: vi.fn(),
-      };
-      appState.setAgentStatusManager(
-        mockAgentStatusManager as unknown as import("../agents").AgentStatusManager
-      );
-
-      // Provider found, should return provider's startup command
-      const command = appState.getAgentStartupCommand(
-        "/project/.worktrees/feature-1" as import("../shared/ipc").WorkspacePath
-      );
-      expect(command).toBe("claude-vscode.terminal.open");
+      expect(appState.getAgentType()).toBe("opencode");
     });
   });
 });

--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -119,16 +119,13 @@ export class AppState {
   }
 
   /**
-   * Get the startup command for the agent in a workspace.
-   * Returns the first command from the provider's startupCommands array,
-   * or falls back to OpenCode's default command if provider not found.
+   * Get the agent type configured for this application.
+   * Used by the sidekick extension to determine which CLI to launch.
    *
-   * @param workspacePath - Path to the workspace
-   * @returns VS Code command to open the agent terminal
+   * @returns The configured agent type ("opencode" or "claude")
    */
-  getAgentStartupCommand(workspacePath: WorkspacePath): string {
-    const provider = this.agentStatusManager?.getProvider(workspacePath);
-    return provider?.startupCommands[0] ?? "opencode.openTerminal";
+  getAgentType(): AgentType {
+    return this.agentType;
   }
 
   /**

--- a/src/services/platform/path-provider.ts
+++ b/src/services/platform/path-provider.ts
@@ -210,7 +210,7 @@ export class DefaultPathProvider implements PathProvider {
     this.claudeCodeHookHandlerPath = new Path(this.binRuntimeDir, "claude-code-hook-handler.cjs");
     this.claudeCodeWrapperPath = new Path(
       this.binDir,
-      this.platform === "win32" ? "claude.cmd" : "claude"
+      this.platform === "win32" ? "ch-claude.cmd" : "ch-claude"
     );
 
     // Application config

--- a/src/services/plugin-server/plugin-server.integration.test.ts
+++ b/src/services/plugin-server/plugin-server.integration.test.ts
@@ -59,7 +59,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
   }
 
   describe("config event on connection", () => {
-    it("sends config with startup commands when client connects", async () => {
+    it("sends config with agent type when client connects", async () => {
       let receivedConfig: PluginConfig | null = null;
       const client = createClient("/test/workspace");
 
@@ -71,7 +71,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
       // Register onConfigData callback
       server.onConfigData(() => ({
         env: null,
-        agentCommand: "myagent.command",
+        agentType: "opencode",
       }));
 
       // Connect and wait
@@ -82,10 +82,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
       expect(receivedConfig).not.toBeNull();
       const config = receivedConfig!;
       expect(config.isDevelopment).toBe(false);
-      expect(config.startupCommands).toBeDefined();
-      expect(config.startupCommands.length).toBeGreaterThan(0);
-      // Check that agent command is included
-      expect(config.startupCommands).toContain("myagent.command");
+      expect(config.agentType).toBe("opencode");
     });
 
     it("sends config with environment variables", async () => {
@@ -100,7 +97,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
       // Register onConfigData callback with env vars
       server.onConfigData(() => ({
         env: { TEST_VAR: "test-value", ANOTHER_VAR: "another" },
-        agentCommand: undefined,
+        agentType: null,
       }));
 
       await waitForConnect(client);
@@ -120,7 +117,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
 
       server.onConfigData(() => ({
         env: null,
-        agentCommand: undefined,
+        agentType: null,
       }));
 
       await waitForConnect(client);
@@ -148,7 +145,7 @@ describe("PluginServer (integration)", { timeout: TEST_TIMEOUT }, () => {
       // Register onConfigData that returns different env for different workspaces
       server.onConfigData((workspacePath) => ({
         env: { WORKSPACE: workspacePath },
-        agentCommand: undefined,
+        agentType: "opencode",
       }));
 
       // Connect both clients

--- a/src/services/plugin-server/plugin-server.test.ts
+++ b/src/services/plugin-server/plugin-server.test.ts
@@ -40,7 +40,7 @@ describe("PluginServer", () => {
       expect(() =>
         server.onConfigData(() => ({
           env: null,
-          agentCommand: undefined,
+          agentType: null,
         }))
       ).not.toThrow();
     });
@@ -48,14 +48,14 @@ describe("PluginServer", () => {
     it("allows provider to be replaced", () => {
       server.onConfigData(() => ({
         env: null,
-        agentCommand: undefined,
+        agentType: null,
       }));
 
       // Should not throw when replacing provider
       expect(() =>
         server.onConfigData(() => ({
           env: { TEST: "value" },
-          agentCommand: "test.command",
+          agentType: "opencode",
         }))
       ).not.toThrow();
     });

--- a/src/services/vscode-setup/bin-scripts.boundary.test.ts
+++ b/src/services/vscode-setup/bin-scripts.boundary.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 /**
- * Boundary tests for the compiled opencode wrapper (dist/bin/opencode.cjs).
+ * Boundary tests for the compiled opencode wrapper (dist/bin/ch-opencode.cjs).
  *
  * Tests the script with real Node.js execution and mock HTTP server.
  * These tests verify:
@@ -19,10 +19,10 @@ import { createTempDir } from "../test-utils";
 const isWindows = process.platform === "win32";
 
 /**
- * Path to the compiled opencode.cjs script.
+ * Path to the compiled ch-opencode.cjs script.
  * This is built by `pnpm build:wrappers` before running tests.
  */
-const COMPILED_SCRIPT_PATH = resolve(__dirname, "../../../dist/bin/opencode.cjs");
+const COMPILED_SCRIPT_PATH = resolve(__dirname, "../../../dist/bin/ch-opencode.cjs");
 
 /**
  * Output from the fake opencode binary.
@@ -138,7 +138,7 @@ async function executeScript(
   });
 }
 
-describe("opencode.cjs boundary tests", () => {
+describe("ch-opencode.cjs boundary tests", () => {
   let tempDir: { path: string; cleanup: () => Promise<void> };
   let opencodeDir: string;
 

--- a/src/services/vscode-setup/vscode-setup-service.boundary.test.ts
+++ b/src/services/vscode-setup/vscode-setup-service.boundary.test.ts
@@ -22,7 +22,7 @@ import type { SpawnedProcess } from "../platform/process";
 const RESOURCES_BIN_DIR = resolve(__dirname, "../../../resources/bin");
 
 /**
- * Path to compiled opencode wrapper (built by pnpm build:wrappers).
+ * Path to compiled wrappers (built by pnpm build:wrappers).
  */
 const DIST_BIN_DIR = resolve(__dirname, "../../../dist/bin");
 
@@ -50,13 +50,13 @@ async function setupBinAssets(binAssetsDir: string): Promise<void> {
   await mkdir(binAssetsDir, { recursive: true });
 
   // Copy shell scripts from resources/bin/
-  const shellScripts = ["code", "code.cmd", "opencode", "opencode.cmd"];
+  const shellScripts = ["code", "code.cmd", "ch-opencode", "ch-opencode.cmd"];
   for (const script of shellScripts) {
     await copyFile(join(RESOURCES_BIN_DIR, script), join(binAssetsDir, script));
   }
 
-  // Copy compiled opencode.cjs from dist/bin/
-  await copyFile(join(DIST_BIN_DIR, "opencode.cjs"), join(binAssetsDir, "opencode.cjs"));
+  // Copy compiled ch-opencode.cjs from dist/bin/
+  await copyFile(join(DIST_BIN_DIR, "ch-opencode.cjs"), join(binAssetsDir, "ch-opencode.cjs"));
 }
 
 describe("VscodeSetupService.setupBinDirectory (boundary)", () => {

--- a/src/services/vscode-setup/vscode-setup-service.integration.test.ts
+++ b/src/services/vscode-setup/vscode-setup-service.integration.test.ts
@@ -80,9 +80,9 @@ describe("VscodeSetupService Integration", () => {
     await mkdir(binAssetsDir, { recursive: true });
     await writeFile(join(binAssetsDir, "code"), "#!/bin/sh\nexec code-server");
     await writeFile(join(binAssetsDir, "code.cmd"), "@echo off\ncall code-server");
-    await writeFile(join(binAssetsDir, "opencode"), "#!/bin/sh\nexec opencode.cjs");
-    await writeFile(join(binAssetsDir, "opencode.cmd"), "@echo off\ncall opencode.cjs");
-    await writeFile(join(binAssetsDir, "opencode.cjs"), "// opencode wrapper");
+    await writeFile(join(binAssetsDir, "ch-opencode"), "#!/bin/sh\nexec ch-opencode.cjs");
+    await writeFile(join(binAssetsDir, "ch-opencode.cmd"), "@echo off\ncall ch-opencode.cjs");
+    await writeFile(join(binAssetsDir, "ch-opencode.cjs"), "// opencode wrapper");
   }
 
   /**
@@ -100,7 +100,7 @@ describe("VscodeSetupService Integration", () => {
 
   /**
    * Create a preflight result for full setup (all components missing).
-   * Note: Agent extensions are handled separately via agentExtensionId parameter.
+   * Note: Agent CLIs are launched via terminal by sidekick extension.
    */
   function createFullSetupPreflightResult(): PreflightResult {
     return {

--- a/src/services/vscode-setup/vscode-setup-service.ts
+++ b/src/services/vscode-setup/vscode-setup-service.ts
@@ -42,7 +42,6 @@ export class VscodeSetupService implements IVscodeSetup {
   private readonly assetsDir: Path;
   private readonly binaryDownloadService: BinaryDownloadService | null;
   private readonly logger: Logger | undefined;
-  private readonly agentExtensionId: string | undefined;
   private readonly agentBinaryType: AgentBinaryType;
 
   constructor(
@@ -52,7 +51,7 @@ export class VscodeSetupService implements IVscodeSetup {
     _platformInfo?: PlatformInfo, // Kept for backward compatibility, no longer used
     binaryDownloadService?: BinaryDownloadService,
     logger?: Logger,
-    agentExtensionId?: string,
+    _agentExtensionId?: string, // Kept for backward compatibility, no longer used
     agentBinaryType: AgentBinaryType = "opencode"
   ) {
     this.processRunner = processRunner;
@@ -61,7 +60,6 @@ export class VscodeSetupService implements IVscodeSetup {
     this.assetsDir = pathProvider.vscodeAssetsDir;
     this.binaryDownloadService = binaryDownloadService ?? null;
     this.logger = logger;
-    this.agentExtensionId = agentExtensionId;
     this.agentBinaryType = agentBinaryType;
   }
 
@@ -136,14 +134,6 @@ export class VscodeSetupService implements IVscodeSetup {
           missingExtensions.push(ext.id);
         } else if (installedVersion !== ext.version) {
           outdatedExtensions.push(ext.id);
-        }
-      }
-
-      // Check agent extension (marketplace - no version pinning, just check if installed)
-      if (this.agentExtensionId) {
-        const isAgentExtensionInstalled = installedExtensions.has(this.agentExtensionId);
-        if (!isAgentExtensionInstalled) {
-          missingExtensions.push(this.agentExtensionId);
         }
       }
 
@@ -602,20 +592,6 @@ export class VscodeSetupService implements IVscodeSetup {
       // Install the extension directly from runtime directory
       // No copy needed - code-server can read from the runtime path
       const result = await this.runInstallExtension(vsixPath.toNative());
-      if (!result.success) {
-        return result;
-      }
-    }
-
-    // Install agent extension from marketplace (if configured and needed)
-    if (this.agentExtensionId && shouldInstall(this.agentExtensionId)) {
-      this.logger?.info("Installing agent extension from marketplace", {
-        extensionId: this.agentExtensionId,
-      });
-      onProgress?.({ step: "extensions", message: `Installing ${this.agentExtensionId}...` });
-
-      // Install directly from marketplace using extension ID
-      const result = await this.runInstallExtension(this.agentExtensionId);
       if (!result.success) {
         return result;
       }

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -39,6 +39,11 @@ export interface CommandRequest {
 // ============================================================================
 
 /**
+ * Agent type for terminal launching.
+ */
+export type AgentType = "opencode" | "claude";
+
+/**
  * Configuration sent from server to client on connection.
  * Contains all data needed for extension startup.
  */
@@ -47,8 +52,8 @@ export interface PluginConfig {
   readonly isDevelopment: boolean;
   /** Agent environment variables for terminal integration (null if agent not ready) */
   readonly env: Record<string, string> | null;
-  /** VS Code commands to execute on startup */
-  readonly startupCommands: readonly string[];
+  /** Agent type for terminal launching (null if no agent configured) */
+  readonly agentType: AgentType | null;
 }
 
 // ============================================================================

--- a/vite.config.bin.ts
+++ b/vite.config.bin.ts
@@ -24,12 +24,12 @@ export default defineConfig({
         {
           src: "out/main/agents/opencode-wrapper.cjs",
           dest: "../../../dist/bin",
-          rename: "opencode.cjs",
+          rename: "ch-opencode.cjs",
         },
         {
           src: "out/main/agents/claude-wrapper.cjs",
           dest: "../../../dist/bin",
-          rename: "claude.cjs",
+          rename: "ch-claude.cjs",
         },
         {
           src: "out/main/agents/hook-handler.cjs",


### PR DESCRIPTION
## Summary
- Replace VS Code marketplace extensions (anthropic.claude-code, sst-dev.opencode) with direct CLI launching via sidekick
- Sidekick opens terminal in editor area (as tab, not bottom panel)
- Terminal env vars set per-terminal instead of globally
- CLI wrappers renamed to ch-claude/ch-opencode to avoid conflicts
- Remove startupCommands from AgentProvider interface
- Remove extensionId from AgentSetupInfo (no more extension installs)
- Pass agentType in PluginConfig instead of startup commands

🤖 Generated with [Claude Code](https://claude.ai/code)