### PR TITLE
chore(intents): migrate all operations to collect(), remove run()

### DIFF
--- a/src/main/intents/infrastructure/dispatcher.integration.test.ts
+++ b/src/main/intents/infrastructure/dispatcher.integration.test.ts
@@ -294,7 +294,7 @@ describe("Dispatcher", () => {
       id: "query-op",
       execute: async (ctx) => {
         const hookCtx: HookContext = { intent: ctx.intent };
-        await ctx.hooks.run("get", hookCtx);
+        await ctx.hooks.collect("get", hookCtx);
         return { answer: 42 };
       },
     });

--- a/src/main/intents/infrastructure/hook-registry.integration.test.ts
+++ b/src/main/intents/infrastructure/hook-registry.integration.test.ts
@@ -1,7 +1,8 @@
 /**
  * Integration tests for HookRegistry.
  *
- * Verifies hook execution order, error propagation, and onError handler behavior.
+ * Verifies hook execution order, collect() isolation, error collection,
+ * and context freezing behavior.
  */
 
 import { describe, it, expect } from "vitest";
@@ -26,14 +27,15 @@ function createHookContext(): HookContext {
 // =============================================================================
 
 describe("HookRegistry", () => {
-  it("empty hook point is no-op", async () => {
+  it("empty hook point returns empty results and errors", async () => {
     const registry = new HookRegistry();
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
 
-    await hooks.run(TEST_HOOK_POINT, ctx);
+    const result = await hooks.collect(TEST_HOOK_POINT, ctx);
 
-    expect(ctx.error).toBeUndefined();
+    expect(result.results).toEqual([]);
+    expect(result.errors).toEqual([]);
   });
 
   it("handlers run in registration order", async () => {
@@ -61,79 +63,109 @@ describe("HookRegistry", () => {
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
 
-    await hooks.run(TEST_HOOK_POINT, ctx);
+    await hooks.collect(TEST_HOOK_POINT, ctx);
 
     expect(order).toEqual([1, 2, 3]);
-    expect(ctx.error).toBeUndefined();
   });
 
-  it("error skips non-onError handlers", async () => {
+  it("returns typed results from handlers", async () => {
     const registry = new HookRegistry();
-    const ran: string[] = [];
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      handler: async () => {
-        ran.push("first");
-        throw new Error("handler failed");
-      },
+      handler: async () => ({ value: 1 }),
     });
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      handler: async () => {
-        ran.push("second");
-      },
+      handler: async () => ({ value: 2 }),
     });
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      handler: async () => {
-        ran.push("third");
+      handler: async () => ({ value: 3 }),
+    });
+
+    const hooks = registry.resolve(TEST_OPERATION_ID);
+    const ctx = createHookContext();
+
+    const result = await hooks.collect<{ value: number }>(TEST_HOOK_POINT, ctx);
+
+    expect(result.results).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("handler mutation of frozen context throws TypeError", async () => {
+    const registry = new HookRegistry();
+
+    registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async (ctx: HookContext) => {
+        // Attempt to mutate frozen context — should throw TypeError
+        (ctx as unknown as Record<string, unknown>).isDirty = true;
       },
     });
 
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
 
-    await hooks.run(TEST_HOOK_POINT, ctx);
+    const result = await hooks.collect(TEST_HOOK_POINT, ctx);
 
-    expect(ran).toEqual(["first"]);
-    expect(ctx.error).toBeInstanceOf(Error);
-    expect(ctx.error?.message).toBe("handler failed");
+    expect(result.results).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toBeInstanceOf(TypeError);
   });
 
-  it("onError handler runs after error", async () => {
+  it("all handlers run even when earlier handlers throw", async () => {
     const registry = new HookRegistry();
-    const ran: string[] = [];
+    const ran: number[] = [];
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
       handler: async () => {
-        ran.push("first");
-        throw new Error("handler failed");
+        ran.push(1);
+        throw new Error("first failed");
       },
     });
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
       handler: async () => {
-        ran.push("normal-skipped");
+        ran.push(2);
+        return "ok";
       },
     });
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      handler: async (ctx) => {
-        ran.push("error-handler");
-        // Verify the error is visible to the onError handler
-        expect(ctx.error).toBeInstanceOf(Error);
-        expect(ctx.error?.message).toBe("handler failed");
+      handler: async () => {
+        ran.push(3);
+        throw new Error("third failed");
       },
-      onError: true,
     });
 
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
 
-    await hooks.run(TEST_HOOK_POINT, ctx);
+    const result = await hooks.collect<string>(TEST_HOOK_POINT, ctx);
 
-    expect(ran).toEqual(["first", "error-handler"]);
-    expect(ctx.error).toBeInstanceOf(Error);
+    expect(ran).toEqual([1, 2, 3]);
+    expect(result.results).toEqual(["ok"]);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]?.message).toBe("first failed");
+    expect(result.errors[1]?.message).toBe("third failed");
+  });
+
+  it("non-Error throws are wrapped in Error", async () => {
+    const registry = new HookRegistry();
+
+    registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async () => {
+        throw "string error";
+      },
+    });
+
+    const hooks = registry.resolve(TEST_OPERATION_ID);
+    const ctx = createHookContext();
+
+    const result = await hooks.collect(TEST_HOOK_POINT, ctx);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toBeInstanceOf(Error);
+    expect(result.errors[0]?.message).toBe("string error");
   });
 
   it("separate hook points are independent", async () => {
@@ -155,156 +187,24 @@ describe("HookRegistry", () => {
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
 
-    await hooks.run("point-a", ctx);
+    await hooks.collect("point-a", ctx);
 
     expect(ran).toEqual(["a"]);
   });
 
-  it("non-Error thrown is wrapped in Error", async () => {
+  it("original input context is not mutated", async () => {
     const registry = new HookRegistry();
 
     registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      handler: async () => {
-        throw "string error";
-      },
+      handler: async () => "result",
     });
 
     const hooks = registry.resolve(TEST_OPERATION_ID);
     const ctx = createHookContext();
+    const originalIntent = ctx.intent;
 
-    await hooks.run(TEST_HOOK_POINT, ctx);
+    await hooks.collect(TEST_HOOK_POINT, ctx);
 
-    expect(ctx.error).toBeInstanceOf(Error);
-    expect(ctx.error?.message).toBe("string error");
-  });
-
-  describe("collect", () => {
-    it("empty hook point returns empty results and errors", async () => {
-      const registry = new HookRegistry();
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-
-      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
-
-      expect(result.results).toEqual([]);
-      expect(result.errors).toEqual([]);
-    });
-
-    it("returns typed results from handlers", async () => {
-      const registry = new HookRegistry();
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => ({ value: 1 }),
-      });
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => ({ value: 2 }),
-      });
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => ({ value: 3 }),
-      });
-
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-
-      const result = await hooks.collect<{ value: number }>(TEST_HOOK_POINT, ctx);
-
-      expect(result.results).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
-      expect(result.errors).toEqual([]);
-    });
-
-    it("handler mutation of frozen context throws TypeError", async () => {
-      const registry = new HookRegistry();
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async (ctx: HookContext) => {
-          // Attempt to mutate frozen context — should throw TypeError
-          (ctx as unknown as Record<string, unknown>).isDirty = true;
-        },
-      });
-
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-
-      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
-
-      expect(result.results).toEqual([]);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toBeInstanceOf(TypeError);
-    });
-
-    it("all handlers run even when earlier handlers throw", async () => {
-      const registry = new HookRegistry();
-      const ran: number[] = [];
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => {
-          ran.push(1);
-          throw new Error("first failed");
-        },
-      });
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => {
-          ran.push(2);
-          return "ok";
-        },
-      });
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => {
-          ran.push(3);
-          throw new Error("third failed");
-        },
-      });
-
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-
-      const result = await hooks.collect<string>(TEST_HOOK_POINT, ctx);
-
-      expect(ran).toEqual([1, 2, 3]);
-      expect(result.results).toEqual(["ok"]);
-      expect(result.errors).toHaveLength(2);
-      expect(result.errors[0]?.message).toBe("first failed");
-      expect(result.errors[1]?.message).toBe("third failed");
-    });
-
-    it("non-Error throws are wrapped in Error", async () => {
-      const registry = new HookRegistry();
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => {
-          throw "string error";
-        },
-      });
-
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-
-      const result = await hooks.collect(TEST_HOOK_POINT, ctx);
-
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toBeInstanceOf(Error);
-      expect(result.errors[0]?.message).toBe("string error");
-    });
-
-    it("original input context is not mutated", async () => {
-      const registry = new HookRegistry();
-
-      registry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-        handler: async () => "result",
-      });
-
-      const hooks = registry.resolve(TEST_OPERATION_ID);
-      const ctx = createHookContext();
-      const originalIntent = ctx.intent;
-
-      await hooks.collect(TEST_HOOK_POINT, ctx);
-
-      expect(ctx.intent).toBe(originalIntent);
-      expect(ctx.error).toBeUndefined();
-    });
+    expect(ctx.intent).toBe(originalIntent);
   });
 });

--- a/src/main/intents/infrastructure/operation.ts
+++ b/src/main/intents/infrastructure/operation.ts
@@ -26,29 +26,21 @@ export type DispatchFn = <I extends Intent>(
 
 /**
  * Base context passed to hook handlers.
- * Operations extend this interface when they need data to flow
- * between hooks (e.g., query results).
- *
- * @example
- * interface GetMetadataHookContext extends HookContext {
- *   metadata?: Readonly<Record<string, string>>;
- * }
+ * Operations build extended contexts (with `readonly` fields) to pass data
+ * between hook points. Each handler receives a frozen shallow copy.
  */
 export interface HookContext {
   readonly intent: Intent;
-  error?: Error;
 }
 
 /**
  * A handler registered for a hook point.
- * If `onError` is true, the handler runs even after a previous handler errors.
  *
  * Generic parameter `T` is the return type for `collect()` — defaults to `unknown`
  * so that `HookDeclarations` (which uses `HookHandler`) accepts handlers with any return type.
  */
 export interface HookHandler<T = unknown> {
   readonly handler: (ctx: HookContext) => Promise<T>;
-  readonly onError?: boolean;
 }
 
 /**
@@ -63,13 +55,10 @@ export interface HookResult<T = unknown> {
 /**
  * Resolved hooks for a specific operation.
  *
- * - `run()`: Legacy shared-context execution. Sets `ctx.error` on failure, skips
- *   subsequent non-onError handlers. Does NOT throw.
- * - `collect()`: Isolated-context execution. Each handler receives a frozen clone
- *   of the input context. All handlers always run. Returns typed results + errors.
+ * `collect()` provides isolated-context execution: each handler receives a frozen
+ * clone of the input context. All handlers always run. Returns typed results + errors.
  */
 export interface ResolvedHooks {
-  run(hookPointId: string, ctx: HookContext): Promise<void>;
   collect<T = unknown>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>>;
 }
 

--- a/src/main/intents/infrastructure/wire.integration.test.ts
+++ b/src/main/intents/infrastructure/wire.integration.test.ts
@@ -49,7 +49,7 @@ describe("wireModules", () => {
     // Verify the hook was registered by resolving and running it
     const hooks = hookRegistry.resolve("action-op");
     const ctx: HookContext = { intent: createActionIntent() };
-    await hooks.run("execute", ctx);
+    await hooks.collect("execute", ctx);
 
     expect(hookRan).toHaveBeenCalledOnce();
   });
@@ -123,7 +123,7 @@ describe("wireModules", () => {
 
     const hooks = hookRegistry.resolve("action-op");
     const ctx: HookContext = { intent: createActionIntent() };
-    await hooks.run("execute", ctx);
+    await hooks.collect("execute", ctx);
 
     expect(order).toEqual(["module-a", "module-b"]);
   });

--- a/src/main/operations/app-shutdown.ts
+++ b/src/main/operations/app-shutdown.ts
@@ -7,9 +7,9 @@
  *    ensuring all modules get a chance to dispose even if earlier ones fail.
  * 2. "quit" - Terminates the process (runs after all cleanup).
  *
- * The operation ignores ctx.error because shutdown is best-effort --
- * individual module errors are logged but do not prevent other modules
- * from disposing.
+ * The operation ignores both results and errors because shutdown is
+ * best-effort -- individual module errors are logged but do not
+ * prevent other modules from disposing.
  *
  * No provider dependencies - hook handlers do the actual work.
  */
@@ -39,15 +39,6 @@ export const INTENT_APP_SHUTDOWN = "app:shutdown" as const;
 
 export const APP_SHUTDOWN_OPERATION_ID = "app-shutdown";
 
-/**
- * Hook context for app:shutdown.
- *
- * Modules use this for "stop" and "quit" hook points. Each module handles its
- * own errors internally (best-effort shutdown).
- * Currently identical to HookContext -- exists as a named alias for clarity.
- */
-export type AppShutdownHookContext = HookContext;
-
 // =============================================================================
 // Operation
 // =============================================================================
@@ -56,18 +47,19 @@ export class AppShutdownOperation implements Operation<AppShutdownIntent, void> 
   readonly id = APP_SHUTDOWN_OPERATION_ID;
 
   async execute(ctx: OperationContext<AppShutdownIntent>): Promise<void> {
-    const hookCtx: AppShutdownHookContext = {
+    const hookCtx: HookContext = {
       intent: ctx.intent,
     };
 
     // Hook: "stop" -- All modules dispose (independent, best-effort)
     // Each module wraps its logic in try/catch internally.
-    await ctx.hooks.run("stop", hookCtx);
+    // With collect(), all handlers always run regardless of errors.
+    await ctx.hooks.collect<void>("stop", hookCtx);
 
     // Hook: "quit" -- Terminate the process (runs after all cleanup)
-    await ctx.hooks.run("quit", hookCtx);
+    await ctx.hooks.collect<void>("quit", hookCtx);
 
-    // Intentionally ignore hookCtx.error -- shutdown is best-effort.
+    // Intentionally ignore both results and errors -- shutdown is best-effort.
     // Individual module errors are logged by each module's handler.
   }
 }

--- a/src/main/operations/create-workspace.integration.test.ts
+++ b/src/main/operations/create-workspace.integration.test.ts
@@ -61,7 +61,7 @@ import {
   INTENT_SWITCH_WORKSPACE,
   SWITCH_WORKSPACE_OPERATION_ID,
 } from "./switch-workspace";
-import type { SwitchWorkspaceIntent, SwitchWorkspaceHookContext } from "./switch-workspace";
+import type { SwitchWorkspaceIntent, SwitchWorkspaceHookResult } from "./switch-workspace";
 
 // =============================================================================
 // Test Constants
@@ -197,17 +197,18 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
   dispatcher.registerOperation(INTENT_CREATE_WORKSPACE, new CreateWorkspaceOperation());
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
 
-  // No-op SwitchViewModule for workspace:switch (just sets resolvedPath to satisfy operation)
+  // No-op SwitchViewModule for workspace:switch (just returns resolvedPath to satisfy operation)
   const switchViewModule: IntentModule = {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as SwitchWorkspaceHookContext;
+          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
             const intent = ctx.intent as SwitchWorkspaceIntent;
-            // Minimal resolve: just set resolvedPath so the operation emits its event
-            hookCtx.resolvedPath = `/workspaces/${intent.payload.workspaceName}`;
-            hookCtx.projectPath = PROJECT_ROOT;
+            // Minimal resolve: just return resolvedPath so the operation emits its event
+            return {
+              resolvedPath: `/workspaces/${intent.payload.workspaceName}`,
+              projectPath: PROJECT_ROOT,
+            };
           },
         },
       },

--- a/src/main/operations/get-active-workspace.integration.test.ts
+++ b/src/main/operations/get-active-workspace.integration.test.ts
@@ -23,10 +23,9 @@ import {
 } from "./get-active-workspace";
 import type {
   GetActiveWorkspaceIntent,
-  GetActiveWorkspaceHookContext,
+  GetActiveWorkspaceHookResult,
 } from "./get-active-workspace";
 import type { IntentModule } from "../intents/infrastructure/module";
-import type { HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
 import type { WorkspaceRef } from "../../shared/api/types";
 import { generateProjectId, extractWorkspaceName } from "../../shared/api/id-utils";
@@ -95,26 +94,26 @@ function createTestSetup(opts: {
     hooks: {
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext) => {
+          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
             const activeWorkspacePath = opts.viewManager.getActiveWorkspacePath();
             if (!activeWorkspacePath) {
-              (ctx as GetActiveWorkspaceHookContext).workspaceRef = null;
-              return;
+              return { workspaceRef: null };
             }
 
             const project = opts.projectFinder.findProjectForWorkspace(activeWorkspacePath);
             if (!project) {
-              (ctx as GetActiveWorkspaceHookContext).workspaceRef = null;
-              return;
+              return { workspaceRef: null };
             }
 
             const projectId = generateProjectId(project.path);
             const workspaceName = extractWorkspaceName(activeWorkspacePath);
 
-            (ctx as GetActiveWorkspaceHookContext).workspaceRef = {
-              projectId,
-              workspaceName,
-              path: activeWorkspacePath,
+            return {
+              workspaceRef: {
+                projectId,
+                workspaceName,
+                path: activeWorkspacePath,
+              },
             };
           },
         },

--- a/src/main/operations/get-agent-session.integration.test.ts
+++ b/src/main/operations/get-agent-session.integration.test.ts
@@ -20,7 +20,7 @@ import {
   GET_AGENT_SESSION_OPERATION_ID,
   INTENT_GET_AGENT_SESSION,
 } from "./get-agent-session";
-import type { GetAgentSessionIntent, GetAgentSessionHookContext } from "./get-agent-session";
+import type { GetAgentSessionIntent, GetAgentSessionHookResult } from "./get-agent-session";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
@@ -106,12 +106,12 @@ function createTestSetup(opts: { agentStatusManager?: MockAgentStatusManager | n
     hooks: {
       [GET_AGENT_SESSION_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext) => {
+          handler: async (ctx: HookContext): Promise<GetAgentSessionHookResult> => {
             const intent = ctx.intent as GetAgentSessionIntent;
             const { workspace } = await resolveWorkspace(intent.payload, workspaceAccessor);
             const manager = opts.agentStatusManager;
-            (ctx as GetAgentSessionHookContext).session =
-              manager?.getSession(workspace.path as WorkspacePath) ?? null;
+            const session = manager?.getSession(workspace.path as WorkspacePath) ?? null;
+            return { session };
           },
         },
       },

--- a/src/main/operations/restart-agent.integration.test.ts
+++ b/src/main/operations/restart-agent.integration.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./restart-agent";
 import type {
   RestartAgentIntent,
-  RestartAgentHookContext,
+  RestartAgentHookResult,
   AgentRestartedEvent,
 } from "./restart-agent";
 import type { IntentModule } from "../intents/infrastructure/module";
@@ -107,13 +107,12 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
     hooks: {
       [RESTART_AGENT_OPERATION_ID]: {
         restart: {
-          handler: async (ctx: HookContext) => {
+          handler: async (ctx: HookContext): Promise<RestartAgentHookResult> => {
             const intent = ctx.intent as RestartAgentIntent;
             const { workspace } = await resolveWorkspace(intent.payload, workspaceAccessor);
             const result = await opts.serverManager.restartServer(workspace.path);
             if (result.success) {
-              (ctx as RestartAgentHookContext).port = result.port;
-              (ctx as RestartAgentHookContext).workspacePath = workspace.path;
+              return { port: result.port, workspacePath: workspace.path };
             } else {
               throw new Error(result.error);
             }

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -30,8 +30,7 @@ import {
   GET_METADATA_OPERATION_ID,
   INTENT_GET_METADATA,
 } from "./get-metadata";
-import type { GetMetadataHookContext } from "./get-metadata";
-import type { GetMetadataIntent } from "./get-metadata";
+import type { GetMetadataIntent, GetMetadataHookResult } from "./get-metadata";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
 import { createMockGitClient } from "../../services/git/git-client.state-mock";
 import { createFileSystemMock, directory } from "../../services/platform/filesystem.state-mock";
@@ -162,11 +161,11 @@ function createTestSetup(): TestSetup {
   });
 
   hookRegistry.register(GET_METADATA_OPERATION_ID, "get", {
-    handler: async (ctx: HookContext) => {
+    handler: async (ctx: HookContext): Promise<GetMetadataHookResult> => {
       const intent = ctx.intent as GetMetadataIntent;
       const { workspace } = await resolveWorkspace(intent.payload, workspaceAccessor);
       const metadata = await globalProvider.getMetadata(new Path(workspace.path));
-      (ctx as GetMetadataHookContext).metadata = metadata;
+      return { metadata };
     },
   });
 

--- a/src/main/operations/set-metadata.ts
+++ b/src/main/operations/set-metadata.ts
@@ -57,11 +57,9 @@ export class SetMetadataOperation implements Operation<SetMetadataIntent, void> 
     };
 
     // Run "set" hook — handler performs the actual provider write
-    await ctx.hooks.run("set", hookCtx);
-
-    // Check for errors from hook handlers
-    if (hookCtx.error) {
-      throw hookCtx.error;
+    const { errors } = await ctx.hooks.collect<void>("set", hookCtx);
+    if (errors.length > 0) {
+      throw errors[0]!;
     }
 
     // Emit domain event for subscribers (e.g., IpcEventBridge)

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -22,7 +22,7 @@ import {
   INTENT_SET_MODE,
   EVENT_MODE_CHANGED,
 } from "./set-mode";
-import type { SetModeIntent, SetModeHookContext, ModeChangedEvent } from "./set-mode";
+import type { SetModeIntent, SetModeHookResult, ModeChangedEvent } from "./set-mode";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { DomainEvent, Intent } from "../intents/infrastructure/types";
@@ -96,11 +96,11 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
     hooks: {
       [SET_MODE_OPERATION_ID]: {
         set: {
-          handler: async (ctx: HookContext) => {
+          handler: async (ctx: HookContext): Promise<SetModeHookResult> => {
             const intent = ctx.intent as SetModeIntent;
             const previousMode = viewManager.getMode();
             viewManager.setMode(intent.payload.mode);
-            (ctx as SetModeHookContext).previousMode = previousMode;
+            return { previousMode };
           },
         },
       },

--- a/src/main/operations/setup.ts
+++ b/src/main/operations/setup.ts
@@ -56,37 +56,34 @@ export const INTENT_SETUP = "app:setup" as const;
 export const SETUP_OPERATION_ID = "setup";
 
 /**
- * Extended hook context for app:setup.
- *
- * Fields are populated from the intent payload (set by AppStartOperation)
- * and by hook modules across the six hook points:
- * - "show-ui": (no fields, sends IPC to show setup screen)
- * - "agent-selection": selectedAgent (from renderer)
- * - "save-agent": (no new fields, persists selectedAgent)
- * - "binary": (no new fields, downloads binaries if needed, updates progress)
- * - "extensions": (no new fields, installs extensions if needed, updates progress)
- * - "hide-ui": (no fields, sends IPC to return to starting screen)
+ * Per-handler result contract for the "agent-selection" hook point.
  */
-export interface SetupHookContext extends HookContext {
-  // Fields from intent payload (set by AppStartOperation check hooks)
-  /** True if agent not selected in config */
-  needsAgentSelection?: boolean;
-  /** Currently configured agent (may be null) */
-  configuredAgent?: ConfigAgentType | null;
-  /** True if any binaries need download */
-  needsBinaryDownload?: boolean;
-  /** List of binaries that need download */
-  missingBinaries?: readonly BinaryType[];
-  /** True if any extensions need install */
-  needsExtensions?: boolean;
-  /** List of extensions that need install */
-  missingExtensions?: readonly string[];
-  /** List of extensions that need update */
-  outdatedExtensions?: readonly string[];
+export interface AgentSelectionHookResult {
+  readonly selectedAgent: ConfigAgentType;
+}
 
-  // Fields set during setup
-  /** Set by RendererModule after user selection: the chosen agent */
-  selectedAgent?: ConfigAgentType;
+/**
+ * Input context for the "save-agent" hook — carries selectedAgent from agent-selection.
+ */
+export interface SaveAgentHookInput extends HookContext {
+  readonly selectedAgent: ConfigAgentType;
+}
+
+/**
+ * Input context for the "binary" hook — carries agent and binary info from payload/selection.
+ */
+export interface BinaryHookInput extends HookContext {
+  readonly selectedAgent?: ConfigAgentType;
+  readonly configuredAgent?: ConfigAgentType | null;
+  readonly missingBinaries?: readonly BinaryType[];
+}
+
+/**
+ * Input context for the "extensions" hook — carries extension info from payload.
+ */
+export interface ExtensionsHookInput extends HookContext {
+  readonly missingExtensions?: readonly string[];
+  readonly outdatedExtensions?: readonly string[];
 }
 
 // =============================================================================
@@ -113,66 +110,77 @@ export class SetupOperation implements Operation<SetupIntent, void> {
   readonly id = SETUP_OPERATION_ID;
 
   async execute(ctx: OperationContext<SetupIntent>): Promise<void> {
-    // Copy payload fields to hook context (exactOptionalPropertyTypes: only include defined values)
     const { payload } = ctx.intent;
-    const hookCtx: SetupHookContext = {
+    const hookCtx: HookContext = {
       intent: ctx.intent,
-      ...(payload.needsAgentSelection !== undefined && {
-        needsAgentSelection: payload.needsAgentSelection,
-      }),
-      ...(payload.configuredAgent !== undefined && { configuredAgent: payload.configuredAgent }),
-      ...(payload.needsBinaryDownload !== undefined && {
-        needsBinaryDownload: payload.needsBinaryDownload,
-      }),
-      ...(payload.missingBinaries !== undefined && { missingBinaries: payload.missingBinaries }),
-      ...(payload.needsExtensions !== undefined && { needsExtensions: payload.needsExtensions }),
-      ...(payload.missingExtensions !== undefined && {
-        missingExtensions: payload.missingExtensions,
-      }),
-      ...(payload.outdatedExtensions !== undefined && {
-        outdatedExtensions: payload.outdatedExtensions,
-      }),
     };
 
     try {
       // Hook 1: "show-ui" -- Show setup screen
-      await ctx.hooks.run("show-ui", hookCtx);
-      if (hookCtx.error) {
-        throw hookCtx.error;
+      const { errors: showUiErrors } = await ctx.hooks.collect<void>("show-ui", hookCtx);
+      if (showUiErrors.length > 0) {
+        throw showUiErrors[0]!;
       }
 
       // Hook 2: "agent-selection" -- (conditional) Show UI, wait for user selection
-      if (hookCtx.needsAgentSelection) {
-        await ctx.hooks.run("agent-selection", hookCtx);
-        if (hookCtx.error) {
-          throw hookCtx.error;
+      let selectedAgent: ConfigAgentType | undefined;
+      if (payload.needsAgentSelection) {
+        const { results: agentResults, errors: agentErrors } =
+          await ctx.hooks.collect<AgentSelectionHookResult>("agent-selection", hookCtx);
+        if (agentErrors.length > 0) {
+          throw agentErrors[0]!;
+        }
+        for (const result of agentResults) {
+          if (result.selectedAgent !== undefined) selectedAgent = result.selectedAgent;
         }
       }
 
       // Hook 3: "save-agent" -- (conditional) Persist agent selection
-      if (hookCtx.selectedAgent) {
-        await ctx.hooks.run("save-agent", hookCtx);
-        if (hookCtx.error) {
-          throw hookCtx.error;
+      if (selectedAgent) {
+        const saveAgentInput: SaveAgentHookInput = {
+          intent: ctx.intent,
+          selectedAgent,
+        };
+        const { errors: saveErrors } = await ctx.hooks.collect<void>("save-agent", saveAgentInput);
+        if (saveErrors.length > 0) {
+          throw saveErrors[0]!;
         }
       }
 
       // Hook 4: "binary" -- Update binary progress (downloads if needed)
-      await ctx.hooks.run("binary", hookCtx);
-      if (hookCtx.error) {
-        throw hookCtx.error;
+      const binaryInput: BinaryHookInput = {
+        intent: ctx.intent,
+        ...(selectedAgent !== undefined && { selectedAgent }),
+        ...(payload.configuredAgent !== undefined && { configuredAgent: payload.configuredAgent }),
+        ...(payload.missingBinaries !== undefined && { missingBinaries: payload.missingBinaries }),
+      };
+      const { errors: binaryErrors } = await ctx.hooks.collect<void>("binary", binaryInput);
+      if (binaryErrors.length > 0) {
+        throw binaryErrors[0]!;
       }
 
       // Hook 5: "extensions" -- Update extension progress (installs if needed)
-      await ctx.hooks.run("extensions", hookCtx);
-      if (hookCtx.error) {
-        throw hookCtx.error;
+      const extensionsInput: ExtensionsHookInput = {
+        intent: ctx.intent,
+        ...(payload.missingExtensions !== undefined && {
+          missingExtensions: payload.missingExtensions,
+        }),
+        ...(payload.outdatedExtensions !== undefined && {
+          outdatedExtensions: payload.outdatedExtensions,
+        }),
+      };
+      const { errors: extensionsErrors } = await ctx.hooks.collect<void>(
+        "extensions",
+        extensionsInput
+      );
+      if (extensionsErrors.length > 0) {
+        throw extensionsErrors[0]!;
       }
 
       // Hook 6: "hide-ui" -- Hide setup screen (return to starting screen)
-      await ctx.hooks.run("hide-ui", hookCtx);
-      if (hookCtx.error) {
-        throw hookCtx.error;
+      const { errors: hideUiErrors } = await ctx.hooks.collect<void>("hide-ui", hookCtx);
+      if (hideUiErrors.length > 0) {
+        throw hideUiErrors[0]!;
       }
 
       // Control returns to AppStartOperation (no dispatch)

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -32,7 +32,7 @@ import {
 } from "./switch-workspace";
 import type {
   SwitchWorkspaceIntent,
-  SwitchWorkspaceHookContext,
+  SwitchWorkspaceHookResult,
   WorkspaceSwitchedEvent,
 } from "./switch-workspace";
 import type { IntentModule } from "../intents/infrastructure/module";
@@ -192,8 +192,7 @@ function createTestSetup(opts?: {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (ctx: HookContext) => {
-            const hookCtx = ctx as SwitchWorkspaceHookContext;
+          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
             // Resolve workspace (simplified -- uses generateProjectId to match)
@@ -212,15 +211,14 @@ function createTestSetup(opts?: {
               throw new Error(`Workspace not found: ${intent.payload.workspaceName}`);
             }
 
-            // No-op: already the active workspace
+            // No-op: already the active workspace -- return empty result
             if (viewManager.getActiveWorkspacePath() === workspace.path) {
-              return;
+              return {};
             }
 
             const focus = intent.payload.focus ?? true;
             viewManager.setActiveWorkspace(workspace.path, focus);
-            hookCtx.resolvedPath = workspace.path;
-            hookCtx.projectPath = projectPath;
+            return { resolvedPath: workspace.path, projectPath };
           },
         },
       },


### PR DESCRIPTION
- Migrate all 11 remaining operations from shared-context `run()` to isolated `collect()` contexts
- Each handler now receives a frozen shallow copy and returns a typed result object
- Operations merge results field-by-field (last-write-wins for scalars, concat for arrays)
- Replace `*HookContext` mutation interfaces with `*HookResult` return types and `*HookInput` readonly input contexts
- Remove `run()` from HookRegistry, `error` from HookContext, `onError` from HookHandler
- Update bootstrap handlers and 15+ test files to match new patterns