### PR TITLE
chore(feature): remove redundant test:boundary from validation steps

### DIFF
--- a/.claude/agents/implement.md
+++ b/.claude/agents/implement.md
@@ -60,7 +60,7 @@ This allows resuming after a plan update without re-doing completed work.
 
 ## After ALL Implementation Steps Complete
 
-Run the validation commands specified in the invocation (typically `pnpm validate:fix` then `pnpm test:boundary`). Fix any issues and re-run until all pass.
+Run the validation commands specified in the invocation (typically `pnpm validate:fix`). Fix any issues and re-run until all pass.
 
 ## Fix Mode
 

--- a/.claude/commands/feature/code-review.md
+++ b/.claude/commands/feature/code-review.md
@@ -74,8 +74,7 @@ Read the plan at: planning/<FEATURE_NAME>.md for context.
 ### Validation Commands
 After ALL fixes complete:
 1. Run: `pnpm validate:fix`
-2. If that passes, run: `pnpm test:boundary`
-3. Fix any failures and re-run until all pass
+2. Fix any failures and re-run until all pass
 
 ### Commit Rules
 **DO NOT COMMIT.** Leave the working tree dirty.

--- a/.claude/commands/feature/implement.md
+++ b/.claude/commands/feature/implement.md
@@ -36,8 +36,7 @@ Read the plan file and follow all implementation steps.
 ### Validation Commands
 After ALL implementation steps complete:
 1. Run: `pnpm validate:fix`
-2. If that passes, run: `pnpm test:boundary`
-3. Fix any failures and re-run until all pass
+2. Fix any failures and re-run until all pass
 
 ### Commit Rules
 **DO NOT COMMIT.** Leave the working tree dirty.


### PR DESCRIPTION
- Remove redundant `pnpm test:boundary` instructions from agent files
- `pnpm validate` already runs all tests including boundary tests, so the separate step was unnecessary duplication

🤖 Generated with [Claude Code](https://claude.ai/code)