### PR TITLE
fix(release): filter for latest release to exclude code-server tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get latest release tag
-          LATEST_TAG=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName // empty')
+          # Get latest release tag (filter for isLatest to exclude code-server Windows builds)
+          LATEST_TAG=$(gh release list --repo "${{ github.repository }}" --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName // empty')
 
           if [[ -z "$LATEST_TAG" ]]; then
             echo "No previous release found, will create first release"


### PR DESCRIPTION
- Filter `gh release list` by `isLatest` flag instead of `--limit 1`
- Prevents code-server Windows build tags from being used as the latest release reference
- Ensures correct commit count comparison against actual CodeHydra releases