### PR TITLE
fix(startup): keep loading screen until projects are loaded

### DIFF
--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -136,7 +136,10 @@ describe("setupDomainEventBindings", () => {
       expect(projectsStore.projects.value).not.toContainEqual(TEST_PROJECT);
     });
 
-    it("auto-opens create dialog when project with no workspaces is opened", () => {
+    it("auto-opens create dialog when project with no workspaces is opened after loading", () => {
+      // Simulate post-startup state (loading complete)
+      projectsStore.setLoaded();
+
       setupDomainEventBindings(notificationService, mockApi.api);
 
       mockApi.emit("project:opened", { project: TEST_PROJECT });
@@ -145,6 +148,18 @@ describe("setupDomainEventBindings", () => {
         type: "create",
         projectId: TEST_PROJECT_ID,
       });
+    });
+
+    it("does not auto-open create dialog during initial loading", () => {
+      // loadingState is "loading" by default after reset
+      expect(projectsStore.loadingState.value).toBe("loading");
+
+      setupDomainEventBindings(notificationService, mockApi.api);
+
+      mockApi.emit("project:opened", { project: TEST_PROJECT });
+
+      // Dialog should NOT open during initial loading
+      expect(dialogsStore.dialogState.value).toEqual({ type: "closed" });
     });
 
     it("does not open create dialog when project has workspaces", () => {

--- a/src/renderer/lib/utils/setup-domain-event-bindings.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.ts
@@ -8,6 +8,7 @@
  */
 import {
   projects,
+  loadingState,
   addProject,
   removeProject,
   setActiveWorkspace,
@@ -110,7 +111,13 @@ export function setupDomainEventBindings(
     },
     {
       onProjectOpenedHook: (project) => {
-        if (project.workspaces.length === 0 && dialogState.value.type === "closed") {
+        // Only auto-open during normal operation, not during initial startup loading.
+        // The auto-show $effect in MainView.svelte handles the post-load case.
+        if (
+          loadingState.value === "loaded" &&
+          project.workspaces.length === 0 &&
+          dialogState.value.type === "closed"
+        ) {
           openCreateDialog(project.id);
         }
       },


### PR DESCRIPTION
- Gate `onProjectOpenedHook` on `loadingState === "loaded"` so the Create Workspace dialog doesn't open prematurely when a project with 0 workspaces loads before projects that have workspaces
- Add a startup overlay in App.svelte that keeps "CodeHydra is starting..." visible until projects finish loading (MainView mounts behind it, marked `inert`)
- Move "Application ready" ARIA announcement to fire only after loading completes