### PR TITLE
fix(wrapper): silently handle missing initial prompt file on restart

### DIFF
--- a/src/agents/claude/wrapper.integration.test.ts
+++ b/src/agents/claude/wrapper.integration.test.ts
@@ -87,23 +87,23 @@ describe("getInitialPromptConfig integration", () => {
     expect(mockRmdirSync).not.toHaveBeenCalled();
   });
 
-  it("returns undefined when file does not exist", () => {
+  it("returns undefined silently when file does not exist (restart scenario)", () => {
     process.env.CODEHYDRA_INITIAL_PROMPT_FILE = "/tmp/nonexistent/initial-prompt.json";
 
-    // Mock file not found error
+    // Mock file not found error (expected on restart - file consumed on first launch)
     mockReadFileSync.mockImplementation(() => {
       const error = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
       error.code = "ENOENT";
       throw error;
     });
 
-    // Suppress console.warn during test
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const result = getInitialPromptConfig();
 
     expect(result).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalled();
+    // ENOENT should NOT produce a warning - it's expected on restart
+    expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -71,7 +71,16 @@ function getInitialPromptConfig(): InitialPromptConfig | undefined {
     const config = JSON.parse(content) as InitialPromptConfig;
     return config;
   } catch (error) {
-    // Log warning but don't fail - initial prompt is optional
+    // File not found is expected on restart (consumed on first launch)
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return undefined;
+    }
+
+    // Log warning for unexpected errors but don't fail
     console.warn(
       `Warning: Failed to read initial prompt file: ${error instanceof Error ? error.message : String(error)}`
     );


### PR DESCRIPTION
- Silently return `undefined` for ENOENT in `getInitialPromptConfig()` instead of logging a warning
- ENOENT is expected on restart: the prompt file was consumed on first launch but the env var persists
- Updated test to assert no warning is logged for the missing-file (restart) scenario