### PR TITLE
fix(release): restore auto-update metadata generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,9 +82,6 @@ jobs:
       - name: Build
         env:
           CODEHYDRA_VERSION: ${{ steps.version.outputs.version }}
-          CODEHYDRA_UPDATE_PROVIDER: github
-          CODEHYDRA_UPDATE_OWNER: ${{ github.repository_owner }}
-          CODEHYDRA_UPDATE_REPO: ${{ github.event.repository.name }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: pnpm build
@@ -148,7 +145,7 @@ jobs:
       - name: Package
         env:
           CODEHYDRA_VERSION: ${{ needs.prepare.outputs.version }}
-        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION
+        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
 
       - name: Rename artifact
         if: matrix.rename

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -2,9 +2,12 @@ appId: com.codehydra.app
 productName: CodeHydra
 copyright: Copyright © 2025 CodeHydra
 
-# Disable auto-publishing (release workflow handles GitHub Releases)
-# Update URL is configured via environment variables at build time
-publish: null
+# GitHub Releases for auto-update metadata generation
+# Note: --publish=never flag in CI prevents actual upload
+publish:
+  provider: github
+  owner: stefanhoelzl
+  repo: codehydra
 
 # Build directories
 directories:

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,11 +11,6 @@ const appVersion = process.env.CODEHYDRA_VERSION ?? "0.0.0-dev";
 const posthogApiKey = process.env.POSTHOG_API_KEY;
 const posthogHost = process.env.POSTHOG_HOST ?? "https://eu.posthog.com";
 
-// Auto-update configuration - injected at build time
-const updateProvider = process.env.CODEHYDRA_UPDATE_PROVIDER;
-const updateOwner = process.env.CODEHYDRA_UPDATE_OWNER;
-const updateRepo = process.env.CODEHYDRA_UPDATE_REPO;
-
 export default defineConfig({
   main: {
     build: {
@@ -31,10 +26,6 @@ export default defineConfig({
       // PostHog constants - undefined if not configured (telemetry disabled)
       __POSTHOG_API_KEY__: posthogApiKey ? JSON.stringify(posthogApiKey) : "undefined",
       __POSTHOG_HOST__: JSON.stringify(posthogHost),
-      // Auto-update constants - undefined if not configured (updates disabled)
-      __UPDATE_PROVIDER__: updateProvider ? JSON.stringify(updateProvider) : "undefined",
-      __UPDATE_OWNER__: updateOwner ? JSON.stringify(updateOwner) : "undefined",
-      __UPDATE_REPO__: updateRepo ? JSON.stringify(updateRepo) : "undefined",
     },
     plugins: [
       // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -23,21 +23,3 @@ declare const __POSTHOG_API_KEY__: string | undefined;
  * Defaults to EU region (https://eu.posthog.com).
  */
 declare const __POSTHOG_HOST__: string | undefined;
-
-/**
- * Provider for auto-update feed (e.g., "github").
- * Injected from CODEHYDRA_UPDATE_PROVIDER during build.
- */
-declare const __UPDATE_PROVIDER__: string | undefined;
-
-/**
- * Owner for auto-update feed (e.g., GitHub username or org).
- * Injected from CODEHYDRA_UPDATE_OWNER during build.
- */
-declare const __UPDATE_OWNER__: string | undefined;
-
-/**
- * Repository for auto-update feed.
- * Injected from CODEHYDRA_UPDATE_REPO during build.
- */
-declare const __UPDATE_REPO__: string | undefined;

--- a/src/services/auto-updater.ts
+++ b/src/services/auto-updater.ts
@@ -50,15 +50,6 @@ export class AutoUpdater {
     this.logger = deps.logger;
     this.isDevelopment = deps.isDevelopment;
 
-    // Configure update feed URL if build-time values are provided
-    if (__UPDATE_PROVIDER__ && __UPDATE_OWNER__ && __UPDATE_REPO__) {
-      autoUpdater.setFeedURL({
-        provider: __UPDATE_PROVIDER__ as "github",
-        owner: __UPDATE_OWNER__,
-        repo: __UPDATE_REPO__,
-      });
-    }
-
     // Configure electron-updater
     // autoInstallOnAppQuit is true by default
     autoUpdater.autoDownload = true;


### PR DESCRIPTION
- Restore GitHub publish provider in electron-builder.yaml to enable metadata file generation
- Add --publish=never flag to packaging step to prevent actual upload while generating latest.yml
- Remove setFeedURL() workaround and related CODEHYDRA_UPDATE_* env vars no longer needed

The release workflow failed because latest.yml files weren't being generated after commit 8e31de2 set publish: null.