### PR TITLE
fix(shortcut): focus UI when no active workspace for Alt+X support

### DIFF
--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -746,6 +746,26 @@ describe("ViewManager", () => {
       expect(manager.getActiveWorkspacePath()).toBeNull();
     });
 
+    it("focuses UI when setting active workspace to null", () => {
+      const deps = createViewManagerDeps();
+      const manager = ViewManager.create(deps);
+
+      manager.createWorkspaceView(
+        "/path/to/workspace",
+        "http://127.0.0.1:8080/?folder=/path",
+        "/path/to/project"
+      );
+      manager.setWorkspaceLoaded("/path/to/workspace");
+      manager.setActiveWorkspace("/path/to/workspace");
+
+      // Set active to null (simulates closing last workspace)
+      manager.setActiveWorkspace(null);
+
+      // UI should be focused to receive keyboard events
+      const uiHandle = manager.getUIViewHandle();
+      expect(deps.viewLayer).toHaveView(uiHandle.id, { focused: true });
+    });
+
     it("updates active workspace path", () => {
       const deps = createViewManagerDeps();
       const manager = ViewManager.create(deps);
@@ -763,12 +783,15 @@ describe("ViewManager", () => {
   });
 
   describe("focusActiveWorkspace", () => {
-    it("does nothing when no active workspace", () => {
+    it("focuses UI when no active workspace", () => {
       const deps = createViewManagerDeps();
       const manager = ViewManager.create(deps);
 
-      // Should not throw
-      expect(() => manager.focusActiveWorkspace()).not.toThrow();
+      manager.focusActiveWorkspace();
+
+      // UI should be focused as fallback
+      const uiHandle = manager.getUIViewHandle();
+      expect(deps.viewLayer).toHaveView(uiHandle.id, { focused: true });
     });
   });
 

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -711,6 +711,9 @@ export class ViewManager implements IViewManager {
         if (state) {
           this.viewLayer.focus(state.handle);
         }
+      } else if (workspacePath === null) {
+        // No workspace active - ensure something is focused for keyboard shortcuts
+        this.focusActiveWorkspace();
       }
 
       // Notify subscribers of workspace change
@@ -742,9 +745,12 @@ export class ViewManager implements IViewManager {
   /**
    * Focuses the active workspace view.
    * Use this to return focus to the workspace (e.g., after exiting shortcut mode).
+   * When no workspace is active, focuses UI as fallback to ensure keyboard shortcuts work.
    */
   focusActiveWorkspace(): void {
     if (!this.activeWorkspacePath) {
+      // No workspace active - focus UI to ensure keyboard shortcuts still work
+      this.focusUI();
       return;
     }
 


### PR DESCRIPTION
- Focus UI as fallback when no active workspace exists in `focusActiveWorkspace()`
- Ensures ShortcutController receives keyboard events (Alt+X) after last workspace closes
- Adds focused state tracking to ViewLayer mock for testing