### PR TITLE
chore(modules): extract KeepFilesModule from bootstrap.ts

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -225,6 +225,7 @@ import { createLocalProjectModule } from "./modules/local-project-module";
 import { createRemoteProjectModule } from "./modules/remote-project-module";
 import { createGitWorktreeWorkspaceModule } from "./modules/git-worktree-workspace-module";
 import { createMetadataModule } from "./modules/metadata-module";
+import { createKeepFilesModule } from "./modules/keepfiles-module";
 
 // =============================================================================
 // Constants
@@ -1277,33 +1278,7 @@ function wireDispatcher(
   // ---------------------------------------------------------------------------
 
   // KeepFilesModule: "setup" hook -- copies .keepfiles to workspace (best-effort)
-  const keepFilesModule: IntentModule = {
-    hooks: {
-      [OPEN_WORKSPACE_OPERATION_ID]: {
-        setup: {
-          handler: async (ctx: HookContext): Promise<SetupHookResult> => {
-            const setupCtx = ctx as SetupHookInput;
-
-            try {
-              await keepFilesService.copyToWorkspace(
-                new Path(setupCtx.projectPath),
-                new Path(setupCtx.workspacePath)
-              );
-            } catch (error) {
-              logger.error(
-                "Keepfiles copy failed for workspace (non-fatal)",
-                { workspacePath: setupCtx.workspacePath },
-                error instanceof Error ? error : undefined
-              );
-              // Do not re-throw -- keepfiles is best-effort
-            }
-
-            return {};
-          },
-        },
-      },
-    },
-  };
+  const keepFilesModule = createKeepFilesModule({ keepFilesService, logger });
 
   // AgentModule: "setup" hook -- starts agent server, sets initial prompt, gets env vars (fatal)
   const agentModule: IntentModule = {

--- a/src/main/modules/keepfiles-module.integration.test.ts
+++ b/src/main/modules/keepfiles-module.integration.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+/**
+ * Integration tests for KeepFilesModule through the Dispatcher.
+ *
+ * Tests verify: dispatcher -> operation -> setup hook -> keepFilesService call,
+ * including best-effort error handling (errors are logged, not re-thrown).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { wireModules } from "../intents/infrastructure/wire";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import type { Intent } from "../intents/infrastructure/types";
+import {
+  OPEN_WORKSPACE_OPERATION_ID,
+  type SetupHookInput,
+  type SetupHookResult,
+} from "../operations/open-workspace";
+import { createKeepFilesModule } from "./keepfiles-module";
+import { SILENT_LOGGER } from "../../services/logging";
+import { createBehavioralLogger } from "../../services/logging/logging.test-utils";
+import { Path } from "../../services/platform/path";
+import type { IKeepFilesService } from "../../services/keepfiles/types";
+
+// =============================================================================
+// Mock Dependencies
+// =============================================================================
+
+function createMockKeepFilesService() {
+  return {
+    copyToWorkspace: vi.fn().mockResolvedValue({
+      configExists: true,
+      copiedCount: 0,
+      skippedCount: 0,
+      errors: [],
+    }),
+  };
+}
+
+// =============================================================================
+// Minimal Test Operation
+// =============================================================================
+
+/**
+ * Minimal operation that runs only the "setup" hook point.
+ * Avoids needing stubs for resolve-project, create, finalize.
+ */
+class MinimalSetupOperation implements Operation<Intent, SetupHookResult> {
+  readonly id = OPEN_WORKSPACE_OPERATION_ID;
+
+  async execute(ctx: OperationContext<Intent>): Promise<SetupHookResult> {
+    const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
+    const input: SetupHookInput = {
+      intent: ctx.intent,
+      projectPath: payload.projectPath,
+      workspacePath: payload.workspacePath,
+    };
+    const { results, errors } = await ctx.hooks.collect<SetupHookResult>("setup", input);
+    if (errors.length > 0) throw errors[0]!;
+    return results[0] ?? {};
+  }
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+interface TestSetup {
+  dispatcher: Dispatcher;
+  keepFilesService: ReturnType<typeof createMockKeepFilesService>;
+}
+
+function createTestSetup(logger = SILENT_LOGGER): TestSetup {
+  const keepFilesService = createMockKeepFilesService();
+
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation("workspace:open", new MinimalSetupOperation());
+
+  const module = createKeepFilesModule({
+    keepFilesService: keepFilesService as unknown as IKeepFilesService,
+    logger,
+  });
+  wireModules([module], hookRegistry, dispatcher);
+
+  return { dispatcher, keepFilesService };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("KeepFilesModule Integration", () => {
+  let setup: TestSetup;
+
+  beforeEach(() => {
+    setup = createTestSetup();
+  });
+
+  describe("open-workspace -> setup", () => {
+    it("calls copyToWorkspace with Path arguments", async () => {
+      const { dispatcher, keepFilesService } = setup;
+
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectPath: "/projects/my-app", workspacePath: "/workspaces/feature-1" },
+      } as Intent);
+
+      expect(keepFilesService.copyToWorkspace).toHaveBeenCalledWith(
+        new Path("/projects/my-app"),
+        new Path("/workspaces/feature-1")
+      );
+    });
+
+    it("logs error and succeeds when copyToWorkspace throws", async () => {
+      const logger = createBehavioralLogger();
+      const { dispatcher, keepFilesService } = createTestSetup(logger);
+
+      keepFilesService.copyToWorkspace.mockRejectedValue(new Error("disk full"));
+
+      const result = await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectPath: "/projects/my-app", workspacePath: "/workspaces/feature-1" },
+      } as Intent);
+
+      // Operation succeeds despite the error
+      expect(result).toEqual({});
+
+      // Error was logged
+      const errors = logger.getMessagesByLevel("error");
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.message).toBe("Keepfiles copy failed for workspace (non-fatal)");
+      expect(errors[0]!.context).toEqual({ workspacePath: "/workspaces/feature-1" });
+    });
+
+    it("returns empty result on success", async () => {
+      const { dispatcher } = setup;
+
+      const result = await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectPath: "/projects/my-app", workspacePath: "/workspaces/feature-1" },
+      } as Intent);
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/src/main/modules/keepfiles-module.ts
+++ b/src/main/modules/keepfiles-module.ts
@@ -1,0 +1,54 @@
+/**
+ * KeepFilesModule - Copies .keepfiles to new workspaces (best-effort).
+ *
+ * Hooks:
+ * - open-workspace → setup: copies keepfiles from project root to workspace
+ *
+ * Errors are caught and logged — keepfiles is non-fatal.
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { IKeepFilesService } from "../../services/keepfiles/types";
+import type { Logger } from "../../services/logging/types";
+import {
+  OPEN_WORKSPACE_OPERATION_ID,
+  type SetupHookInput,
+  type SetupHookResult,
+} from "../operations/open-workspace";
+import { Path } from "../../services/platform/path";
+
+interface KeepFilesModuleDeps {
+  readonly keepFilesService: IKeepFilesService;
+  readonly logger: Logger;
+}
+
+export function createKeepFilesModule(deps: KeepFilesModuleDeps): IntentModule {
+  return {
+    hooks: {
+      [OPEN_WORKSPACE_OPERATION_ID]: {
+        setup: {
+          handler: async (ctx: HookContext): Promise<SetupHookResult> => {
+            const setupCtx = ctx as SetupHookInput;
+
+            try {
+              await deps.keepFilesService.copyToWorkspace(
+                new Path(setupCtx.projectPath),
+                new Path(setupCtx.workspacePath)
+              );
+            } catch (error) {
+              deps.logger.error(
+                "Keepfiles copy failed for workspace (non-fatal)",
+                { workspacePath: setupCtx.workspacePath },
+                error instanceof Error ? error : undefined
+              );
+              // Do not re-throw -- keepfiles is best-effort
+            }
+
+            return {};
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
- Extract inline `keepFilesModule` from `bootstrap.ts` into `src/main/modules/keepfiles-module.ts` with factory function and explicit deps interface
- Add integration tests in `keepfiles-module.integration.test.ts` covering success, error handling, and return value
- Follow established pattern from badge-module and git-worktree-workspace-module