### PR TITLE
fix(sidekick): prevent agent terminal from persisting between sessions

### DIFF
--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -83,10 +83,12 @@ function openAgentTerminal(agentType: AgentType, env: Record<string, string>): v
   const command = agentType === "claude" ? "ch-claude" : "ch-opencode";
 
   // Create terminal in editor area using viewColumn
+  // isTransient prevents the terminal from being restored on VS Code restart
   agentTerminal = vscode.window.createTerminal({
     name: terminalName,
     location: { viewColumn: vscode.ViewColumn.Active },
     env: env,
+    isTransient: true,
   });
 
   agentTerminal.show();


### PR DESCRIPTION
- Add `isTransient: true` to terminal creation options so VS Code doesn't restore the terminal tab on restart
- Prevents confusion from disconnected terminal tabs from previous sessions