### PR TITLE
fix(ui): update branch dropdown when remote branches are pruned

### DIFF
--- a/src/renderer/lib/components/BranchDropdown.svelte
+++ b/src/renderer/lib/components/BranchDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { projects, type ProjectId, type BaseInfo } from "$lib/api";
+  import { projects, on, type ProjectId, type BaseInfo } from "$lib/api";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
 
   interface BranchDropdownProps {
@@ -32,6 +32,18 @@
         error = err instanceof Error ? err.message : "Failed to load branches";
         loading = false;
       });
+
+    // Subscribe to bases-updated events for this project
+    const unsubscribe = on<{ projectId: ProjectId; bases: readonly BaseInfo[] }>(
+      "project:bases-updated",
+      (event) => {
+        if (event.projectId === projectId) {
+          branches = event.bases;
+        }
+      }
+    );
+
+    return () => unsubscribe();
   });
 
   // Reset validation flag when value prop changes from parent

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -40,6 +40,8 @@ vi.mock("$lib/api", () => ({
   onWorkspaceCreated: vi.fn(() => vi.fn()),
   onWorkspaceRemoved: vi.fn(() => vi.fn()),
   onWorkspaceSwitched: vi.fn(() => vi.fn()),
+  // Event subscription (needed by BranchDropdown)
+  on: vi.fn(() => vi.fn()),
   // Flat API structure
   workspaces: {
     create: mockCreateWorkspace,


### PR DESCRIPTION
- Subscribe to `project:bases-updated` events in BranchDropdown component
- UI now reflects pruned remote branches after background `git fetch --prune`