### PR TITLE
refactor(ui): make deletion progress server name dynamic via hook result

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -1472,6 +1472,9 @@ function wireDispatcher(
     },
   };
 
+  const agentServerName =
+    lifecycleRefs.selectedAgentType === "claude" ? "Claude Code hook" : "OpenCode";
+
   const deleteAgentModule: IntentModule = {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
@@ -1509,13 +1512,15 @@ function wireDispatcher(
                 payload.workspacePath as WorkspacePath
               );
 
-              return serverError ? { error: serverError } : {};
+              return serverError
+                ? { serverName: agentServerName, error: serverError }
+                : { serverName: agentServerName };
             } catch (error) {
               if (payload.force) {
                 logger.warn("AgentModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return { error: getErrorMessage(error) };
+                return { serverName: agentServerName, error: getErrorMessage(error) };
               }
               throw error;
             }

--- a/src/renderer/lib/components/DeletionProgressView.test.ts
+++ b/src/renderer/lib/components/DeletionProgressView.test.ts
@@ -482,7 +482,7 @@ describe("DeletionProgressView", () => {
         operations: [
           { id: "killing-blockers", label: "Killing blocking tasks...", status: "in-progress" },
           { id: "kill-terminals", label: "Terminating processes", status: "pending" },
-          { id: "stop-server", label: "Stopping OpenCode server", status: "pending" },
+          { id: "stop-server", label: "Stopping agent server", status: "pending" },
           { id: "cleanup-vscode", label: "Closing VS Code view", status: "pending" },
           { id: "cleanup-workspace", label: "Removing workspace", status: "pending" },
         ],
@@ -512,7 +512,7 @@ describe("DeletionProgressView", () => {
         operations: [
           { id: "closing-handles", label: "Closing blocking handles...", status: "in-progress" },
           { id: "kill-terminals", label: "Terminating processes", status: "pending" },
-          { id: "stop-server", label: "Stopping OpenCode server", status: "pending" },
+          { id: "stop-server", label: "Stopping agent server", status: "pending" },
           { id: "cleanup-vscode", label: "Closing VS Code view", status: "pending" },
           { id: "cleanup-workspace", label: "Removing workspace", status: "pending" },
         ],
@@ -542,7 +542,7 @@ describe("DeletionProgressView", () => {
         operations: [
           { id: "killing-blockers", label: "Killing blocking tasks...", status: "done" },
           { id: "kill-terminals", label: "Terminating processes", status: "in-progress" },
-          { id: "stop-server", label: "Stopping OpenCode server", status: "pending" },
+          { id: "stop-server", label: "Stopping agent server", status: "pending" },
           { id: "cleanup-vscode", label: "Closing VS Code view", status: "pending" },
           { id: "cleanup-workspace", label: "Removing workspace", status: "pending" },
         ],
@@ -586,7 +586,7 @@ describe("DeletionProgressView", () => {
       ...defaultProgress,
       operations: [
         { id: "kill-terminals", label: "Terminating processes", status: "done" },
-        { id: "stop-server", label: "Stopping OpenCode server", status: "done" },
+        { id: "stop-server", label: "Stopping agent server", status: "done" },
         { id: "cleanup-vscode", label: "Closing VS Code view", status: "done" },
         {
           id: "cleanup-workspace",


### PR DESCRIPTION
- Added `serverName` field to `ShutdownHookResult` so hook modules can provide a display name
- `deleteAgentModule` returns type-specific names: "OpenCode" or "Claude Code hook"
- `buildProgress()` uses the hook-provided name instead of hardcoded "Stopping OpenCode server"
- Fallback to "Stopping agent server" when no name is provided