### PR TITLE
refactor(intents): migrate project:open to isolated hook contexts via collect()

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -113,7 +113,11 @@ import {
 } from "./operations/open-project";
 import type {
   OpenProjectIntent,
-  OpenProjectHookContext,
+  ResolveHookResult,
+  DiscoverHookInput,
+  DiscoverHookResult,
+  RegisterHookInput,
+  RegisterHookResult,
   ProjectOpenedEvent,
 } from "./operations/open-project";
 import {
@@ -1828,17 +1832,17 @@ function wireDispatcher(
   // Project:open hook modules
   // ---------------------------------------------------------------------------
 
-  // ProjectResolverModule: "open" hook -- clone if URL, validate git, create provider
+  // ProjectResolverModule: "resolve" hook -- clone if URL, validate git
   const projectResolverModule: IntentModule = {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { path, git } = intent.payload;
 
             let projectPath: Path;
+            let remoteUrl: string | undefined;
 
             if (git) {
               const expanded = expandGitUrl(git);
@@ -1874,95 +1878,115 @@ function wireDispatcher(
                 projectPath = gitPath;
               }
 
-              hookCtx.remoteUrl = expanded;
+              remoteUrl = expanded;
             } else {
               projectPath = path!;
             }
 
-            // Validate git repo and create provider
-            const workspacesDir = pathProvider.getProjectWorkspacesDir(projectPath);
+            // Validate git repo
             await globalProvider.validateRepository(projectPath);
-            const provider: IWorkspaceProvider = new ProjectScopedWorkspaceProvider(
-              globalProvider,
-              projectPath,
-              workspacesDir
-            );
 
-            hookCtx.projectPath = projectPath.toString();
-            hookCtx.provider = provider;
+            return {
+              projectPath: projectPath.toString(),
+              ...(remoteUrl !== undefined && { remoteUrl }),
+            };
           },
         },
       },
     },
   };
 
-  // ProjectDiscoveryModule: "open" hook -- discover workspaces, orphan cleanup
+  // ProjectDiscoveryModule: "discover" hook -- discover workspaces, orphan cleanup
   const projectDiscoveryModule: IntentModule = {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
-            const provider = hookCtx.provider!;
+        discover: {
+          handler: async (ctx: HookContext): Promise<DiscoverHookResult> => {
+            const { projectPath } = ctx as DiscoverHookInput;
+            const projectPathObj = new Path(projectPath);
+            const workspacesDir = pathProvider.getProjectWorkspacesDir(projectPathObj);
+            const provider: IWorkspaceProvider = new ProjectScopedWorkspaceProvider(
+              globalProvider,
+              projectPathObj,
+              workspacesDir
+            );
 
-            hookCtx.workspaces = await provider.discover();
+            const workspaces = await provider.discover();
 
             // Fire-and-forget cleanup
             if (provider.cleanupOrphanedWorkspaces) {
               void provider.cleanupOrphanedWorkspaces().catch((err: unknown) => {
                 logger.error(
                   "Workspace cleanup failed",
-                  { projectPath: hookCtx.projectPath ?? "unknown" },
+                  { projectPath },
                   err instanceof Error ? err : undefined
                 );
               });
             }
+
+            return { workspaces };
           },
         },
       },
     },
   };
 
-  // ProjectRegistryModule: "open" hook -- generate ID, load config, store state, persist
+  // ProjectRegistryModule: "register" hook -- generate ID, load config, store state, persist
   const projectRegistryModule: IntentModule = {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
-            const projectPathStr = hookCtx.projectPath!;
+        register: {
+          handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+            const { projectPath: projectPathStr, remoteUrl: resolvedRemoteUrl } =
+              ctx as RegisterHookInput;
             const projectPath = new Path(projectPathStr);
 
             // Generate project ID
-            hookCtx.projectId = generateProjectId(projectPathStr);
+            const projectId = generateProjectId(projectPathStr);
 
             // Load project config for remoteUrl
             const projectConfig = await projectStore.getProjectConfig(projectPathStr);
+            let remoteUrl = resolvedRemoteUrl;
             if (projectConfig?.remoteUrl) {
-              hookCtx.remoteUrl = projectConfig.remoteUrl;
+              remoteUrl = projectConfig.remoteUrl;
             }
+
+            // Create provider for AppState registration
+            const workspacesDir = pathProvider.getProjectWorkspacesDir(projectPath);
+            const provider: IWorkspaceProvider = new ProjectScopedWorkspaceProvider(
+              globalProvider,
+              projectPath,
+              workspacesDir
+            );
 
             // Register in AppState
             appState.registerProject({
-              id: hookCtx.projectId,
+              id: projectId,
               name: projectPath.basename,
               path: projectPath,
               workspaces: [],
-              provider: hookCtx.provider!,
-              ...(hookCtx.remoteUrl !== undefined && { remoteUrl: hookCtx.remoteUrl }),
+              provider,
+              ...(remoteUrl !== undefined && { remoteUrl }),
             });
 
             // Get and cache default base branch
-            const defaultBaseBranch = await appState.getDefaultBaseBranch(projectPathStr);
-            if (defaultBaseBranch) {
-              appState.setLastBaseBranch(projectPathStr, defaultBaseBranch);
-              hookCtx.defaultBaseBranch = defaultBaseBranch;
+            let defaultBaseBranch: string | undefined;
+            const baseBranch = await appState.getDefaultBaseBranch(projectPathStr);
+            if (baseBranch) {
+              appState.setLastBaseBranch(projectPathStr, baseBranch);
+              defaultBaseBranch = baseBranch;
             }
 
             // Persist to store if new
             if (!projectConfig) {
               await projectStore.saveProject(projectPathStr);
             }
+
+            return {
+              projectId,
+              ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              ...(remoteUrl !== undefined && { remoteUrl }),
+            };
           },
         },
       },

--- a/src/main/operations/open-project.integration.test.ts
+++ b/src/main/operations/open-project.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for OpenProjectOperation.
  *
  * Tests the full project:open pipeline through dispatcher.dispatch():
- * - Operation orchestrates "open" hook then dispatches workspace:create per workspace
+ * - Operation orchestrates resolve → discover → register hooks via collect()
  * - Idempotency interceptor prevents duplicate opens
  * - Best-effort handling when individual workspace:create fails
  * - URL detection and clone handling
@@ -31,7 +31,14 @@ import {
   INTENT_OPEN_PROJECT,
   EVENT_PROJECT_OPENED,
 } from "./open-project";
-import type { OpenProjectIntent, OpenProjectHookContext, ProjectOpenedEvent } from "./open-project";
+import type {
+  OpenProjectIntent,
+  ResolveHookResult,
+  DiscoverHookResult,
+  RegisterHookInput,
+  RegisterHookResult,
+  ProjectOpenedEvent,
+} from "./open-project";
 import type { Intent } from "../intents/infrastructure/types";
 import {
   CreateWorkspaceOperation,
@@ -240,14 +247,32 @@ function createTestHarness(options?: {
         });
       }
     ),
-    registerWorkspace: vi
-      .fn()
-      .mockImplementation((projectPath: string, workspace: { path: Path }) => {
+    registerWorkspace: vi.fn().mockImplementation(
+      (
+        projectPath: string,
+        workspace: {
+          path: Path;
+          branch: string | null;
+          metadata: Record<string, string>;
+        }
+      ) => {
         projectState.registeredWorkspaces.push({
           projectPath,
           workspacePath: workspace.path.toString(),
         });
-      }),
+        // Also add to the project's workspaces (matches real AppState behavior)
+        const project = projectState.registeredProjects.find(
+          (p) => p.path === new Path(projectPath).toString()
+        );
+        if (project) {
+          project.workspaces.push({
+            path: workspace.path.toString(),
+            branch: workspace.branch,
+            metadata: workspace.metadata,
+          });
+        }
+      }
+    ),
     setLastBaseBranch: vi.fn().mockImplementation((path: string, branch: string) => {
       projectState.lastBaseBranches.set(new Path(path).toString(), branch);
     }),
@@ -351,13 +376,13 @@ function createTestHarness(options?: {
   const projectResolverModule: IntentModule = {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { path, git } = intent.payload;
 
             let projectPath: Path;
+            let remoteUrl: string | undefined;
 
             if (git) {
               const expanded = expandGitUrl(git);
@@ -373,15 +398,56 @@ function createTestHarness(options?: {
                 projectStoreState.configs.set(gitPath.toString(), { remoteUrl: expanded });
                 projectPath = gitPath;
               }
-              hookCtx.remoteUrl = expanded;
+              remoteUrl = expanded;
             } else {
               projectPath = path!;
             }
 
             await globalProvider.validateRepository(projectPath);
 
-            hookCtx.projectPath = projectPath.toString();
-            hookCtx.provider = {
+            return {
+              projectPath: projectPath.toString(),
+              ...(remoteUrl !== undefined && { remoteUrl }),
+            };
+          },
+        },
+      },
+    },
+  };
+
+  // ProjectDiscoveryModule
+  const projectDiscoveryModule: IntentModule = {
+    hooks: {
+      [OPEN_PROJECT_OPERATION_ID]: {
+        discover: {
+          handler: async (): Promise<DiscoverHookResult> => {
+            return { workspaces: discoverResult };
+          },
+        },
+      },
+    },
+  };
+
+  // ProjectRegistryModule
+  const projectRegistryModule: IntentModule = {
+    hooks: {
+      [OPEN_PROJECT_OPERATION_ID]: {
+        register: {
+          handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+            const { projectPath: projectPathStr, remoteUrl: resolvedRemoteUrl } =
+              ctx as RegisterHookInput;
+            const projectPath = new Path(projectPathStr);
+
+            const projectId = generateProjectId(projectPathStr);
+
+            const config = await projectStore.getProjectConfig(projectPathStr);
+            let remoteUrl = resolvedRemoteUrl;
+            if (config?.remoteUrl) {
+              remoteUrl = config.remoteUrl;
+            }
+
+            // Create mock provider for AppState registration
+            const mockProvider = {
               projectRoot: projectPath,
               discover: vi.fn(),
               listBases: vi.fn(),
@@ -394,61 +460,32 @@ function createTestHarness(options?: {
                 .fn()
                 .mockResolvedValue({ removedCount: 0, failedPaths: [] }),
             } as unknown as import("../../services/git/workspace-provider").IWorkspaceProvider;
-          },
-        },
-      },
-    },
-  };
-
-  // ProjectDiscoveryModule
-  const projectDiscoveryModule: IntentModule = {
-    hooks: {
-      [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
-            hookCtx.workspaces = discoverResult;
-          },
-        },
-      },
-    },
-  };
-
-  // ProjectRegistryModule
-  const projectRegistryModule: IntentModule = {
-    hooks: {
-      [OPEN_PROJECT_OPERATION_ID]: {
-        open: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as OpenProjectHookContext;
-            const projectPathStr = hookCtx.projectPath!;
-            const projectPath = new Path(projectPathStr);
-
-            hookCtx.projectId = generateProjectId(projectPathStr);
-
-            const config = await projectStore.getProjectConfig(projectPathStr);
-            if (config?.remoteUrl) {
-              hookCtx.remoteUrl = config.remoteUrl;
-            }
 
             appState.registerProject({
-              id: hookCtx.projectId,
+              id: projectId,
               name: projectPath.basename,
               path: projectPath,
-              workspaces: hookCtx.workspaces ?? [],
-              provider: hookCtx.provider!,
-              ...(hookCtx.remoteUrl !== undefined && { remoteUrl: hookCtx.remoteUrl }),
+              workspaces: [],
+              provider: mockProvider,
+              ...(remoteUrl !== undefined && { remoteUrl }),
             });
 
-            const defaultBaseBranch = await appState.getDefaultBaseBranch(projectPathStr);
-            if (defaultBaseBranch) {
-              appState.setLastBaseBranch(projectPathStr, defaultBaseBranch);
-              hookCtx.defaultBaseBranch = defaultBaseBranch;
+            let defaultBaseBranch: string | undefined;
+            const baseBranch = await appState.getDefaultBaseBranch(projectPathStr);
+            if (baseBranch) {
+              appState.setLastBaseBranch(projectPathStr, baseBranch);
+              defaultBaseBranch = baseBranch;
             }
 
             if (!config) {
               await projectStore.saveProject(projectPathStr);
             }
+
+            return {
+              projectId,
+              ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              ...(remoteUrl !== undefined && { remoteUrl }),
+            };
           },
         },
       },


### PR DESCRIPTION
- Replace shared mutable `OpenProjectHookContext` with 3 sequential `collect()` calls (`resolve` → `discover` → `register`), each returning typed results
- Operation mediates data flow between hook points — only pure data flows through contexts
- Providers are now created per-module via closure instead of being passed through the shared context
- Single errors from `collect()` are re-thrown directly to preserve original error messages