### PR TITLE
fix(build): pass version to electron-builder for Windows installer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,9 @@ jobs:
           sudo apt-get install -y wine64 wine32:i386
 
       - name: Package
-        run: pnpm dist:${{ matrix.target }}
+        env:
+          CODEHYDRA_VERSION: ${{ needs.prepare.outputs.version }}
+        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION
 
       - name: Rename artifact
         if: matrix.rename


### PR DESCRIPTION
- Pass computed version to electron-builder via `--config.extraMetadata.version` flag
- Fixes Windows installer showing "0.1.0" instead of release version (e.g., 2026.2.3)