### PR TITLE
chore: update code-server to 4.109.2

### DIFF
--- a/src/services/binary-download/versions.ts
+++ b/src/services/binary-download/versions.ts
@@ -12,7 +12,7 @@ export { OPENCODE_VERSION, CLAUDE_VERSION };
 /**
  * Current version of code-server to download.
  */
-export const CODE_SERVER_VERSION = "4.108.2";
+export const CODE_SERVER_VERSION = "4.109.2";
 
 /**
  * GitHub repository for Windows code-server builds.

--- a/src/services/vscode-setup/extension-manager.integration.test.ts
+++ b/src/services/vscode-setup/extension-manager.integration.test.ts
@@ -200,7 +200,7 @@ describe("ExtensionManager", () => {
       await manager.install(["codehydra.sidekick"]);
 
       expect(processRunner.run).toHaveBeenCalledWith(
-        path.normalize("/app/binaries/code-server-4.108.2"),
+        path.normalize("/app/binaries/code-server-4.109.2"),
         expect.arrayContaining([
           "--install-extension",
           expect.stringContaining("codehydra-sidekick-0.0.1.vsix"),


### PR DESCRIPTION
- Bump code-server from 4.108.2 to 4.109.2
- Update hardcoded version in extension manager test