### PR TITLE
feat(claude): add automatic session resume on wrapper launch

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -477,6 +477,24 @@ Since Claude Code doesn't provide explicit status events, status is derived from
 - **Response completed**: `busy` → `idle`
 - **Inactivity timeout**: `busy` → `idle` (safety fallback)
 
+### Session Resumption
+
+The Claude wrapper automatically attempts to resume previous sessions using the `--continue` flag:
+
+1. On launch, checks if user passed `--continue`, `-c`, or `--resume` flags
+2. If not, prepends `--continue` to attempt resuming the most recent session for this directory
+3. If continuation fails (no session exists), automatically retries without `--continue`
+4. This enables seamless session continuity across CodeHydra restarts
+
+**How `--continue` works**: The Claude CLI `--continue` flag loads the most recent conversation from the current project directory. Sessions are stored in `~/.claude/projects/` and are per-directory.
+
+**Flag precedence**: If user passes `--resume <session-id>`, it takes precedence over `--continue`. The wrapper detects this and skips adding `--continue` to avoid conflicts.
+
+Users can still use their own flags:
+
+- `--resume <session>` - Resume a specific named session
+- `--continue` or `-c` - Explicitly continue most recent session
+
 ---
 
 ## Implementing a New Agent


### PR DESCRIPTION
The Claude wrapper now automatically attempts to resume the most recent session using `--continue` flag. If no session exists (or continuation fails), it gracefully falls back to starting a fresh session.

- Add `runClaude()` function with retry-with-continue logic
- Skip auto-continue when user passes `--continue`, `-c`, or `--resume`
- Preserve all arguments including initial prompts across retry
- Add 8 integration tests for session resume behavior
- Document session resumption in AGENTS.md