### PR TITLE
fix(updater): configure update feed via env vars to avoid CI publish error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,9 @@ jobs:
       - name: Build
         env:
           CODEHYDRA_VERSION: ${{ steps.version.outputs.version }}
+          CODEHYDRA_UPDATE_PROVIDER: github
+          CODEHYDRA_UPDATE_OWNER: ${{ github.repository_owner }}
+          CODEHYDRA_UPDATE_REPO: ${{ github.event.repository.name }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: pnpm build

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -2,11 +2,9 @@ appId: com.codehydra.app
 productName: CodeHydra
 copyright: Copyright © 2025 CodeHydra
 
-# Auto-update configuration using GitHub Releases
-publish:
-  provider: github
-  owner: stefanhoelzl
-  repo: codehydra
+# Disable auto-publishing (release workflow handles GitHub Releases)
+# Update URL is configured via environment variables at build time
+publish: null
 
 # Build directories
 directories:

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,6 +11,11 @@ const appVersion = process.env.CODEHYDRA_VERSION ?? "0.0.0-dev";
 const posthogApiKey = process.env.POSTHOG_API_KEY;
 const posthogHost = process.env.POSTHOG_HOST ?? "https://eu.posthog.com";
 
+// Auto-update configuration - injected at build time
+const updateProvider = process.env.CODEHYDRA_UPDATE_PROVIDER;
+const updateOwner = process.env.CODEHYDRA_UPDATE_OWNER;
+const updateRepo = process.env.CODEHYDRA_UPDATE_REPO;
+
 export default defineConfig({
   main: {
     build: {
@@ -26,6 +31,10 @@ export default defineConfig({
       // PostHog constants - undefined if not configured (telemetry disabled)
       __POSTHOG_API_KEY__: posthogApiKey ? JSON.stringify(posthogApiKey) : "undefined",
       __POSTHOG_HOST__: JSON.stringify(posthogHost),
+      // Auto-update constants - undefined if not configured (updates disabled)
+      __UPDATE_PROVIDER__: updateProvider ? JSON.stringify(updateProvider) : "undefined",
+      __UPDATE_OWNER__: updateOwner ? JSON.stringify(updateOwner) : "undefined",
+      __UPDATE_REPO__: updateRepo ? JSON.stringify(updateRepo) : "undefined",
     },
     plugins: [
       // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -23,3 +23,21 @@ declare const __POSTHOG_API_KEY__: string | undefined;
  * Defaults to EU region (https://eu.posthog.com).
  */
 declare const __POSTHOG_HOST__: string | undefined;
+
+/**
+ * Provider for auto-update feed (e.g., "github").
+ * Injected from CODEHYDRA_UPDATE_PROVIDER during build.
+ */
+declare const __UPDATE_PROVIDER__: string | undefined;
+
+/**
+ * Owner for auto-update feed (e.g., GitHub username or org).
+ * Injected from CODEHYDRA_UPDATE_OWNER during build.
+ */
+declare const __UPDATE_OWNER__: string | undefined;
+
+/**
+ * Repository for auto-update feed.
+ * Injected from CODEHYDRA_UPDATE_REPO during build.
+ */
+declare const __UPDATE_REPO__: string | undefined;

--- a/src/services/auto-updater.ts
+++ b/src/services/auto-updater.ts
@@ -50,6 +50,15 @@ export class AutoUpdater {
     this.logger = deps.logger;
     this.isDevelopment = deps.isDevelopment;
 
+    // Configure update feed URL if build-time values are provided
+    if (__UPDATE_PROVIDER__ && __UPDATE_OWNER__ && __UPDATE_REPO__) {
+      autoUpdater.setFeedURL({
+        provider: __UPDATE_PROVIDER__ as "github",
+        owner: __UPDATE_OWNER__,
+        repo: __UPDATE_REPO__,
+      });
+    }
+
     // Configure electron-updater
     // autoInstallOnAppQuit is true by default
     autoUpdater.autoDownload = true;


### PR DESCRIPTION
- Set `publish: null` in electron-builder.yaml to prevent publish attempts during CI
- Inject update feed configuration via environment variables at build time
- Configure `autoUpdater.setFeedURL()` programmatically using injected values
- Add `CODEHYDRA_UPDATE_PROVIDER`, `CODEHYDRA_UPDATE_OWNER`, `CODEHYDRA_UPDATE_REPO` env vars to build workflow

Fixes release workflow failure caused by missing `GH_TOKEN` in package job.