### PR TITLE
fix(shell): force UI view re-composite on Windows startup

### DIFF
--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -728,6 +728,25 @@ describe("ViewManager", () => {
       });
     });
 
+    it("keeps UI view at index 0 in workspace mode (DirectComposition workaround)", () => {
+      const deps = createViewManagerDeps();
+      const manager = ViewManager.create(deps);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
+
+      manager.createWorkspaceView(
+        "/path/to/workspace",
+        "http://127.0.0.1:8080/?folder=/path",
+        "/path/to/project"
+      );
+      manager.setWorkspaceLoaded("/path/to/workspace");
+      manager.setActiveWorkspace("/path/to/workspace");
+
+      // UI view should be at index 0 (bottom)
+      const uiHandle = manager.getUIViewHandle();
+      const children = deps.viewLayer.$.windowChildren.get(windowId);
+      expect(children?.[0]).toBe(uiHandle.id);
+    });
+
     it("null workspace detaches current", () => {
       const deps = createViewManagerDeps();
       const manager = ViewManager.create(deps);

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -707,6 +707,18 @@ export class ViewManager implements IViewManager {
         } catch {
           // Ignore errors during z-order change - window may be closing
         }
+      } else {
+        // Windows DirectComposition workaround: force UI view re-composite
+        // so the transparent sidebar strip is rendered on startup
+        try {
+          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
+            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, 0, {
+              force: true,
+            });
+          }
+        } catch {
+          // window may be closing
+        }
       }
 
       this.updateBounds();
@@ -943,6 +955,18 @@ export class ViewManager implements IViewManager {
           }
         } catch {
           // Ignore errors - window may be closing
+        }
+      } else {
+        // Windows DirectComposition workaround: force UI view re-composite
+        // so the transparent sidebar strip is rendered on startup
+        try {
+          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
+            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, 0, {
+              force: true,
+            });
+          }
+        } catch {
+          // window may be closing
         }
       }
 

--- a/src/services/shell/view.integration.test.ts
+++ b/src/services/shell/view.integration.test.ts
@@ -181,6 +181,23 @@ describe("ViewLayer (integration)", () => {
       expect(viewLayer).toHaveView(handle.id, { attachedTo: "window-1" });
     });
 
+    it("force re-attaches view already at correct index", () => {
+      const handle1 = viewLayer.createView({});
+      const handle2 = viewLayer.createView({});
+      const windowHandle = { id: "window-1", __brand: "WindowHandle" as const };
+
+      // Attach handle1 at index 0, handle2 on top
+      viewLayer.attachToWindow(handle1, windowHandle, 0);
+      viewLayer.attachToWindow(handle2, windowHandle);
+
+      // Force re-attach handle1 at index 0 (triggers remove+add cycle)
+      viewLayer.attachToWindow(handle1, windowHandle, 0, { force: true });
+
+      // handle1 should still be at index 0 and attached
+      expect(viewLayer).toHaveView(handle1.id, { attachedTo: "window-1" });
+      expect(viewLayer).toHaveView(handle2.id, { attachedTo: "window-1" });
+    });
+
     it("detach is idempotent", () => {
       const handle = viewLayer.createView({});
 


### PR DESCRIPTION
- Force UI view re-composite on Windows startup to fix DirectComposition not rendering the transparent sidebar strip
- Add `force` option to `attachToWindow` that bypasses the early-return optimization, triggering a remove+re-add cycle
- Use forced re-attach in `setActiveWorkspace` and `setWorkspaceLoaded` to ensure sidebar visibility