### PR TITLE
feat(agents): use agent-specific permission flags for claude wrapper

### DIFF
--- a/src/agents/claude/wrapper.test.ts
+++ b/src/agents/claude/wrapper.test.ts
@@ -5,7 +5,29 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildInitialPromptArgs, type InitialPromptConfig } from "./wrapper";
+import { buildInitialPromptArgs, buildPermissionArgs, type InitialPromptConfig } from "./wrapper";
+
+describe("buildPermissionArgs", () => {
+  it("returns --dangerously-skip-permissions when no agent", () => {
+    expect(buildPermissionArgs()).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("returns --dangerously-skip-permissions for implement agent", () => {
+    expect(buildPermissionArgs("implement")).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("returns plan mode flags for plan agent", () => {
+    expect(buildPermissionArgs("plan")).toEqual([
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode",
+      "plan",
+    ]);
+  });
+
+  it("returns --dangerously-skip-permissions for unknown agents", () => {
+    expect(buildPermissionArgs("coder")).toEqual(["--dangerously-skip-permissions"]);
+  });
+});
 
 describe("buildInitialPromptArgs", () => {
   it("with prompt only returns prompt as single argument", () => {

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -98,6 +98,21 @@ function getInitialPromptConfig(): InitialPromptConfig | undefined {
 }
 
 /**
+ * Build permission flags based on agent type.
+ * - "plan" agent: read-only mode with --permissions-mode plan
+ * - All others (including "implement" and no agent): full permissions
+ *
+ * @param agent - The agent name from initial prompt config
+ * @returns Array of CLI permission flags
+ */
+function buildPermissionArgs(agent?: string): string[] {
+  if (agent === "plan") {
+    return ["--allow-dangerously-skip-permissions", "--permission-mode", "plan"];
+  }
+  return ["--dangerously-skip-permissions"];
+}
+
+/**
  * Build CLI arguments from initial prompt config.
  * Returns array of arguments to prepend to claude command.
  *
@@ -359,7 +374,7 @@ async function main(): Promise<never> {
   const isWindows = process.platform === "win32";
   const args = [
     ...initialPromptArgs,
-    "--allow-dangerously-skip-permissions",
+    ...buildPermissionArgs(initialPromptConfig?.agent),
     "--ide",
     "--settings",
     settingsPath,
@@ -400,4 +415,10 @@ if (!process.env.VITEST) {
 }
 
 // Export for testing
-export { findSystemClaude, notifyHook, getInitialPromptConfig, buildInitialPromptArgs };
+export {
+  findSystemClaude,
+  notifyHook,
+  getInitialPromptConfig,
+  buildInitialPromptArgs,
+  buildPermissionArgs,
+};


### PR DESCRIPTION
- Plan agent uses `--allow-dangerously-skip-permissions --permission-mode plan` for read-only mode
- All other agents (including implement and default) use `--dangerously-skip-permissions` for full permissions
- Added `buildPermissionArgs` function with tests