### PR TITLE
feat(modules): extract CodeServerModule from inline bootstrap modules

### DIFF
--- a/src/main/bootstrap.integration.test.ts
+++ b/src/main/bootstrap.integration.test.ts
@@ -148,6 +148,25 @@ function createMockDeps(): BootstrapDeps {
     lifecycleRefsFn: () =>
       ({
         loggingService: { createLogger: () => createMockLogger() },
+        pluginServer: null,
+        codeServerManager: {
+          ensureRunning: vi.fn().mockResolvedValue(undefined),
+          port: vi.fn().mockReturnValue(9090),
+          getConfig: vi.fn().mockReturnValue({
+            runtimeDir: "/mock/runtime",
+            extensionsDir: "/mock/extensions",
+            userDataDir: "/mock/user-data",
+          }),
+          setPluginPort: vi.fn(),
+          stop: vi.fn().mockResolvedValue(undefined),
+        },
+        fileSystemLayer: {
+          mkdir: vi.fn().mockResolvedValue(undefined),
+        },
+        agentStatusManager: {
+          getEnvironmentVariables: vi.fn().mockReturnValue(null),
+        },
+        selectedAgentType: "opencode",
       }) as unknown as import("./bootstrap").LifecycleServiceRefs,
     getUIWebContentsFn: () => null,
     setupDeps: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -865,9 +865,6 @@ async function bootstrap(): Promise<void> {
         },
         windowManager: windowManagerRef,
         waitForProvider: (wp: string) => appStateRef.waitForProvider(wp),
-        updateCodeServerPort: () => {
-          // No-op: code-server port is now tracked locally in wireDispatcher scope
-        },
         setMcpServerManager: (mgr) => appStateRef.setMcpServerManager(mgr),
       };
     },

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -1,0 +1,795 @@
+// @vitest-environment node
+/**
+ * Integration tests for CodeServerModule through the Dispatcher.
+ *
+ * Tests verify the full pipeline: dispatcher -> operation -> hook handlers.
+ * Uses minimal test operations that exercise specific hook points, with
+ * all dependencies mocked via vi.fn().
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { wireModules } from "../intents/infrastructure/wire";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import type { Intent } from "../intents/infrastructure/types";
+import { APP_START_OPERATION_ID } from "../operations/app-start";
+import type { CheckDepsResult, StartHookResult } from "../operations/app-start";
+import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { SETUP_OPERATION_ID } from "../operations/setup";
+import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
+import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
+import type {
+  FinalizeHookInput,
+  FinalizeHookResult,
+  OpenWorkspaceIntent,
+} from "../operations/open-workspace";
+import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
+import type { DeleteWorkspaceIntent, DeleteHookResult } from "../operations/delete-workspace";
+import {
+  createCodeServerModule,
+  type CodeServerModuleDeps,
+  type CodeServerLifecycleDeps,
+  type CodeServerWorkspaceDeps,
+} from "./code-server-module";
+import { SILENT_LOGGER } from "../../services/logging";
+import { Path } from "../../services/platform/path";
+import { SetupError } from "../../services/errors";
+import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+
+// =============================================================================
+// Minimal Test Operations
+// =============================================================================
+
+class MinimalCheckDepsOperation implements Operation<Intent, CheckDepsResult> {
+  readonly id = APP_START_OPERATION_ID;
+
+  async execute(ctx: OperationContext<Intent>): Promise<CheckDepsResult> {
+    const { results } = await ctx.hooks.collect<CheckDepsResult>("check-deps", {
+      intent: ctx.intent,
+    });
+    // Merge all results
+    const merged: CheckDepsResult = {};
+    for (const r of results) {
+      if (r.missingBinaries) {
+        (merged as Record<string, unknown>).missingBinaries = [
+          ...((merged.missingBinaries as string[]) ?? []),
+          ...r.missingBinaries,
+        ];
+      }
+      if (r.missingExtensions) {
+        (merged as Record<string, unknown>).missingExtensions = r.missingExtensions;
+      }
+      if (r.outdatedExtensions) {
+        (merged as Record<string, unknown>).outdatedExtensions = r.outdatedExtensions;
+      }
+    }
+    return merged;
+  }
+}
+
+class MinimalStartOperation implements Operation<Intent, StartHookResult> {
+  readonly id = APP_START_OPERATION_ID;
+
+  async execute(ctx: OperationContext<Intent>): Promise<StartHookResult> {
+    const { results, errors } = await ctx.hooks.collect<StartHookResult>("start", {
+      intent: ctx.intent,
+    });
+    if (errors.length > 0) throw errors[0]!;
+    // Merge results
+    const merged: StartHookResult = {};
+    for (const r of results) {
+      if (r.codeServerPort !== undefined) {
+        (merged as Record<string, unknown>).codeServerPort = r.codeServerPort;
+      }
+    }
+    return merged;
+  }
+}
+
+class MinimalStopOperation implements Operation<Intent, void> {
+  readonly id = APP_SHUTDOWN_OPERATION_ID;
+
+  async execute(ctx: OperationContext<Intent>): Promise<void> {
+    const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
+    if (errors.length > 0) throw errors[0]!;
+  }
+}
+
+class MinimalBinaryOperation implements Operation<Intent, void> {
+  readonly id = SETUP_OPERATION_ID;
+  private readonly hookInput: Partial<BinaryHookInput>;
+
+  constructor(hookInput: Partial<BinaryHookInput> = {}) {
+    this.hookInput = hookInput;
+  }
+
+  async execute(ctx: OperationContext<Intent>): Promise<void> {
+    const { errors } = await ctx.hooks.collect("binary", {
+      intent: ctx.intent,
+      ...this.hookInput,
+    });
+    if (errors.length > 0) throw errors[0]!;
+  }
+}
+
+class MinimalExtensionsOperation implements Operation<Intent, void> {
+  readonly id = SETUP_OPERATION_ID;
+  private readonly hookInput: Partial<ExtensionsHookInput>;
+
+  constructor(hookInput: Partial<ExtensionsHookInput> = {}) {
+    this.hookInput = hookInput;
+  }
+
+  async execute(ctx: OperationContext<Intent>): Promise<void> {
+    const { errors } = await ctx.hooks.collect("extensions", {
+      intent: ctx.intent,
+      ...this.hookInput,
+    });
+    if (errors.length > 0) throw errors[0]!;
+  }
+}
+
+class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, FinalizeHookResult> {
+  readonly id = OPEN_WORKSPACE_OPERATION_ID;
+  private readonly hookInput: Partial<FinalizeHookInput>;
+
+  constructor(hookInput: Partial<FinalizeHookInput> = {}) {
+    this.hookInput = hookInput;
+  }
+
+  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<FinalizeHookResult> {
+    const { results, errors } = await ctx.hooks.collect<FinalizeHookResult>("finalize", {
+      intent: ctx.intent,
+      workspacePath: "/test/project/.worktrees/feature-1",
+      envVars: { OPENCODE_PORT: "8080" },
+      ...this.hookInput,
+    });
+    if (errors.length > 0) throw errors[0]!;
+    return results[0] ?? {};
+  }
+}
+
+class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteHookResult> {
+  readonly id = DELETE_WORKSPACE_OPERATION_ID;
+
+  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<DeleteHookResult> {
+    const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", {
+      intent: ctx.intent,
+    });
+    if (errors.length > 0) throw errors[0]!;
+    return results[0] ?? {};
+  }
+}
+
+// =============================================================================
+// Mock Factories
+// =============================================================================
+
+function createMockLifecycleDeps(): CodeServerLifecycleDeps {
+  return {
+    pluginServer: {
+      start: vi.fn().mockResolvedValue(3456),
+      close: vi.fn().mockResolvedValue(undefined),
+      onConfigData: vi.fn(),
+    } as unknown as CodeServerLifecycleDeps["pluginServer"],
+    codeServerManager: {
+      ensureRunning: vi.fn().mockResolvedValue(9090),
+      port: vi.fn().mockReturnValue(9090),
+      getConfig: vi.fn().mockReturnValue({
+        runtimeDir: new Path("/runtime"),
+        extensionsDir: new Path("/extensions"),
+        userDataDir: new Path("/user-data"),
+      }),
+      setPluginPort: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    },
+    fileSystemLayer: {
+      mkdir: vi.fn().mockResolvedValue(undefined),
+    },
+    configDataProvider: vi.fn().mockReturnValue({ env: null, agentType: null }),
+    onPortChanged: vi.fn(),
+  };
+}
+
+function createMockWorkspaceDeps(): CodeServerWorkspaceDeps {
+  return {
+    workspaceFileService: {
+      ensureWorkspaceFile: vi
+        .fn()
+        .mockResolvedValue(new Path("/test/project/.worktrees/feature-1.code-workspace")),
+      deleteWorkspaceFile: vi.fn().mockResolvedValue(undefined),
+      createWorkspaceFile: vi.fn(),
+      getWorkspaceFilePath: vi.fn(),
+    },
+    wrapperPath: "/path/to/wrapper",
+  };
+}
+
+function createMockDeps(overrides?: {
+  lifecycleDeps?: CodeServerLifecycleDeps;
+  workspaceDeps?: CodeServerWorkspaceDeps;
+}): CodeServerModuleDeps {
+  const lifecycleDeps = overrides?.lifecycleDeps ?? createMockLifecycleDeps();
+  const workspaceDeps = overrides?.workspaceDeps ?? createMockWorkspaceDeps();
+
+  return {
+    codeServerManager: {
+      preflight: vi.fn().mockResolvedValue({ success: true, needsDownload: false }),
+      downloadBinary: vi.fn().mockResolvedValue(undefined),
+    },
+    extensionManager: {
+      preflight: vi.fn().mockResolvedValue({
+        success: true,
+        needsInstall: false,
+        missingExtensions: [],
+        outdatedExtensions: [],
+      }),
+      install: vi.fn().mockResolvedValue(undefined),
+      cleanOutdated: vi.fn().mockResolvedValue(undefined),
+    },
+    reportProgress: vi.fn(),
+    logger: SILENT_LOGGER,
+    getLifecycleDeps: () => lifecycleDeps,
+    getWorkspaceDeps: () => workspaceDeps,
+  };
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+function createTestSetup(mockDeps?: CodeServerModuleDeps) {
+  const deps = mockDeps ?? createMockDeps();
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  const module = createCodeServerModule(deps);
+
+  wireModules([module], hookRegistry, dispatcher);
+
+  return { deps, dispatcher, hookRegistry };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("CodeServerModule", () => {
+  // ---------------------------------------------------------------------------
+  // check-deps
+  // ---------------------------------------------------------------------------
+
+  describe("check-deps", () => {
+    it("returns code-server in missingBinaries when download needed", async () => {
+      const deps = createMockDeps();
+      (deps.codeServerManager.preflight as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        needsDownload: true,
+      });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as CheckDepsResult;
+
+      expect(result.missingBinaries).toContain("code-server");
+    });
+
+    it("returns empty missingBinaries when up-to-date", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as CheckDepsResult;
+
+      expect(result.missingBinaries ?? []).not.toContain("code-server");
+    });
+
+    it("returns missing extensions when extensions need install", async () => {
+      const deps = createMockDeps();
+      (deps.extensionManager.preflight as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        needsInstall: true,
+        missingExtensions: ["ext.one"],
+        outdatedExtensions: ["ext.two"],
+      });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as CheckDepsResult;
+
+      expect(result.missingExtensions).toEqual(["ext.one"]);
+      expect(result.outdatedExtensions).toEqual(["ext.two"]);
+    });
+
+    it("returns empty extensions when preflight fails (graceful)", async () => {
+      const deps = createMockDeps();
+      (deps.extensionManager.preflight as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: false,
+        error: { type: "preflight-failed", message: "disk error" },
+      });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as CheckDepsResult;
+
+      expect(result.missingExtensions).toBeUndefined();
+      expect(result.outdatedExtensions).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // start
+  // ---------------------------------------------------------------------------
+
+  describe("start", () => {
+    it("starts PluginServer and code-server, updates port", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as StartHookResult;
+
+      expect(result.codeServerPort).toBe(9090);
+      expect(lifecycleDeps.pluginServer!.start).toHaveBeenCalled();
+      expect(lifecycleDeps.codeServerManager.ensureRunning).toHaveBeenCalled();
+      expect(lifecycleDeps.onPortChanged).toHaveBeenCalledWith(9090);
+    });
+
+    it("ensures required directories exist", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      expect(lifecycleDeps.fileSystemLayer.mkdir).toHaveBeenCalledTimes(3);
+    });
+
+    it("wires config data provider on PluginServer", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      expect(lifecycleDeps.pluginServer!.onConfigData).toHaveBeenCalledWith(
+        lifecycleDeps.configDataProvider
+      );
+    });
+
+    it("sets plugin port on CodeServerManager", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      expect(lifecycleDeps.codeServerManager.setPluginPort).toHaveBeenCalledWith(3456);
+    });
+
+    it("degrades gracefully when PluginServer fails", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      (lifecycleDeps.pluginServer!.start as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("bind failed")
+      );
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as StartHookResult;
+
+      // code-server should still start
+      expect(result.codeServerPort).toBe(9090);
+      expect(lifecycleDeps.codeServerManager.ensureRunning).toHaveBeenCalled();
+    });
+
+    it("works with null PluginServer", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      (lifecycleDeps as unknown as Record<string, unknown>).pluginServer = null;
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+
+      const result = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as StartHookResult;
+
+      expect(result.codeServerPort).toBe(9090);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // stop
+  // ---------------------------------------------------------------------------
+
+  describe("stop", () => {
+    it("stops code-server then PluginServer", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const callOrder: string[] = [];
+      (lifecycleDeps.codeServerManager.stop as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          callOrder.push("cs-stop");
+        }
+      );
+      (lifecycleDeps.pluginServer!.close as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          callOrder.push("plugin-close");
+        }
+      );
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+
+      await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
+
+      expect(callOrder).toEqual(["cs-stop", "plugin-close"]);
+    });
+
+    it("handles non-fatal stop errors", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      (lifecycleDeps.codeServerManager.stop as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("stop failed")
+      );
+      const deps = createMockDeps({ lifecycleDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+
+      // Should not throw
+      await expect(
+        dispatcher.dispatch({ type: "app:shutdown", payload: {} })
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // binary download
+  // ---------------------------------------------------------------------------
+
+  describe("binary download", () => {
+    it("downloads code-server when missing", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalBinaryOperation({ missingBinaries: ["code-server"] })
+      );
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.codeServerManager.downloadBinary).toHaveBeenCalled();
+      expect(deps.reportProgress).toHaveBeenCalledWith("vscode", "done");
+    });
+
+    it("skips download when not missing", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("setup", new MinimalBinaryOperation({ missingBinaries: [] }));
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.codeServerManager.downloadBinary).not.toHaveBeenCalled();
+      expect(deps.reportProgress).toHaveBeenCalledWith("vscode", "done");
+    });
+
+    it("reports progress during download", async () => {
+      const deps = createMockDeps();
+      (deps.codeServerManager.downloadBinary as ReturnType<typeof vi.fn>).mockImplementation(
+        async (cb: (p: { phase: string; bytesDownloaded: number; totalBytes: number }) => void) => {
+          cb({ phase: "downloading", bytesDownloaded: 50, totalBytes: 100 });
+          cb({ phase: "extracting", bytesDownloaded: 100, totalBytes: 100 });
+        }
+      );
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalBinaryOperation({ missingBinaries: ["code-server"] })
+      );
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.reportProgress).toHaveBeenCalledWith(
+        "vscode",
+        "running",
+        "Downloading...",
+        undefined,
+        50
+      );
+      expect(deps.reportProgress).toHaveBeenCalledWith("vscode", "running", "Extracting...");
+    });
+
+    it("throws SetupError on download failure", async () => {
+      const deps = createMockDeps();
+      (deps.codeServerManager.downloadBinary as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("network error")
+      );
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalBinaryOperation({ missingBinaries: ["code-server"] })
+      );
+
+      await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
+      expect(deps.reportProgress).toHaveBeenCalledWith(
+        "vscode",
+        "failed",
+        undefined,
+        "network error"
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // extensions install
+  // ---------------------------------------------------------------------------
+
+  describe("extensions install", () => {
+    it("installs missing extensions", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalExtensionsOperation({ missingExtensions: ["ext.one"] })
+      );
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.extensionManager.install).toHaveBeenCalledWith(["ext.one"], expect.any(Function));
+      expect(deps.reportProgress).toHaveBeenCalledWith("setup", "done");
+    });
+
+    it("cleans and reinstalls outdated extensions", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalExtensionsOperation({ outdatedExtensions: ["ext.old"] })
+      );
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.extensionManager.cleanOutdated).toHaveBeenCalledWith(["ext.old"]);
+      expect(deps.extensionManager.install).toHaveBeenCalledWith(["ext.old"], expect.any(Function));
+    });
+
+    it("skips when no extensions need install", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("setup", new MinimalExtensionsOperation());
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(deps.extensionManager.install).not.toHaveBeenCalled();
+      expect(deps.reportProgress).toHaveBeenCalledWith("setup", "done");
+    });
+
+    it("throws SetupError on install failure", async () => {
+      const deps = createMockDeps();
+      (deps.extensionManager.install as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("install failed")
+      );
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalExtensionsOperation({ missingExtensions: ["ext.one"] })
+      );
+
+      await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
+      expect(deps.reportProgress).toHaveBeenCalledWith(
+        "setup",
+        "failed",
+        undefined,
+        "install failed"
+      );
+    });
+
+    it("throws SetupError on clean failure", async () => {
+      const deps = createMockDeps();
+      (deps.extensionManager.cleanOutdated as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("clean failed")
+      );
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(
+        "setup",
+        new MinimalExtensionsOperation({ outdatedExtensions: ["ext.old"] })
+      );
+
+      await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // finalize
+  // ---------------------------------------------------------------------------
+
+  describe("finalize", () => {
+    it("creates workspace file and returns URL using port from start", async () => {
+      // Create deps that will be shared
+      const lifecycleDeps = createMockLifecycleDeps();
+      const workspaceDeps = createMockWorkspaceDeps();
+      const deps = createMockDeps({ lifecycleDeps, workspaceDeps });
+
+      // Create single setup with both operations
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      const module = createCodeServerModule(deps);
+      wireModules([module], hookRegistry, dispatcher);
+
+      // Register start operation and run it to set port
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      // Now register finalize operation and test it
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalFinalizeOperation({
+          workspacePath: "/test/project/.worktrees/feature-1",
+          envVars: { OPENCODE_PORT: "8080" },
+        })
+      );
+
+      const result = (await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as OpenWorkspaceIntent)) as FinalizeHookResult;
+
+      expect(result.workspaceUrl).toContain("9090");
+      expect(result.workspaceUrl).toContain("workspace=");
+      expect(workspaceDeps.workspaceFileService.ensureWorkspaceFile).toHaveBeenCalledWith(
+        new Path("/test/project/.worktrees/feature-1"),
+        new Path("/test/project/.worktrees"),
+        expect.objectContaining({
+          "claudeCode.useTerminal": true,
+          "claudeCode.claudeProcessWrapper": "/path/to/wrapper",
+        })
+      );
+    });
+
+    it("falls back to folder URL on workspace file error", async () => {
+      const lifecycleDeps = createMockLifecycleDeps();
+      const workspaceDeps = createMockWorkspaceDeps();
+      (
+        workspaceDeps.workspaceFileService.ensureWorkspaceFile as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error("disk full"));
+      const deps = createMockDeps({ lifecycleDeps, workspaceDeps });
+
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      const module = createCodeServerModule(deps);
+      wireModules([module], hookRegistry, dispatcher);
+
+      // Start to set port
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      // Finalize
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalFinalizeOperation({
+          workspacePath: "/test/project/.worktrees/feature-1",
+          envVars: {},
+        })
+      );
+
+      const result = (await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as OpenWorkspaceIntent)) as FinalizeHookResult;
+
+      expect(result.workspaceUrl).toContain("9090");
+      expect(result.workspaceUrl).toContain("folder=");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // delete
+  // ---------------------------------------------------------------------------
+
+  describe("delete", () => {
+    it("deletes workspace file", async () => {
+      const workspaceDeps = createMockWorkspaceDeps();
+      const deps = createMockDeps({ workspaceDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+
+      await dispatcher.dispatch({
+        type: "workspace:delete",
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "feature-1" as WorkspaceName,
+          workspacePath: "/test/project/.worktrees/feature-1",
+          projectPath: "/test/project",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent);
+
+      expect(workspaceDeps.workspaceFileService.deleteWorkspaceFile).toHaveBeenCalledWith(
+        "feature-1",
+        new Path("/test/project/.worktrees")
+      );
+    });
+
+    it("suppresses errors in force mode", async () => {
+      const workspaceDeps = createMockWorkspaceDeps();
+      (
+        workspaceDeps.workspaceFileService.deleteWorkspaceFile as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error("permission denied"));
+      const deps = createMockDeps({ workspaceDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+
+      // Should not throw
+      const result = (await dispatcher.dispatch({
+        type: "workspace:delete",
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "feature-1" as WorkspaceName,
+          workspacePath: "/test/project/.worktrees/feature-1",
+          projectPath: "/test/project",
+          keepBranch: false,
+          force: true,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent)) as DeleteHookResult;
+
+      expect(result).toEqual({});
+    });
+
+    it("throws on non-force error", async () => {
+      const workspaceDeps = createMockWorkspaceDeps();
+      (
+        workspaceDeps.workspaceFileService.deleteWorkspaceFile as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error("permission denied"));
+      const deps = createMockDeps({ workspaceDeps });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+
+      await expect(
+        dispatcher.dispatch({
+          type: "workspace:delete",
+          payload: {
+            projectId: "test-12345678" as ProjectId,
+            workspaceName: "feature-1" as WorkspaceName,
+            workspacePath: "/test/project/.worktrees/feature-1",
+            projectPath: "/test/project",
+            keepBranch: false,
+            force: false,
+            removeWorktree: true,
+          },
+        } as DeleteWorkspaceIntent)
+      ).rejects.toThrow("permission denied");
+    });
+  });
+});

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -1,0 +1,369 @@
+/**
+ * CodeServerModule - Manages code-server lifecycle, extensions, and per-workspace files.
+ *
+ * Consolidates seven inline bootstrap modules into a single extracted module:
+ * - Binary preflight (code-server part)
+ * - Extension preflight
+ * - Binary download (code-server part)
+ * - Extension install
+ * - Code-server lifecycle (start/stop + PluginServer)
+ * - Per-workspace file creation (finalize hook)
+ * - Per-workspace file deletion (delete hook)
+ *
+ * Internal state: code-server port set by `start` hook, read by `finalize` hook.
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { CodeServerManager } from "../../services/code-server/code-server-manager";
+import type { ExtensionManager } from "../../services/vscode-setup/extension-manager";
+import type { FileSystemLayer } from "../../services/platform/filesystem";
+import type { IWorkspaceFileService } from "../../services/vscode-workspace/types";
+import type { PluginServer, ConfigDataProvider } from "../../services/plugin-server/plugin-server";
+import type { Logger } from "../../services/logging/types";
+import type { SetupRowId, SetupRowStatus } from "../../shared/api/types";
+import type { CheckDepsResult, StartHookResult } from "../operations/app-start";
+import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
+import type { FinalizeHookInput, FinalizeHookResult } from "../operations/open-workspace";
+import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
+import type { DeleteHookResult } from "../operations/delete-workspace";
+import { APP_START_OPERATION_ID } from "../operations/app-start";
+import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { SETUP_OPERATION_ID } from "../operations/setup";
+import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
+import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
+import { urlForWorkspace, urlForFolder } from "../../services/code-server/code-server-manager";
+import { Path } from "../../services/platform/path";
+import { SetupError, getErrorMessage } from "../../services/errors";
+
+// =============================================================================
+// Dependency Interfaces
+// =============================================================================
+
+/**
+ * Progress reporter callback for setup screen rows.
+ */
+export type SetupProgressReporter = (
+  id: SetupRowId,
+  status: SetupRowStatus,
+  message?: string,
+  error?: string,
+  progress?: number
+) => void;
+
+/**
+ * Dependencies resolved when lifecycle hooks execute (after startServices).
+ */
+export interface CodeServerLifecycleDeps {
+  readonly pluginServer: PluginServer | null;
+  readonly codeServerManager: Pick<
+    CodeServerManager,
+    "ensureRunning" | "port" | "getConfig" | "setPluginPort" | "stop"
+  >;
+  readonly fileSystemLayer: Pick<FileSystemLayer, "mkdir">;
+  readonly configDataProvider: ConfigDataProvider;
+  readonly onPortChanged: (port: number) => void;
+}
+
+/**
+ * Dependencies resolved when per-workspace hooks execute (after startServices).
+ */
+export interface CodeServerWorkspaceDeps {
+  readonly workspaceFileService: IWorkspaceFileService;
+  readonly wrapperPath: string;
+}
+
+/**
+ * All dependencies for CodeServerModule.
+ *
+ * Split into eager (available at creation) and lazy (resolved at hook execution).
+ */
+export interface CodeServerModuleDeps {
+  // Eager: available at creation time (initializeBootstrap scope)
+  readonly codeServerManager: Pick<CodeServerManager, "preflight" | "downloadBinary">;
+  readonly extensionManager: Pick<ExtensionManager, "preflight" | "install" | "cleanOutdated">;
+  readonly reportProgress: SetupProgressReporter;
+  readonly logger: Logger;
+
+  // Lazy: resolved when lifecycle hooks execute (after startServices)
+  readonly getLifecycleDeps: () => CodeServerLifecycleDeps;
+
+  // Lazy: resolved when per-workspace hooks execute (after startServices)
+  readonly getWorkspaceDeps: () => CodeServerWorkspaceDeps;
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+/**
+ * Create a CodeServerModule that manages code-server lifecycle, extensions,
+ * and per-workspace .code-workspace files.
+ */
+export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule {
+  const { codeServerManager, extensionManager, reportProgress, logger } = deps;
+
+  // Internal state: port set by start hook, read by finalize hook
+  let codeServerPort = 0;
+
+  return {
+    hooks: {
+      // -------------------------------------------------------------------
+      // app-start → check-deps: preflight code-server binary + extensions
+      // -------------------------------------------------------------------
+      [APP_START_OPERATION_ID]: {
+        "check-deps": {
+          handler: async (): Promise<CheckDepsResult> => {
+            const missingBinaries: import("../../services/vscode-setup/types").BinaryType[] = [];
+
+            // Check code-server binary
+            const codeServerResult = await codeServerManager.preflight();
+            if (codeServerResult.success && codeServerResult.needsDownload) {
+              missingBinaries.push("code-server");
+            }
+
+            // Check extensions
+            const extResult = await extensionManager.preflight();
+            if (extResult.success) {
+              return {
+                missingBinaries,
+                missingExtensions: extResult.missingExtensions,
+                outdatedExtensions: extResult.outdatedExtensions,
+              };
+            }
+
+            // Extension preflight failed -- return binaries only
+            return { missingBinaries };
+          },
+        },
+
+        // -------------------------------------------------------------------
+        // app-start → start: start PluginServer + code-server, update port
+        // -------------------------------------------------------------------
+        start: {
+          handler: async (): Promise<StartHookResult> => {
+            const lifecycle = deps.getLifecycleDeps();
+
+            // Start PluginServer BEFORE code-server (graceful degradation)
+            let pluginPort: number | undefined;
+            if (lifecycle.pluginServer) {
+              try {
+                pluginPort = await lifecycle.pluginServer.start();
+                logger.info("PluginServer started", { port: pluginPort });
+
+                // Wire config data provider
+                lifecycle.pluginServer.onConfigData(lifecycle.configDataProvider);
+
+                // Pass pluginPort to CodeServerManager so extensions can connect
+                lifecycle.codeServerManager.setPluginPort(pluginPort);
+              } catch (error) {
+                const message = error instanceof Error ? error.message : "Unknown error";
+                logger.warn("PluginServer start failed", { error: message });
+                pluginPort = undefined;
+              }
+            }
+
+            // Ensure required directories exist
+            const config = lifecycle.codeServerManager.getConfig();
+            await Promise.all([
+              lifecycle.fileSystemLayer.mkdir(config.runtimeDir),
+              lifecycle.fileSystemLayer.mkdir(config.extensionsDir),
+              lifecycle.fileSystemLayer.mkdir(config.userDataDir),
+            ]);
+
+            // Start code-server
+            await lifecycle.codeServerManager.ensureRunning();
+            const port = lifecycle.codeServerManager.port()!;
+
+            // Update internal port and notify
+            codeServerPort = port;
+            lifecycle.onPortChanged(port);
+
+            return { codeServerPort: port };
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // app-shutdown → stop: stop code-server + PluginServer
+      // -------------------------------------------------------------------
+      [APP_SHUTDOWN_OPERATION_ID]: {
+        stop: {
+          handler: async () => {
+            try {
+              const lifecycle = deps.getLifecycleDeps();
+
+              // Stop code-server
+              await lifecycle.codeServerManager.stop();
+
+              // Close PluginServer AFTER code-server (extensions disconnect first)
+              if (lifecycle.pluginServer) {
+                await lifecycle.pluginServer.close();
+              }
+            } catch (error) {
+              logger.error(
+                "CodeServer lifecycle shutdown failed (non-fatal)",
+                {},
+                error instanceof Error ? error : undefined
+              );
+            }
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // setup → binary: download code-server if missing
+      // -------------------------------------------------------------------
+      [SETUP_OPERATION_ID]: {
+        binary: {
+          handler: async (ctx: HookContext) => {
+            const hookCtx = ctx as BinaryHookInput;
+            const missingBinaries = hookCtx.missingBinaries ?? [];
+
+            if (missingBinaries.includes("code-server")) {
+              reportProgress("vscode", "running", "Downloading...");
+              try {
+                await codeServerManager.downloadBinary((p) => {
+                  if (p.phase === "downloading" && p.totalBytes) {
+                    const pct = Math.floor((p.bytesDownloaded / p.totalBytes) * 100);
+                    reportProgress("vscode", "running", "Downloading...", undefined, pct);
+                  } else if (p.phase === "extracting") {
+                    reportProgress("vscode", "running", "Extracting...");
+                  }
+                });
+                reportProgress("vscode", "done");
+              } catch (error) {
+                reportProgress("vscode", "failed", undefined, getErrorMessage(error));
+                throw new SetupError(
+                  `Failed to download code-server: ${getErrorMessage(error)}`,
+                  "BINARY_DOWNLOAD_FAILED"
+                );
+              }
+            } else {
+              reportProgress("vscode", "done");
+            }
+          },
+        },
+
+        // -------------------------------------------------------------------
+        // setup → extensions: install missing/outdated extensions
+        // -------------------------------------------------------------------
+        extensions: {
+          handler: async (ctx: HookContext) => {
+            const hookCtx = ctx as ExtensionsHookInput;
+            const missingExtensions = hookCtx.missingExtensions ?? [];
+            const outdatedExtensions = hookCtx.outdatedExtensions ?? [];
+
+            const extensionsToInstall = [...missingExtensions, ...outdatedExtensions];
+            if (extensionsToInstall.length === 0) {
+              reportProgress("setup", "done");
+              return;
+            }
+
+            reportProgress("setup", "running", "Installing extensions...");
+
+            // Clean outdated extensions before reinstalling
+            if (outdatedExtensions.length > 0) {
+              try {
+                await extensionManager.cleanOutdated(outdatedExtensions);
+              } catch (error) {
+                reportProgress("setup", "failed", undefined, getErrorMessage(error));
+                throw new SetupError(
+                  `Failed to clean outdated extensions: ${getErrorMessage(error)}`,
+                  "EXTENSION_INSTALL_FAILED"
+                );
+              }
+            }
+
+            // Install extensions
+            try {
+              await extensionManager.install(extensionsToInstall, (message) => {
+                reportProgress("setup", "running", message);
+              });
+              reportProgress("setup", "done");
+            } catch (error) {
+              reportProgress("setup", "failed", undefined, getErrorMessage(error));
+              throw new SetupError(
+                `Failed to install extensions: ${getErrorMessage(error)}`,
+                "EXTENSION_INSTALL_FAILED"
+              );
+            }
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // open-workspace → finalize: create .code-workspace file, return URL
+      // -------------------------------------------------------------------
+      [OPEN_WORKSPACE_OPERATION_ID]: {
+        finalize: {
+          handler: async (ctx: HookContext): Promise<FinalizeHookResult> => {
+            const finalizeCtx = ctx as FinalizeHookInput;
+            const workspace = deps.getWorkspaceDeps();
+
+            try {
+              const workspacePathObj = new Path(finalizeCtx.workspacePath);
+              const projectWorkspacesDir = workspacePathObj.dirname;
+              const envVarsArray = Object.entries(finalizeCtx.envVars).map(([name, value]) => ({
+                name,
+                value,
+              }));
+              const agentSettings: Record<string, unknown> = {
+                "claudeCode.useTerminal": true,
+                "claudeCode.claudeProcessWrapper": workspace.wrapperPath,
+                "claudeCode.environmentVariables": envVarsArray,
+              };
+              const workspaceFilePath = await workspace.workspaceFileService.ensureWorkspaceFile(
+                workspacePathObj,
+                projectWorkspacesDir,
+                agentSettings
+              );
+              return {
+                workspaceUrl: urlForWorkspace(codeServerPort, workspaceFilePath.toString()),
+              };
+            } catch (error) {
+              logger.warn("Failed to ensure workspace file, using folder URL", {
+                workspacePath: finalizeCtx.workspacePath,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              return {
+                workspaceUrl: urlForFolder(codeServerPort, finalizeCtx.workspacePath),
+              };
+            }
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // delete-workspace → delete: delete .code-workspace file
+      // -------------------------------------------------------------------
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        delete: {
+          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+            const workspace = deps.getWorkspaceDeps();
+
+            try {
+              const workspacePath = new Path(payload.workspacePath);
+              const workspaceName = workspacePath.basename;
+              const projectWorkspacesDir = workspacePath.dirname;
+              await workspace.workspaceFileService.deleteWorkspaceFile(
+                workspaceName,
+                projectWorkspacesDir
+              );
+              return {};
+            } catch (error) {
+              if (payload.force) {
+                logger.warn("CodeServerModule: error in force mode (ignored)", {
+                  error: getErrorMessage(error),
+                });
+                return {};
+              }
+              throw error;
+            }
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
- Consolidate 7 inline bootstrap modules (binary preflight, extension preflight, binary download, extension install, code-server lifecycle, finalize, delete) into a single `CodeServerModule`
- Use lazy dependency injection (`getLifecycleDeps`, `getWorkspaceDeps`) to bridge creation-time vs execution-time scoping
- Replace remaining inline agent-only code with slim `agentBinaryPreflightModule` and `agentBinaryDownloadModule` stubs
- Remove `updateCodeServerPort` no-op from `LifecycleServiceRefs` interface and `index.ts`
- Remove `coreDeps` and `workspaceFileService` params from `wireDispatcher()` (now injected via CodeServerModule)
- Add 26 integration tests covering all 7 hook handlers