### PR TITLE
fix(release): disable CI detection for electron-builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Package
         env:
           CODEHYDRA_VERSION: ${{ needs.prepare.outputs.version }}
-        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
+        run: CI= pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
 
       - name: Rename artifact
         if: matrix.rename


### PR DESCRIPTION
- Unset CI environment variable before running electron-builder to prevent it from attempting to validate GitHub draft releases
- Fixes GH_TOKEN error in package jobs since the token isn't needed when not publishing