### PR TITLE
fix(editor): disable editContext for code-server compatibility

### DIFF
--- a/extensions/sidekick/package.json
+++ b/extensions/sidekick/package.json
@@ -63,6 +63,7 @@
       }
     ],
     "configurationDefaults": {
+      "editor.editContext": false,
       "workbench.startupEditor": "none",
       "window.autoDetectColorScheme": true,
       "workbench.preferredDarkColorTheme": "Default Dark+",


### PR DESCRIPTION
## Summary

- Disable `editor.editContext` via sidekick extension `configurationDefaults` and workspace default settings to fix broken VS Code editor after recent code-server update
- Delay `lifecycle.ready` response until initial `project:open` dispatches complete, preventing "Create Workspace" dialog flash on startup
- Large refactoring of intent dispatcher: migrate project/workspace state from AppState into extracted modules (LocalProjectModule, RemoteProjectModule, GitWorktreeWorkspaceModule) with event-driven registries
- Replace snapshot-based renderer initialization with event-driven `lifecycle.ready()` signal
- Remove dead query handlers, WorkspaceResolver coupling, and per-project adapter indirection

## Test plan

- [ ] Open app and verify no "Create Workspace" dialog flash on startup
- [ ] Edit a file in code-server editor — should work without errors
- [ ] Create/delete/switch workspaces
- [ ] Open/close local and remote projects
- [ ] Verify agent status updates propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)