### PR TITLE
feat(git-clone): add clone from git URL functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,9 @@ Some components use external libraries directly without abstraction layers. Thes
 
 | Concept         | Description                                                                                                                |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Project         | Git repository path (container, not viewable)                                                                              |
+| Project         | Git repository path (container, not viewable). Can be local path or cloned from URL.                                       |
 | Workspace       | Git worktree (viewable in code-server) - NOT the main directory                                                            |
+| Remote Project  | Project cloned from git URL. Has `remoteUrl` field in config. Stored as bare clone in app-data.                            |
 | WebContentsView | Electron view for embedding (not iframe)                                                                                   |
 | Shortcut Mode   | Alt+X activates keyboard navigation. Keys: ↑↓ navigate, ←→ navigate idle, 1-0 jump, Enter new, Delete remove, Escape exits |
 | .keepfiles      | Config listing files to copy to new workspaces. Gitignore syntax with **inverted semantics**                               |

--- a/docs/API.md
+++ b/docs/API.md
@@ -770,13 +770,30 @@ const unsubscribe = on("workspace:switched", (event) => {
 
 #### `projects` - Project Management
 
-| Method       | Signature                                                  | Description                            |
-| ------------ | ---------------------------------------------------------- | -------------------------------------- |
-| `open`       | `(path: string) => Promise<Project>`                       | Open a git repository as a project     |
-| `close`      | `(projectId: ProjectId) => Promise<void>`                  | Close a project and all its workspaces |
-| `list`       | `() => Promise<readonly Project[]>`                        | List all open projects                 |
-| `get`        | `(projectId: ProjectId) => Promise<Project \| undefined>`  | Get a project by ID                    |
-| `fetchBases` | `(projectId: ProjectId) => Promise<{ bases: BaseInfo[] }>` | Fetch available base branches          |
+| Method       | Signature                                                                | Description                                           |
+| ------------ | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `open`       | `(path: string) => Promise<Project>`                                     | Open a git repository as a project                    |
+| `close`      | `(projectId: ProjectId, options?: ProjectCloseOptions) => Promise<void>` | Close a project and all its workspaces                |
+| `clone`      | `(url: string) => Promise<Project>`                                      | Clone a git repository from URL and open as a project |
+| `list`       | `() => Promise<readonly Project[]>`                                      | List all open projects                                |
+| `get`        | `(projectId: ProjectId) => Promise<Project \| undefined>`                | Get a project by ID                                   |
+| `fetchBases` | `(projectId: ProjectId) => Promise<{ bases: BaseInfo[] }>`               | Fetch available base branches                         |
+
+**`ProjectCloseOptions`:**
+
+```typescript
+interface ProjectCloseOptions {
+  /** If true and project has remoteUrl, delete the entire project directory including cloned repo */
+  removeLocalRepo?: boolean;
+}
+```
+
+**`clone()` behavior:**
+
+- If the URL was already cloned, returns the existing project (no duplicate clones)
+- Creates a bare clone in the app data directory
+- The project will have a `remoteUrl` field indicating it was cloned from a URL
+- URL formats supported: HTTPS (`https://github.com/org/repo.git`), SSH (`git@github.com:org/repo.git`)
 
 #### `workspaces` - Workspace Management
 
@@ -889,8 +906,11 @@ interface Project {
   readonly path: string; // Absolute path
   readonly workspaces: readonly Workspace[];
   readonly defaultBaseBranch?: string;
+  readonly remoteUrl?: string; // Original git URL if project was cloned
 }
 ```
+
+**Note:** The `remoteUrl` field is present only for projects that were cloned using `projects.clone()`. For projects opened locally via `projects.open()`, this field is undefined.
 
 #### `Workspace`
 

--- a/planning/GIT_CLONE_PROJECT.md
+++ b/planning/GIT_CLONE_PROJECT.md
@@ -1,0 +1,427 @@
+---
+status: APPROVED
+last_updated: 2026-01-25
+reviewers: [review-arch, review-quality, review-testing, review-ui]
+---
+
+# GIT_CLONE_PROJECT
+
+## Overview
+
+- **Problem**: Users must manually clone git repositories before opening them in CodeHydra. This creates friction when starting new projects from remote URLs.
+- **Solution**: Add a "Clone from Git" button in the CreateWorkspaceDialog that opens a GitCloneDialog. Users enter a git URL, the repo is cloned (bare mode) to app-data, and the new project is auto-selected for workspace creation.
+- **Risks**:
+  - Clone failures (network/auth) → mitigated by error display and retry capability
+  - Duplicate detection for same URL → mitigated by URL comparison and "open existing" behavior
+- **Alternatives Considered**:
+  - Inline clone UI in CreateWorkspaceDialog → rejected (makes dialog too complex)
+  - Modal sub-dialog → rejected (requires architectural change to exclusive-dialog pattern)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              User Flow                                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  CreateWorkspaceDialog                                                      │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │  [Project Dropdown] [Open Folder] [Clone from Git]  ← NEW BUTTON    │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                              │                                              │
+│                              │ click (opens git-clone, closes create)       │
+│                              ▼                                              │
+│  GitCloneDialog (NEW) - replaces CreateWorkspaceDialog (exclusive pattern)  │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │  Clone from Git Repository                                          │   │
+│  │  ┌───────────────────────────────────────────────────────────────┐  │   │
+│  │  │ https://github.com/org/repo.git                               │  │   │
+│  │  └───────────────────────────────────────────────────────────────┘  │   │
+│  │                                                                     │   │
+│  │  [Cancel]                                      [Clone] ← spinner   │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                              │                                              │
+│                              │ success OR cancel → openCreateDialog()       │
+│                              ▼                                              │
+│  CreateWorkspaceDialog (reopened with new project selected)                 │
+│                                                                             │
+│  NOTE: GitCloneDialog currently only returns to CreateWorkspaceDialog.      │
+│  This is the only entry point - if new entry points are added, the return   │
+│  behavior will need to be parameterized.                                    │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Storage Layout                                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ~/.local/share/codehydra/projects/                                         │
+│  └── repo-name-<url-hash>/        ← hash computed from remote URL           │
+│      ├── config.json              ← includes remoteUrl field                │
+│      ├── git/                     ← bare clone location (NEW)               │
+│      │   └── (bare repo files)                                              │
+│      └── workspaces/                                                        │
+│          └── feature-x/           ← worktrees created here                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+1. **Project ID from Remote URL**: For cloned projects, the hash is computed from the normalized remote URL (not folder path) using a new `generateProjectIdFromUrl(url): ProjectId` function. This ensures the same repo cloned multiple times is detected as a duplicate. The function returns the same `ProjectId` branded type as `generateProjectId`.
+
+2. **Bare Clone to `git/` Subdirectory**: The bare repo lives in `<project-dir>/git/` rather than the project dir itself. Worktrees are created in `workspaces/` as usual.
+
+3. **URL Storage**: The original remote URL is stored in `config.json`. Comparison uses a normalized form (lowercase hostname, path normalized, `.git` suffix removed). URL normalization handles edge cases: embedded credentials are stripped, port numbers preserved, trailing slashes removed.
+
+4. **Duplicate Handling**: If URL already cloned, open/select the existing project instead of cloning again.
+
+5. **Remote Project Cleanup**: When closing a remote project (one with `remoteUrl`), the CloseProjectDialog shows an additional "Delete cloned repository" checkbox. The two checkboxes are independent, but checking "Delete cloned repository" implies all workspaces will also be removed (enforced in UI). When checked, the entire project directory (including the bare clone in `git/`) is deleted.
+
+6. **Dialog Transition Pattern**: GitCloneDialog follows the exclusive single-dialog pattern. Opening it closes CreateWorkspaceDialog. Both Cancel and successful clone call `openCreateDialog()` to return - Cancel passes no project ID (returns to previous state), success passes the new project ID.
+
+### Modified/New Interfaces
+
+**NOTE: These API/IPC interface changes require explicit user approval per CLAUDE.md rules.**
+
+```typescript
+// IGitClient - new method
+interface IGitClient {
+  // ... existing methods ...
+
+  /**
+   * Clone a repository in bare mode.
+   * @param url - Git remote URL (HTTPS or SSH format)
+   * @param targetPath - Destination path for the bare clone
+   * @throws GitError - On network failure, auth failure, invalid URL, or target exists
+   */
+  clone(url: string, targetPath: Path): Promise<void>;
+}
+
+// ProjectConfig - extended
+interface ProjectConfig {
+  readonly version: number;
+  readonly path: string;
+  readonly remoteUrl?: string; // NEW: Original git remote URL
+}
+
+// IProjectApi - new/modified methods
+interface IProjectApi {
+  // ... existing methods ...
+  clone(url: string): Promise<Project>; // NEW
+  close(projectId: ProjectId, options?: { removeLocalRepo?: boolean }): Promise<void>; // MODIFIED (backward compatible)
+}
+
+// Project type - extended
+interface Project {
+  // ... existing fields ...
+  readonly remoteUrl?: string; // NEW: Present if project was cloned from URL
+}
+
+// DialogState - extended
+type DialogState =
+  | { type: "closed" }
+  | { type: "create"; projectId?: ProjectId }
+  | { type: "remove"; workspaceRef: WorkspaceRef }
+  | { type: "close-project"; projectId: ProjectId }
+  | { type: "git-clone" }; // NEW
+
+// IPC Channels
+api: project: clone; // NEW - must be added to docs/ARCHITECTURE.md IPC Contract section
+api: project: close; // MODIFIED (add removeLocalRepo option - backward compatible, optional param)
+```
+
+## UI Design
+
+### GitCloneDialog Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Clone from Git Repository          [titleId]           │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  Repository URL                                         │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │ https://github.com/org/repo.git   [autofocus]     │  │
+│  └───────────────────────────────────────────────────┘  │
+│  {inline validation error for malformed URLs}           │
+│                                                         │
+│  {error alert box - shown only on clone failure}        │
+│                                                         │
+│  {status: <vscode-progress-ring> Cloning repository...} │
+│                               [descriptionId]           │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│                            [Cancel]  [Clone]            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### User Interactions
+
+- **URL input**: `<vscode-textfield>` with placeholder "https://github.com/org/repo.git", autofocus on dialog open
+- **URL validation**: Inline validation for malformed URLs (missing protocol, no domain) before submit
+- **Clone button**: Disabled when URL empty, URL invalid, or during cloning; shows "Cloning..." when active
+- **Cancel button**: Closes dialog, calls `openCreateDialog()` to return to CreateWorkspaceDialog
+- **Error display**: Red alert box with error message, dialog stays open for retry
+- **Loading state**: `<vscode-progress-ring>` with "Cloning repository..." text in `aria-live="polite"` region
+- **All elements disabled during clone**: Prevents user interaction during async operation
+- **Accessibility**: Define `titleId="git-clone-title"` and `descriptionId="git-clone-status"` for ARIA labeling
+
+### CreateWorkspaceDialog Modification
+
+Add git icon button next to the existing folder icon button:
+
+```svelte
+<vscode-button appearance="icon" onclick={handleOpenProject} disabled={isSubmitting}>
+  <Icon name="folder-opened" />
+</vscode-button>
+<vscode-button appearance="icon" onclick={handleCloneProject} disabled={isSubmitting}>
+  <Icon name="git" />
+  <!-- NEW -->
+</vscode-button>
+```
+
+### CloseProjectDialog Modification (Remote Projects)
+
+For projects with `remoteUrl` (cloned from git), show an additional checkbox:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Close Project                                          │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  Are you sure you want to close "my-repo"?              │
+│                                                         │
+│  [ ] Remove all workspaces (3 workspaces)               │
+│  [ ] Delete cloned repository and all local files       │
+│                               ↑ NEW (remote only)       │
+│                                                         │
+│  {warning when delete checkbox checked:}                │
+│  ┌─────────────────────────────────────────────────────┐│
+│  │ ⚠ Warning: This will permanently delete the cloned ││
+│  │ repository and all workspaces. You can clone it    ││
+│  │ again from: https://github.com/org/repo            ││
+│  └─────────────────────────────────────────────────────┘│
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│                            [Cancel]  [Close]            │
+└─────────────────────────────────────────────────────────┘
+```
+
+- **Checkbox visibility**: "Delete cloned repository" only shown when project has `remoteUrl`
+- **Checkbox interaction**: The two checkboxes are independent. When "Delete cloned repository" is checked, "Remove all workspaces" is automatically checked and disabled (deletion implies workspace removal).
+- **Warning message**: Shown when "Delete cloned repository" is checked, displays the original remote URL
+- **Behavior**: When checked, after closing project, delete the entire project directory (including `git/` bare clone)
+- **Tab order**: New checkbox placed after existing "Remove all workspaces" checkbox
+
+## Testing Strategy
+
+### Integration Tests
+
+Test behavior through API entry points with behavioral mocks.
+
+| #   | Test Case                           | Entry Point                                   | Boundary Mocks        | Behavior Verified                                                                       |
+| --- | ----------------------------------- | --------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------- |
+| 1   | Clone public HTTPS repo             | `projects.clone(url)`                         | GitClient, FileSystem | Project created with remoteUrl in config                                                |
+| 2   | Clone SSH URL                       | `projects.clone(url)`                         | GitClient, FileSystem | Project created, URL stored as-is                                                       |
+| 3   | Clone duplicate URL                 | `projects.clone(url)`                         | GitClient, FileSystem | Returns project with matching ID, gitClient.clone() not called, project count unchanged |
+| 4   | Clone failure (network)             | `projects.clone(url)`                         | GitClient (throws)    | Error propagated, no project created, no partial state left behind                      |
+| 5   | Lookup project by URL               | `projectStore.findByRemoteUrl()`              | FileSystem            | Returns project if normalized URL matches                                               |
+| 6   | Close remote project with remove    | `projects.close(id, {removeLocalRepo: true})` | FileSystem            | Project removed from list, project directory deleted including git/                     |
+| 7   | Close remote project without remove | `projects.close(id)`                          | FileSystem            | Project removed from list, project directory preserved on filesystem                    |
+| 8   | Close local project (no remoteUrl)  | `projects.close(id)`                          | FileSystem            | Normal close behavior unchanged                                                         |
+
+### UI Integration Tests
+
+| #   | Test Case                              | Category | Component             | Behavior Verified                                               |
+| --- | -------------------------------------- | -------- | --------------------- | --------------------------------------------------------------- |
+| 1   | Clone button opens dialog              | UI-state | CreateWorkspaceDialog | Clicking git icon opens GitCloneDialog                          |
+| 2   | Clone success returns to create        | API-call | GitCloneDialog        | After clone, CreateWorkspaceDialog opens with project           |
+| 3   | Clone error shows alert                | UI-state | GitCloneDialog        | Error displayed, dialog stays open                              |
+| 4   | Inputs disabled during clone           | UI-state | GitCloneDialog        | All inputs disabled while isCloning=true                        |
+| 5   | Cancel returns to create               | UI-state | GitCloneDialog        | Cancel closes and reopens CreateWorkspaceDialog                 |
+| 6   | Remote project shows remove checkbox   | UI-state | CloseProjectDialog    | Checkbox visible when project has remoteUrl                     |
+| 7   | Local project hides remove checkbox    | UI-state | CloseProjectDialog    | Checkbox hidden when project has no remoteUrl                   |
+| 8   | Remove checkbox shows warning          | UI-state | CloseProjectDialog    | Warning message shown when checkbox checked                     |
+| 9   | Remove checkbox auto-checks workspaces | UI-state | CloseProjectDialog    | Checking delete repo auto-checks and disables remove workspaces |
+| 10  | Close with remove calls API correctly  | API-call | CloseProjectDialog    | Calls close() with removeLocalRepo: true                        |
+
+### Boundary Tests
+
+| #   | Test Case               | Interface        | External System | Behavior Verified                          |
+| --- | ----------------------- | ---------------- | --------------- | ------------------------------------------ |
+| 1   | Bare clone creates repo | IGitClient.clone | Git CLI         | Bare repo created at target path           |
+| 2   | Clone invalid URL fails | IGitClient.clone | Git CLI         | GitError thrown with message               |
+| 3   | Clone auth failure      | IGitClient.clone | Git CLI         | GitError thrown with auth-specific message |
+
+### Focused Tests
+
+| #   | Test Case                          | Function                 | Input/Output                                                        |
+| --- | ---------------------------------- | ------------------------ | ------------------------------------------------------------------- |
+| 1   | URL normalization HTTPS            | normalizeGitUrl          | "https://GitHub.com/Org/Repo.git" → "github.com/org/repo"           |
+| 2   | URL normalization SSH              | normalizeGitUrl          | "git@github.com:Org/Repo.git" → "github.com/org/repo"               |
+| 3   | URL normalization with credentials | normalizeGitUrl          | "https://user:pass@github.com/org/repo.git" → "github.com/org/repo" |
+| 4   | URL normalization with port        | normalizeGitUrl          | "https://github.com:443/org/repo.git" → "github.com:443/org/repo"   |
+| 5   | URL normalization trailing slash   | normalizeGitUrl          | "https://github.com/org/repo/" → "github.com/org/repo"              |
+| 6   | Hash from URL                      | generateProjectIdFromUrl | URL → `ProjectId` ("<name>-<8-char-hash>")                          |
+| 7   | Hash consistency                   | generateProjectIdFromUrl | Same normalized URL always produces same hash                       |
+
+### Manual Testing Checklist
+
+- [ ] Clone public GitHub repo via HTTPS
+- [ ] Clone private repo via SSH (with SSH key configured)
+- [ ] Attempt clone of invalid URL - error shown
+- [ ] Attempt clone of already-cloned URL - existing project selected
+- [ ] Cancel during clone - returns to create dialog
+- [ ] Create workspace after successful clone
+- [ ] Close remote project - "Delete cloned repository" checkbox visible
+- [ ] Close local project - "Delete cloned repository" checkbox NOT visible
+- [ ] Check "Delete cloned repository" - warning message shown, workspaces checkbox auto-checked
+- [ ] Close with "Delete cloned repository" checked - git directory deleted
+- [ ] Close without "Delete cloned repository" checked - git directory preserved
+
+## Implementation Steps
+
+- [x] **Step 1: Add IGitClient.clone() method**
+  - Add `clone(url: string, targetPath: Path): Promise<void>` to IGitClient interface
+  - Add JSDoc with `@throws GitError` documenting error cases (network, auth, invalid URL, target exists)
+  - Implement in SimpleGitClient using `await git.clone(url, targetPath.toNative(), { '--bare': null })`
+  - Follow `wrapGitOperation` pattern for consistent error logging and GitError conversion
+  - Add boundary test for clone operation including auth failure case
+  - Files: `src/services/git/git-client.ts`, `src/services/git/simple-git-client.ts`, `src/services/git/simple-git-client.boundary.test.ts`
+  - Test criteria: Boundary test passes, bare repo created
+
+- [x] **Step 2: Add GitClient mock support**
+  - Extend GitClientMock state to track cloned repositories with bare/remote properties
+  - Add cloned repo to in-memory state when clone() is called
+  - Use outcome-based matcher `toHaveClonedRepository(path)` that verifies repository exists in state
+  - Do NOT use call-tracking pattern (avoid `toHaveCloned(url, path)`)
+  - Files: `src/services/git/git-client.state-mock.ts`
+  - Test criteria: Mock correctly simulates clone behavior with outcome verification
+
+- [x] **Step 3: Extend ProjectConfig and ProjectStore**
+  - Add optional `remoteUrl` field to ProjectConfig interface
+  - Add `findByRemoteUrl(url: string): Promise<string | undefined>` to ProjectStore
+  - Add URL normalization utility function in `src/services/project/url-utils.ts` (NOT in shared/)
+  - Add `generateProjectIdFromUrl(url: string): ProjectId` function returning branded type
+  - Increment CURRENT_PROJECT_VERSION to 2 - no migration needed, remoteUrl is optional. Version bump for forward compatibility only.
+  - Add focused tests for URL normalization edge cases (credentials, ports, trailing slashes)
+  - Files: `src/services/project/types.ts`, `src/services/project/project-store.ts`, `src/services/project/url-utils.ts`
+  - Test criteria: Integration tests for URL lookup pass, focused tests for normalization pass
+
+- [x] **Step 4: Add projects.clone() API method**
+  - **NOTE: This adds new IPC channel - requires user approval per CLAUDE.md**
+  - Add `clone` method to IProjectApi interface
+  - Add IPC channel `api:project:clone`
+  - Implement in CoreModule:
+    1. Validate URL format (reject obviously invalid URLs early)
+    2. Normalize URL and check for existing project
+    3. If exists, return existing project
+    4. Generate project ID from URL hash using `generateProjectIdFromUrl`
+    5. Create project directory structure
+    6. Call gitClient.clone() to bare clone to `git/` subdir
+    7. On failure, clean up any partial state (no orphaned directories)
+    8. Save project config with remoteUrl
+    9. Return project
+  - Files: `src/shared/api/interfaces.ts`, `src/shared/ipc.ts`, `src/main/modules/core/index.ts`, `src/preload/index.ts`
+  - Test criteria: Integration tests for clone flow pass, including failure cleanup test
+
+- [x] **Step 5: Add GitCloneDialog component**
+  - Create new Svelte component with URL input, Cancel/Clone buttons
+  - Set autofocus on URL textfield
+  - Add inline URL validation before submit (regex check for protocol/domain)
+  - Implement loading state (isCloning) with `<vscode-progress-ring>` and status text
+  - Define `titleId="git-clone-title"` and `descriptionId="git-clone-status"` for accessibility
+  - Call `projects.clone()` on submit
+  - On success: call `openCreateDialog(newProject.id)` to return
+  - On cancel: call `openCreateDialog()` to return (no project ID)
+  - Files: `src/renderer/lib/components/GitCloneDialog.svelte`
+  - Test criteria: Component renders, form validation works, accessibility IDs present
+
+- [x] **Step 6: Extend dialog store**
+  - Add `{ type: "git-clone" }` to DialogState union
+  - Add `openGitCloneDialog()` action
+  - Files: `src/renderer/lib/stores/dialogs.svelte.ts`
+  - Test criteria: Dialog state transitions work correctly
+
+- [x] **Step 7: Update MainView and CreateWorkspaceDialog**
+  - Add GitCloneDialog rendering in MainView
+  - Add git icon button to CreateWorkspaceDialog
+  - Wire button to open git-clone dialog via `openGitCloneDialog()`
+  - Files: `src/renderer/lib/components/MainView.svelte`, `src/renderer/lib/components/CreateWorkspaceDialog.svelte`
+  - Test criteria: UI integration tests pass
+
+- [x] **Step 8: Extend projects.close() for remote repo removal**
+  - **NOTE: This modifies IPC channel signature - backward compatible (optional param)**
+  - Add optional `removeLocalRepo` parameter to close method
+  - When true and project has remoteUrl, delete entire project directory
+  - Update IPC payload type
+  - Files: `src/shared/api/interfaces.ts`, `src/main/modules/core/index.ts`, `src/preload/index.ts`
+  - Test criteria: Integration tests for close with remove pass
+
+- [x] **Step 9: Update CloseProjectDialog for remote projects**
+  - Add `removeLocalRepo` checkbox state (only shown when project.remoteUrl exists)
+  - Change checkbox label to "Delete cloned repository and all local files"
+  - Add warning message (styled alert box) when checkbox is checked, showing original URL
+  - When "Delete cloned repository" checked, auto-check and disable "Remove all workspaces"
+  - Pass `removeLocalRepo` option to close() call
+  - Ensure correct tab order (new checkbox after existing one)
+  - Files: `src/renderer/lib/components/CloseProjectDialog.svelte`
+  - Test criteria: UI shows/hides checkbox correctly, warning displays, auto-check behavior works
+
+- [x] **Step 10: Add UI integration tests**
+  - Test clone button opens dialog
+  - Test clone success flow
+  - Test clone error handling
+  - Test cancel behavior
+  - Test CloseProjectDialog remove checkbox visibility
+  - Test CloseProjectDialog remove warning
+  - Test CloseProjectDialog auto-check workspaces behavior
+  - Files: `src/renderer/lib/components/GitCloneDialog.integration.test.ts`, `src/renderer/lib/components/CloseProjectDialog.integration.test.ts`
+  - Test criteria: All UI integration tests pass
+
+- [x] **Step 11: Update documentation**
+  - Document `projects.clone()` API in docs/API.md (new section or extend existing)
+  - Document `projects.close()` extended options in docs/API.md
+  - Document remoteUrl config field in docs/ARCHITECTURE.md
+  - Add `api:project:clone` to IPC Contract section in docs/ARCHITECTURE.md
+  - Document GitCloneDialog and CloseProjectDialog changes in docs/USER_INTERFACE.md
+  - Update CLAUDE.md with:
+    - `remoteUrl` concept in Project key concepts
+    - URL normalization pattern for remote projects in External System Access Rules if needed
+  - Files: `docs/API.md`, `docs/ARCHITECTURE.md`, `docs/USER_INTERFACE.md`, `CLAUDE.md`
+  - Test criteria: Documentation is accurate and complete
+
+## Dependencies
+
+No new packages required. Uses existing `simple-git` library.
+
+## Documentation Updates
+
+### Files to Update
+
+| File                     | Changes Required                                                                                                |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `docs/API.md`            | Add `projects.clone(url)` method, document `projects.close()` extended options                                  |
+| `docs/ARCHITECTURE.md`   | Document `remoteUrl` field in ProjectConfig, bare clone storage layout, add `api:project:clone` to IPC Contract |
+| `docs/USER_INTERFACE.md` | Document GitCloneDialog and CloseProjectDialog changes for remote projects                                      |
+| `CLAUDE.md`              | Add `remoteUrl` to Project key concepts, document URL normalization pattern                                     |
+
+### New Documentation Required
+
+None - all changes fit within existing documentation structure.
+
+## Definition of Done
+
+- [ ] All implementation steps complete
+- [ ] `pnpm validate:fix` passes
+- [ ] Documentation updated (including CLAUDE.md)
+- [ ] User acceptance testing passed:
+  - [ ] Can clone public repo and create workspace
+  - [ ] Can clone via SSH URL
+  - [ ] Duplicate URL detection works
+  - [ ] Error handling works correctly
+  - [ ] CloseProjectDialog shows delete checkbox for remote projects
+  - [ ] Delete checkbox auto-checks workspaces removal
+  - [ ] Deleting local repository removes git directory
+- [ ] CI passed

--- a/src/main/api/registry-types.test.ts
+++ b/src/main/api/registry-types.test.ts
@@ -48,7 +48,7 @@ describe("registry-types.paths", () => {
   it("ALL_METHOD_PATHS contains all MethodRegistry keys", () => {
     // This test is compile-time verified by the `satisfies` constraint in registry-types.ts
     // At runtime, we verify the count matches
-    const registryKeyCount = 24; // Count of all methods in MethodRegistry
+    const registryKeyCount = 25; // Count of all methods in MethodRegistry
     expect(ALL_METHOD_PATHS.length).toBe(registryKeyCount);
   });
 
@@ -116,10 +116,15 @@ describe("registry-types.payload", () => {
   });
 
   it("extracts ProjectIdPayload for project ID methods", () => {
-    expectTypeOf<MethodPayload<"projects.close">>().toEqualTypeOf<ProjectIdPayload>();
     expectTypeOf<MethodPayload<"projects.get">>().toEqualTypeOf<ProjectIdPayload>();
     expectTypeOf<MethodPayload<"projects.fetchBases">>().toEqualTypeOf<ProjectIdPayload>();
     // Verify shape
+    expectTypeOf<MethodPayload<"projects.get">>().toHaveProperty("projectId");
+    expectTypeOf<MethodPayload<"projects.get">["projectId"]>().toEqualTypeOf<ProjectId>();
+  });
+
+  it("extracts ProjectClosePayload for projects.close", () => {
+    // projects.close has optional removeLocalRepo parameter
     expectTypeOf<MethodPayload<"projects.close">>().toHaveProperty("projectId");
     expectTypeOf<MethodPayload<"projects.close">["projectId"]>().toEqualTypeOf<ProjectId>();
   });

--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -32,7 +32,19 @@ export interface ProjectOpenPayload {
   readonly path: string;
 }
 
-/** projects.close, projects.get, projects.fetchBases */
+/** projects.close */
+export interface ProjectClosePayload {
+  readonly projectId: ProjectId;
+  /** If true and project has remoteUrl, delete the entire project directory including cloned repo */
+  readonly removeLocalRepo?: boolean;
+}
+
+/** projects.clone */
+export interface ProjectClonePayload {
+  readonly url: string;
+}
+
+/** projects.get, projects.fetchBases */
 export interface ProjectIdPayload {
   readonly projectId: ProjectId;
 }
@@ -121,7 +133,8 @@ export interface MethodRegistry {
 
   // Projects
   "projects.open": (payload: ProjectOpenPayload) => Promise<Project>;
-  "projects.close": (payload: ProjectIdPayload) => Promise<void>;
+  "projects.close": (payload: ProjectClosePayload) => Promise<void>;
+  "projects.clone": (payload: ProjectClonePayload) => Promise<Project>;
   "projects.list": (payload: EmptyPayload) => Promise<readonly Project[]>;
   "projects.get": (payload: ProjectIdPayload) => Promise<Project | undefined>;
   "projects.fetchBases": (
@@ -173,6 +186,7 @@ export type LifecyclePath =
 export type ProjectPath =
   | "projects.open"
   | "projects.close"
+  | "projects.clone"
   | "projects.list"
   | "projects.get"
   | "projects.fetchBases";
@@ -222,6 +236,7 @@ export const ALL_METHOD_PATHS = [
   "lifecycle.quit",
   "projects.open",
   "projects.close",
+  "projects.clone",
   "projects.list",
   "projects.get",
   "projects.fetchBases",

--- a/src/main/api/registry.integration.test.ts
+++ b/src/main/api/registry.integration.test.ts
@@ -525,6 +525,7 @@ function registerAllMethodsWithStubs(
     "lifecycle.quit": async () => {},
     "projects.open": async () => createMockProject(),
     "projects.close": async () => {},
+    "projects.clone": async () => createMockProject(),
     "projects.list": async () => [],
     "projects.get": async () => undefined,
     "projects.fetchBases": async () => ({ bases: [] }),

--- a/src/main/api/registry.test-utils.ts
+++ b/src/main/api/registry.test-utils.ts
@@ -197,7 +197,8 @@ function createMockCodeHydraApi(
   return {
     projects: {
       open: (path) => get("projects.open")({ path }),
-      close: (projectId) => get("projects.close")({ projectId }),
+      close: (projectId, options) => get("projects.close")({ projectId, ...options }),
+      clone: (url) => get("projects.clone")({ url }),
       list: () => get("projects.list")({}),
       get: (projectId) => get("projects.get")({ projectId }),
       fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),
@@ -271,6 +272,7 @@ export function registerAllMethodsWithStubs(
     "lifecycle.quit": async () => {},
     "projects.open": async () => createMockProject(),
     "projects.close": async () => {},
+    "projects.clone": async () => createMockProject(),
     "projects.list": async () => [],
     "projects.get": async () => undefined,
     "projects.fetchBases": async () => ({ bases: [] }),

--- a/src/main/api/registry.ts
+++ b/src/main/api/registry.ts
@@ -171,7 +171,8 @@ export class ApiRegistry implements IApiRegistry {
     return {
       projects: {
         open: (path) => get("projects.open")({ path }),
-        close: (projectId) => get("projects.close")({ projectId }),
+        close: (projectId, options) => get("projects.close")({ projectId, ...options }),
+        clone: (url) => get("projects.clone")({ url }),
         list: () => get("projects.list")({}),
         get: (projectId) => get("projects.get")({ projectId }),
         fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),

--- a/src/main/api/wire-plugin-api.test.ts
+++ b/src/main/api/wire-plugin-api.test.ts
@@ -30,6 +30,7 @@ function createMockApi(): ICodeHydraApi {
     projects: {
       open: vi.fn(),
       close: vi.fn(),
+      clone: vi.fn(),
       list: vi.fn().mockResolvedValue([]),
       get: vi.fn(),
       fetchBases: vi.fn().mockResolvedValue({ bases: [] }),

--- a/src/main/bootstrap.integration.test.ts
+++ b/src/main/bootstrap.integration.test.ts
@@ -143,6 +143,18 @@ function createMockCoreDeps(): CoreModuleDeps {
   return {
     appState: createMockAppState(),
     viewManager: createMockViewManager(),
+    gitClient: {
+      clone: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../services").IGitClient,
+    pathProvider: {
+      projectsDir: "/test/projects",
+    } as unknown as import("../services").PathProvider,
+    projectStore: {
+      findByRemoteUrl: vi.fn().mockResolvedValue(undefined),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      getProjectConfig: vi.fn().mockResolvedValue(undefined),
+      deleteProjectDirectory: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../services").ProjectStore,
     emitDeletionProgress: vi.fn(),
     logger: createMockLogger(),
   };

--- a/src/main/bootstrap.test.ts
+++ b/src/main/bootstrap.test.ts
@@ -104,6 +104,18 @@ function createMockCoreDeps(): CoreModuleDeps {
   return {
     appState: createMockAppState(),
     viewManager: createMockViewManager(),
+    gitClient: {
+      clone: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../services").IGitClient,
+    pathProvider: {
+      projectsDir: "/test/projects",
+    } as unknown as import("../services").PathProvider,
+    projectStore: {
+      findByRemoteUrl: vi.fn().mockResolvedValue(undefined),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      getProjectConfig: vi.fn().mockResolvedValue(undefined),
+      deleteProjectDirectory: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../services").ProjectStore,
     emitDeletionProgress: vi.fn(),
     logger: createMockLogger(),
   };

--- a/src/main/ipc/api-handlers.integration.test.ts
+++ b/src/main/ipc/api-handlers.integration.test.ts
@@ -71,6 +71,7 @@ function createMockApiWithEvents(): {
     projects: {
       open: vi.fn().mockResolvedValue(TEST_PROJECT),
       close: vi.fn().mockResolvedValue(undefined),
+      clone: vi.fn().mockResolvedValue(TEST_PROJECT),
       list: vi.fn().mockResolvedValue([TEST_PROJECT]),
       get: vi.fn().mockResolvedValue(TEST_PROJECT),
       fetchBases: vi.fn().mockResolvedValue({ bases: [] }),

--- a/src/main/ipc/api-handlers.test.ts
+++ b/src/main/ipc/api-handlers.test.ts
@@ -17,6 +17,7 @@ function createMockApi(): ICodeHydraApi {
     projects: {
       open: vi.fn(),
       close: vi.fn(),
+      clone: vi.fn(),
       list: vi.fn().mockResolvedValue([]),
       get: vi.fn(),
       fetchBases: vi.fn().mockResolvedValue({ bases: [] }),

--- a/src/main/modules/core/index.integration.test.ts
+++ b/src/main/modules/core/index.integration.test.ts
@@ -93,6 +93,18 @@ function createMockDeps(overrides: Partial<CoreModuleDeps> = {}): CoreModuleDeps
   const defaults: CoreModuleDeps = {
     appState: createMockAppState(),
     viewManager: createMockViewManager(),
+    gitClient: {
+      clone: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../../../services").IGitClient,
+    pathProvider: {
+      projectsDir: "/test/projects",
+    } as unknown as import("../../../services").PathProvider,
+    projectStore: {
+      findByRemoteUrl: vi.fn().mockResolvedValue(undefined),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      getProjectConfig: vi.fn().mockResolvedValue(undefined),
+      deleteProjectDirectory: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../../../services").ProjectStore,
     emitDeletionProgress: vi.fn(),
     logger: createMockLogger(),
   };

--- a/src/main/modules/core/index.test.ts
+++ b/src/main/modules/core/index.test.ts
@@ -87,6 +87,18 @@ function createMockDeps(overrides: Partial<CoreModuleDeps> = {}): CoreModuleDeps
   const defaults: CoreModuleDeps = {
     appState: createMockAppState(),
     viewManager: createMockViewManager(),
+    gitClient: {
+      clone: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../../../services").IGitClient,
+    pathProvider: {
+      projectsDir: "/test/projects",
+    } as unknown as import("../../../services").PathProvider,
+    projectStore: {
+      findByRemoteUrl: vi.fn().mockResolvedValue(undefined),
+      saveProject: vi.fn().mockResolvedValue(undefined),
+      getProjectConfig: vi.fn().mockResolvedValue(undefined),
+      deleteProjectDirectory: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("../../../services").ProjectStore,
     emitDeletionProgress: vi.fn(),
     logger: createMockLogger(),
   };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -32,7 +32,9 @@ contextBridge.exposeInMainWorld("api", {
 
   projects: {
     open: (path: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_OPEN, { path }),
-    close: (projectId: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLOSE, { projectId }),
+    close: (projectId: string, options?: { removeLocalRepo?: boolean }) =>
+      ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLOSE, { projectId, ...options }),
+    clone: (url: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLONE, { url }),
     list: () => ipcRenderer.invoke(ApiIpcChannels.PROJECT_LIST),
     get: (projectId: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_GET, { projectId }),
     fetchBases: (projectId: string) =>

--- a/src/renderer/lib/components/CloseProjectDialog.svelte
+++ b/src/renderer/lib/components/CloseProjectDialog.svelte
@@ -19,6 +19,7 @@
 
   // Form state
   let removeAll = $state(false);
+  let deleteLocalRepo = $state(false);
   let submitError = $state<string | null>(null);
   let isSubmitting = $state(false);
 
@@ -28,11 +29,15 @@
   const workspaceText = $derived(
     workspaceCount === 1 ? "1 workspace" : `${workspaceCount} workspaces`
   );
+  const isRemoteProject = $derived(Boolean(project?.remoteUrl));
 
   // Dynamic button label
-  const buttonLabel = $derived(
-    isSubmitting ? "Closing..." : removeAll ? "Remove & Close" : "Close Project"
-  );
+  const buttonLabel = $derived.by(() => {
+    if (isSubmitting) return "Closing...";
+    if (deleteLocalRepo) return "Delete & Close";
+    if (removeAll) return "Remove & Close";
+    return "Close Project";
+  });
 
   // Handle form submission
   async function handleSubmit(): Promise<void> {
@@ -75,7 +80,8 @@
       }
 
       // Always close the project (even if some removals failed)
-      await projectsApi.close(projectId);
+      // Pass removeLocalRepo option if checked (and project is remote)
+      await projectsApi.close(projectId, deleteLocalRepo ? { removeLocalRepo: true } : undefined);
       closeDialog();
     } catch (error) {
       const message = getErrorMessage(error);
@@ -92,8 +98,18 @@
   }
 
   // Handle checkbox change - vscode-checkbox exposes checked property
-  function handleCheckboxChange(event: Event): void {
+  function handleRemoveAllChange(event: Event): void {
     removeAll = (event.target as unknown as { checked: boolean }).checked;
+  }
+
+  // Handle delete local repo checkbox change
+  function handleDeleteLocalRepoChange(event: Event): void {
+    const checked = (event.target as unknown as { checked: boolean }).checked;
+    deleteLocalRepo = checked;
+    // When delete local repo is checked, also check remove all workspaces
+    if (checked) {
+      removeAll = true;
+    }
   }
 
   // IDs for accessibility
@@ -122,11 +138,34 @@
       <div class="ch-checkbox-row">
         <vscode-checkbox
           checked={removeAll}
-          onchange={handleCheckboxChange}
-          disabled={isSubmitting}
+          onchange={handleRemoveAllChange}
+          disabled={isSubmitting || deleteLocalRepo}
           label="Remove all workspaces and their branches"
         ></vscode-checkbox>
       </div>
+    {/if}
+
+    {#if isRemoteProject}
+      <div class="ch-checkbox-row">
+        <vscode-checkbox
+          checked={deleteLocalRepo}
+          onchange={handleDeleteLocalRepoChange}
+          disabled={isSubmitting}
+          label="Delete cloned repository and all local files"
+        ></vscode-checkbox>
+      </div>
+
+      {#if deleteLocalRepo}
+        <div class="ch-alert-box warning" role="alert">
+          <span class="ch-alert-box-icon" aria-hidden="true">
+            <Icon name="warning" />
+          </span>
+          <span class="warning-text">
+            This will permanently delete the cloned repository and all workspaces. You can clone it
+            again from: {project?.remoteUrl}
+          </span>
+        </div>
+      {/if}
     {/if}
 
     {#if submitError}
@@ -155,5 +194,13 @@
   /* Component-specific styles only - shared styles in variables.css */
   .error-text {
     white-space: pre-line;
+  }
+
+  .warning-text {
+    word-break: break-word;
+  }
+
+  .ch-alert-box.warning {
+    margin-top: var(--ch-spacing-md);
   }
 </style>

--- a/src/renderer/lib/components/GitCloneDialog.svelte
+++ b/src/renderer/lib/components/GitCloneDialog.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import Dialog from "./Dialog.svelte";
+  import Icon from "./Icon.svelte";
+  import { projects } from "$lib/api";
+  import { openCreateDialog } from "$lib/stores/dialogs.svelte.js";
+  import { createLogger } from "$lib/logging";
+  import { getErrorMessage } from "@shared/error-utils";
+
+  const logger = createLogger("ui");
+
+  interface GitCloneDialogProps {
+    open: boolean;
+  }
+
+  let { open }: GitCloneDialogProps = $props();
+
+  // Form state
+  let url = $state("");
+  let submitError = $state<string | null>(null);
+  let isCloning = $state(false);
+
+  // URL validation state
+  // Validates full URLs and shorthand formats (org/repo, github.com/org/repo)
+  const urlValidationError = $derived(() => {
+    if (!url.trim()) return null;
+    const trimmed = url.trim();
+
+    // Full URL formats (HTTPS, HTTP, SSH, git://, ssh://)
+    if (/^https?:\/\/[^\s]+/.test(trimmed)) return null;
+    if (/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+:[^\s]+/.test(trimmed)) return null;
+    if (/^git:\/\/[^\s]+/.test(trimmed)) return null;
+    if (/^ssh:\/\/[^\s]+/.test(trimmed)) return null;
+
+    // Shorthand: org/repo (GitHub shorthand - no dots in first segment)
+    if (/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/.test(trimmed)) return null;
+
+    // Partial URL: github.com/org/repo (domain without protocol)
+    if (/^[a-z0-9.-]+\/[^\s]+$/i.test(trimmed) && trimmed.includes(".")) return null;
+
+    return "Enter a git URL, org/repo, or github.com/org/repo";
+  });
+
+  // Clone button disabled state
+  const isCloneDisabled = $derived(!url.trim() || urlValidationError() !== null || isCloning);
+
+  // Handle form submission
+  async function handleSubmit(): Promise<void> {
+    if (isCloning || isCloneDisabled) return;
+
+    submitError = null;
+    isCloning = true;
+
+    logger.debug("Cloning repository", { url });
+
+    try {
+      const project = await projects.clone(url.trim());
+      logger.info("Repository cloned successfully", { projectId: project.id });
+      // Return to CreateWorkspaceDialog with the new project selected
+      openCreateDialog(project.id);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.warn("Clone failed", { url, error: message });
+      submitError = message;
+      isCloning = false;
+    }
+  }
+
+  // Handle cancel
+  function handleCancel(): void {
+    logger.debug("Dialog closed", { type: "git-clone" });
+    // Return to CreateWorkspaceDialog without selecting a project
+    openCreateDialog();
+  }
+
+  // Handle URL input
+  function handleUrlInput(event: Event): void {
+    url = (event.target as HTMLInputElement).value;
+    // Clear submit error when user types
+    if (submitError) {
+      submitError = null;
+    }
+  }
+
+  // Handle Enter key in textfield
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Enter" && !isCloneDisabled) {
+      event.preventDefault();
+      void handleSubmit();
+    }
+  }
+
+  // IDs for accessibility
+  const titleId = "git-clone-title";
+  const descriptionId = "git-clone-status";
+</script>
+
+<Dialog
+  {open}
+  onClose={handleCancel}
+  busy={isCloning}
+  {titleId}
+  {descriptionId}
+  initialFocusSelector="vscode-textfield"
+>
+  {#snippet title()}
+    <h2 id={titleId} class="ch-dialog-title">Clone from Git Repository</h2>
+  {/snippet}
+
+  {#snippet content()}
+    <div class="ch-form-group">
+      <label for="clone-url" class="ch-label">Repository URL</label>
+      <!-- svelte-ignore a11y_autofocus, a11y_no_static_element_interactions -->
+      <vscode-textfield
+        id="clone-url"
+        value={url}
+        oninput={handleUrlInput}
+        onkeydown={handleKeydown}
+        placeholder="org/repo or https://github.com/org/repo.git"
+        disabled={isCloning}
+        autofocus
+        class="ch-textfield-full"
+      ></vscode-textfield>
+      {#if urlValidationError() && url.trim()}
+        <p class="ch-validation-error">{urlValidationError()}</p>
+      {/if}
+    </div>
+
+    {#if submitError}
+      <div class="ch-alert-box" role="alert">
+        <span class="ch-alert-box-icon" aria-hidden="true">
+          <Icon name="error" />
+        </span>
+        <span class="error-text">{submitError}</span>
+      </div>
+    {/if}
+  {/snippet}
+
+  {#snippet actions()}
+    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+    <vscode-button onclick={handleSubmit} disabled={isCloneDisabled} class="clone-button">
+      {#if isCloning}
+        <vscode-progress-ring class="button-spinner"></vscode-progress-ring>
+        <span id={descriptionId}>Cloning...</span>
+      {:else}
+        Clone
+      {/if}
+    </vscode-button>
+    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+    <vscode-button secondary={true} onclick={handleCancel} disabled={isCloning}>
+      Cancel
+    </vscode-button>
+  {/snippet}
+</Dialog>
+
+<style>
+  .error-text {
+    white-space: pre-line;
+  }
+
+  /* Style for clone button to have consistent layout */
+  :global(.clone-button) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  /* Make the spinner smaller to fit in the button */
+  :global(.button-spinner) {
+    width: 14px;
+    height: 14px;
+  }
+</style>

--- a/src/renderer/lib/components/GitCloneDialog.test.ts
+++ b/src/renderer/lib/components/GitCloneDialog.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for the GitCloneDialog component.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import type { Project, ProjectId } from "@shared/api/types";
+
+// Create mock functions with vi.hoisted
+const { mockCloneProject, mockOpenCreateDialog, mockCloseDialog } = vi.hoisted(() => ({
+  mockCloneProject: vi.fn(),
+  mockOpenCreateDialog: vi.fn(),
+  mockCloseDialog: vi.fn(),
+}));
+
+// Mock $lib/api
+vi.mock("$lib/api", () => ({
+  projects: {
+    clone: mockCloneProject,
+  },
+}));
+
+// Mock $lib/stores/dialogs.svelte.js
+vi.mock("$lib/stores/dialogs.svelte.js", () => ({
+  openCreateDialog: mockOpenCreateDialog,
+  closeDialog: mockCloseDialog,
+}));
+
+// Import component after mocks
+import GitCloneDialog from "./GitCloneDialog.svelte";
+
+// Test data
+const testProjectId = "test-repo-12345678" as ProjectId;
+const testUrl = "https://github.com/org/test-repo.git";
+
+function createProject(id: ProjectId): Project {
+  return {
+    id,
+    name: "test-repo",
+    path: "/test/projects/test-repo",
+    workspaces: [],
+    remoteUrl: testUrl,
+  };
+}
+
+/**
+ * Helper to get the URL textfield (vscode-textfield).
+ */
+function getUrlInput(): HTMLElement & { value?: string } {
+  const input = document.querySelector("vscode-textfield");
+  if (!input) throw new Error("URL input not found");
+  return input as HTMLElement & { value?: string };
+}
+
+describe("GitCloneDialog component", () => {
+  const defaultProps = {
+    open: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockCloneProject.mockResolvedValue(createProject(testProjectId));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  describe("structure", () => {
+    it("uses Dialog base component", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it('renders title "Clone from Git Repository"', async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByText("Clone from Git Repository")).toBeInTheDocument();
+    });
+
+    it("renders URL textfield with placeholder", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      expect(input).toBeInTheDocument();
+      // vscode-textfield may not reflect placeholder as attribute in test environment
+      // Check either attribute or property
+      const placeholder =
+        input.getAttribute("placeholder") ??
+        (input as unknown as { placeholder?: string }).placeholder;
+      expect(placeholder).toBe("org/repo or https://github.com/org/repo.git");
+    });
+
+    it("renders Cancel and Clone buttons", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /clone/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("URL input has autofocus", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      // vscode-textfield with autofocus attribute
+      expect(input.hasAttribute("autofocus")).toBe(true);
+    });
+
+    it("dialog has ARIA attributes", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-labelledby", "git-clone-title");
+      expect(dialog).toHaveAttribute("aria-describedby", "git-clone-status");
+    });
+  });
+
+  describe("URL validation", () => {
+    it("Clone button disabled when URL is empty", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      expect(cloneButton).toBeDisabled();
+    });
+
+    it("Clone button enabled for valid HTTPS URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      expect(cloneButton).not.toBeDisabled();
+    });
+
+    it("Clone button enabled for valid SSH URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: "git@github.com:org/repo.git" } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      expect(cloneButton).not.toBeDisabled();
+    });
+
+    it("shows validation error for invalid URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: "invalid-url" } });
+
+      expect(screen.getByText(/enter a git url, org\/repo/i)).toBeInTheDocument();
+    });
+
+    it("Clone button disabled for invalid URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: "not-a-url" } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      expect(cloneButton).toBeDisabled();
+    });
+  });
+
+  describe("clone flow", () => {
+    it("calls api.projects.clone() with URL on submit", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(mockCloneProject).toHaveBeenCalledWith(testUrl);
+    });
+
+    it("shows loading state during clone", async () => {
+      mockCloneProject.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(createProject(testProjectId)), 1000))
+      );
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      // Should show loading state in the button
+      expect(screen.getByText(/cloning\.\.\./i)).toBeInTheDocument();
+
+      await vi.runAllTimersAsync();
+    });
+
+    it("disables inputs during clone", async () => {
+      mockCloneProject.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(createProject(testProjectId)), 1000))
+      );
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      // Input and buttons should be disabled
+      expect(input).toBeDisabled();
+      expect(cloneButton).toBeDisabled();
+
+      await vi.runAllTimersAsync();
+    });
+
+    it("opens CreateWorkspaceDialog with project ID on success", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(mockOpenCreateDialog).toHaveBeenCalledWith(testProjectId);
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows error message on clone failure", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Network error: could not connect"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText(/network error/i)).toBeInTheDocument();
+    });
+
+    it("stays open after error for retry", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Auth failed"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      // Dialog should still be visible
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      // Input should be re-enabled
+      expect(getUrlInput()).not.toBeDisabled();
+    });
+
+    it("clears error when user types", async () => {
+      mockCloneProject.mockRejectedValueOnce(new Error("Failed"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      // Error should be shown
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Type in the input
+      await fireEvent.input(input, { target: { value: "https://github.com/other/repo.git" } });
+
+      // Error should be cleared
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("cancel flow", () => {
+    it("calls openCreateDialog() without project ID on cancel", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      await fireEvent.click(cancelButton);
+
+      expect(mockOpenCreateDialog).toHaveBeenCalledWith();
+    });
+
+    it("Escape key cancels dialog", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      await fireEvent.keyDown(document.body, { key: "Escape" });
+
+      expect(mockOpenCreateDialog).toHaveBeenCalledWith();
+    });
+
+    it("cancel button disabled during clone", async () => {
+      mockCloneProject.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(createProject(testProjectId)), 1000))
+      );
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      expect(cancelButton).toBeDisabled();
+
+      await vi.runAllTimersAsync();
+    });
+  });
+
+  describe("Enter key handling", () => {
+    it("submits form when Enter is pressed with valid URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      await vi.runAllTimersAsync();
+
+      expect(mockCloneProject).toHaveBeenCalledWith(testUrl);
+    });
+
+    it("does not submit when Enter is pressed with invalid URL", async () => {
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: "invalid" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      await vi.runAllTimersAsync();
+
+      expect(mockCloneProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("closed state", () => {
+    it("does not render when open is false", async () => {
+      render(GitCloneDialog, {
+        props: { ...defaultProps, open: false },
+      });
+      await vi.runAllTimersAsync();
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -238,7 +238,7 @@ describe("MainView close project integration", () => {
 
       // Should only call close, not remove
       expect(mockApi.workspaces.remove).not.toHaveBeenCalled();
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");
@@ -290,7 +290,7 @@ describe("MainView close project integration", () => {
       );
 
       // Then close the project
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");
@@ -331,7 +331,7 @@ describe("MainView close project integration", () => {
       expect(mockApi.workspaces.remove).toHaveBeenCalledTimes(2);
 
       // Project should still be closed despite partial failure
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");

--- a/src/renderer/lib/components/ShortcutOverlay.svelte
+++ b/src/renderer/lib/components/ShortcutOverlay.svelte
@@ -2,7 +2,6 @@
   interface Props {
     active: boolean;
     workspaceCount?: number;
-    hasActiveProject?: boolean;
     hasActiveWorkspace?: boolean;
     activeWorkspaceDeletionInProgress?: boolean;
     idleWorkspaceCount?: number;
@@ -11,7 +10,6 @@
   let {
     active,
     workspaceCount = 0,
-    hasActiveProject = false,
     hasActiveWorkspace = false,
     activeWorkspaceDeletionInProgress = false,
     idleWorkspaceCount = 0,
@@ -19,7 +17,8 @@
 
   const showNavigation = $derived(workspaceCount > 1);
   const showJump = $derived(workspaceCount > 1);
-  const showNew = $derived(hasActiveProject);
+  // Always show "New" hint - Enter opens Create Workspace dialog even without projects
+  const showNew = true;
   const showDelete = $derived(hasActiveWorkspace && !activeWorkspaceDeletionInProgress);
   const showIdleNavigation = $derived(idleWorkspaceCount >= 2);
 </script>

--- a/src/renderer/lib/components/ShortcutOverlay.test.ts
+++ b/src/renderer/lib/components/ShortcutOverlay.test.ts
@@ -11,7 +11,6 @@ describe("ShortcutOverlay component", () => {
   const defaultProps = {
     active: true,
     workspaceCount: 3,
-    hasActiveProject: true,
     hasActiveWorkspace: true,
   };
 
@@ -169,15 +168,6 @@ describe("ShortcutOverlay component", () => {
 
       const jumpHint = screen.getByLabelText("Number keys 1 through 0 to jump");
       expect(jumpHint).toHaveClass("shortcut-hint--hidden");
-    });
-
-    it("should-hide-new-hint-when-no-active-project", () => {
-      render(ShortcutOverlay, {
-        props: { ...defaultProps, hasActiveProject: false },
-      });
-
-      const newHint = screen.getByLabelText("Enter key to create new workspace");
-      expect(newHint).toHaveClass("shortcut-hint--hidden");
     });
 
     it("should-hide-delete-hint-when-no-active-workspace", () => {

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -10,9 +10,10 @@ import { activeWorkspace, projects } from "./projects.svelte.js";
 
 export type DialogState =
   | { type: "closed" }
-  | { type: "create"; projectId: ProjectId }
+  | { type: "create"; projectId?: ProjectId }
   | { type: "remove"; workspaceRef: WorkspaceRef }
-  | { type: "close-project"; projectId: ProjectId };
+  | { type: "close-project"; projectId: ProjectId }
+  | { type: "git-clone" };
 
 // ============ State ============
 
@@ -32,11 +33,14 @@ export const dialogState = {
  * Open the create workspace dialog.
  * @param defaultProjectId - Optional ID of the project to create workspace in.
  *   Falls back to activeWorkspace's project, then first project.
+ *   If no projects exist, opens dialog without a selected project.
  */
 export function openCreateDialog(defaultProjectId?: ProjectId): void {
   const projectId = defaultProjectId ?? activeWorkspace.value?.projectId ?? projects.value[0]?.id;
-  if (projectId) {
+  if (projectId !== undefined) {
     _dialogState = { type: "create", projectId };
+  } else {
+    _dialogState = { type: "create" };
   }
 }
 
@@ -54,6 +58,13 @@ export function openRemoveDialog(workspaceRef: WorkspaceRef): void {
  */
 export function openCloseProjectDialog(projectId: ProjectId): void {
   _dialogState = { type: "close-project", projectId };
+}
+
+/**
+ * Open the git clone dialog.
+ */
+export function openGitCloneDialog(): void {
+  _dialogState = { type: "git-clone" };
 }
 
 /**

--- a/src/renderer/lib/stores/dialogs.test.ts
+++ b/src/renderer/lib/stores/dialogs.test.ts
@@ -139,14 +139,14 @@ describe("dialog state store", () => {
       });
     });
 
-    it("stays closed when no projects available", () => {
+    it("opens without projectId when no projects available", () => {
       mockActiveWorkspace.mockReturnValue(null);
       mockProjects.mockReturnValue([]);
 
-      // Open with no projects - dialog should stay closed
+      // Open with no projects - dialog opens with no projectId
       openCreateDialog();
 
-      expect(dialogState.value).toEqual({ type: "closed" });
+      expect(dialogState.value).toEqual({ type: "create" });
     });
   });
 

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -247,9 +247,10 @@ export type ProjectWithId = Project;
 
 /**
  * Get a project by its ID.
- * @param id - The project ID to look up
+ * @param id - The project ID to look up (can be undefined)
  * @returns The project if found, undefined otherwise
  */
-export function getProjectById(id: ProjectId): ProjectWithId | undefined {
+export function getProjectById(id: ProjectId | undefined): ProjectWithId | undefined {
+  if (id === undefined) return undefined;
   return _projectsWithIds.find((p) => p.id === id);
 }

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -270,13 +270,12 @@ async function handleJump(key: JumpKey): Promise<void> {
  */
 function handleDialog(key: DialogKey): void {
   if (key === "Enter") {
-    // Use active project, or fallback to first project if none active
-    const project = activeProject.value ?? projects.value[0];
-    if (!project) return;
     // Deactivate shortcut mode locally for immediate UI feedback
     // The ui-mode store will compute desiredMode="dialog" when dialog opens
     setModeFromMain("workspace");
-    openCreateDialog(project.id);
+    // Use active project, or fallback to first project if none active
+    const project = activeProject.value ?? projects.value[0];
+    openCreateDialog(project?.id);
   } else {
     // Delete or Backspace
     const workspaceRef = activeWorkspace.value;

--- a/src/renderer/lib/stores/shortcuts.test.ts
+++ b/src/renderer/lib/stores/shortcuts.test.ts
@@ -793,14 +793,16 @@ describe("shortcuts store", () => {
         expect(shortcutModeActive.value).toBe(false);
       });
 
-      it("should-not-open-create-dialog-when-no-projects-exist", () => {
+      it("should-open-create-dialog-with-undefined-when-no-projects-exist", () => {
         mockProjectsStore.activeProject.value = null;
         mockProjectsStore.projects.value = [];
 
         enableShortcutMode();
         handleShortcutKey("enter");
 
-        expect(mockDialogState.openCreateDialog).not.toHaveBeenCalled();
+        // Opens dialog with undefined projectId when no projects exist
+        expect(mockDialogState.openCreateDialog).toHaveBeenCalledWith(undefined);
+        expect(shortcutModeActive.value).toBe(false);
       });
 
       it("should-open-remove-dialog-on-delete", () => {

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -28,6 +28,13 @@ export function createMockApi(): Api {
         workspaces: [],
       }),
       close: vi.fn().mockResolvedValue(undefined),
+      clone: vi.fn().mockResolvedValue({
+        id: "cloned-12345678",
+        name: "cloned",
+        path: "/cloned",
+        workspaces: [],
+        remoteUrl: "https://github.com/org/repo.git",
+      }),
       list: vi.fn().mockResolvedValue([]),
       get: vi.fn().mockResolvedValue(undefined),
       fetchBases: vi.fn().mockResolvedValue({ bases: [] }),

--- a/src/renderer/lib/utils/initialize-app.test.ts
+++ b/src/renderer/lib/utils/initialize-app.test.ts
@@ -250,46 +250,6 @@ describe("initializeApp", () => {
     });
   });
 
-  describe("auto-open project picker", () => {
-    it("calls onAutoOpenProject when no projects exist", async () => {
-      const api = createMockApi({ projects: [] });
-      const onAutoOpenProject = vi.fn();
-      const options: InitializeAppOptions = {
-        containerRef: undefined,
-        notificationService,
-        onAutoOpenProject,
-      };
-
-      await initializeApp(options, api);
-
-      expect(onAutoOpenProject).toHaveBeenCalled();
-    });
-
-    it("does not call onAutoOpenProject when projects exist", async () => {
-      const api = createMockApi({ projects: [TEST_PROJECT] });
-      const onAutoOpenProject = vi.fn();
-      const options: InitializeAppOptions = {
-        containerRef: undefined,
-        notificationService,
-        onAutoOpenProject,
-      };
-
-      await initializeApp(options, api);
-
-      expect(onAutoOpenProject).not.toHaveBeenCalled();
-    });
-
-    it("does not fail when onAutoOpenProject is not provided", async () => {
-      const api = createMockApi({ projects: [] });
-      const options: InitializeAppOptions = {
-        containerRef: undefined,
-        notificationService,
-      };
-
-      await expect(initializeApp(options, api)).resolves.not.toThrow();
-    });
-  });
-
   describe("focus management", () => {
     it("focuses vscode-button element", async () => {
       const container = createMockContainer("vscode-button");

--- a/src/renderer/lib/utils/initialize-app.ts
+++ b/src/renderer/lib/utils/initialize-app.ts
@@ -1,5 +1,5 @@
 /**
- * Initialize the application: load projects, agent statuses, set focus, auto-open picker.
+ * Initialize the application: load projects, agent statuses, set focus.
  *
  * This is an async setup function that returns a cleanup callback for consistent
  * composition, even though the cleanup is a no-op (initialization is one-time).
@@ -26,8 +26,6 @@ export interface InitializeAppOptions {
   containerRef: HTMLElement | undefined;
   /** Notification service to seed with initial agent counts */
   notificationService: AgentNotificationService;
-  /** Callback when no projects exist (first launch experience) */
-  onAutoOpenProject?: () => Promise<void>;
 }
 
 export interface InitializeAppApi {
@@ -95,7 +93,6 @@ const defaultApi: InitializeAppApi = {
  * 3. Focus first focusable element (including VSCode Elements)
  * 4. Fetch agent statuses for all workspaces
  * 5. Seed notification service with initial counts
- * 6. Auto-open project picker if no projects exist
  *
  * @param options - Initialization options
  * @param apiImpl - API implementation (defaults to window.api)
@@ -105,7 +102,7 @@ export async function initializeApp(
   options: InitializeAppOptions,
   apiImpl: InitializeAppApi = defaultApi
 ): Promise<() => void> {
-  const { containerRef, notificationService, onAutoOpenProject } = options;
+  const { containerRef, notificationService } = options;
 
   try {
     // Load projects
@@ -151,11 +148,6 @@ export async function initializeApp(
       notificationService.seedInitialCounts(initialCounts);
     } catch {
       // Agent status is optional, don't fail initialization
-    }
-
-    // Auto-open project picker on first launch (no projects)
-    if (projectList.length === 0 && onAutoOpenProject) {
-      await onAutoOpenProject();
     }
   } catch (err: unknown) {
     setError(err instanceof Error ? err.message : "Failed to load projects");

--- a/src/services/git/git-client.ts
+++ b/src/services/git/git-client.ts
@@ -174,4 +174,20 @@ export interface IGitClient {
    * @throws GitError if not a git repository
    */
   unsetBranchConfig(repoPath: Path, branch: string, key: string): Promise<void>;
+
+  /**
+   * Clone a repository in bare mode.
+   * @param url Git remote URL (HTTPS or SSH format)
+   * @param targetPath Destination path for the bare clone
+   * @throws GitError on network failure, auth failure, invalid URL, or target exists
+   */
+  clone(url: string, targetPath: Path): Promise<void>;
+
+  /**
+   * Check if a repository is a bare repository.
+   * @param repoPath Absolute path to the git repository
+   * @returns Promise resolving to true if repository is bare
+   * @throws GitError if not a git repository
+   */
+  isBare(repoPath: Path): Promise<boolean>;
 }

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -43,6 +43,12 @@ function createMockCoreApi(overrides?: {
       workspaces: [],
     }),
     close: vi.fn().mockResolvedValue(undefined),
+    clone: vi.fn().mockResolvedValue({
+      id: "test-12345678" as ProjectId,
+      name: "test",
+      path: "/path",
+      workspaces: [],
+    }),
     list: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(undefined),
     fetchBases: vi.fn().mockResolvedValue({ bases: [] }),

--- a/src/services/project/types.ts
+++ b/src/services/project/types.ts
@@ -12,9 +12,12 @@ export interface ProjectConfig {
   readonly version: number;
   /** Absolute path to the project directory */
   readonly path: string;
+  /** Original git remote URL if project was cloned from URL */
+  readonly remoteUrl?: string;
 }
 
 /**
  * Current schema version for ProjectConfig.
+ * Version 2: Added optional remoteUrl field for cloned projects.
  */
-export const CURRENT_PROJECT_VERSION = 1;
+export const CURRENT_PROJECT_VERSION = 2;

--- a/src/services/project/url-utils.test.ts
+++ b/src/services/project/url-utils.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Focused tests for URL normalization utilities.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeGitUrl,
+  extractRepoName,
+  generateProjectIdFromUrl,
+  isValidGitUrl,
+  expandGitUrl,
+} from "./url-utils";
+
+describe("normalizeGitUrl", () => {
+  it("normalizes HTTPS URLs", () => {
+    expect(normalizeGitUrl("https://GitHub.com/Org/Repo.git")).toBe("github.com/org/repo");
+  });
+
+  it("normalizes SSH URLs", () => {
+    expect(normalizeGitUrl("git@github.com:Org/Repo.git")).toBe("github.com/org/repo");
+  });
+
+  it("strips user credentials from HTTPS URLs", () => {
+    expect(normalizeGitUrl("https://user:pass@github.com/org/repo.git")).toBe(
+      "github.com/org/repo"
+    );
+  });
+
+  it("preserves non-default port numbers", () => {
+    // Note: Default ports (443 for HTTPS, 80 for HTTP) are stripped by URL API
+    expect(normalizeGitUrl("https://github.com:8443/org/repo.git")).toBe(
+      "github.com:8443/org/repo"
+    );
+  });
+
+  it("removes trailing slashes", () => {
+    expect(normalizeGitUrl("https://github.com/org/repo/")).toBe("github.com/org/repo");
+  });
+
+  it("removes .git suffix", () => {
+    expect(normalizeGitUrl("https://github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  it("handles URLs without .git suffix", () => {
+    expect(normalizeGitUrl("https://github.com/org/repo")).toBe("github.com/org/repo");
+  });
+
+  it("normalizes case for hostname and path", () => {
+    expect(normalizeGitUrl("https://GITHUB.COM/ORG/REPO.git")).toBe("github.com/org/repo");
+  });
+
+  it("handles ssh:// protocol", () => {
+    expect(normalizeGitUrl("ssh://git@github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  it("handles git:// protocol", () => {
+    expect(normalizeGitUrl("git://github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  it("handles complex paths", () => {
+    expect(normalizeGitUrl("https://gitlab.com/group/subgroup/repo.git")).toBe(
+      "gitlab.com/group/subgroup/repo"
+    );
+  });
+});
+
+describe("extractRepoName", () => {
+  it("extracts repo name from HTTPS URL", () => {
+    expect(extractRepoName("https://github.com/org/my-repo.git")).toBe("my-repo");
+  });
+
+  it("extracts repo name from SSH URL", () => {
+    expect(extractRepoName("git@github.com:org/my-repo.git")).toBe("my-repo");
+  });
+
+  it("handles nested paths", () => {
+    expect(extractRepoName("https://gitlab.com/group/subgroup/repo.git")).toBe("repo");
+  });
+});
+
+describe("generateProjectIdFromUrl", () => {
+  it("generates a ProjectId from URL", () => {
+    const id = generateProjectIdFromUrl("https://github.com/org/my-repo.git");
+    expect(id).toMatch(/^my-repo-[a-f0-9]{8}$/);
+  });
+
+  it("generates consistent IDs for equivalent URLs", () => {
+    const httpsId = generateProjectIdFromUrl("https://github.com/org/my-repo.git");
+    const sshId = generateProjectIdFromUrl("git@github.com:org/my-repo.git");
+    expect(httpsId).toBe(sshId);
+  });
+
+  it("generates different IDs for different URLs", () => {
+    const id1 = generateProjectIdFromUrl("https://github.com/org/repo-a.git");
+    const id2 = generateProjectIdFromUrl("https://github.com/org/repo-b.git");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("handles repo names with special characters", () => {
+    const id = generateProjectIdFromUrl("https://github.com/org/my.cool-repo.git");
+    expect(id).toMatch(/^my-cool-repo-[a-f0-9]{8}$/);
+  });
+});
+
+describe("isValidGitUrl", () => {
+  it("validates HTTPS URLs", () => {
+    expect(isValidGitUrl("https://github.com/org/repo.git")).toBe(true);
+    expect(isValidGitUrl("http://github.com/org/repo.git")).toBe(true);
+  });
+
+  it("validates SSH URLs", () => {
+    expect(isValidGitUrl("git@github.com:org/repo.git")).toBe(true);
+    expect(isValidGitUrl("user@gitlab.com:group/repo.git")).toBe(true);
+  });
+
+  it("validates git:// URLs", () => {
+    expect(isValidGitUrl("git://github.com/org/repo.git")).toBe(true);
+  });
+
+  it("validates ssh:// URLs", () => {
+    expect(isValidGitUrl("ssh://git@github.com/org/repo.git")).toBe(true);
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(isValidGitUrl("not-a-url")).toBe(false);
+    expect(isValidGitUrl("just-text")).toBe(false);
+    expect(isValidGitUrl("")).toBe(false);
+    expect(isValidGitUrl("   ")).toBe(false);
+  });
+
+  it("handles URLs with whitespace", () => {
+    expect(isValidGitUrl("  https://github.com/org/repo.git  ")).toBe(true);
+  });
+});
+
+describe("expandGitUrl", () => {
+  it("returns full HTTPS URLs unchanged", () => {
+    expect(expandGitUrl("https://github.com/org/repo.git")).toBe("https://github.com/org/repo.git");
+  });
+
+  it("returns full SSH URLs unchanged", () => {
+    expect(expandGitUrl("git@github.com:org/repo.git")).toBe("git@github.com:org/repo.git");
+  });
+
+  it("expands org/repo shorthand to GitHub URL", () => {
+    expect(expandGitUrl("stefanhoelzl/codehydra")).toBe(
+      "https://github.com/stefanhoelzl/codehydra.git"
+    );
+  });
+
+  it("expands partial URL with domain to full URL", () => {
+    expect(expandGitUrl("github.com/org/repo")).toBe("https://github.com/org/repo.git");
+  });
+
+  it("expands gitlab.com partial URL", () => {
+    expect(expandGitUrl("gitlab.com/group/project")).toBe("https://gitlab.com/group/project.git");
+  });
+
+  it("does not double-add .git suffix", () => {
+    expect(expandGitUrl("github.com/org/repo.git")).toBe("https://github.com/org/repo.git");
+  });
+
+  it("handles HTTPS URL without .git suffix", () => {
+    expect(expandGitUrl("https://github.com/org/repo")).toBe("https://github.com/org/repo");
+  });
+
+  it("handles whitespace", () => {
+    expect(expandGitUrl("  org/repo  ")).toBe("https://github.com/org/repo.git");
+  });
+
+  it("returns invalid input unchanged for validation to catch", () => {
+    expect(expandGitUrl("not-valid")).toBe("not-valid");
+  });
+
+  it("handles repo names with dots", () => {
+    expect(expandGitUrl("org/my.repo")).toBe("https://github.com/org/my.repo.git");
+  });
+
+  it("handles repo names with hyphens and underscores", () => {
+    expect(expandGitUrl("org/my-cool_repo")).toBe("https://github.com/org/my-cool_repo.git");
+  });
+});

--- a/src/services/project/url-utils.ts
+++ b/src/services/project/url-utils.ts
@@ -1,0 +1,243 @@
+/**
+ * URL utilities for git remote URL handling.
+ *
+ * Provides URL normalization and project ID generation from URLs.
+ */
+
+import * as crypto from "node:crypto";
+import type { ProjectId } from "../../shared/api/types";
+
+/**
+ * Normalize a git remote URL to a canonical form for comparison.
+ *
+ * Normalization rules:
+ * - Lowercase hostname
+ * - Remove protocol (https://, git://, ssh://)
+ * - Remove user credentials (user:pass@)
+ * - Remove .git suffix
+ * - Remove trailing slashes
+ * - Convert SSH format (git@host:path) to standard format (host/path)
+ * - Preserve port numbers
+ *
+ * @param url Git remote URL (HTTPS, SSH, or git:// format)
+ * @returns Normalized URL string
+ *
+ * @example
+ * normalizeGitUrl("https://GitHub.com/Org/Repo.git") // "github.com/org/repo"
+ * normalizeGitUrl("git@github.com:Org/Repo.git") // "github.com/org/repo"
+ * normalizeGitUrl("https://user:pass@github.com/org/repo.git") // "github.com/org/repo"
+ * normalizeGitUrl("https://github.com:443/org/repo.git") // "github.com:443/org/repo"
+ */
+export function normalizeGitUrl(url: string): string {
+  let normalized = url.trim();
+
+  // First, try to handle URL format (https://, git://, ssh://)
+  // These have :// in them which distinguishes from SSH git@host:path format
+  if (/^[a-z]+:\/\//i.test(normalized)) {
+    try {
+      // Try to parse as URL
+      const parsed = new URL(normalized);
+
+      // Extract host (lowercase)
+      let host = parsed.hostname.toLowerCase();
+
+      // Include port if non-standard
+      if (parsed.port) {
+        host = `${host}:${parsed.port}`;
+      }
+
+      // Get path and normalize
+      let path = parsed.pathname;
+
+      // Remove leading slashes
+      path = path.replace(/^\/+/, "");
+
+      // Remove .git suffix
+      if (path.endsWith(".git")) {
+        path = path.slice(0, -4);
+      }
+
+      // Remove trailing slashes
+      path = path.replace(/\/+$/, "");
+
+      // Lowercase the path for case-insensitive comparison
+      return `${host}/${path.toLowerCase()}`;
+    } catch {
+      // If URL parsing fails, fall through to simple path handling
+    }
+  }
+
+  // Handle SSH format: git@host:path -> host/path
+  // This regex matches patterns like:
+  // - git@github.com:org/repo.git
+  // - user@gitlab.com:group/project
+  const sshMatch = normalized.match(/^(?:[^@]+@)?([^:/]+):(.+)$/);
+  if (sshMatch && sshMatch[1] && sshMatch[2]) {
+    // SSH format detected (git@host:path)
+    const host = sshMatch[1].toLowerCase();
+    let path = sshMatch[2];
+
+    // Remove .git suffix
+    if (path.endsWith(".git")) {
+      path = path.slice(0, -4);
+    }
+
+    // Remove trailing slashes
+    path = path.replace(/\/+$/, "");
+
+    // Lowercase the path for case-insensitive comparison
+    return `${host}/${path.toLowerCase()}`;
+  }
+
+  // Fallback: try to handle as a simple path
+  // Remove any protocol-like prefix
+  normalized = normalized.replace(/^[a-z]+:\/\//i, "");
+
+  // Remove credentials
+  normalized = normalized.replace(/^[^@]+@/, "");
+
+  // Remove .git suffix
+  if (normalized.endsWith(".git")) {
+    normalized = normalized.slice(0, -4);
+  }
+
+  // Remove trailing slashes
+  normalized = normalized.replace(/\/+$/, "");
+
+  return normalized.toLowerCase();
+}
+
+/**
+ * Extract a human-readable name from a git URL.
+ * Returns the repository name (last path segment).
+ *
+ * @param url Git remote URL
+ * @returns Repository name
+ *
+ * @example
+ * extractRepoName("https://github.com/org/my-repo.git") // "my-repo"
+ * extractRepoName("git@github.com:org/my-repo.git") // "my-repo"
+ */
+export function extractRepoName(url: string): string {
+  const normalized = normalizeGitUrl(url);
+  const segments = normalized.split("/").filter((s) => s.length > 0);
+  return segments[segments.length - 1] ?? "repo";
+}
+
+/**
+ * Generate a deterministic ProjectId from a git remote URL.
+ *
+ * The ID format is: `<repo-name>-<8-char-hex-hash>`
+ * - repo-name: Repository name extracted from URL
+ * - hash: first 8 characters of SHA-256 hash of normalized URL
+ *
+ * @param url Git remote URL
+ * @returns A deterministic ProjectId
+ *
+ * @example
+ * generateProjectIdFromUrl("https://github.com/org/my-repo.git") // "my-repo-abcd1234"
+ * // Same URL variants produce same ID:
+ * generateProjectIdFromUrl("git@github.com:org/my-repo.git") // "my-repo-abcd1234"
+ */
+export function generateProjectIdFromUrl(url: string): ProjectId {
+  const normalized = normalizeGitUrl(url);
+  const repoName = extractRepoName(url);
+
+  // Create safe name:
+  // 1. Replace non-alphanumeric characters with dashes
+  // 2. Collapse consecutive dashes
+  // 3. Remove leading/trailing dashes
+  // 4. Use "repo" as fallback for empty result
+  const safeName =
+    repoName
+      .replace(/[^a-zA-Z0-9]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "repo";
+
+  // Generate hash from normalized URL
+  const hash = crypto.createHash("sha256").update(normalized).digest("hex").slice(0, 8);
+
+  return `${safeName}-${hash}` as ProjectId;
+}
+
+/**
+ * Expand shorthand git URLs to full URLs.
+ *
+ * Supports:
+ * - Full URLs (returned as-is): "https://github.com/org/repo.git"
+ * - GitHub shorthand: "org/repo" -> "https://github.com/org/repo.git"
+ * - Partial URLs: "github.com/org/repo" -> "https://github.com/org/repo.git"
+ *
+ * @param input User input (may be shorthand or full URL)
+ * @returns Expanded URL (may still be invalid if input is malformed)
+ *
+ * @example
+ * expandGitUrl("org/repo") // "https://github.com/org/repo.git"
+ * expandGitUrl("github.com/org/repo") // "https://github.com/org/repo.git"
+ * expandGitUrl("https://github.com/org/repo") // "https://github.com/org/repo.git"
+ * expandGitUrl("git@github.com:org/repo.git") // "git@github.com:org/repo.git" (unchanged)
+ */
+export function expandGitUrl(input: string): string {
+  const trimmed = input.trim();
+
+  // Already a full URL - return as-is
+  if (isValidGitUrl(trimmed)) {
+    return trimmed;
+  }
+
+  // Shorthand: org/repo (no dots in first segment, no protocol)
+  // e.g., "stefanhoelzl/codehydra" -> "https://github.com/stefanhoelzl/codehydra.git"
+  const shorthandMatch = trimmed.match(/^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)$/);
+  if (shorthandMatch && shorthandMatch[1] && shorthandMatch[2]) {
+    return `https://github.com/${shorthandMatch[1]}/${shorthandMatch[2]}.git`;
+  }
+
+  // Partial URL: github.com/org/repo (domain without protocol)
+  // e.g., "github.com/org/repo" -> "https://github.com/org/repo.git"
+  if (/^[a-z0-9.-]+\/[^\s]+$/i.test(trimmed) && trimmed.includes(".")) {
+    const withProtocol = `https://${trimmed}`;
+    // Add .git suffix if not present
+    return withProtocol.endsWith(".git") ? withProtocol : `${withProtocol}.git`;
+  }
+
+  // Unknown format - return as-is (will fail validation)
+  return trimmed;
+}
+
+/**
+ * Validate that a string looks like a git URL.
+ * Supports HTTPS, SSH, and git:// protocols.
+ *
+ * @param url String to validate
+ * @returns true if the string appears to be a valid git URL
+ *
+ * @example
+ * isValidGitUrl("https://github.com/org/repo.git") // true
+ * isValidGitUrl("git@github.com:org/repo.git") // true
+ * isValidGitUrl("not-a-url") // false
+ */
+export function isValidGitUrl(url: string): boolean {
+  const trimmed = url.trim();
+
+  // Check for HTTPS/HTTP/GIT protocol
+  if (/^https?:\/\/[^\s]+/.test(trimmed)) {
+    return true;
+  }
+
+  // Check for git:// protocol
+  if (/^git:\/\/[^\s]+/.test(trimmed)) {
+    return true;
+  }
+
+  // Check for SSH format (git@host:path or user@host:path)
+  if (/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+:[^\s]+/.test(trimmed)) {
+    return true;
+  }
+
+  // Check for ssh:// protocol
+  if (/^ssh:\/\/[^\s]+/.test(trimmed)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/shared/api/interfaces.test.ts
+++ b/src/shared/api/interfaces.test.ts
@@ -39,6 +39,10 @@ describe("IProjectApi Interface", () => {
       async close(projectId: ProjectId): Promise<void> {
         void projectId;
       },
+      async clone(url: string): Promise<Project> {
+        void url;
+        throw new Error("mock");
+      },
       async list(): Promise<readonly Project[]> {
         return [];
       },

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -28,9 +28,26 @@ export type { IDisposable, Unsubscribe } from "../types";
 // Domain API Interfaces - Stubs
 // =============================================================================
 
+/**
+ * Options for closing a project.
+ */
+export interface ProjectCloseOptions {
+  /** If true and project has remoteUrl, delete the entire project directory including cloned repo */
+  readonly removeLocalRepo?: boolean;
+}
+
 export interface IProjectApi {
   open(path: string): Promise<Project>;
-  close(projectId: ProjectId): Promise<void>;
+  close(projectId: ProjectId, options?: ProjectCloseOptions): Promise<void>;
+  /**
+   * Clone a git repository and create a new project.
+   * If the URL has already been cloned, returns the existing project.
+   *
+   * @param url Git remote URL (HTTPS or SSH format)
+   * @returns The created or existing project
+   * @throws Error if clone fails (network, auth, invalid URL)
+   */
+  clone(url: string): Promise<Project>;
   list(): Promise<readonly Project[]>;
   get(projectId: ProjectId): Promise<Project | undefined>;
   fetchBases(projectId: ProjectId): Promise<{ readonly bases: readonly BaseInfo[] }>;

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -125,6 +125,8 @@ export interface Project {
   readonly path: string;
   readonly workspaces: readonly Workspace[];
   readonly defaultBaseBranch?: string;
+  /** Original git remote URL if project was cloned from URL */
+  readonly remoteUrl?: string;
 }
 
 /**

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -36,7 +36,8 @@ export interface Api {
 
   projects: {
     open(path: string): Promise<Project>;
-    close(projectId: string): Promise<void>;
+    close(projectId: string, options?: { removeLocalRepo?: boolean }): Promise<void>;
+    clone(url: string): Promise<Project>;
     list(): Promise<readonly Project[]>;
     get(projectId: string): Promise<Project | undefined>;
     fetchBases(projectId: string): Promise<{ readonly bases: readonly ApiBaseInfo[] }>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -80,6 +80,7 @@ export const ApiIpcChannels = {
   // Project commands
   PROJECT_OPEN: "api:project:open",
   PROJECT_CLOSE: "api:project:close",
+  PROJECT_CLONE: "api:project:clone",
   PROJECT_LIST: "api:project:list",
   PROJECT_GET: "api:project:get",
   PROJECT_FETCH_BASES: "api:project:fetch-bases",


### PR DESCRIPTION
- New GitCloneDialog for entering repository URLs
- Support URL shortcuts (org/repo, github.com/org/repo)
- Clone to bare repository with remote-tracking branches
- Duplicate URL detection returns existing project
- CloseProjectDialog shows "Delete cloned repository" option
- Fix: bare clones show branches under "Remote Branches" header
- IGitClient.clone() for bare clone operations
- URL normalization and expansion utilities
- ProjectStore.findByRemoteUrl() for duplicate detection
- projects.clone() and projects.close() API extensions