### PR TITLE
fix(release): set author to replace inherited GitHub Inc publisher in Windows artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "site:check": "svelte-check --tsconfig site/tsconfig.web.json"
   },
   "keywords": [],
-  "author": "",
+  "author": "Stefan Hoelzl",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",


### PR DESCRIPTION
- Set `author` field in package.json to "Stefan Hoelzl" so electron-builder overwrites the default CompanyName in Windows executable version info
- Fixes Windows SmartScreen dialog showing "GitHub Inc" as publisher for the unsigned NSIS installer