### PR TITLE
fix(code-server): prevent port collision between dev and packaged versions

### DIFF
--- a/src/services/code-server/code-server-manager.integration.test.ts
+++ b/src/services/code-server/code-server-manager.integration.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join, delimiter } from "node:path";
-import { CodeServerManager } from "./code-server-manager";
+import { CodeServerManager, CODE_SERVER_PORT } from "./code-server-manager";
 import { createMockProcessRunner } from "../platform/process.state-mock";
 import { createPortManagerMock } from "../platform/network.test-utils";
 import { createMockHttpClient } from "../platform/http-client.state-mock";
@@ -43,12 +43,13 @@ describe("CodeServerManager Integration", () => {
       process.env.PATH = "/usr/bin:/usr/local/bin";
 
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -74,12 +75,13 @@ describe("CodeServerManager Integration", () => {
 
     it("includes EDITOR with absolute path and flags", async () => {
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -111,12 +113,13 @@ describe("CodeServerManager Integration", () => {
 
     it("includes GIT_SEQUENCE_EDITOR same as EDITOR", async () => {
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -148,12 +151,13 @@ describe("CodeServerManager Integration", () => {
       process.env.VSCODE_CODE_CACHE_PATH = "/some/cache";
 
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -186,12 +190,13 @@ describe("CodeServerManager Integration", () => {
       process.env.MY_CUSTOM_VAR = "custom-value";
 
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -219,12 +224,13 @@ describe("CodeServerManager Integration", () => {
 
     it("includes CODEHYDRA_PLUGIN_PORT when pluginPort configured", async () => {
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -251,12 +257,13 @@ describe("CodeServerManager Integration", () => {
 
     it("omits CODEHYDRA_PLUGIN_PORT when pluginPort undefined", async () => {
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",
@@ -283,12 +290,13 @@ describe("CodeServerManager Integration", () => {
 
     it("includes CODEHYDRA_CODE_SERVER_DIR and CODEHYDRA_OPENCODE_DIR", async () => {
       const processRunner = createMockProcessRunner({
-        onSpawn: () => ({ pid: 12345 }),
+        onSpawn: () => ({ pid: 12345, running: true }),
       });
 
       const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
       const portManager = createPortManagerMock([8080]);
       const config = {
+        port: CODE_SERVER_PORT,
         binaryPath: "/app/code-server",
         runtimeDir: "/tmp/runtime",
         extensionsDir: "/tmp/extensions",

--- a/src/services/code-server/types.ts
+++ b/src/services/code-server/types.ts
@@ -13,6 +13,8 @@ export type InstanceState = "stopped" | "starting" | "running" | "stopping" | "f
  * Configuration for code-server instance.
  */
 export interface CodeServerConfig {
+  /** Port for code-server to listen on */
+  readonly port: number;
   /** Absolute path to the code-server binary */
   readonly binaryPath: string;
   /** Directory for runtime files (sockets, pid files) */

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -34,6 +34,7 @@ export {
   CodeServerManager,
   urlForFolder,
   urlForWorkspace,
+  getCodeServerPort,
 } from "./code-server/code-server-manager";
 
 // Project store

--- a/src/services/mcp-server/mcp-server-manager.integration.test.ts
+++ b/src/services/mcp-server/mcp-server-manager.integration.test.ts
@@ -34,11 +34,26 @@ async function findFreePort(): Promise<number> {
 }
 
 /**
+ * Check if a port is available for binding.
+ */
+async function isPortAvailable(port: number): Promise<boolean> {
+  const { createServer } = await import("node:net");
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/**
  * Create a real port manager that finds free ports.
  */
 function createRealPortManager(): PortManager {
   return {
     findFreePort,
+    isPortAvailable,
   };
 }
 


### PR DESCRIPTION
When running a dev version while a packaged version is already running, code-server would fail to bind to port 25448 but the health check would pass by hitting the packaged version's code-server, causing the sidekick extension to connect to the wrong instance.

## Changes

- Add `isPortAvailable()` to PortManager interface for pre-spawn validation
- Check port availability before spawning code-server (deterministic)
- Remove 200ms delay in health check (no longer needed)
- Dev mode derives port from git branch name for consistency
- Production uses fixed port 25448 for IndexedDB persistence
- Propagate code-server errors to renderer for proper error UI
- Remove `CODE_SERVER_PORT` from public API exports (internal only)
- Boundary tests use dynamic ports to avoid conflicts