### PR TITLE
fix(ui): update empty state help text to show correct shortcut

### DIFF
--- a/src/renderer/lib/components/EmptyState.svelte
+++ b/src/renderer/lib/components/EmptyState.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
   // EmptyState is a simple message component shown when no projects are open.
-  // Users can open a project via the Create Workspace dialog's folder icon.
+  // Users can open a project by pressing Alt+X Enter.
 </script>
 
 <div class="empty-state">
-  <p class="empty-message">
-    No projects open. Click the + button on a project header to create a workspace, or open a
-    project via the Create Workspace dialog.
-  </p>
+  <p class="empty-message">No projects open.</p>
+  <p class="empty-message">Press <vscode-badge>Alt+X+Enter</vscode-badge> to open a project.</p>
 </div>
 
 <style>

--- a/src/renderer/lib/components/EmptyState.test.ts
+++ b/src/renderer/lib/components/EmptyState.test.ts
@@ -2,7 +2,7 @@
  * Tests for the EmptyState component.
  *
  * Note: EmptyState is a simple message-only component that guides users
- * to open a project via the Create Workspace dialog's folder icon.
+ * to open a project by pressing Alt+X Enter.
  */
 
 import { describe, it, expect } from "vitest";
@@ -13,9 +13,10 @@ describe("EmptyState component", () => {
   it("renders guidance message for opening a project", () => {
     render(EmptyState);
 
+    expect(screen.getByText(/No projects open\./)).toBeInTheDocument();
     expect(
       screen.getByText(
-        /No projects open\. Click the \+ button on a project header to create a workspace, or open a project via the Create Workspace dialog\./
+        (_content, element) => element?.textContent === "Press Alt+X+Enter to open a project."
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
- Replace misleading "Click the + button" text with actual `Alt+X+Enter` shortcut
- Display shortcut in a `<vscode-badge>` matching existing UI patterns
- Split help text into two lines for readability

resolves #139