### PR TITLE
fix(windows): use correct node.exe path in code CLI wrapper

### DIFF
--- a/resources/bin/code.cmd
+++ b/resources/bin/code.cmd
@@ -1,7 +1,9 @@
 @echo off
+setlocal
 if "%CODEHYDRA_CODE_SERVER_DIR%"=="" (
   echo Error: CODEHYDRA_CODE_SERVER_DIR not set. >&2
   echo Make sure you're in a CodeHydra workspace terminal. >&2
   exit /b 1
 )
-"%CODEHYDRA_CODE_SERVER_DIR%\lib\vscode\bin\remote-cli\code.cmd" %*
+"%CODEHYDRA_CODE_SERVER_DIR%\lib\node.exe" "%CODEHYDRA_CODE_SERVER_DIR%\lib\vscode\out\server-cli.js" "code-server" "" "" "code.cmd" %*
+endlocal


### PR DESCRIPTION
- Fix Windows code CLI failing when git uses it as editor (e.g., git rebase -i)
- Call node.exe directly at lib/node.exe instead of delegating to remote-cli script
- The remote-cli script resolves to wrong path (<code-server-root>/node.exe vs lib/node.exe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)