### PR TITLE
fix(release): pass secrets to build workflow for telemetry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       release: true
+    secrets: inherit
 
   release:
     needs: build


### PR DESCRIPTION
- Add `secrets: inherit` to release workflow build job
- Enables POSTHOG_API_KEY to be passed to build.yaml during releases
- Fixes telemetry being disabled in release builds due to missing API key