### PR TITLE
fix(ui): replace close icons with trash icons in sidebar

### DIFF
--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -163,7 +163,7 @@
                   aria-label="Close project"
                   onclick={() => onCloseProject(project.id)}
                 >
-                  <Icon name="close" size={14} />
+                  <Icon name="trash" size={14} />
                 </button>
               </div>
             </div>
@@ -217,7 +217,7 @@
                         aria-label="Remove workspace"
                         onclick={() => handleRemoveWorkspace(workspaceRef)}
                       >
-                        <Icon name="close" size={14} />
+                        <Icon name="trash" size={14} />
                       </button>
                     {/if}
                     {#if deletionStatus === "in-progress"}


### PR DESCRIPTION
- Replace close (x) icons with trash icons on close-project and remove-workspace buttons in sidebar
- Makes destructive actions visually distinct from the add workspace (+) button at 14px size