### PR TITLE
chore(skills): defer document reads and add interfaces to plan overview

### DIFF
--- a/.claude/commands/feature/plan.md
+++ b/.claude/commands/feature/plan.md
@@ -212,7 +212,7 @@ reviewers: []
 
 ## Overview
 
-- Problem, Solution, Risks, Alternatives
+- Problem, Solution, Interfaces, Risks, Alternatives
 
 ## Architecture
 

--- a/.claude/templates/plan.md
+++ b/.claude/templates/plan.md
@@ -15,6 +15,7 @@ reviewers: []
 
 - **Problem**: What problem does this solve?
 - **Solution**: High-level approach
+- **Interfaces**: New or changed interfaces (IPC channels, types, abstraction layers)
 - **Risks**: Identified risks and mitigations
 - **Alternatives Considered**: Other approaches and why they were rejected
 

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -26,15 +26,15 @@ Use `.claude/templates/plan.md` for the exact structure. Every plan must include
 
 ### Required Sections
 
-| Section                  | What It Answers                                                      |
-| ------------------------ | -------------------------------------------------------------------- |
-| **Overview**             | What problem? What solution? What risks? What alternatives?          |
-| **Architecture**         | How does this fit into the system? (diagram for significant changes) |
-| **Testing Strategy**     | Which test types needed? (per docs/TESTING.md)                       |
-| **Implementation Steps** | What to build, in what order, with test criteria for each step       |
-| **Dependencies**         | Any new packages needed? (require user approval)                     |
-| **Documentation**        | What docs need updating?                                             |
-| **Definition of Done**   | Acceptance criteria                                                  |
+| Section                  | What It Answers                                                              |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| **Overview**             | What problem? What solution? What interfaces? What risks? What alternatives? |
+| **Architecture**         | How does this fit into the system? (diagram for significant changes)         |
+| **Testing Strategy**     | Which test types needed? (per docs/TESTING.md)                               |
+| **Implementation Steps** | What to build, in what order, with test criteria for each step               |
+| **Dependencies**         | Any new packages needed? (require user approval)                             |
+| **Documentation**        | What docs need updating?                                                     |
+| **Definition of Done**   | Acceptance criteria                                                          |
 
 ### Optional Sections
 


### PR DESCRIPTION
- Defer document reads in feature:plan skill: only read `docs/PLANNING.md` on invocation; change-type docs load in Phase 2, plan template loads in Phase 5
- Drop redundant `CLAUDE.md` read (already loaded as project instructions)
- Add **Interfaces** field to plan overview section across template, skill, and planning docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)