### PR TITLE
fix(updater): fix AppImage auto-update crash on download 404

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,8 +103,7 @@ jobs:
         include:
           - artifact: linux-x64
             target: linux:appimage
-            output: CodeHydra-linux-x86_64.AppImage
-            rename: CodeHydra-linux-x64.AppImage
+            output: CodeHydra-linux-x64.AppImage
           - artifact: win-installer-x64
             target: win:installer
             output: CodeHydra-win-installer-x64.exe

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -79,7 +79,7 @@ linux:
 
 # AppImage-specific settings
 appImage:
-  artifactName: ${productName}-linux-${arch}.${ext}
+  artifactName: ${productName}-linux-x64.${ext}
 
 # macOS configuration
 mac:


### PR DESCRIPTION
- Fix artifact naming mismatch: use literal `x64` in AppImage `artifactName` instead of `${arch}` (which expands to `x86_64`), so `latest-linux.yml` metadata matches the actual uploaded filename
- Remove now-unnecessary rename step in build workflow
- Disable `autoDownload` and manually call `downloadUpdate()` with `.catch()` to prevent unhandled promise rejections from crashing the app