### PR TITLE
feat(shortcut): add left/right arrows to navigate between idle workspaces

### DIFF
--- a/src/main/shortcut-controller.ts
+++ b/src/main/shortcut-controller.ts
@@ -30,6 +30,8 @@ const SHORTCUT_ACTIVATION_KEY = "x";
 const KEY_MAP: Record<string, ShortcutKey> = {
   ArrowUp: "up",
   ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
   Enter: "enter",
   Delete: "delete",
   Backspace: "delete",

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -56,6 +56,7 @@
   import Logo from "./Logo.svelte";
 
   import { clearDeletion, getDeletionStatus, deletionStates } from "$lib/stores/deletion.svelte.js";
+  import { getStatus } from "$lib/stores/agent-status.svelte.js";
   import { isWorkspaceLoading } from "$lib/stores/workspace-loading.svelte.js";
   import type { ProjectId, WorkspaceRef } from "$lib/api";
   import { getErrorMessage } from "@shared/error-utils";
@@ -92,6 +93,11 @@
   // Derive loading state for active workspace
   const activeLoading = $derived(
     activeWorkspacePath.value ? isWorkspaceLoading(activeWorkspacePath.value) : false
+  );
+
+  // Derive count of idle workspaces for shortcut overlay
+  const idleWorkspaceCount = $derived(
+    getAllWorkspaces().filter((ws) => getStatus(ws.path).type === "idle").length
   );
 
   // Initialize and subscribe to events on mount
@@ -320,6 +326,7 @@
     hasActiveWorkspace={activeWorkspacePath.value !== null}
     activeWorkspaceDeletionInProgress={activeWorkspacePath.value !== null &&
       getDeletionStatus(activeWorkspacePath.value) === "in-progress"}
+    {idleWorkspaceCount}
   />
 
   <!-- Backdrop/overlay shown based on workspace state -->

--- a/src/renderer/lib/components/ShortcutOverlay.svelte
+++ b/src/renderer/lib/components/ShortcutOverlay.svelte
@@ -5,6 +5,7 @@
     hasActiveProject?: boolean;
     hasActiveWorkspace?: boolean;
     activeWorkspaceDeletionInProgress?: boolean;
+    idleWorkspaceCount?: number;
   }
 
   let {
@@ -13,12 +14,14 @@
     hasActiveProject = false,
     hasActiveWorkspace = false,
     activeWorkspaceDeletionInProgress = false,
+    idleWorkspaceCount = 0,
   }: Props = $props();
 
   const showNavigation = $derived(workspaceCount > 1);
   const showJump = $derived(workspaceCount > 1);
   const showNew = $derived(hasActiveProject);
   const showDelete = $derived(hasActiveWorkspace && !activeWorkspaceDeletionInProgress);
+  const showIdleNavigation = $derived(idleWorkspaceCount >= 2);
 </script>
 
 <!-- 
@@ -37,6 +40,13 @@
     aria-label="Up and Down arrows to navigate"
   >
     <vscode-badge>↑↓</vscode-badge> Navigate
+  </span>
+  <span
+    class="shortcut-hint"
+    class:shortcut-hint--hidden={!showIdleNavigation}
+    aria-label="Left and Right arrows to jump to idle"
+  >
+    <vscode-badge>←→</vscode-badge> Idle
   </span>
   <span
     class="shortcut-hint"

--- a/src/shared/shortcuts.test.ts
+++ b/src/shared/shortcuts.test.ts
@@ -171,6 +171,8 @@ describe("shortcuts type guards", () => {
       const expectedKeys = [
         "up",
         "down",
+        "left",
+        "right",
         "enter",
         "delete",
         "o",
@@ -193,6 +195,8 @@ describe("shortcuts type guards", () => {
     it.each([
       "up",
       "down",
+      "left",
+      "right",
       "enter",
       "delete",
       "o",

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -89,6 +89,8 @@ export function jumpKeyToIndex(key: JumpKey): number {
 export const SHORTCUT_KEYS = [
   "up",
   "down",
+  "left",
+  "right",
   "enter",
   "delete",
   "o",


### PR DESCRIPTION
- Add left/right arrow shortcuts in Alt+X mode to navigate between idle workspaces
- Skip busy workspaces when navigating
- Show "←→ Idle" hint in overlay when 2+ idle workspaces exist