### PR TITLE
feat(telemetry): add PostHog analytics for DAU, version, and platform tracking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,8 @@ jobs:
       - name: Build
         env:
           CODEHYDRA_VERSION: ${{ steps.version.outputs.version }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: pnpm build
 
       - name: Upload build output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ All external access MUST use abstraction interfaces:
 | Electron App     | `AppLayer`                            | `app`                   |
 | Electron Menu    | `MenuLayer`                           | `Menu`                  |
 
+**Acceptable exceptions**: Third-party libraries that encapsulate their own I/O (like `ignore`, `posthog-node`) do not need abstraction layers. We abstract our own I/O, not the internals of external libraries.
+
 ### Path Handling
 
 **ALWAYS use the `Path` class** for internal path handling:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,6 +206,7 @@ Services are pure Node.js for testability without Electron:
 | NetworkLayer             | HTTP, SSE, port operations (HttpClient, SseClient, PortManager) | Implemented |
 | PluginServer             | Socket.IO server for VS Code extension communication            | Implemented |
 | McpServerManager         | MCP server for AI agent workspace API access                    | Implemented |
+| TelemetryService         | PostHog analytics for DAU, version, platform, errors            | Implemented |
 
 ### Workspace Cleanup
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -6,6 +6,11 @@ import { codehydraDefaults } from "./vite.defaults";
 
 const appVersion = process.env.CODEHYDRA_VERSION ?? "0.0.0-dev";
 
+// PostHog configuration - injected at build time from environment variables
+// API key is stored in GitHub secrets and passed via CI, or in .env.local for local dev
+const posthogApiKey = process.env.POSTHOG_API_KEY;
+const posthogHost = process.env.POSTHOG_HOST ?? "https://eu.posthog.com";
+
 export default defineConfig({
   main: {
     build: {
@@ -18,6 +23,9 @@ export default defineConfig({
     },
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
+      // PostHog constants - undefined if not configured (telemetry disabled)
+      __POSTHOG_API_KEY__: posthogApiKey ? JSON.stringify(posthogApiKey) : "undefined",
+      __POSTHOG_HOST__: JSON.stringify(posthogHost),
     },
     plugins: [
       // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "electron-log": "^5.4.3",
     "execa": "^9.6.1",
     "ignore": "^7.0.5",
+    "posthog-node": "^5.24.2",
     "simple-git": "^3.30.0",
     "socket.io": "^4.8.1",
     "tar": "^7.5.2",

--- a/planning/POSTHOG_TELEMETRY.md
+++ b/planning/POSTHOG_TELEMETRY.md
@@ -1,0 +1,324 @@
+---
+status: IMPLEMENTATION_REVIEW
+last_updated: 2026-01-25
+reviewers: [review-arch, review-quality, review-testing]
+---
+
+# POSTHOG_TELEMETRY
+
+## Overview
+
+- **Problem**: No visibility into CodeHydra usage - daily active users, version distribution, platform breakdown, or crash patterns
+- **Solution**: Integrate PostHog for minimal product analytics with opt-out configuration
+- **Risks**:
+  - PostHog SDK uses internal HTTP (acceptable exception - third-party library like `ignore` package)
+  - User privacy concerns (mitigated by opt-out and minimal data collection)
+- **Alternatives Considered**:
+  - TelemetryDeck (rejected - weaker Electron/Node.js support, smaller free tier)
+  - Direct SDK usage without wrapper (rejected - less testable, violates project patterns)
+  - Opt-in telemetry (considered - opt-out chosen for better data coverage, user can disable via config)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Main Process                                │
+│                                                                     │
+│  bootstrap()                                                        │
+│       │                                                             │
+│       ├─ buildInfo ──────────┐                                      │
+│       ├─ platformInfo ───────┼──► TelemetryService ◄── logger       │
+│       ├─ configService ──────┤         │               [telemetry]  │
+│       ├─ __POSTHOG_API_KEY__ ┤         │                            │
+│       └─ __POSTHOG_HOST__ ───┘         │                            │
+│           (build-time inject)          │                            │
+│                              ┌─────────┴─────────┐                  │
+│                              │                   │                  │
+│                    capture('app_launched')   captureError()         │
+│                    { version, platform,      (uncaught exceptions)  │
+│                      arch, isDev }                                  │
+│                              │                   │                  │
+│                              ├───────────────────┤                  │
+│                              │                   │                  │
+│                              ▼                   ▼                  │
+│                    ┌─────────────────┐   ┌─────────────┐            │
+│                    │  posthog-node   │   │   Logger    │            │
+│                    │     SDK         │   │  (INFO)     │            │
+│                    └────────┬────────┘   └─────────────┘            │
+│                             │                                       │
+└─────────────────────────────┼───────────────────────────────────────┘
+                              │
+                              ▼
+                     ┌─────────────────┐
+                     │  PostHog Cloud  │
+                     │ (__POSTHOG_HOST__)│
+                     └─────────────────┘
+```
+
+### Data Flow
+
+1. On app startup, `TelemetryService` checks config and API key availability
+2. If enabled and API key present, uses lazy initialization for PostHog client
+3. Generates anonymous `distinct_id` if missing (in TelemetryService, persisted via ConfigService)
+4. Captures `app_launched` event with version, platform, arch
+5. **All captured events are also logged at INFO level** via injected logger
+6. Registers global error handlers for unhandled exceptions (using `process.prependListener`)
+7. On app shutdown, calls `posthog.shutdown()` to flush pending events
+
+### Configuration
+
+| Setting           | Source                         | Default                  | Description                                    |
+| ----------------- | ------------------------------ | ------------------------ | ---------------------------------------------- |
+| `POSTHOG_API_KEY` | Build-time env / GitHub secret | (none)                   | Project API key, telemetry disabled if missing |
+| `POSTHOG_HOST`    | Build-time env                 | `https://eu.posthog.com` | PostHog instance URL (EU or US region)         |
+
+**API Key Handling**:
+
+- **Not in source code**: Key is never committed to the repository
+- **GitHub Secret**: Stored as `POSTHOG_API_KEY` in GitHub repository secrets
+- **CI Injection**: Injected via Vite `define` during CI builds
+- **Development**: Developers use `.env.local` (gitignored) or telemetry is disabled
+- **Fallback**: If key is missing at runtime, telemetry is silently disabled (no-op)
+
+### Events Captured
+
+| Event          | Properties                                     | Frequency              |
+| -------------- | ---------------------------------------------- | ---------------------- |
+| `app_launched` | `version`, `platform`, `arch`, `isDevelopment` | Once per session       |
+| `error`        | `message`, `stack` (sanitized), `version`      | On unhandled exception |
+
+### Error Stack Sanitization
+
+Error stacks are sanitized before sending to PostHog:
+
+- **Strip home directory**: Replace `/home/user/...` or `C:\Users\user\...` with `<home>/...`
+- **Strip project paths**: Replace absolute project paths with relative paths
+- **Truncate length**: Maximum 10 stack frames, 2000 characters total
+- **No query parameters**: Strip query strings from any URLs in stack
+
+### Anonymous Identity
+
+- `distinct_id` is a random UUID generated on first launch
+- Generated by TelemetryService, persisted via ConfigService in `config.json`
+- Stored under `telemetry.distinctId`
+- No PII collected (no user email, IP not stored by PostHog)
+
+### Type Definitions
+
+```typescript
+// PostHog client factory for dependency injection
+type PostHogClientFactory = (apiKey: string, options: { host: string }) => PostHogClient;
+
+// TelemetryService dependencies (follows project pattern)
+interface TelemetryServiceDeps {
+  readonly buildInfo: BuildInfo;
+  readonly platformInfo: PlatformInfo;
+  readonly configService: ConfigService;
+  readonly logger: Logger;
+  readonly apiKey?: string;
+  readonly host?: string;
+  readonly postHogClientFactory?: PostHogClientFactory;
+}
+
+// PostHog client interface (subset of posthog-node)
+interface PostHogClient {
+  capture(params: {
+    distinctId: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }): void;
+  shutdown(): Promise<void>;
+}
+```
+
+## Implementation Steps
+
+- [x] **Step 1: Add posthog-node dependency**
+  - Run `pnpm add posthog-node`
+  - Files affected: `package.json`, `pnpm-lock.yaml`
+  - Test criteria: Package installs successfully
+
+- [x] **Step 2: Create TelemetryService interface and types**
+  - Create `src/services/telemetry/types.ts`
+  - Define `TelemetryService` interface with `capture()`, `captureError()`, `shutdown()`
+  - Define `TelemetryServiceDeps` interface (see Type Definitions above)
+  - Define `PostHogClientFactory` type
+  - Define `PostHogClient` interface (subset we use)
+  - Add `"telemetry"` to `LoggerName` type in `src/services/logging/types.ts`
+  - Files affected: `src/services/telemetry/types.ts`, `src/services/logging/types.ts`
+  - Test criteria: Types compile without error
+
+- [x] **Step 3: Extend ConfigService with telemetry settings**
+  - Update `AppConfig` interface in `src/services/config/types.ts`:
+    ```typescript
+    telemetry?: {
+      enabled: boolean;
+      distinctId?: string;
+    }
+    ```
+  - Update `DEFAULT_APP_CONFIG` to include `telemetry: { enabled: true }`
+  - Update `validateConfig()` to accept and validate the new `telemetry` field:
+    - `telemetry.enabled` must be boolean
+    - `telemetry.distinctId` must be string or undefined
+  - **Note**: ConfigService only persists config, does NOT generate distinctId
+  - Files affected: `src/services/config/config-service.ts`, `src/services/config/types.ts`
+  - Test criteria: Config loads with telemetry defaults, validation accepts new field
+
+- [x] **Step 4: Implement PostHogTelemetryService**
+  - Create `src/services/telemetry/posthog-telemetry-service.ts`
+  - Constructor receives `TelemetryServiceDeps` object (follows project pattern)
+  - Inject `PostHogClientFactory` for testability (default: creates real PostHog client)
+  - Use **lazy initialization**: PostHog client created on first `capture()` call, not in constructor
+  - Generate `distinctId` on first capture if missing, persist via ConfigService
+  - Implement `capture()`, `captureError()`, `shutdown()`
+  - Implement `sanitizeStack()` private method (see Error Stack Sanitization)
+  - **Log all captured events at INFO level**: `this.logger.info('Telemetry event', { event, ...properties })`
+  - If `apiKey` is undefined/empty, service operates in no-op mode (no events sent)
+  - Add privacy comment: "Do NOT log user paths or PII"
+  - Files affected: `src/services/telemetry/posthog-telemetry-service.ts`
+  - Test criteria: Service instantiates, events captured when enabled, events logged at INFO, no-op when disabled or no API key
+
+- [x] **Step 5: Create mock PostHog client for testing**
+  - Create `src/services/telemetry/posthog-client.state-mock.ts`
+  - Define `PostHogClientMockState` interface:
+    ```typescript
+    interface PostHogClientMockState extends MockState {
+      readonly capturedEvents: readonly CapturedEvent[];
+      readonly flushed: boolean;
+      readonly shutdownCalled: boolean;
+      snapshot(): Snapshot;
+      toString(): string;
+    }
+    ```
+  - Implement in-memory event capture with behavioral state
+  - Add custom matchers: `toHaveCaptured(eventName)`, `toHaveCapturedError()`
+  - Export `createMockPostHogClientFactory()` that returns mock with `$` state accessor
+  - Files affected: `src/services/telemetry/posthog-client.state-mock.ts`
+  - Test criteria: Mock captures events, matchers work correctly
+
+- [x] **Step 6: Create behavioral logger mock for testing**
+  - Create `src/services/telemetry/logger.state-mock.ts` (or extend existing if available)
+  - Define `LoggerMockState` with `loggedEntries` array
+  - Add custom matcher: `toHaveLoggedAtInfo(properties)`
+  - Files affected: `src/services/telemetry/logger.state-mock.ts`
+  - Test criteria: Logger mock captures log calls with level and properties
+
+- [x] **Step 7: Write integration tests**
+  - Create `src/services/telemetry/posthog-telemetry-service.integration.test.ts`
+  - Use behavioral mocks for PostHogClient and Logger
+  - Use real ConfigService with FileSystemLayer mock (not ConfigService mock)
+  - Reset mocks in `beforeEach` using `$.reset()` pattern
+  - Test cases:
+    - Captures app_launched when enabled
+    - No-op when telemetry disabled in config
+    - No-op when API key is missing
+    - Captures unhandled errors
+    - Sanitizes user paths from error stacks
+    - Shutdown flushes events
+    - Uses persisted distinctId across restarts
+    - Logs all events at INFO level (via behavioral logger mock)
+  - Files affected: `src/services/telemetry/posthog-telemetry-service.integration.test.ts`
+  - Test criteria: All tests pass
+
+- [x] **Step 8: Wire TelemetryService into bootstrap**
+  - Create service after `configService` in `bootstrap()`, between lines 697-699 in `src/main/index.ts`
+  - Call `telemetryService.capture('app_launched', { ... })` after initialization
+  - Register error handlers using `process.prependListener()` (not `process.on()`) to capture before other handlers:
+    - `process.prependListener('uncaughtException', ...)` - call `captureError()` then re-throw
+    - `process.prependListener('unhandledRejection', ...)` - call `captureError()` then re-throw
+  - Call `telemetryService.shutdown()` in app quit handler (ensure flush before exit)
+  - Files affected: `src/main/index.ts`
+  - Test criteria: Events appear in PostHog dashboard when running dev mode with `.env.local`
+
+- [x] **Step 9: Configure PostHog build-time injection**
+  - Add `__POSTHOG_API_KEY__` to Vite `define` config (reads from `process.env.POSTHOG_API_KEY`)
+  - Add `__POSTHOG_HOST__` to Vite `define` config (reads from `process.env.POSTHOG_HOST`, default `https://eu.posthog.com`)
+  - Add TypeScript declarations to `src/globals.d.ts` (or `vite-env.d.ts`):
+    ```typescript
+    declare const __POSTHOG_API_KEY__: string | undefined;
+    declare const __POSTHOG_HOST__: string | undefined;
+    ```
+  - Add `.env.local` to `.gitignore` (for local development with key)
+  - Add `.env.example` with placeholder values and comments
+  - Update GitHub Actions workflow to pass secret to build step: `POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}`
+  - Files affected: `vite.config.ts`, `.env.example`, `.gitignore`, `.github/workflows/build.yml`, `src/globals.d.ts`
+  - Test criteria:
+    - CI builds inject key from GitHub secret
+    - Local dev without `.env.local` runs with telemetry disabled (no-op)
+    - Key never appears in source or logs
+    - TypeScript compiles without errors for global constants
+
+- [x] **Step 10: Update documentation**
+  - Update `docs/ARCHITECTURE.md` App Services table to include:
+    | TelemetryService | PostHog analytics for DAU, version, platform, errors | Implemented |
+  - Update `CLAUDE.md` to note that `posthog-node` SDK's internal HTTP is an acceptable exception (like `ignore` package) since it's a third-party library with no I/O abstraction needed
+  - Files affected: `docs/ARCHITECTURE.md`, `CLAUDE.md`
+  - Test criteria: Documentation accurately reflects new service
+
+## Testing Strategy
+
+### Integration Tests
+
+Test behavior through TelemetryService with behavioral mocks. Reset all mocks in `beforeEach` using `$.reset()`.
+
+| #   | Test Case                          | Entry Point                       | Boundary Mocks      | Behavior Verified                                                  |
+| --- | ---------------------------------- | --------------------------------- | ------------------- | ------------------------------------------------------------------ |
+| 1   | Captures app_launched when enabled | `TelemetryService.capture()`      | PostHogClient       | `expect(mock).toHaveCaptured('app_launched')`                      |
+| 2   | No-op when telemetry disabled      | `TelemetryService.capture()`      | PostHogClient       | `expect(mock).not.toHaveCaptured(...)`                             |
+| 3   | No-op when API key missing         | `TelemetryService.capture()`      | PostHogClient       | `expect(mock).not.toHaveCaptured(...)`                             |
+| 4   | Captures error on exception        | `TelemetryService.captureError()` | PostHogClient       | `expect(mock).toHaveCapturedError()`                               |
+| 5   | Sanitizes user paths from stacks   | `TelemetryService.captureError()` | PostHogClient       | Stack does not contain home directory                              |
+| 6   | Shutdown flushes pending events    | `TelemetryService.shutdown()`     | PostHogClient       | `expect(mock.$.flushed).toBe(true)`                                |
+| 7   | Uses persisted distinctId          | Constructor                       | FileSystemLayer     | Same ID in config after restart                                    |
+| 8   | Logs events at INFO level          | `TelemetryService.capture()`      | Logger (behavioral) | `expect(loggerMock).toHaveLoggedAtInfo({ event: 'app_launched' })` |
+
+### Boundary Tests
+
+**Not required.** The `posthog-node` SDK is a well-tested third-party library. Our integration tests verify correct SDK usage via behavioral mocks. Actual network delivery is the SDK's responsibility.
+
+Sending real events would pollute production analytics, so we skip boundary tests for this service.
+
+### Manual Testing Checklist
+
+- [ ] Fresh install: telemetry enabled by default, distinctId generated
+- [ ] Set `telemetry.enabled: false` in config.json: no events sent
+- [ ] Run without API key (no `.env.local`): telemetry disabled, no errors
+- [ ] Cause unhandled exception: error event captured with sanitized stack
+- [ ] Check PostHog dashboard: see app_launched events with correct properties
+- [ ] Check app logs: telemetry events appear at INFO level with `[telemetry]` scope
+
+## Dependencies
+
+| Package        | Purpose                           | Approved |
+| -------------- | --------------------------------- | -------- |
+| `posthog-node` | PostHog Node.js SDK for analytics | [x]      |
+
+**User must approve all dependencies before implementation begins.**
+**Dependencies are installed via `pnpm add <package>` to use the latest versions.**
+
+**Note**: The `posthog-node` SDK uses internal HTTP calls. This is an acceptable exception to the External System Access Rules (similar to the `ignore` package) because it's a third-party library and we don't need to abstract its internal networking.
+
+## Documentation Updates
+
+### Files to Update
+
+| File                   | Changes Required                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `docs/ARCHITECTURE.md` | Add TelemetryService to App Services table                                                |
+| `CLAUDE.md`            | Add note that `posthog-node` SDK is acceptable exception for HTTP (like `ignore` package) |
+
+### New Documentation Required
+
+None.
+
+## Definition of Done
+
+- [ ] All implementation steps complete
+- [ ] `pnpm validate:fix` passes
+- [ ] Integration tests pass
+- [ ] Manual testing checklist complete
+- [ ] Events visible in PostHog dashboard (with `.env.local` configured)
+- [ ] Events logged at INFO level (visible in app logs)
+- [ ] GitHub secret `POSTHOG_API_KEY` configured
+- [ ] Documentation updated (ARCHITECTURE.md, CLAUDE.md)
+- [ ] CI passed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
+      posthog-node:
+        specifier: ^5.24.2
+        version: 5.24.2
       simple-git:
         specifier: ^3.30.0
         version: 3.30.0
@@ -1112,6 +1115,9 @@ packages:
     resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.14.0':
+    resolution: {integrity: sha512-havjGYHwL8Gy6LXIR911h+M/sYlJLQbepxP/cc1M7Cp3v8F92bzpqkbuvUIUyb7/izkxfGwc9wMqKAo0QxMTrg==}
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
     resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
@@ -3706,6 +3712,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-node@5.24.2:
+    resolution: {integrity: sha512-cywIUYtSIC9BilgLlZd1R2xNk6omKL6tywG/SCPmUJKeG2jhjvJHSrHXYx4x3uQsUjn8aB9UVI8km+W326Zm8g==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
@@ -4210,10 +4220,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -5567,6 +5579,10 @@ snapshots:
   '@playwright/test@1.57.0':
     dependencies:
       playwright: 1.57.0
+
+  '@posthog/core@1.14.0':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
@@ -8521,6 +8537,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-node@5.24.2:
+    dependencies:
+      '@posthog/core': 1.14.0
 
   postject@1.0.0-alpha.6:
     dependencies:

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,3 +9,17 @@
  * Dev builds: "{commit-date}-dev.{short-hash}[-dirty]"
  */
 declare const __APP_VERSION__: string;
+
+/**
+ * PostHog API key for telemetry.
+ * Injected from POSTHOG_API_KEY environment variable during build.
+ * Undefined in development unless .env.local is configured.
+ */
+declare const __POSTHOG_API_KEY__: string | undefined;
+
+/**
+ * PostHog host URL for telemetry.
+ * Injected from POSTHOG_HOST environment variable during build.
+ * Defaults to EU region (https://eu.posthog.com).
+ */
+declare const __POSTHOG_HOST__: string | undefined;

--- a/src/services/config/config-service.ts
+++ b/src/services/config/config-service.ts
@@ -143,6 +143,25 @@ export class ConfigService {
       return null;
     }
 
+    // Check telemetry field (optional for backwards compatibility)
+    let telemetry: { enabled: boolean; distinctId?: string } | undefined;
+    if (obj.telemetry !== undefined) {
+      if (typeof obj.telemetry !== "object" || obj.telemetry === null) {
+        return null;
+      }
+      const tel = obj.telemetry as Record<string, unknown>;
+      if (typeof tel.enabled !== "boolean") {
+        return null;
+      }
+      if (tel.distinctId !== undefined && typeof tel.distinctId !== "string") {
+        return null;
+      }
+      telemetry = {
+        enabled: tel.enabled,
+        ...(tel.distinctId !== undefined && { distinctId: tel.distinctId as string }),
+      };
+    }
+
     return {
       agent: obj.agent as ConfigAgentType,
       versions: {
@@ -150,6 +169,7 @@ export class ConfigService {
         opencode: versions.opencode as string | null,
         codeServer: versions.codeServer as string,
       },
+      ...(telemetry !== undefined && { telemetry }),
     };
   }
 }

--- a/src/services/config/types.ts
+++ b/src/services/config/types.ts
@@ -26,6 +26,16 @@ export interface VersionConfig {
 }
 
 /**
+ * Telemetry configuration.
+ */
+export interface TelemetryConfig {
+  /** Whether telemetry is enabled. Default: true */
+  readonly enabled: boolean;
+  /** Anonymous user ID for PostHog. Generated on first launch. */
+  readonly distinctId?: string;
+}
+
+/**
  * Application configuration stored in config.json.
  */
 export interface AppConfig {
@@ -33,6 +43,8 @@ export interface AppConfig {
   readonly agent: ConfigAgentType;
   /** Binary version configuration */
   readonly versions: VersionConfig;
+  /** Telemetry configuration. Optional for backwards compatibility. */
+  readonly telemetry?: TelemetryConfig;
 }
 
 /**
@@ -45,5 +57,8 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
     claude: null,
     opencode: null,
     codeServer: "4.107.0",
+  },
+  telemetry: {
+    enabled: true,
   },
 };

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -50,7 +50,8 @@ export type LoggerName =
   | "dialog" // DialogLayer - system dialogs
   | "menu" // MenuLayer - application menu
   | "workspace-file" // WorkspaceFileService - .code-workspace file management
-  | "config"; // ConfigService - application config
+  | "config" // ConfigService - application config
+  | "telemetry"; // TelemetryService - PostHog analytics
 
 /**
  * Context data for log entries.

--- a/src/services/telemetry/index.ts
+++ b/src/services/telemetry/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Telemetry service exports.
+ */
+
+export type {
+  TelemetryService,
+  TelemetryServiceDeps,
+  PostHogClient,
+  PostHogClientFactory,
+} from "./types";
+
+export { PostHogTelemetryService, createTelemetryService } from "./posthog-telemetry-service";

--- a/src/services/telemetry/posthog-client.state-mock.ts
+++ b/src/services/telemetry/posthog-client.state-mock.ts
@@ -1,0 +1,278 @@
+/**
+ * Behavioral mock for PostHog client with in-memory state.
+ *
+ * Provides a stateful mock that simulates PostHog behavior:
+ * - In-memory event storage
+ * - Shutdown tracking
+ * - Custom matchers for behavioral assertions
+ *
+ * @example
+ * const { factory, getMock } = createMockPostHogClientFactory();
+ * const service = new PostHogTelemetryService({ postHogClientFactory: factory, ... });
+ *
+ * service.capture('app_launched', { version: '1.0.0' });
+ * expect(getMock()).toHaveCaptured('app_launched');
+ */
+
+import { expect } from "vitest";
+import type { PostHogClient, PostHogClientFactory } from "./types";
+import type {
+  MockState,
+  MockWithState,
+  Snapshot,
+  MatcherImplementationsFor,
+} from "../../test/state-mock";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Captured event in the mock.
+ */
+export interface CapturedEvent {
+  readonly distinctId: string;
+  readonly event: string;
+  readonly properties?: Record<string, unknown> | undefined;
+  readonly timestamp: number;
+}
+
+/**
+ * State interface for the PostHog client mock.
+ */
+export interface PostHogClientMockState extends MockState {
+  /** All captured events */
+  readonly capturedEvents: readonly CapturedEvent[];
+
+  /** Whether shutdown() has been called */
+  readonly shutdownCalled: boolean;
+
+  /** Reset state for next test */
+  reset(): void;
+
+  snapshot(): Snapshot;
+  toString(): string;
+}
+
+/**
+ * PostHog client with behavioral mock state access via `$` property.
+ */
+export type MockPostHogClient = PostHogClient & MockWithState<PostHogClientMockState>;
+
+// =============================================================================
+// State Implementation
+// =============================================================================
+
+class PostHogClientMockStateImpl implements PostHogClientMockState {
+  private _capturedEvents: CapturedEvent[] = [];
+  private _shutdownCalled: boolean = false;
+
+  get capturedEvents(): readonly CapturedEvent[] {
+    return [...this._capturedEvents];
+  }
+
+  get shutdownCalled(): boolean {
+    return this._shutdownCalled;
+  }
+
+  addEvent(event: CapturedEvent): void {
+    this._capturedEvents.push(event);
+  }
+
+  markShutdown(): void {
+    this._shutdownCalled = true;
+  }
+
+  reset(): void {
+    this._capturedEvents = [];
+    this._shutdownCalled = false;
+  }
+
+  snapshot(): Snapshot {
+    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+  }
+
+  toString(): string {
+    const events = this._capturedEvents
+      .map((e) => `  ${e.event}: ${JSON.stringify(e.properties ?? {})}`)
+      .join("\n");
+    return [
+      `PostHogClient (shutdown: ${this._shutdownCalled})`,
+      `Events (${this._capturedEvents.length}):`,
+      events || "  (none)",
+    ].join("\n");
+  }
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+/**
+ * Result of createMockPostHogClientFactory.
+ */
+export interface MockPostHogClientFactoryResult {
+  /** Factory function to pass to TelemetryServiceDeps */
+  factory: PostHogClientFactory;
+
+  /**
+   * Get the mock client instance.
+   * Returns null if factory hasn't been called yet.
+   */
+  getMock(): MockPostHogClient | null;
+}
+
+/**
+ * Create a mock PostHog client factory for testing.
+ *
+ * @example
+ * const { factory, getMock } = createMockPostHogClientFactory();
+ * const service = new PostHogTelemetryService({
+ *   postHogClientFactory: factory,
+ *   apiKey: 'test-key',
+ *   ...
+ * });
+ *
+ * service.capture('app_launched', { version: '1.0.0' });
+ *
+ * const mock = getMock();
+ * expect(mock).toHaveCaptured('app_launched');
+ */
+export function createMockPostHogClientFactory(): MockPostHogClientFactoryResult {
+  let mockClient: MockPostHogClient | null = null;
+
+  const factory: PostHogClientFactory = (_apiKey: string, _options: { host: string }) => {
+    const state = new PostHogClientMockStateImpl();
+
+    const client: PostHogClient = {
+      capture(params: {
+        distinctId: string;
+        event: string;
+        properties?: Record<string, unknown>;
+      }): void {
+        state.addEvent({
+          distinctId: params.distinctId,
+          event: params.event,
+          properties: params.properties,
+          timestamp: Date.now(),
+        });
+      },
+
+      async shutdown(): Promise<void> {
+        state.markShutdown();
+      },
+    };
+
+    mockClient = Object.assign(client, { $: state });
+    return mockClient;
+  };
+
+  return {
+    factory,
+    getMock: () => mockClient,
+  };
+}
+
+// =============================================================================
+// Custom Matchers
+// =============================================================================
+
+/**
+ * Custom matchers for PostHog client mock assertions.
+ */
+interface PostHogClientMatchers {
+  /**
+   * Assert that an event was captured.
+   *
+   * @param eventName - Event name to check
+   * @param properties - Optional properties to match (partial match)
+   */
+  toHaveCaptured(eventName: string, properties?: Record<string, unknown>): void;
+
+  /**
+   * Assert that an error event was captured.
+   */
+  toHaveCapturedError(): void;
+
+  /**
+   * Assert that shutdown was called.
+   */
+  toHaveBeenShutdown(): void;
+}
+
+declare module "vitest" {
+  interface Assertion<T> extends PostHogClientMatchers {}
+}
+
+export const postHogClientMatchers: MatcherImplementationsFor<
+  MockPostHogClient,
+  PostHogClientMatchers
+> = {
+  toHaveCaptured(received, eventName, properties?) {
+    const events = received.$.capturedEvents;
+    const matchingEvent = events.find((e) => {
+      if (e.event !== eventName) return false;
+      if (properties) {
+        // Partial match on properties
+        for (const [key, value] of Object.entries(properties)) {
+          if (e.properties?.[key] !== value) return false;
+        }
+      }
+      return true;
+    });
+
+    if (!matchingEvent) {
+      const eventsList = events.map((e) => `  - ${e.event}`).join("\n") || "  (none)";
+      return {
+        pass: false,
+        message: () =>
+          properties
+            ? `Expected to capture event "${eventName}" with properties ${JSON.stringify(properties)}, but it was not found.\nCaptured events:\n${eventsList}`
+            : `Expected to capture event "${eventName}", but it was not found.\nCaptured events:\n${eventsList}`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () => `Expected not to capture event "${eventName}", but it was found`,
+    };
+  },
+
+  toHaveCapturedError(received) {
+    const events = received.$.capturedEvents;
+    const errorEvent = events.find((e) => e.event === "error");
+
+    if (!errorEvent) {
+      const eventsList = events.map((e) => `  - ${e.event}`).join("\n") || "  (none)";
+      return {
+        pass: false,
+        message: () =>
+          `Expected to capture an error event, but none was found.\nCaptured events:\n${eventsList}`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () => `Expected not to capture an error event, but one was found`,
+    };
+  },
+
+  toHaveBeenShutdown(received) {
+    if (!received.$.shutdownCalled) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected PostHog client to have been shut down, but shutdown() was not called`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () =>
+        `Expected PostHog client not to have been shut down, but shutdown() was called`,
+    };
+  },
+};
+
+// Register matchers with expect
+expect.extend(postHogClientMatchers);

--- a/src/services/telemetry/posthog-telemetry-service.integration.test.ts
+++ b/src/services/telemetry/posthog-telemetry-service.integration.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Integration tests for PostHogTelemetryService.
+ *
+ * Tests use behavioral mocks for PostHogClient and real ConfigService
+ * with FileSystemLayer mock.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { PostHogTelemetryService } from "./posthog-telemetry-service";
+import { ConfigService } from "../config/config-service";
+import type { TelemetryServiceDeps } from "./types";
+import type { AppConfig } from "../config/types";
+import { createMockPathProvider } from "../platform/path-provider.test-utils";
+import { createMockBuildInfo } from "../platform/build-info.test-utils";
+import { createMockPlatformInfo } from "../platform/platform-info.test-utils";
+import {
+  createFileSystemMock,
+  file,
+  directory,
+  type MockFileSystemLayer,
+} from "../platform/filesystem.state-mock";
+import { createBehavioralLogger, type BehavioralLogger } from "../logging/logging.test-utils";
+import type { PathProvider } from "../platform/path-provider";
+import type { BuildInfo } from "../platform/build-info";
+import type { PlatformInfo } from "../platform/platform-info";
+import {
+  createMockPostHogClientFactory,
+  type MockPostHogClient,
+} from "./posthog-client.state-mock";
+
+describe("PostHogTelemetryService", () => {
+  let fileSystem: MockFileSystemLayer;
+  let pathProvider: PathProvider;
+  let buildInfo: BuildInfo;
+  let platformInfo: PlatformInfo;
+  let configService: ConfigService;
+  let logger: BehavioralLogger;
+
+  // Mock PostHog client factory
+  let postHogFactory: ReturnType<typeof createMockPostHogClientFactory>;
+
+  beforeEach(() => {
+    // Reset mocks
+    pathProvider = createMockPathProvider();
+    buildInfo = createMockBuildInfo({ version: "1.0.0", isDevelopment: false });
+    platformInfo = createMockPlatformInfo();
+
+    // Create filesystem with parent directory for config file
+    fileSystem = createFileSystemMock({
+      entries: {
+        [pathProvider.dataRootDir.toString()]: directory(),
+      },
+    });
+
+    // Create real ConfigService with mock filesystem
+    configService = new ConfigService({
+      fileSystem,
+      pathProvider,
+      logger: createBehavioralLogger(),
+    });
+
+    // Create behavioral logger for telemetry service
+    logger = createBehavioralLogger();
+
+    // Create fresh PostHog mock factory
+    postHogFactory = createMockPostHogClientFactory();
+  });
+
+  function createDeps(overrides?: Partial<TelemetryServiceDeps>): TelemetryServiceDeps {
+    return {
+      buildInfo,
+      platformInfo,
+      configService,
+      logger,
+      apiKey: "test-api-key",
+      host: "https://test.posthog.com",
+      postHogClientFactory: postHogFactory.factory,
+      ...overrides,
+    };
+  }
+
+  function getMock(): MockPostHogClient {
+    const mock = postHogFactory.getMock();
+    if (!mock) {
+      throw new Error("PostHog client not created yet");
+    }
+    return mock;
+  }
+
+  describe("capture", () => {
+    it("captures app_launched when enabled", async () => {
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", {
+        platform: "linux",
+        arch: "x64",
+        isDevelopment: false,
+      });
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const mock = getMock();
+      expect(mock).toHaveCaptured("app_launched");
+      expect(mock).toHaveCaptured("app_launched", { platform: "linux" });
+      expect(mock).toHaveCaptured("app_launched", { version: "1.0.0" });
+    });
+
+    it("no-op when telemetry disabled in config", async () => {
+      // Pre-create config with telemetry disabled
+      const config: AppConfig = {
+        agent: null,
+        versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+        telemetry: { enabled: false },
+      };
+      fileSystem.$.setEntry(pathProvider.configPath.toString(), file(JSON.stringify(config)));
+
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", { platform: "linux" });
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No mock created because telemetry is disabled
+      expect(postHogFactory.getMock()).toBeNull();
+    });
+
+    it("no-op when API key is missing", async () => {
+      const service = new PostHogTelemetryService(createDeps({ apiKey: undefined }));
+
+      service.capture("app_launched", { platform: "linux" });
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No mock created because no API key
+      expect(postHogFactory.getMock()).toBeNull();
+    });
+
+    it("no-op when API key is empty string", async () => {
+      const service = new PostHogTelemetryService(createDeps({ apiKey: "" }));
+
+      service.capture("app_launched", { platform: "linux" });
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No mock created because API key is empty
+      expect(postHogFactory.getMock()).toBeNull();
+    });
+
+    it("logs events at INFO level", async () => {
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", { platform: "linux" });
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const infoMessages = logger.getMessagesByLevel("info");
+      expect(infoMessages.length).toBeGreaterThan(0);
+      expect(infoMessages.some((m) => m.message === "Telemetry event")).toBe(true);
+      expect(infoMessages.some((m) => m.context?.event === "app_launched")).toBe(true);
+    });
+  });
+
+  describe("captureError", () => {
+    it("captures error events", async () => {
+      const service = new PostHogTelemetryService(createDeps());
+
+      const error = new Error("Test error message");
+      service.captureError(error);
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const mock = getMock();
+      expect(mock).toHaveCapturedError();
+      expect(mock).toHaveCaptured("error", { message: "Test error message" });
+    });
+
+    it("sanitizes user paths from error stacks", async () => {
+      // Use platform-specific home directory
+      const homeDir = platformInfo.homeDir;
+      const service = new PostHogTelemetryService(createDeps());
+
+      // Create error with home directory in stack
+      const error = new Error("Test error");
+      error.stack = `Error: Test error
+    at Object.<anonymous> (${homeDir}/projects/myapp/src/index.ts:10:5)
+    at Module._compile (node:internal/modules/cjs/loader:1369:14)
+    at ${homeDir}/.config/myapp/plugin.js:5:10`;
+
+      service.captureError(error);
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const mock = getMock();
+      const errorEvent = mock.$.capturedEvents.find((e) => e.event === "error");
+      expect(errorEvent).toBeDefined();
+
+      const stack = errorEvent?.properties?.stack as string;
+      expect(stack).not.toContain(homeDir);
+      expect(stack).toContain("<home>");
+    });
+  });
+
+  describe("shutdown", () => {
+    it("flushes pending events on shutdown", async () => {
+      const service = new PostHogTelemetryService(createDeps());
+
+      // Trigger initialization by capturing an event
+      service.capture("app_launched", {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await service.shutdown();
+
+      const mock = getMock();
+      expect(mock).toHaveBeenShutdown();
+    });
+  });
+
+  describe("distinctId persistence", () => {
+    it("uses persisted distinctId across restarts", async () => {
+      const testDistinctId = "test-uuid-12345";
+
+      // Pre-create config with existing distinctId
+      const config: AppConfig = {
+        agent: null,
+        versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+        telemetry: { enabled: true, distinctId: testDistinctId },
+      };
+      fileSystem.$.setEntry(pathProvider.configPath.toString(), file(JSON.stringify(config)));
+
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", {});
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const mock = getMock();
+      const event = mock.$.capturedEvents[0];
+      expect(event?.distinctId).toBe(testDistinctId);
+    });
+
+    it("generates and persists new distinctId if missing", async () => {
+      // Start with default config (no distinctId)
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", {});
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Check that distinctId was generated and persisted
+      const configContent = fileSystem.$.entries.get(pathProvider.configPath.toString());
+      expect(configContent?.type).toBe("file");
+      if (configContent?.type === "file") {
+        const savedConfig = JSON.parse(configContent.content as string) as AppConfig;
+        expect(savedConfig.telemetry?.distinctId).toBeDefined();
+        expect(savedConfig.telemetry?.distinctId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+        );
+      }
+    });
+  });
+
+  describe("backwards compatibility", () => {
+    it("enables telemetry by default when telemetry config is missing", async () => {
+      // Pre-create config without telemetry field (old config format)
+      const config = {
+        agent: null,
+        versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+      };
+      fileSystem.$.setEntry(pathProvider.configPath.toString(), file(JSON.stringify(config)));
+
+      const service = new PostHogTelemetryService(createDeps());
+
+      service.capture("app_launched", {});
+
+      // Wait for async initialization
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should have captured the event (telemetry enabled by default)
+      const mock = getMock();
+      expect(mock).toHaveCaptured("app_launched");
+    });
+  });
+});

--- a/src/services/telemetry/posthog-telemetry-service.ts
+++ b/src/services/telemetry/posthog-telemetry-service.ts
@@ -1,0 +1,254 @@
+/**
+ * PostHog telemetry service implementation.
+ *
+ * Provides anonymous product analytics using PostHog.
+ * PRIVACY NOTE: Do NOT log user paths or PII.
+ *
+ * Features:
+ * - Lazy initialization: PostHog client created on first capture
+ * - No-op mode when API key missing or telemetry disabled
+ * - All events logged at INFO level for visibility
+ * - Error stack sanitization (strips home directory, limits length)
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  TelemetryService,
+  TelemetryServiceDeps,
+  PostHogClient,
+  PostHogClientFactory,
+} from "./types";
+
+/** Default PostHog host (EU region) */
+const DEFAULT_HOST = "https://eu.posthog.com";
+
+/** Maximum stack frames to include */
+const MAX_STACK_FRAMES = 10;
+
+/** Maximum stack string length */
+const MAX_STACK_LENGTH = 2000;
+
+/** Cached PostHog constructor for lazy loading */
+let PostHogConstructor: typeof import("posthog-node").PostHog | null = null;
+
+/**
+ * Create the default PostHog client using posthog-node SDK.
+ * Uses cached constructor to avoid repeated dynamic imports.
+ */
+async function createDefaultPostHogClient(
+  apiKey: string,
+  options: { host: string }
+): Promise<PostHogClient> {
+  if (!PostHogConstructor) {
+    const posthogModule = await import("posthog-node");
+    PostHogConstructor = posthogModule.PostHog;
+  }
+  return new PostHogConstructor(apiKey, options);
+}
+
+/**
+ * PostHog telemetry service implementation.
+ */
+export class PostHogTelemetryService implements TelemetryService {
+  private readonly deps: TelemetryServiceDeps;
+  private readonly host: string;
+  private readonly postHogClientFactory: PostHogClientFactory;
+
+  /** PostHog client - lazily initialized on first capture */
+  private client: PostHogClient | null = null;
+
+  /** Cached distinctId - loaded from config or generated */
+  private distinctId: string | null = null;
+
+  /** Whether telemetry is enabled (checked on first capture) */
+  private enabled: boolean | null = null;
+
+  constructor(deps: TelemetryServiceDeps) {
+    this.deps = deps;
+    this.host = deps.host ?? DEFAULT_HOST;
+    this.postHogClientFactory = deps.postHogClientFactory ?? createDefaultPostHogClient;
+  }
+
+  /**
+   * Initialize the PostHog client lazily.
+   * Returns false if telemetry should be disabled.
+   */
+  private async ensureInitialized(): Promise<boolean> {
+    // Already initialized
+    if (this.enabled !== null) {
+      return this.enabled;
+    }
+
+    // Check if API key is available
+    if (!this.deps.apiKey || this.deps.apiKey.trim() === "") {
+      this.deps.logger.debug("Telemetry disabled: no API key");
+      this.enabled = false;
+      return false;
+    }
+
+    // Load config to check if telemetry is enabled
+    const config = await this.deps.configService.load();
+
+    // Default to enabled if telemetry config is missing (backwards compatibility)
+    const telemetryEnabled = config.telemetry?.enabled ?? true;
+
+    if (!telemetryEnabled) {
+      this.deps.logger.debug("Telemetry disabled: config");
+      this.enabled = false;
+      return false;
+    }
+
+    // Get or generate distinctId
+    if (config.telemetry?.distinctId) {
+      this.distinctId = config.telemetry.distinctId;
+    } else {
+      // Generate new distinctId and persist it
+      this.distinctId = randomUUID();
+      const updatedConfig = {
+        ...config,
+        telemetry: {
+          ...config.telemetry,
+          enabled: true,
+          distinctId: this.distinctId,
+        },
+      };
+      await this.deps.configService.save(updatedConfig);
+      this.deps.logger.debug("Generated new distinctId");
+    }
+
+    // Create PostHog client (factory can be sync or async)
+    this.client = await Promise.resolve(
+      this.postHogClientFactory(this.deps.apiKey, { host: this.host })
+    );
+    this.enabled = true;
+
+    this.deps.logger.debug("Telemetry initialized", { host: this.host });
+    return true;
+  }
+
+  /**
+   * Capture an analytics event.
+   */
+  capture(event: string, properties?: Record<string, unknown>): void {
+    // Fire and forget - don't block on async initialization
+    void this.captureAsync(event, properties);
+  }
+
+  private async captureAsync(event: string, properties?: Record<string, unknown>): Promise<void> {
+    const initialized = await this.ensureInitialized();
+    if (!initialized || !this.client || !this.distinctId) {
+      return;
+    }
+
+    // Always include version in properties
+    const fullProperties = {
+      ...properties,
+      version: this.deps.buildInfo.version,
+    };
+
+    // Log at INFO level for visibility
+    this.deps.logger.info("Telemetry event", { event, ...fullProperties });
+
+    // Capture to PostHog
+    this.client.capture({
+      distinctId: this.distinctId,
+      event,
+      properties: fullProperties,
+    });
+  }
+
+  /**
+   * Capture an error event with sanitized stack trace.
+   */
+  captureError(error: Error): void {
+    void this.captureErrorAsync(error);
+  }
+
+  private async captureErrorAsync(error: Error): Promise<void> {
+    const initialized = await this.ensureInitialized();
+    if (!initialized || !this.client || !this.distinctId) {
+      return;
+    }
+
+    const sanitizedStack = this.sanitizeStack(error.stack);
+
+    const properties = {
+      message: error.message,
+      stack: sanitizedStack,
+      version: this.deps.buildInfo.version,
+    };
+
+    // Log at INFO level (not error - that would duplicate error logs)
+    this.deps.logger.info("Telemetry error event", { message: error.message });
+
+    this.client.capture({
+      distinctId: this.distinctId,
+      event: "error",
+      properties,
+    });
+  }
+
+  /**
+   * Sanitize error stack trace for privacy.
+   * - Strips home directory paths
+   * - Strips project paths (makes them relative)
+   * - Limits to MAX_STACK_FRAMES frames
+   * - Truncates to MAX_STACK_LENGTH characters
+   * - Removes query parameters from URLs
+   */
+  private sanitizeStack(stack: string | undefined): string | undefined {
+    if (!stack) {
+      return undefined;
+    }
+
+    // Get home directory for sanitization (use injected platformInfo)
+    const homeDir = this.deps.platformInfo.homeDir;
+    // Escape special regex characters in path
+    const homeDirEscaped = homeDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Also handle Windows paths with forward slashes
+    const homeDirRegex = new RegExp(homeDirEscaped.replace(/\\\\/g, "[\\\\/]"), "gi");
+
+    // Split into lines, limit frames, and sanitize
+    const lines = stack.split("\n");
+    const limitedLines = lines.slice(0, MAX_STACK_FRAMES + 1); // +1 for error message line
+
+    const sanitizedLines = limitedLines.map((line) => {
+      let sanitized = line;
+
+      // Replace home directory with <home>
+      sanitized = sanitized.replace(homeDirRegex, "<home>");
+
+      // Remove query parameters from URLs (e.g., file:///path?query=value)
+      sanitized = sanitized.replace(/\?[^\s)]+/g, "");
+
+      return sanitized;
+    });
+
+    let result = sanitizedLines.join("\n");
+
+    // Truncate if too long
+    if (result.length > MAX_STACK_LENGTH) {
+      result = result.substring(0, MAX_STACK_LENGTH) + "...";
+    }
+
+    return result;
+  }
+
+  /**
+   * Flush pending events and shut down.
+   */
+  async shutdown(): Promise<void> {
+    if (this.client) {
+      this.deps.logger.debug("Telemetry shutting down");
+      await this.client.shutdown();
+      this.client = null;
+    }
+  }
+}
+
+/**
+ * Create a TelemetryService instance.
+ */
+export function createTelemetryService(deps: TelemetryServiceDeps): TelemetryService {
+  return new PostHogTelemetryService(deps);
+}

--- a/src/services/telemetry/types.ts
+++ b/src/services/telemetry/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Telemetry service types and interfaces.
+ *
+ * Provides types for anonymous product analytics via PostHog.
+ * PRIVACY NOTE: No user paths or PII should ever be collected.
+ */
+
+import type { BuildInfo } from "../platform/build-info";
+import type { PlatformInfo } from "../platform/platform-info";
+import type { ConfigService } from "../config/config-service";
+import type { Logger } from "../logging";
+
+/**
+ * PostHog client interface (subset we use).
+ * Extracted from posthog-node for dependency injection and testing.
+ */
+export interface PostHogClient {
+  /**
+   * Capture an analytics event.
+   */
+  capture(params: {
+    distinctId: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }): void;
+
+  /**
+   * Flush pending events and shut down the client.
+   */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Factory function to create a PostHog client.
+ * Injected for testability - tests provide a mock factory.
+ * Can be sync (for testing) or async (for lazy-loading the SDK).
+ */
+export type PostHogClientFactory = (
+  apiKey: string,
+  options: { host: string }
+) => PostHogClient | Promise<PostHogClient>;
+
+/**
+ * Dependencies for TelemetryService.
+ * Follows the project's dependency injection pattern.
+ */
+export interface TelemetryServiceDeps {
+  readonly buildInfo: BuildInfo;
+  readonly platformInfo: PlatformInfo;
+  readonly configService: ConfigService;
+  readonly logger: Logger;
+  /** PostHog API key. If undefined/empty, telemetry is disabled. */
+  readonly apiKey?: string | undefined;
+  /** PostHog host URL. Defaults to EU region. */
+  readonly host?: string | undefined;
+  /** Factory to create PostHog client. Defaults to real posthog-node. */
+  readonly postHogClientFactory?: PostHogClientFactory | undefined;
+}
+
+/**
+ * Telemetry service interface for product analytics.
+ *
+ * All events are also logged at INFO level for visibility.
+ * Service operates in no-op mode when:
+ * - API key is missing/empty
+ * - Telemetry is disabled in config
+ */
+export interface TelemetryService {
+  /**
+   * Capture an analytics event.
+   * Events are logged at INFO level.
+   *
+   * @param event - Event name (e.g., "app_launched")
+   * @param properties - Optional event properties
+   */
+  capture(event: string, properties?: Record<string, unknown>): void;
+
+  /**
+   * Capture an error event with sanitized stack trace.
+   * Stack traces have user paths stripped for privacy.
+   *
+   * @param error - Error to capture
+   */
+  captureError(error: Error): void;
+
+  /**
+   * Flush pending events and shut down.
+   * Call this before app exit to ensure events are sent.
+   */
+  shutdown(): Promise<void>;
+}


### PR DESCRIPTION
- Track daily active users via `app_launched` event
- Capture version, platform, and architecture distribution
- Handle unhandled exceptions with sanitized stack traces
- Lazy initialization with no-op mode when API key missing
- All events logged at INFO level for visibility
- API key injected at build time via GitHub secrets (`POSTHOG_API_KEY`) and variables (`POSTHOG_HOST`)
- Telemetry disabled by default in dev without `.env.local` configuration