### PR TITLE
feat(intents): add collect() for isolated hook contexts, migrate get-workspace-status

### DIFF
--- a/src/main/intents/infrastructure/hook-registry.integration.test.ts
+++ b/src/main/intents/infrastructure/hook-registry.integration.test.ts
@@ -177,4 +177,134 @@ describe("HookRegistry", () => {
     expect(ctx.error).toBeInstanceOf(Error);
     expect(ctx.error?.message).toBe("string error");
   });
+
+  describe("collect", () => {
+    it("empty hook point returns empty results and errors", async () => {
+      const registry = new HookRegistry();
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+
+      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
+
+      expect(result.results).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("returns typed results from handlers", async () => {
+      const registry = new HookRegistry();
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => ({ value: 1 }),
+      });
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => ({ value: 2 }),
+      });
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => ({ value: 3 }),
+      });
+
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+
+      const result = await hooks.collect<{ value: number }>(TEST_HOOK_POINT, ctx);
+
+      expect(result.results).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("handler mutation of frozen context throws TypeError", async () => {
+      const registry = new HookRegistry();
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async (ctx: HookContext) => {
+          // Attempt to mutate frozen context — should throw TypeError
+          (ctx as unknown as Record<string, unknown>).isDirty = true;
+        },
+      });
+
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+
+      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
+
+      expect(result.results).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(TypeError);
+    });
+
+    it("all handlers run even when earlier handlers throw", async () => {
+      const registry = new HookRegistry();
+      const ran: number[] = [];
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => {
+          ran.push(1);
+          throw new Error("first failed");
+        },
+      });
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => {
+          ran.push(2);
+          return "ok";
+        },
+      });
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => {
+          ran.push(3);
+          throw new Error("third failed");
+        },
+      });
+
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+
+      const result = await hooks.collect<string>(TEST_HOOK_POINT, ctx);
+
+      expect(ran).toEqual([1, 2, 3]);
+      expect(result.results).toEqual(["ok"]);
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]?.message).toBe("first failed");
+      expect(result.errors[1]?.message).toBe("third failed");
+    });
+
+    it("non-Error throws are wrapped in Error", async () => {
+      const registry = new HookRegistry();
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => {
+          throw "string error";
+        },
+      });
+
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+
+      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(Error);
+      expect(result.errors[0]?.message).toBe("string error");
+    });
+
+    it("original input context is not mutated", async () => {
+      const registry = new HookRegistry();
+
+      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+        handler: async () => "result",
+      });
+
+      const hooks = registry.resolve(TEST_OPERATION_ID);
+      const ctx = createHookContext();
+      const originalIntent = ctx.intent;
+
+      await hooks.collect(TEST_HOOK_POINT, ctx);
+
+      expect(ctx.intent).toBe(originalIntent);
+      expect(ctx.error).toBeUndefined();
+    });
+  });
 });

--- a/src/main/intents/infrastructure/index.ts
+++ b/src/main/intents/infrastructure/index.ts
@@ -14,6 +14,7 @@ export type {
   DispatchFn,
   HookContext,
   HookHandler,
+  HookResult,
   ResolvedHooks,
 } from "./operation";
 


### PR DESCRIPTION
- Add `collect()` to `ResolvedHooks` — each handler receives a frozen context clone and returns typed results, enforcing the "hooks are unordered" principle
- Add `HookHandler<T>`, `HookResult<T>` generics for typed hook results
- Add 6 infrastructure tests for `collect()` (isolation, error collection, frozen context)
- Migrate `get-workspace-status` as first validation: handlers return `GetStatusHookResult` instead of mutating shared `GetWorkspaceStatusHookContext`
- Operation merges results explicitly (OR semantics for `isDirty`)