### PR TITLE
fix(editor): disable EditContext at Blink level for reliable code-server compatibility

### DIFF
--- a/extensions/sidekick/package.json
+++ b/extensions/sidekick/package.json
@@ -63,7 +63,6 @@
       }
     ],
     "configurationDefaults": {
-      "editor.editContext": false,
       "workbench.startupEditor": "none",
       "window.autoDetectColorScheme": true,
       "workbench.preferredDarkColorTheme": "Default Dark+",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -168,6 +168,11 @@ function applyElectronFlags(): void {
 // CRITICAL: Must be before app.whenReady() and any code that might trigger GPU initialization.
 applyElectronFlags();
 
+// Disable EditContext API at the Blink level. Code-server's web context
+// doesn't reliably support EditContext, and configurationDefaults for
+// editor.editContext don't always apply before the editor initializes.
+app.commandLine.appendSwitch("disable-blink-features", "EditContext");
+
 const __dirname = nodePath.dirname(fileURLToPath(import.meta.url));
 
 const fileSystemLayer = new DefaultFileSystemLayer(loggingService.createLogger("fs"));


### PR DESCRIPTION
- Disable EditContext Blink feature via `app.commandLine.appendSwitch("disable-blink-features", "EditContext")` before any rendering occurs
- Remove `editor.editContext: false` from sidekick configurationDefaults (no longer needed — API is disabled at engine level)
- Fixes intermittent editor breakage on Windows and Linux where configurationDefaults didn't apply before the editor initialized