### PR TITLE
fix(release): provide GH_TOKEN to electron-builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,8 @@ jobs:
       - name: Package
         env:
           CODEHYDRA_VERSION: ${{ needs.prepare.outputs.version }}
-        run: CI= pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
+          GH_TOKEN: ${{ github.token }}
+        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
 
       - name: Rename artifact
         if: matrix.rename


### PR DESCRIPTION
- Provide GH_TOKEN to electron-builder Package step to fix draft release check
- Remove CI= workaround that didn't resolve the issue
- Uses github.token which has sufficient read access