### PR TITLE
fix(ci): add 5-minute timeout to Wine installation step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,6 +139,7 @@ jobs:
 
       - name: Install Wine
         if: matrix.wine
+        timeout-minutes: 5
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update


### PR DESCRIPTION
- Add `timeout-minutes: 5` to the "Install Wine" step in the build workflow
- Prevents hangs like run 22114659241 where Wine install took 15 minutes (vs normal ~70s)
- 5-minute timeout gives ~4x headroom over normal duration