### PR TITLE
fix(ui): improve green status indicator visibility

### DIFF
--- a/src/renderer/lib/styles/variables.css
+++ b/src/renderer/lib/styles/variables.css
@@ -74,7 +74,7 @@
   --ch-error-bg: var(--vscode-inputValidation-errorBackground, #5a1d1d);
 
   /* Semantic colors */
-  --ch-success: var(--vscode-terminal-ansiGreen, #4ec9b0);
+  --ch-success: var(--vscode-terminal-ansiGreen, #4ade80);
   --ch-danger: var(--vscode-errorForeground, #f14c4c);
   --ch-warning: var(--vscode-editorWarning-foreground, #cca700);
 
@@ -233,7 +233,7 @@
     --ch-error-bg: var(--vscode-inputValidation-errorBackground, #f2dede);
 
     /* Semantic colors */
-    --ch-success: var(--vscode-terminal-ansiGreen, #008000);
+    --ch-success: var(--vscode-terminal-ansiGreen, #22c55e);
     --ch-danger: var(--vscode-errorForeground, #e51400);
     --ch-warning: var(--vscode-editorWarning-foreground, #bf8803);
 


### PR DESCRIPTION
- Use more saturated green colors for `--ch-success` fallback values
- Dark theme: `#4ade80` (Tailwind green 400) - brighter, more saturated
- Light theme: `#22c55e` (Tailwind green 500) - better contrast on white

The previous teal-cyan color (`#4ec9b0`) was hard to distinguish from grey in some circumstances.