### PR TITLE
fix(projects): prevent duplicate config for cloned projects

### DIFF
--- a/src/main/app-state.integration.test.ts
+++ b/src/main/app-state.integration.test.ts
@@ -68,6 +68,7 @@ const { mockProjectStore, mockWorkspaceProvider, mockCreateGitWorktreeProvider }
       saveProject: vi.fn(() => Promise.resolve()),
       removeProject: vi.fn(() => Promise.resolve()),
       loadAllProjects: vi.fn(() => Promise.resolve([] as string[])),
+      getProjectConfig: vi.fn(() => Promise.resolve(undefined)),
     };
 
     return {

--- a/src/main/modules/core/index.ts
+++ b/src/main/modules/core/index.ts
@@ -306,17 +306,11 @@ export class CoreModule implements IApiModule {
     // Open the newly cloned project (at git/ subdirectory where the repo is)
     const project = await this.deps.appState.openProject(gitPath.toString());
 
-    // Convert to API type and add remoteUrl
     const apiProject = this.toApiProject(project, project.defaultBaseBranch);
-    // Add remoteUrl to the response
-    const projectWithRemoteUrl: Project = {
-      ...apiProject,
-      remoteUrl: url,
-    };
 
-    this.api.emit("project:opened", { project: projectWithRemoteUrl });
+    this.api.emit("project:opened", { project: apiProject });
 
-    return projectWithRemoteUrl;
+    return apiProject;
   }
 
   private async projectList(payload: EmptyPayload): Promise<readonly Project[]> {
@@ -599,6 +593,7 @@ export class CoreModule implements IApiModule {
     internalProject: {
       path: string;
       name: string;
+      remoteUrl?: string;
       workspaces: ReadonlyArray<{
         path: string;
         branch?: string | null;
@@ -614,6 +609,7 @@ export class CoreModule implements IApiModule {
       path: internalProject.path,
       workspaces: internalProject.workspaces.map((w) => this.toApiWorkspace(projectId, w)),
       ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+      ...(internalProject.remoteUrl !== undefined && { remoteUrl: internalProject.remoteUrl }),
     };
   }
 

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -143,9 +143,13 @@
           {#if projectIndex > 0}
             <vscode-divider></vscode-divider>
           {/if}
+          {@const projectTitle = project.remoteUrl ?? project.path}
           <li class="project-item">
             <div class="project-header">
-              <span class="project-name" title={project.path}>{project.name}</span>
+              <span class="project-icon" title={projectTitle}>
+                <Icon name={project.remoteUrl ? "source-control" : "folder-opened"} size={14} />
+              </span>
+              <span class="project-name" title={projectTitle}>{project.name}</span>
               <div class="project-actions">
                 <button
                   type="button"
@@ -383,7 +387,15 @@
     min-width: var(--ch-sidebar-width, 250px);
   }
 
+  .project-icon {
+    opacity: 0.7;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+  }
+
   .project-name {
+    flex: 1;
     font-weight: 600;
     font-size: 13px;
     overflow: hidden;

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -697,8 +697,10 @@ describe("Sidebar component", () => {
         },
       });
 
-      // Get all project names in rendered order
-      const projectNames = screen.getAllByTitle(/^\//);
+      // Get all project names in rendered order (filter to .project-name elements only)
+      const projectNames = screen
+        .getAllByTitle(/^\//)
+        .filter((el) => el.classList.contains("project-name"));
       const names = projectNames.map((el) => el.textContent);
 
       expect(names).toEqual(["Alpha", "alpha", "beta", "charlie"]);


### PR DESCRIPTION
- Fix duplicate project config: `openProject()` now skips `saveProject` when config already exists, preventing a second path-hashed config from overwriting the URL-hashed one created during clone
- Remove redundant manual `remoteUrl` patching in `projectClone()` since `openProject` now loads `remoteUrl` from the existing config and passes it through `toApiProject`
- Add project icons in sidebar: folder icon for local projects, source-control icon for cloned projects
- Add test for skip-save behavior when project config already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)