### PR TITLE
fix(test): prevent OpenCode temp file accumulation in /tmp

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,2 +1,29 @@
 /// <reference types="@testing-library/jest-dom" />
 import "@testing-library/jest-dom/vitest";
+
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, beforeAll } from "vitest";
+
+// Redirect Bun's temp files to a per-suite directory to prevent orphaned
+// .so/.hm files accumulating in /tmp (OpenCode's Zig runtime extracts
+// shared libraries to BUN_TMPDIR on every launch and never cleans them up).
+let bunTmpDir: string | undefined;
+const originalBunTmpDir = process.env.BUN_TMPDIR;
+
+beforeAll(async () => {
+  bunTmpDir = await mkdtemp(join(tmpdir(), "codehydra-bun-tmp-"));
+  process.env.BUN_TMPDIR = bunTmpDir;
+});
+
+afterAll(async () => {
+  if (originalBunTmpDir !== undefined) {
+    process.env.BUN_TMPDIR = originalBunTmpDir;
+  } else {
+    delete process.env.BUN_TMPDIR;
+  }
+  if (bunTmpDir) {
+    await rm(bunTmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 200 });
+  }
+});


### PR DESCRIPTION
- Set BUN_TMPDIR to a per-suite temp directory in test setup so OpenCode's Zig runtime extracts .so/.hm files there instead of /tmp
- Directory is cleaned up in afterAll, preventing ~4MB files from accumulating on every boundary test run