### PR TITLE
feat(dialog): improve Create Workspace dialog UX

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -945,8 +945,17 @@ interface AgentStatusCounts {
 interface BaseInfo {
   readonly name: string;
   readonly isRemote: boolean;
+  readonly base?: string;
+  readonly derives?: string;
 }
 ```
+
+| Field      | Type      | Description                                                                                                                                                         |
+| ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | `string`  | Full branch reference (e.g., "main" or "origin/main")                                                                                                               |
+| `isRemote` | `boolean` | Whether this is a remote-tracking branch                                                                                                                            |
+| `base`     | `string?` | Suggested base branch for creating a workspace. For local branches: `codehydra.base` config value, or matching `origin/*` branch. For remote branches: the full ref |
+| `derives`  | `string?` | Derivable workspace name if a workspace can be created from this branch. Set for local branches without worktrees or remote branches without local counterparts     |
 
 #### `UIMode`
 

--- a/docs/USER_INTERFACE.md
+++ b/docs/USER_INTERFACE.md
@@ -371,11 +371,32 @@ They can click "Open Project" to try again.
 1. Click [+] on project row
 2. Create dialog opens
 3. Select target project from dropdown (defaults to current workspace's project)
-4. Enter workspace name (validated in real-time against selected project's workspaces)
+4. Enter workspace name OR select an existing branch from the dropdown
 5. Select base branch from dropdown (the branch to create new worktree from)
 6. Click OK
 7. Git worktree created in managed location (NOT in main directory)
 8. New workspace becomes active
+
+**Name field behavior:**
+
+The Name field is a filterable dropdown that supports both:
+
+- **Custom name entry**: Type a new branch name and press Enter
+- **Existing branch selection**: Select from local branches without worktrees or remote branches without local counterparts
+
+When selecting an existing branch from the dropdown:
+
+- The name field auto-fills with the branch name
+- The base branch field auto-fills with a suggested base:
+  - For local branches: uses `codehydra.base` config or matching `origin/*` branch
+  - For remote branches: uses the full remote ref (e.g., `origin/feature-x`)
+
+When typing a custom name and pressing Enter with no dropdown selection:
+
+- The typed text is used as the new branch name
+- No auto-fill of base branch (user must select manually)
+
+Validation occurs when the user presses Enter or selects an option, not on blur.
 
 **Default branch pre-selection:**
 

--- a/planning/CREATE_WORKSPACE_DIALOG_IMPROVEMENTS.md
+++ b/planning/CREATE_WORKSPACE_DIALOG_IMPROVEMENTS.md
@@ -1,0 +1,254 @@
+---
+status: IMPLEMENTATION_REVIEW
+last_updated: 2026-01-23
+reviewers: []
+---
+
+# CREATE_WORKSPACE_DIALOG_IMPROVEMENTS
+
+## Overview
+
+- **Problem**: The Create Workspace dialog has several UX issues:
+  1. Arrow key navigation doesn't scroll the branch list to keep highlighted items visible
+  2. Remote branches that no longer exist on the remote still appear (stale refs)
+  3. Users can't select existing branches - must type names manually
+  4. No auto-selection of base branch when selecting an existing branch
+  5. Default base branch prefers local over remote (should prefer `origin/main` over `main`)
+
+- **Solution**:
+  1. Add `scrollIntoView()` to FilterableDropdown on keyboard navigation
+  2. Add `--prune` flag to git fetch in `updateBases()`
+  3. Convert name input to a filterable dropdown that allows both selection and free text
+  4. Enhance `fetchBases()` API to return suggested base branch and derivable workspace names
+  5. Update `defaultBase()` to prefer remote branches
+
+- **Risks**:
+  - API change to `BaseInfo` type (mitigated: additive change, backwards compatible)
+  - Git fetch --prune removes refs user might expect (acceptable: these are stale)
+
+- **Alternatives Considered**:
+  - New API endpoint instead of enhancing `fetchBases()` - rejected for simplicity
+  - Separate worktree status endpoint - rejected, can compute in single call
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    CreateWorkspaceDialog                         │
+│  ┌─────────────────┐  ┌──────────────────┐  ┌────────────────┐  │
+│  │ ProjectDropdown │  │NameBranchDropdown│  │ BranchDropdown │  │
+│  └─────────────────┘  └──────────────────┘  └────────────────┘  │
+│                              │                      │            │
+│                              └──────────┬───────────┘            │
+│                                         │                        │
+│                              ┌──────────▼───────────┐            │
+│                              │ FilterableDropdown   │            │
+│                              │ (+ scrollIntoView)   │            │
+│                              └──────────────────────┘            │
+└─────────────────────────────────────────────────────────────────┘
+                                         │
+                                         │ fetchBases()
+                                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       GitWorktreeProvider                        │
+│  listBases() - returns BaseInfo[] with:                         │
+│    - name: full ref ("main" or "origin/main")                   │
+│    - isRemote: boolean                                          │
+│    - base?: suggested base branch                               │
+│    - derives?: workspace name if can create workspace           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Data computation in `listBases()`:**
+
+1. Get all branches (`git branch -a`)
+2. Get all worktrees (to know which local branches have worktrees)
+3. Get `codehydra.base` config for local branches
+4. Compute `derives`:
+   - Local branch without worktree → `derives` = branch name
+   - Remote branch without local counterpart → `derives` = name without remote prefix (e.g., `origin/feature-x` → `feature-x`)
+   - For branches with `/` in name (e.g., `origin/feature/login`), strip only the remote prefix → `feature/login`
+   - Dedupe across multiple remotes: prefer `origin`, then alphabetically first remote
+5. Compute `base`:
+   - Local: `codehydra.base` config if set, otherwise matching `origin/*` branch if exists
+   - Remote: the full ref itself (e.g., `origin/feature-x`)
+
+## UI Design
+
+### Name Field (NameBranchDropdown)
+
+```
+┌─────────────────────────────────────────┐
+│ Name                                    │
+│ ┌─────────────────────────────────────┐ │
+│ │ feature-login                     ▼ │ │  ← Input with dropdown
+│ └─────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────┐ │
+│ │ LOCAL BRANCHES                      │ │  ← Header (non-selectable)
+│ │   feature-auth                      │ │
+│ │   bugfix-header                     │ │
+│ │ REMOTE BRANCHES                     │ │
+│ │   feature-payments                  │ │  ← Shown without "origin/"
+│ │   feature-dashboard                 │ │
+│ └─────────────────────────────────────┘ │
+└─────────────────────────────────────────┘
+```
+
+### User Interactions
+
+1. **Type custom name**: User types "my-feature" → creates new branch from selected base
+2. **Select existing local branch**: User selects "feature-auth" → base auto-fills from config or matching remote
+3. **Select remote branch**: User selects "feature-payments" (actually `origin/feature-payments`) → base auto-fills to `origin/feature-payments`
+4. **Arrow navigation**: Highlighted option scrolls into view when moving up/down
+5. **Keyboard for custom name**: When user types a name and presses Enter with no option highlighted, the typed text is used as the new branch name (no auto-fill of base)
+
+## Testing Strategy
+
+### Integration Tests
+
+Note: Tests 1-7 use `GitWorktreeProvider.listBases()` directly as the entry point because the `derives` and `base` computation logic is internal to the provider and not exposed through the public API. This allows focused testing of the computation logic with controlled mock state.
+
+| #   | Test Case                                                      | Entry Point                         | Boundary Mocks | Behavior Verified                                                         |
+| --- | -------------------------------------------------------------- | ----------------------------------- | -------------- | ------------------------------------------------------------------------- |
+| 1   | listBases returns derives for local branch without worktree    | `GitWorktreeProvider.listBases()`   | GitClient      | Branch with no worktree has `derives` set                                 |
+| 2   | listBases excludes derives for local branch with worktree      | `GitWorktreeProvider.listBases()`   | GitClient      | Branch with worktree has `derives` undefined                              |
+| 3   | listBases returns derives for remote without local counterpart | `GitWorktreeProvider.listBases()`   | GitClient      | Remote branch gets `derives` = name without prefix                        |
+| 4   | listBases excludes derives for remote with local counterpart   | `GitWorktreeProvider.listBases()`   | GitClient      | Remote branch has `derives` undefined when local exists                   |
+| 5   | listBases deduplicates remotes for derives                     | `GitWorktreeProvider.listBases()`   | GitClient      | Only one remote gets `derives` when multiple exist (prefer origin)        |
+| 6   | listBases returns base from codehydra.base config              | `GitWorktreeProvider.listBases()`   | GitClient      | Local branch `base` = config value                                        |
+| 7   | listBases returns base from matching remote                    | `GitWorktreeProvider.listBases()`   | GitClient      | Local branch `base` = `origin/*` when exists                              |
+| 8   | updateBases removes stale remote refs after fetch              | `GitWorktreeProvider.updateBases()` | GitClient      | Stale remote branches no longer appear in listBases() after updateBases() |
+| 9   | defaultBase prefers remote over local                          | `GitWorktreeProvider.defaultBase()` | GitClient      | Returns `origin/main` when both `main` and `origin/main` exist            |
+
+**Note for Test #8**: The GitClient mock must simulate prune behavior - when `fetch()` is called with prune enabled, the mock should remove any remote branches from its in-memory state that are marked as "deleted on remote". This tests the actual outcome, not the implementation detail.
+
+### UI Integration Tests
+
+| #   | Test Case                                            | Category | Component             | Behavior Verified                           |
+| --- | ---------------------------------------------------- | -------- | --------------------- | ------------------------------------------- |
+| 1   | Arrow down scrolls into view                         | Pure-UI  | FilterableDropdown    | Highlighted option visible after navigation |
+| 2   | Arrow up scrolls into view                           | Pure-UI  | FilterableDropdown    | Highlighted option visible after navigation |
+| 3   | Name dropdown shows local branches without worktrees | UI-state | NameBranchDropdown    | Only branches with `derives` shown          |
+| 4   | Name dropdown shows remote branches without local    | UI-state | NameBranchDropdown    | Remote branches displayed without prefix    |
+| 5   | Selecting branch auto-fills base                     | API-call | CreateWorkspaceDialog | Base dropdown value updated                 |
+| 6   | Custom name entry works                              | Pure-UI  | NameBranchDropdown    | Typed text used as workspace name           |
+| 7   | Name validation still applies                        | Pure-UI  | CreateWorkspaceDialog | Invalid names show error                    |
+
+**Note for UI Tests 1-2**: `scrollIntoView()` may not work as expected in JSDOM. These tests should verify the method is called with correct arguments, and actual scroll behavior should be verified in manual testing.
+
+### Manual Testing Checklist
+
+- [ ] Open Create Workspace dialog
+- [ ] Arrow down through long branch list - verify scroll follows
+- [ ] Arrow up through long branch list - verify scroll follows
+- [ ] Type partial branch name - verify filtering works
+- [ ] Select local branch - verify base auto-fills
+- [ ] Select remote branch - verify base auto-fills to origin/\*
+- [ ] Type custom name - verify new branch created with selected base
+- [ ] Type custom name and press Enter with no selection - verify no base auto-fill
+- [ ] Delete remote branch externally, re-open dialog after fetch - verify stale branch removed
+- [ ] Test with repo having multiple remotes
+- [ ] Verify default base is origin/main (not main) when both exist
+
+## Implementation Steps
+
+- [x] **Step 1: Add scrollIntoView to FilterableDropdown**
+  - Use ID-based approach: `document.getElementById(highlightedId)?.scrollIntoView({ block: 'nearest' })` in an `$effect` that watches `highlightedIndex`
+  - The option IDs are already computed as `${baseId}-option-${...}`
+  - Files: `src/renderer/lib/components/FilterableDropdown.svelte`
+  - Test: Arrow navigation scrolls highlighted option into view
+
+- [x] **Step 2: Add --prune flag to git fetch**
+  - Modify `fetch()` method in SimpleGitClient:
+    - With remote: `await git.fetch([remote, '--prune'])`
+    - Without remote: `await git.fetch(['--all', '--prune'])`
+  - Files: `src/services/git/simple-git-client.ts`
+  - Test: Stale remote refs removed after fetch
+
+- [x] **Step 3: Enhance BaseInfo type**
+  - Add `base?: string` and `derives?: string` fields with JSDoc comments
+  - Files: `src/shared/api/types.ts`
+  - Test: Types compile
+
+- [x] **Step 4: Enhance listBases() to compute derives and base**
+  - Get worktrees to determine which local branches have worktrees
+  - Get codehydra.base configs for local branches
+  - Compute `derives` with deduplication across remotes (prefer `origin`, then alphabetically)
+  - Compute `base` from config or matching remote
+  - Consider extracting derives computation to a private `computeDerives()` method for testability
+  - Files: `src/services/git/git-worktree-provider.ts`
+  - Test: Integration tests 1-7
+
+- [x] **Step 5: Update defaultBase() to prefer remote**
+  - Return full ref `origin/main` when it exists (not just `main`)
+  - Check order: `origin/main` → `main` → `origin/master` → `master`
+  - Fallback: if only local `main` exists without remote, return `main`
+  - Files: `src/services/git/git-worktree-provider.ts`
+  - Test: Integration test 9
+
+- [x] **Step 6: Create NameBranchDropdown component**
+  - Wrap FilterableDropdown
+  - Filter options to those with `derives` set
+  - Group by local/remote with headers (headers hidden when their group has no matching options after filtering)
+  - DropdownOption mapping:
+    - `label`: the `derives` value (display name, e.g., "feature-payments")
+    - `value`: the full ref for API calls (e.g., "origin/feature-payments")
+  - Allow free text entry for new branch names
+  - Callback signature:
+    ```typescript
+    interface NameBranchSelection {
+      name: string;                    // The workspace/branch name
+      suggestedBase?: string;          // Base branch if selecting existing branch
+      isExistingBranch: boolean;       // true if selected from list, false if custom typed
+    }
+    onSelect: (selection: NameBranchSelection) => void;
+    ```
+  - When user types custom name and presses Enter with no highlighted option, emit with `isExistingBranch: false` and no `suggestedBase`
+  - Files: `src/renderer/lib/components/NameBranchDropdown.svelte`
+  - Test: UI tests 3-6
+
+- [x] **Step 7: Update CreateWorkspaceDialog to use NameBranchDropdown**
+  - Replace `<vscode-textfield>` with `<NameBranchDropdown>`
+  - Handle selection to auto-fill base branch only when `isExistingBranch` is true
+  - Preserve existing validation timing: validate on blur, show errors only after `touched` state is true
+  - Keep existing validation logic (no `/`, `\`, `..`, max length, etc.)
+  - Files: `src/renderer/lib/components/CreateWorkspaceDialog.svelte`
+  - Test: UI tests 5, 7
+
+- [x] **Step 8: Update BranchDropdown for new BaseInfo structure**
+  - Ensure it handles new optional fields gracefully (they're not used in BranchDropdown)
+  - Files: `src/renderer/lib/components/BranchDropdown.svelte`
+  - Test: Existing branch dropdown functionality preserved
+  - Note: No changes needed - BranchDropdown only uses `name` and `isRemote`, new optional fields are handled gracefully by TypeScript
+
+## Dependencies
+
+None - using existing libraries.
+
+## Documentation Updates
+
+### Files to Update
+
+| File                      | Changes Required                                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/shared/api/types.ts` | Add JSDoc for new `base` and `derives` fields                                                                                            |
+| `docs/API.md`             | Update BaseInfo type documentation to include new `base` and `derives` fields                                                            |
+| `docs/USER_INTERFACE.md`  | Update "Creating a Workspace" section to document the new name dropdown behavior (selecting existing branches, auto-fill of base branch) |
+
+### New Documentation Required
+
+None - internal implementation change.
+
+## Definition of Done
+
+- [ ] All implementation steps complete
+- [ ] `pnpm validate:fix` passes
+- [ ] Arrow key navigation scrolls highlighted option into view
+- [ ] Stale remote branches no longer appear after fetch
+- [ ] Name field allows selecting existing branches
+- [ ] Selecting branch auto-fills base branch
+- [ ] Custom names still work for new branches
+- [ ] Default base branch prefers remote (origin/main > main)
+- [ ] All tests pass
+- [ ] Manual testing checklist complete
+- [ ] Documentation updated (API.md, USER_INTERFACE.md)

--- a/src/renderer/lib/components/NameBranchDropdown.svelte
+++ b/src/renderer/lib/components/NameBranchDropdown.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { projects, type ProjectId, type BaseInfo } from "$lib/api";
+  import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
+
+  /**
+   * Selection result from the NameBranchDropdown.
+   */
+  export interface NameBranchSelection {
+    /** The workspace/branch name */
+    name: string;
+    /** Suggested base branch if selecting an existing branch */
+    suggestedBase?: string;
+    /** true if selected from list, false if custom typed */
+    isExistingBranch: boolean;
+  }
+
+  interface NameBranchDropdownProps {
+    projectId: ProjectId;
+    value: string;
+    onSelect: (selection: NameBranchSelection) => void;
+    disabled?: boolean;
+    /** Optional id for the dropdown */
+    id?: string;
+    /** Called after Enter key is handled (after selection) */
+    onEnter?: (() => void) | undefined;
+    /** Called on every input change with the current text */
+    onInput?: ((value: string) => void) | undefined;
+    /** Whether to open dropdown on focus. Defaults to false for name field (free text). */
+    openOnFocus?: boolean;
+    /** Whether to focus the input on mount */
+    autofocus?: boolean;
+  }
+
+  let {
+    projectId,
+    value,
+    onSelect,
+    disabled = false,
+    id,
+    onEnter,
+    onInput,
+    openOnFocus = false, // Default to false for name field - user types custom names
+    autofocus = false,
+  }: NameBranchDropdownProps = $props();
+
+  // State
+  let branches = $state<readonly BaseInfo[]>([]);
+  let error = $state<string | null>(null);
+
+  // Load branches on mount or when projectId changes
+  $effect(() => {
+    error = null;
+
+    projects
+      .fetchBases(projectId)
+      .then((result: { bases: readonly BaseInfo[] }) => {
+        branches = result.bases;
+      })
+      .catch((err: unknown) => {
+        error = err instanceof Error ? err.message : "Failed to load branches";
+      });
+  });
+
+  /**
+   * Filter branches to only those with derives set (can create workspace from them).
+   */
+  const derivableBranches = $derived(branches.filter((b) => b.derives !== undefined));
+
+  /**
+   * Transform branches to DropdownOption[] with headers for local/remote groups.
+   * Only includes branches with derives set.
+   */
+  const dropdownOptions = $derived.by((): DropdownOption[] => {
+    const localBranches = derivableBranches.filter((b) => !b.isRemote);
+    const remoteBranches = derivableBranches.filter((b) => b.isRemote);
+
+    const options: DropdownOption[] = [];
+
+    if (localBranches.length > 0) {
+      options.push({ type: "header", label: "Local Branches", value: "__header_local__" });
+      for (const branch of localBranches) {
+        // Label is the derives value (display name), value is full ref for lookup
+        options.push({ type: "option", label: branch.derives!, value: branch.name });
+      }
+    }
+
+    if (remoteBranches.length > 0) {
+      options.push({ type: "header", label: "Remote Branches", value: "__header_remote__" });
+      for (const branch of remoteBranches) {
+        // Label is the derives value (without remote prefix), value is full ref
+        options.push({ type: "option", label: branch.derives!, value: branch.name });
+      }
+    }
+
+    return options;
+  });
+
+  /**
+   * Filter function for branches - matches by label (derives value).
+   * Headers are shown only if there are matching branches in their group.
+   */
+  function filterBranch(option: DropdownOption, filterLowercase: string): boolean {
+    if (option.type === "header") {
+      // Keep headers if there are matching branches in their group
+      if (option.value === "__header_local__") {
+        return derivableBranches.some(
+          (b) => !b.isRemote && b.derives?.toLowerCase().includes(filterLowercase)
+        );
+      }
+      if (option.value === "__header_remote__") {
+        return derivableBranches.some(
+          (b) => b.isRemote && b.derives?.toLowerCase().includes(filterLowercase)
+        );
+      }
+      return false;
+    }
+    return option.label.toLowerCase().includes(filterLowercase);
+  }
+
+  /**
+   * Handle selection from the dropdown.
+   * Looks up the branch to get the suggested base.
+   */
+  function handleSelect(selectedValue: string): void {
+    // Find the branch that was selected
+    const branch = branches.find((b) => b.name === selectedValue);
+
+    if (branch?.derives) {
+      // Selected an existing branch - conditionally include suggestedBase
+      const selection: NameBranchSelection = {
+        name: branch.derives,
+        isExistingBranch: true,
+      };
+      if (branch.base !== undefined) {
+        onSelect({ ...selection, suggestedBase: branch.base });
+      } else {
+        onSelect(selection);
+      }
+    } else {
+      // Custom name typed (not in list)
+      onSelect({
+        name: selectedValue,
+        isExistingBranch: false,
+      });
+    }
+  }
+</script>
+
+<div class="name-branch-dropdown">
+  {#if error}
+    <div class="error-message" role="alert">{error}</div>
+  {:else}
+    <FilterableDropdown
+      options={dropdownOptions}
+      {value}
+      onSelect={handleSelect}
+      {disabled}
+      placeholder="Enter name or select branch..."
+      filterOption={filterBranch}
+      id={id ?? `name-branch-dropdown-${projectId}`}
+      allowFreeText={true}
+      {onEnter}
+      {onInput}
+      {openOnFocus}
+      {autofocus}
+    />
+    <!-- No optionSnippet needed - content inherits FilterableDropdown's
+         .group-header and .dropdown-option styling -->
+  {/if}
+</div>
+
+<style>
+  .name-branch-dropdown {
+    width: 100%;
+  }
+
+  .error-message {
+    padding: 8px;
+    font-size: 12px;
+    color: var(--ch-error-fg);
+  }
+
+  /* Note: .header-text and .branch-text removed - content inherits
+     FilterableDropdown's .group-header and .dropdown-option styling */
+</style>

--- a/src/renderer/lib/components/NameBranchDropdown.test.ts
+++ b/src/renderer/lib/components/NameBranchDropdown.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for the NameBranchDropdown component.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import type { BaseInfo, ProjectId } from "@shared/api/types";
+
+// Create mock functions with vi.hoisted - required for vitest mocking pattern
+const { mockFetchBases } = vi.hoisted(() => ({
+  mockFetchBases: vi.fn(),
+}));
+
+// Mock $lib/api - must be a static mock, not dynamic (no importOriginal)
+vi.mock("$lib/api", () => ({
+  projects: {
+    fetchBases: mockFetchBases,
+  },
+}));
+
+// Import component after mocks
+import NameBranchDropdown, { type NameBranchSelection } from "./NameBranchDropdown.svelte";
+
+describe("NameBranchDropdown component", () => {
+  const testProjectId = "test-project-12345678" as ProjectId;
+
+  const defaultProps = {
+    projectId: testProjectId,
+    value: "",
+    onSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * Helper to set up mock branches and render component
+   */
+  async function renderWithBranches(
+    branches: BaseInfo[],
+    props: Partial<
+      typeof defaultProps & {
+        id?: string;
+        onEnter?: () => void;
+        openOnFocus?: boolean;
+        autofocus?: boolean;
+      }
+    > = {}
+  ): Promise<void> {
+    mockFetchBases.mockResolvedValue({ bases: branches });
+    render(NameBranchDropdown, { props: { ...defaultProps, ...props } });
+    // Wait for promise to resolve
+    await vi.advanceTimersByTimeAsync(0);
+    await tick();
+  }
+
+  /**
+   * Helper to focus input and open dropdown.
+   * NameBranchDropdown has openOnFocus=false by default, so we need ArrowDown.
+   */
+  async function focusAndOpenDropdown(input: HTMLElement): Promise<void> {
+    await fireEvent.focus(input);
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+  }
+
+  // UI Test #3: Name dropdown shows local branches without worktrees
+  describe("UI-state: shows local branches without worktrees", () => {
+    it("shows local branches with derives set (no worktree)", async () => {
+      const branches: BaseInfo[] = [
+        { name: "main", isRemote: false }, // No derives - has worktree
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" }, // Has derives - no worktree
+        { name: "feature-login", isRemote: false, derives: "feature-login" }, // Has derives - no worktree
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      // Should show branches with derives
+      expect(screen.getByText("feature-auth")).toBeInTheDocument();
+      expect(screen.getByText("feature-login")).toBeInTheDocument();
+
+      // Should NOT show branch without derives (main has worktree)
+      const options = screen.getAllByRole("option");
+      const optionTexts = options.map((o) => o.textContent);
+      expect(optionTexts).not.toContain("main");
+    });
+
+    it("shows LOCAL BRANCHES header when local branches with derives exist", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.getByText("Local Branches")).toBeInTheDocument();
+    });
+
+    it("hides LOCAL BRANCHES header when no local branches have derives", async () => {
+      const branches: BaseInfo[] = [
+        { name: "main", isRemote: false }, // No derives
+        { name: "origin/feature-x", isRemote: true, derives: "feature-x" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.queryByText("Local Branches")).not.toBeInTheDocument();
+    });
+  });
+
+  // UI Test #4: Name dropdown shows remote branches without local
+  describe("UI-state: shows remote branches without local counterpart", () => {
+    it("shows remote branches with derives set (no local counterpart)", async () => {
+      const branches: BaseInfo[] = [
+        { name: "origin/main", isRemote: true }, // No derives - has local counterpart
+        { name: "origin/feature-payments", isRemote: true, derives: "feature-payments" },
+        { name: "origin/feature-dashboard", isRemote: true, derives: "feature-dashboard" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      // Should show branches with derives (displayed without remote prefix)
+      expect(screen.getByText("feature-payments")).toBeInTheDocument();
+      expect(screen.getByText("feature-dashboard")).toBeInTheDocument();
+
+      // Should NOT show branch without derives
+      const options = screen.getAllByRole("option");
+      const optionTexts = options.map((o) => o.textContent);
+      expect(optionTexts).not.toContain("origin/main");
+      expect(optionTexts).not.toContain("main");
+    });
+
+    it("shows REMOTE BRANCHES header when remote branches with derives exist", async () => {
+      const branches: BaseInfo[] = [
+        { name: "origin/feature-x", isRemote: true, derives: "feature-x" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.getByText("Remote Branches")).toBeInTheDocument();
+    });
+
+    it("hides REMOTE BRANCHES header when no remote branches have derives", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+        { name: "origin/main", isRemote: true }, // No derives
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.queryByText("Remote Branches")).not.toBeInTheDocument();
+    });
+  });
+
+  // UI Test #5: Selecting branch auto-fills base
+  describe("selecting branch auto-fills base", () => {
+    it("onSelect receives suggestedBase when branch has base field", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        {
+          name: "feature-auth",
+          isRemote: false,
+          derives: "feature-auth",
+          base: "origin/feature-auth",
+        },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      const option = screen.getByText("feature-auth");
+      await fireEvent.mouseDown(option);
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "feature-auth",
+        suggestedBase: "origin/feature-auth",
+        isExistingBranch: true,
+      });
+    });
+
+    it("onSelect receives remote branch base when selecting remote", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        {
+          name: "origin/feature-payments",
+          isRemote: true,
+          derives: "feature-payments",
+          base: "origin/feature-payments",
+        },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      const option = screen.getByText("feature-payments");
+      await fireEvent.mouseDown(option);
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "feature-payments",
+        suggestedBase: "origin/feature-payments",
+        isExistingBranch: true,
+      });
+    });
+
+    it("onSelect omits suggestedBase when branch has no base field", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-x", isRemote: false, derives: "feature-x" }, // No base field
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      const option = screen.getByText("feature-x");
+      await fireEvent.mouseDown(option);
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "feature-x",
+        isExistingBranch: true,
+      });
+      // Verify suggestedBase is not in the call
+      const callArg = onSelect.mock.calls[0]![0] as NameBranchSelection;
+      expect(callArg.suggestedBase).toBeUndefined();
+    });
+  });
+
+  // UI Test #6: Custom name entry works
+  describe("custom name entry", () => {
+    it("typing custom name and pressing Enter emits with isExistingBranch: false", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+      await fireEvent.input(input, { target: { value: "my-new-feature" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "my-new-feature",
+        isExistingBranch: false,
+      });
+    });
+
+    it("custom name entry does not include suggestedBase", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth", base: "main" },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+      await fireEvent.input(input, { target: { value: "custom-branch" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      const callArg = onSelect.mock.calls[0]![0] as NameBranchSelection;
+      expect(callArg.isExistingBranch).toBe(false);
+      expect(callArg.suggestedBase).toBeUndefined();
+    });
+
+    it("pressing Enter with highlighted option selects that option", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth", base: "main" },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+      await fireEvent.keyDown(input, { key: "ArrowDown" }); // Highlight first option
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "feature-auth",
+        suggestedBase: "main",
+        isExistingBranch: true,
+      });
+    });
+  });
+
+  describe("error states", () => {
+    it("shows error message when fetch fails", async () => {
+      mockFetchBases.mockRejectedValue(new Error("Network error"));
+      render(NameBranchDropdown, { props: defaultProps });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await tick();
+
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+
+  describe("filtering", () => {
+    it("filters branches by derives value (label)", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+        { name: "feature-login", isRemote: false, derives: "feature-login" },
+        { name: "origin/feature-payment", isRemote: true, derives: "feature-payment" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      // Type to filter
+      await fireEvent.input(input, { target: { value: "auth" } });
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+
+      expect(screen.getByText("feature-auth")).toBeInTheDocument();
+      expect(screen.queryByText("feature-login")).not.toBeInTheDocument();
+      expect(screen.queryByText("feature-payment")).not.toBeInTheDocument();
+    });
+
+    it("hides headers when no matching branches in group", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+        { name: "origin/bugfix-payment", isRemote: true, derives: "bugfix-payment" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      // Filter to only match remote
+      await fireEvent.input(input, { target: { value: "bugfix" } });
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+
+      // Local header should be hidden (no local matches)
+      expect(screen.queryByText("Local Branches")).not.toBeInTheDocument();
+      // Remote header should be visible
+      expect(screen.getByText("Remote Branches")).toBeInTheDocument();
+    });
+  });
+
+  describe("id prop", () => {
+    it("forwards id prop to FilterableDropdown input", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      mockFetchBases.mockResolvedValue({ bases: branches });
+      render(NameBranchDropdown, { props: { ...defaultProps, id: "workspace-name" } });
+      await vi.advanceTimersByTimeAsync(0);
+      await tick();
+
+      const input = screen.getByRole("combobox");
+      expect(input).toHaveAttribute("id", "workspace-name-input");
+    });
+  });
+
+  describe("onEnter callback", () => {
+    it("calls onEnter when Enter is pressed", async () => {
+      const onEnter = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      await renderWithBranches(branches, { onEnter });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+      await fireEvent.input(input, { target: { value: "my-branch" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onEnter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("autofocus prop", () => {
+    it("sets data-autofocus attribute when autofocus is true", async () => {
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      await renderWithBranches(branches, { autofocus: true });
+
+      const input = screen.getByRole("combobox");
+      expect(input).toHaveAttribute("data-autofocus");
+    });
+  });
+});

--- a/src/renderer/lib/components/ProjectDropdown.test.ts
+++ b/src/renderer/lib/components/ProjectDropdown.test.ts
@@ -58,6 +58,15 @@ describe("ProjectDropdown component", () => {
     onSelect: vi.fn(),
   };
 
+  /**
+   * Helper to focus input and open dropdown.
+   * When dropdown has a value, there's a 50ms delay before opening.
+   */
+  async function focusAndOpenDropdown(input: HTMLElement): Promise<void> {
+    await fireEvent.focus(input);
+    await vi.advanceTimersByTimeAsync(50);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
@@ -74,7 +83,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
 
       expect(screen.getByText("project-alpha")).toBeInTheDocument();
       expect(screen.getByText("project-beta")).toBeInTheDocument();
@@ -85,7 +94,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
 
       const options = screen.getAllByRole("option");
       expect(options[0]).toHaveTextContent("project-alpha");
@@ -98,7 +107,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: { ...defaultProps, onSelect } });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
 
       const option = screen.getByText("project-beta");
       await fireEvent.mouseDown(option);
@@ -121,7 +130,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
       await fireEvent.input(input, { target: { value: "beta" } });
 
       // Wait for debounce
@@ -137,7 +146,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
       await fireEvent.input(input, { target: { value: "ALPHA" } });
 
       await vi.advanceTimersByTimeAsync(250);
@@ -153,7 +162,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      // ArrowDown opens the dropdown immediately
       await fireEvent.keyDown(input, { key: "ArrowDown" });
 
       const options = screen.getAllByRole("option");
@@ -165,7 +174,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: { ...defaultProps, onSelect } });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      // ArrowDown opens the dropdown immediately
       await fireEvent.keyDown(input, { key: "ArrowDown" });
       await fireEvent.keyDown(input, { key: "Enter" });
 
@@ -178,7 +187,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: { ...defaultProps, onSelect } });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
       expect(input).toHaveAttribute("aria-expanded", "true");
 
       await fireEvent.keyDown(input, { key: "Escape" });
@@ -206,7 +215,7 @@ describe("ProjectDropdown component", () => {
       });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
 
       const option = screen.getByText(longProjectName);
       expect(option).toBeInTheDocument();
@@ -243,7 +252,7 @@ describe("ProjectDropdown component", () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      await focusAndOpenDropdown(input);
 
       const options = screen.getAllByRole("option");
       expect(options).toHaveLength(3);

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -337,11 +337,11 @@ describe("Integration tests", () => {
         expect(screen.getByText("Create Workspace")).toBeInTheDocument();
       });
 
-      // Verify the dialog has project dropdown, name input, and branch dropdown
-      // Note: vscode-textfield is a web component, so we query by id
-      expect(document.getElementById("workspace-name")).toBeInTheDocument();
-      // Should have 2 comboboxes: project dropdown and branch dropdown
-      expect(screen.getAllByRole("combobox")).toHaveLength(2);
+      // Verify the dialog has project dropdown, name/branch dropdown, and base branch dropdown
+      // NameBranchDropdown is a filterable combobox, query its container
+      expect(document.querySelector(".name-branch-dropdown")).toBeInTheDocument();
+      // Should have 3 comboboxes: project dropdown, name dropdown, and branch dropdown
+      expect(screen.getAllByRole("combobox")).toHaveLength(3);
 
       // Simulate workspace:created event (v2 format uses projectId)
       // Get actual projectId from store (ID is regenerated from path)
@@ -520,11 +520,11 @@ describe("Integration tests", () => {
         expect(screen.getByRole("dialog")).toBeInTheDocument();
       });
 
-      // Verify dialog opened with correct context (has project dropdown, name input, and branch dropdown)
-      // Note: vscode-textfield is a web component, so we query by id
-      expect(document.getElementById("workspace-name")).toBeInTheDocument();
-      // Should have 2 comboboxes: project dropdown and branch dropdown
-      expect(screen.getAllByRole("combobox")).toHaveLength(2);
+      // Verify dialog opened with correct context (has project dropdown, name dropdown, and branch dropdown)
+      // NameBranchDropdown is a filterable combobox, query its container
+      expect(document.querySelector(".name-branch-dropdown")).toBeInTheDocument();
+      // Should have 3 comboboxes: project dropdown, name dropdown, and branch dropdown
+      expect(screen.getAllByRole("combobox")).toHaveLength(3);
     });
 
     it("removeWorkspace uses fire-and-forget pattern → dialog closes immediately", async () => {

--- a/src/services/git/simple-git-client.ts
+++ b/src/services/git/simple-git-client.ts
@@ -332,9 +332,11 @@ export class SimpleGitClient implements IGitClient {
         const git = this.getGit(repoPath);
         if (remote) {
           // Use array format to ensure remote is treated as remote name, not refspec
-          await git.fetch([remote]);
+          // Include --prune to remove stale remote-tracking branches
+          await git.fetch([remote, "--prune"]);
         } else {
-          await git.fetch();
+          // Fetch all remotes with pruning
+          await git.fetch(["--all", "--prune"]);
         }
       },
       "fetch",

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -184,8 +184,24 @@ export interface AgentStatusCounts {
  * Information about a base branch.
  */
 export interface BaseInfo {
+  /** Full branch reference (e.g., "main" or "origin/main") */
   readonly name: string;
+  /** Whether this is a remote-tracking branch */
   readonly isRemote: boolean;
+  /**
+   * Suggested base branch for creating a workspace from this branch.
+   * For local branches: codehydra.base config value, or matching origin/* branch if exists.
+   * For remote branches: the full ref itself (e.g., "origin/feature-x").
+   */
+  readonly base?: string;
+  /**
+   * Derivable workspace name if a workspace can be created from this branch.
+   * Set when:
+   * - Local branch without an existing worktree (derives = branch name)
+   * - Remote branch without a local counterpart (derives = name without remote prefix, e.g., "feature-x")
+   * Undefined when a workspace already exists or local counterpart exists.
+   */
+  readonly derives?: string;
 }
 
 /**


### PR DESCRIPTION
- Add NameBranchDropdown component for selecting existing branches
- Auto-fill base branch when selecting existing local/remote branch
- Add scrollIntoView to FilterableDropdown for keyboard navigation
- ESC closes dropdown without closing dialog when dropdown is open
- Auto-open dropdown when typing produces matches
- Add --prune flag to git fetch to remove stale remote refs
- Prefer remote branches (origin/main) over local for default base
- Extend BaseInfo type with optional base and derives fields

🤖 Generated with [Claude Code](https://claude.ai/code)