### PR TITLE
fix(updater): include latest.yml in releases for auto-update

### DIFF
--- a/.github/workflows/build-code-server-windows.yaml
+++ b/.github/workflows/build-code-server-windows.yaml
@@ -232,6 +232,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "code-server $VERSION for Windows" \
             --notes-file release-notes.md \
+            --latest=false \
             "$ARCHIVE_NAME"
 
       - name: Summary

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,3 +159,12 @@ jobs:
           path: dist/${{ matrix.rename || matrix.output }}
           retention-days: 1
           if-no-files-found: error
+
+      - name: Upload update metadata
+        if: matrix.artifact == 'win-installer-x64' || matrix.artifact == 'linux-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-metadata-${{ matrix.artifact }}
+          path: dist/latest*.yml
+          retention-days: 1
+          if-no-files-found: warn

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: CodeHydra-*
+          pattern: "{CodeHydra-*,update-metadata-*}"
           merge-multiple: false
 
       - name: Prepare release assets
@@ -85,6 +85,13 @@ jobs:
           zip -r ../release-assets/CodeHydra-win-portable-x64.zip CodeHydra-win-portable-x64
           zip -r ../release-assets/CodeHydra-darwin-x64.zip CodeHydra-darwin-x64
           zip -r ../release-assets/CodeHydra-darwin-arm64.zip CodeHydra-darwin-arm64
+          cd ..
+
+          # Copy update metadata files for auto-updater
+          cp artifacts/update-metadata-win-installer-x64/latest.yml \
+             release-assets/latest.yml
+          cp artifacts/update-metadata-linux-x64/latest-linux.yml \
+             release-assets/latest-linux.yml
 
       - name: Generate checksums
         working-directory: release-assets


### PR DESCRIPTION
- Add `--latest=false` to code-server releases to prevent them from taking over the "Latest" designation
- Upload `latest.yml` and `latest-linux.yml` as artifacts in build workflow
- Include update metadata files in GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)