### PR TITLE
fix(release): set package.json version before packaging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,9 @@ jobs:
         env:
           CODEHYDRA_VERSION: ${{ needs.prepare.outputs.version }}
           GH_TOKEN: ${{ github.token }}
-        run: pnpm dist:${{ matrix.target }} -- --config.extraMetadata.version=$CODEHYDRA_VERSION --publish=never
+        run: |
+          pnpm pkg set "version=$CODEHYDRA_VERSION"
+          pnpm dist:${{ matrix.target }} -- --publish=never
 
       - name: Rename artifact
         if: matrix.rename


### PR DESCRIPTION
- Set package.json version directly via `pnpm pkg set` before running electron-builder
- Remove `--config.extraMetadata.version` flag which was silently ignored
- Fixes auto-updater seeing 0.1.0 instead of the actual release version