### PR TITLE
feat(title): show app version in window title for packaged mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -478,8 +478,11 @@ async function startServices(): Promise<void> {
     wirePluginApi(pluginServer, codeHydraApi, appState, loggingService.createLogger("plugin"));
   }
 
+  // Title suffix: branch in dev mode, version in packaged mode
+  const titleSuffix = buildInfo.gitBranch ?? buildInfo.version;
+
   // Default window title (used when no workspace is active)
-  const defaultTitle = formatWindowTitle(undefined, undefined, buildInfo.gitBranch);
+  const defaultTitle = formatWindowTitle(undefined, undefined, titleSuffix);
 
   // Capture references for closures (TypeScript narrow refinement doesn't persist)
   const windowManagerRef = windowManager;
@@ -490,7 +493,7 @@ async function startServices(): Promise<void> {
   apiEventCleanup = wireApiEvents(codeHydraApi, () => viewManager?.getUIWebContents() ?? null, {
     setTitle: (title) => windowManagerRef?.setTitle(title),
     defaultTitle,
-    ...(buildInfo.gitBranch && { devBranch: buildInfo.gitBranch }),
+    ...(titleSuffix && { version: titleSuffix }),
     getProjectName: (workspacePath) => {
       const project = appStateRef?.findProjectForWorkspace(workspacePath);
       return project?.name;
@@ -655,7 +658,7 @@ async function startServices(): Promise<void> {
       // so renderer will get correct state via getActiveWorkspace() on mount)
       const projectName = projects[0]?.name;
       const workspaceName = nodePath.basename(firstWorkspace.path);
-      const title = formatWindowTitle(projectName, workspaceName, buildInfo.gitBranch);
+      const title = formatWindowTitle(projectName, workspaceName, titleSuffix);
       windowManager.setTitle(title);
     }
   }

--- a/src/main/ipc/api-handlers.test.ts
+++ b/src/main/ipc/api-handlers.test.ts
@@ -78,38 +78,38 @@ const TEST_WORKSPACE: Workspace = {
 // =============================================================================
 
 describe("formatWindowTitle", () => {
-  it("formats title with project, workspace, and dev branch", () => {
+  it("formats title with project, workspace, and version", () => {
     const title = formatWindowTitle("my-app", "feature-login", "main");
 
     expect(title).toBe("CodeHydra - my-app / feature-login - (main)");
   });
 
-  it("formats title with project and workspace, no dev branch", () => {
+  it("formats title with project and workspace, no version", () => {
     const title = formatWindowTitle("my-app", "feature-login", undefined);
 
     expect(title).toBe("CodeHydra - my-app / feature-login");
   });
 
-  it("formats title with only dev branch when no workspace", () => {
+  it("formats title with only version when no workspace", () => {
     const title = formatWindowTitle(undefined, undefined, "main");
 
     expect(title).toBe("CodeHydra - (main)");
   });
 
-  it("formats title as plain CodeHydra when no workspace and no dev branch", () => {
+  it("formats title as plain CodeHydra when no workspace and no version", () => {
     const title = formatWindowTitle(undefined, undefined, undefined);
 
     expect(title).toBe("CodeHydra");
   });
 
-  it("formats title without project name (uses only dev branch)", () => {
+  it("formats title without project name (uses only version)", () => {
     // Edge case: workspace name provided but no project name
     const title = formatWindowTitle(undefined, "feature", "main");
 
     expect(title).toBe("CodeHydra - (main)");
   });
 
-  it("formats title without workspace name (uses only dev branch)", () => {
+  it("formats title without workspace name (uses only version)", () => {
     // Edge case: project name provided but no workspace name
     const title = formatWindowTitle("my-app", undefined, "main");
 
@@ -233,7 +233,7 @@ describe("wireApiEvents", () => {
       wireApiEvents(mockApi, () => mockWebContents as never, {
         setTitle: mockSetTitle,
         defaultTitle: "CodeHydra - (main)",
-        devBranch: "main",
+        version: "main",
         getProjectName: () => "my-project",
       });
 
@@ -251,7 +251,7 @@ describe("wireApiEvents", () => {
       wireApiEvents(mockApi, () => mockWebContents as never, {
         setTitle: mockSetTitle,
         defaultTitle: "CodeHydra - (main)",
-        devBranch: "main",
+        version: "main",
         getProjectName: () => "my-project",
       });
 
@@ -265,7 +265,7 @@ describe("wireApiEvents", () => {
       wireApiEvents(mockApi, () => mockWebContents as never, {
         setTitle: mockSetTitle,
         defaultTitle: "CodeHydra - (dev)",
-        devBranch: "dev",
+        version: "dev",
         getProjectName: () => undefined, // Project not found
       });
 
@@ -276,15 +276,15 @@ describe("wireApiEvents", () => {
         path: "/home/user/.worktrees/feature-x",
       });
 
-      // Without project name, falls back to just dev branch
+      // Without project name, falls back to just version
       expect(mockSetTitle).toHaveBeenCalledWith("CodeHydra - (dev)");
     });
 
-    it("formats title without dev branch in production", () => {
+    it("formats title without version in production", () => {
       wireApiEvents(mockApi, () => mockWebContents as never, {
         setTitle: mockSetTitle,
         defaultTitle: "CodeHydra",
-        // No devBranch - production mode
+        // No version - production mode without version display
         getProjectName: () => "my-project",
       });
 

--- a/src/main/ipc/api-handlers.ts
+++ b/src/main/ipc/api-handlers.ts
@@ -21,8 +21,8 @@ export interface TitleConfig {
   setTitle: (title: string) => void;
   /** Default title (used when no workspace active) */
   defaultTitle: string;
-  /** Dev branch name (from buildInfo.gitBranch), undefined in production */
-  devBranch?: string;
+  /** Version suffix for title (branch in dev mode, version in packaged mode) */
+  version?: string;
   /** Function to resolve project name from workspace path */
   getProjectName: (workspacePath: string) => string | undefined;
 }
@@ -30,27 +30,27 @@ export interface TitleConfig {
 /**
  * Formats the window title based on current workspace.
  *
- * Format: "CodeHydra - <project> / <workspace> - (<devBranch>)"
- * No workspace: "CodeHydra - (<devBranch>)" or "CodeHydra"
+ * Format: "CodeHydra - <project> / <workspace> - (<version>)"
+ * No workspace: "CodeHydra - (<version>)" or "CodeHydra"
  *
  * @param projectName - Name of the active project, or undefined
  * @param workspaceName - Name of the active workspace, or undefined
- * @param devBranch - Development branch name (from buildInfo.gitBranch), or undefined
+ * @param version - Version suffix (branch in dev mode, version in packaged mode), or undefined
  * @returns Formatted window title
  */
 export function formatWindowTitle(
   projectName: string | undefined,
   workspaceName: string | undefined,
-  devBranch?: string
+  version?: string
 ): string {
   const base = "CodeHydra";
-  const devSuffix = devBranch ? ` - (${devBranch})` : "";
+  const versionSuffix = version ? ` - (${version})` : "";
 
   if (projectName && workspaceName) {
-    return `${base} - ${projectName} / ${workspaceName}${devSuffix}`;
+    return `${base} - ${projectName} / ${workspaceName}${versionSuffix}`;
   }
 
-  return `${base}${devSuffix}`;
+  return `${base}${versionSuffix}`;
 }
 
 // =============================================================================
@@ -123,7 +123,7 @@ export function wireApiEvents(
       if (titleConfig) {
         if (event) {
           const projectName = titleConfig.getProjectName(event.path);
-          const title = formatWindowTitle(projectName, event.workspaceName, titleConfig.devBranch);
+          const title = formatWindowTitle(projectName, event.workspaceName, titleConfig.version);
           titleConfig.setTitle(title);
         } else {
           titleConfig.setTitle(titleConfig.defaultTitle);


### PR DESCRIPTION
- Rename `devBranch` → `version` parameter in `formatWindowTitle()` and `TitleConfig`
- In dev mode, shows git branch (unchanged behavior)
- In packaged mode, shows app version (e.g., "1.2.3")