### PR TITLE
feat(mcp): extract McpModule and add workspace:mcp-attached domain event

### DIFF
--- a/src/main/modules/mcp-module.integration.test.ts
+++ b/src/main/modules/mcp-module.integration.test.ts
@@ -1,0 +1,559 @@
+// @vitest-environment node
+/**
+ * Integration tests for McpModule through the Dispatcher.
+ *
+ * Tests verify the full pipeline:
+ * - workspace:created event → mcpServerManager.registerWorkspace()
+ * - workspace:deleted event → mcpServerManager.unregisterWorkspace()
+ * - onFirstRequest → dispatches workspace:mcp-attached intent → event subscribers
+ * - workspace:mcp-attached event → viewManager.setWorkspaceLoaded() + agentStatusManager.markActive()
+ * - app:shutdown / stop → dispose MCP server, cleanup callbacks
+ * - workspace:delete / shutdown → unregister workspace from MCP
+ * - Agent server configured with MCP port
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { wireModules } from "../intents/infrastructure/wire";
+import {
+  McpAttachedOperation,
+  INTENT_MCP_ATTACHED,
+  EVENT_MCP_ATTACHED,
+} from "../operations/mcp-attached";
+import type { McpAttachedEvent } from "../operations/mcp-attached";
+import { INTENT_OPEN_WORKSPACE, EVENT_WORKSPACE_CREATED } from "../operations/open-workspace";
+import type { OpenWorkspaceIntent, WorkspaceCreatedEvent } from "../operations/open-workspace";
+import {
+  INTENT_DELETE_WORKSPACE,
+  EVENT_WORKSPACE_DELETED,
+  DELETE_WORKSPACE_OPERATION_ID,
+} from "../operations/delete-workspace";
+import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../operations/delete-workspace";
+import { INTENT_APP_START, APP_START_OPERATION_ID } from "../operations/app-start";
+import type { AppStartIntent } from "../operations/app-start";
+import {
+  AppShutdownOperation,
+  INTENT_APP_SHUTDOWN,
+  APP_SHUTDOWN_OPERATION_ID,
+} from "../operations/app-shutdown";
+import type { AppShutdownIntent } from "../operations/app-shutdown";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import type { IntentModule } from "../intents/infrastructure/module";
+import { createMcpModule, type McpModuleDeps } from "./mcp-module";
+import { SILENT_LOGGER } from "../../services/logging";
+import type { McpRequestCallback } from "../../services/mcp-server/types";
+import type { Unsubscribe } from "../../shared/api/interfaces";
+import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import type { Path } from "../../services/platform/path";
+
+// =============================================================================
+// Mock McpServerManager
+// =============================================================================
+
+interface MockMcpServerManager {
+  start: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  registerWorkspace: ReturnType<typeof vi.fn>;
+  unregisterWorkspace: ReturnType<typeof vi.fn>;
+  onFirstRequest: ReturnType<typeof vi.fn>;
+  getPort: ReturnType<typeof vi.fn>;
+  /** Captured onFirstRequest callback for triggering in tests */
+  capturedFirstRequestCallback: McpRequestCallback | null;
+}
+
+function createMockMcpServerManager(port = 9999): MockMcpServerManager {
+  const mock: MockMcpServerManager = {
+    start: vi.fn().mockResolvedValue(port),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    registerWorkspace: vi.fn(),
+    unregisterWorkspace: vi.fn(),
+    getPort: vi.fn().mockReturnValue(port),
+    capturedFirstRequestCallback: null,
+    onFirstRequest: vi.fn().mockImplementation((callback: McpRequestCallback): Unsubscribe => {
+      mock.capturedFirstRequestCallback = callback;
+      return () => {
+        mock.capturedFirstRequestCallback = null;
+      };
+    }),
+  };
+  return mock;
+}
+
+// =============================================================================
+// Mock ViewManager
+// =============================================================================
+
+function createMockViewManager(): { setWorkspaceLoaded: ReturnType<typeof vi.fn> } {
+  return {
+    setWorkspaceLoaded: vi.fn(),
+  };
+}
+
+// =============================================================================
+// Mock AgentStatusManager
+// =============================================================================
+
+function createMockAgentStatusManager(): { markActive: ReturnType<typeof vi.fn> } {
+  return {
+    markActive: vi.fn(),
+  };
+}
+
+// =============================================================================
+// Mock AgentServerManager (OpenCode variant)
+// =============================================================================
+
+function createMockAgentServerManager(): {
+  setMcpConfig: ReturnType<typeof vi.fn>;
+} {
+  return {
+    setMcpConfig: vi.fn(),
+  };
+}
+
+// =============================================================================
+// Mock PathProvider
+// =============================================================================
+
+function createMockPathProvider(): { opencodeConfig: { toString: () => string } } {
+  return {
+    opencodeConfig: { toString: () => "/mock/opencode.config.json" } as unknown as Path,
+  };
+}
+
+// =============================================================================
+// Minimal operations that emit events for testing
+// =============================================================================
+
+class MinimalOpenOperation implements Operation<OpenWorkspaceIntent, unknown> {
+  readonly id = "open-workspace";
+
+  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<unknown> {
+    const { payload } = ctx.intent;
+    const event: WorkspaceCreatedEvent = {
+      type: EVENT_WORKSPACE_CREATED,
+      payload: {
+        projectId: payload.projectId as unknown as ProjectId,
+        workspaceName: payload.workspaceName as unknown as WorkspaceName,
+        workspacePath: `/workspaces/${payload.workspaceName}`,
+        projectPath: `/projects/test`,
+        branch: payload.base ?? "main",
+        base: payload.base ?? "main",
+        metadata: {},
+        workspaceUrl: `http://127.0.0.1:0/?folder=/workspaces/${payload.workspaceName}`,
+      },
+    };
+    ctx.emit(event);
+    return {};
+  }
+}
+
+class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { started: true }> {
+  readonly id = DELETE_WORKSPACE_OPERATION_ID;
+
+  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+    const { payload } = ctx.intent;
+    const event: WorkspaceDeletedEvent = {
+      type: EVENT_WORKSPACE_DELETED,
+      payload: {
+        projectId: payload.projectId,
+        workspaceName: payload.workspaceName,
+        workspacePath: payload.workspacePath,
+        projectPath: payload.projectPath,
+      },
+    };
+    ctx.emit(event);
+    return { started: true };
+  }
+}
+
+/**
+ * Minimal app:start that only runs the "start" hook point.
+ * The real AppStartOperation has many hook points (show-ui, check-config, etc.)
+ * but we only need "start" for MCP module testing.
+ */
+class MinimalAppStartOperation implements Operation<AppStartIntent, void> {
+  readonly id = APP_START_OPERATION_ID;
+
+  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
+    await ctx.hooks.collect("start", { intent: ctx.intent });
+  }
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+interface TestSetup {
+  dispatcher: Dispatcher;
+  hookRegistry: HookRegistry;
+  mcpServerManager: MockMcpServerManager;
+  viewManager: ReturnType<typeof createMockViewManager>;
+  agentStatusManager: ReturnType<typeof createMockAgentStatusManager>;
+  agentServerManager: ReturnType<typeof createMockAgentServerManager>;
+  setMcpServerManager: ReturnType<typeof vi.fn>;
+}
+
+function createTestSetup(agentType: "opencode" | "claude" = "opencode"): TestSetup {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  const mcpServerManager = createMockMcpServerManager();
+  const viewManager = createMockViewManager();
+  const agentStatusManager = createMockAgentStatusManager();
+  const agentServerManager = createMockAgentServerManager();
+  const pathProvider = createMockPathProvider();
+  const setMcpServerManager = vi.fn();
+
+  // Register operations
+  dispatcher.registerOperation(INTENT_MCP_ATTACHED, new McpAttachedOperation());
+  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new MinimalOpenOperation());
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new MinimalDeleteOperation());
+  dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+  const mcpModule = createMcpModule({
+    mcpServerManager: mcpServerManager as unknown as McpModuleDeps["mcpServerManager"],
+    pathProvider: pathProvider as unknown as McpModuleDeps["pathProvider"],
+    viewManager: viewManager as unknown as McpModuleDeps["viewManager"],
+    agentStatusManager: agentStatusManager as unknown as McpModuleDeps["agentStatusManager"],
+    serverManager: agentServerManager as unknown as McpModuleDeps["serverManager"],
+    selectedAgentType: agentType,
+    dispatcher,
+    logger: SILENT_LOGGER,
+    setMcpServerManager,
+  });
+
+  wireModules([mcpModule], hookRegistry, dispatcher);
+
+  return {
+    dispatcher,
+    hookRegistry,
+    mcpServerManager,
+    viewManager,
+    agentStatusManager,
+    agentServerManager,
+    setMcpServerManager,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("McpModule Integration", () => {
+  describe("workspace:created event triggers registerWorkspace", () => {
+    it("registers workspace with MCP server manager on workspace:created", async () => {
+      const { dispatcher, mcpServerManager } = createTestSetup();
+
+      await dispatcher.dispatch({
+        type: INTENT_OPEN_WORKSPACE,
+        payload: {
+          projectId: "test-project" as unknown as ProjectId,
+          workspaceName: "ws1" as unknown as WorkspaceName,
+          base: "main",
+        },
+      } as OpenWorkspaceIntent);
+
+      expect(mcpServerManager.registerWorkspace).toHaveBeenCalledWith({
+        projectId: "test-project",
+        workspaceName: "ws1",
+        workspacePath: "/workspaces/ws1",
+      });
+    });
+  });
+
+  describe("workspace:deleted event triggers unregisterWorkspace", () => {
+    it("unregisters workspace from MCP server manager on workspace:deleted", async () => {
+      const { dispatcher, mcpServerManager } = createTestSetup();
+
+      await dispatcher.dispatch({
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "ws1" as WorkspaceName,
+          workspacePath: "/workspaces/ws1",
+          projectPath: "/projects/test",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent);
+
+      expect(mcpServerManager.unregisterWorkspace).toHaveBeenCalledWith("/workspaces/ws1");
+    });
+  });
+
+  describe("onFirstRequest dispatches workspace:mcp-attached intent", () => {
+    it("dispatches mcp-attached intent and triggers event subscribers", async () => {
+      const { dispatcher, mcpServerManager, viewManager, agentStatusManager } = createTestSetup();
+
+      // Start the app to wire callbacks
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      // Verify onFirstRequest was registered
+      expect(mcpServerManager.onFirstRequest).toHaveBeenCalled();
+      expect(mcpServerManager.capturedFirstRequestCallback).not.toBeNull();
+
+      // Trigger the first request callback
+      mcpServerManager.capturedFirstRequestCallback!("/workspaces/test");
+
+      // Allow the async dispatch to settle
+      await vi.waitFor(() => {
+        expect(viewManager.setWorkspaceLoaded).toHaveBeenCalledWith("/workspaces/test");
+      });
+      expect(agentStatusManager.markActive).toHaveBeenCalledWith("/workspaces/test");
+    });
+
+    it("emits workspace:mcp-attached event observable by external subscribers", async () => {
+      const { dispatcher, mcpServerManager } = createTestSetup();
+      const receivedEvents: DomainEvent[] = [];
+      dispatcher.subscribe(EVENT_MCP_ATTACHED, (event) => {
+        receivedEvents.push(event);
+      });
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      mcpServerManager.capturedFirstRequestCallback!("/workspaces/alpha");
+
+      await vi.waitFor(() => {
+        expect(receivedEvents).toHaveLength(1);
+      });
+      const event = receivedEvents[0] as McpAttachedEvent;
+      expect(event.type).toBe(EVENT_MCP_ATTACHED);
+      expect(event.payload.workspacePath).toBe("/workspaces/alpha");
+    });
+  });
+
+  describe("app:start / start hook", () => {
+    it("starts MCP server and returns port", async () => {
+      const { dispatcher, mcpServerManager } = createTestSetup();
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(mcpServerManager.start).toHaveBeenCalled();
+    });
+
+    it("configures OpenCode agent server manager with MCP config", async () => {
+      const { dispatcher, agentServerManager } = createTestSetup("opencode");
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(agentServerManager.setMcpConfig).toHaveBeenCalledWith({
+        configPath: "/mock/opencode.config.json",
+        port: 9999,
+      });
+    });
+
+    it("configures Claude agent server manager with MCP port only", async () => {
+      const { dispatcher, agentServerManager } = createTestSetup("claude");
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(agentServerManager.setMcpConfig).toHaveBeenCalledWith({
+        port: 9999,
+      });
+    });
+
+    it("injects MCP server manager into AppState", async () => {
+      const { dispatcher, mcpServerManager, setMcpServerManager } = createTestSetup();
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(setMcpServerManager).toHaveBeenCalledWith(mcpServerManager);
+    });
+  });
+
+  describe("workspace:delete / shutdown hook", () => {
+    it("unregisters workspace from MCP during deletion", async () => {
+      // Setup with a delete operation that calls shutdown hooks
+      const hookRegistry = new HookRegistry();
+      const d = new Dispatcher(hookRegistry);
+
+      const msm = createMockMcpServerManager();
+      d.registerOperation(INTENT_MCP_ATTACHED, new McpAttachedOperation());
+      d.registerOperation(
+        INTENT_DELETE_WORKSPACE,
+        new (class implements Operation<DeleteWorkspaceIntent, { started: true }> {
+          readonly id = DELETE_WORKSPACE_OPERATION_ID;
+          async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+            await ctx.hooks.collect("shutdown", { intent: ctx.intent });
+            const event: WorkspaceDeletedEvent = {
+              type: EVENT_WORKSPACE_DELETED,
+              payload: {
+                projectId: ctx.intent.payload.projectId,
+                workspaceName: ctx.intent.payload.workspaceName,
+                workspacePath: ctx.intent.payload.workspacePath,
+                projectPath: ctx.intent.payload.projectPath,
+              },
+            };
+            ctx.emit(event);
+            return { started: true };
+          }
+        })()
+      );
+
+      const mcpModule = createMcpModule({
+        mcpServerManager: msm as unknown as McpModuleDeps["mcpServerManager"],
+        pathProvider: createMockPathProvider() as unknown as McpModuleDeps["pathProvider"],
+        viewManager: createMockViewManager() as unknown as McpModuleDeps["viewManager"],
+        agentStatusManager:
+          createMockAgentStatusManager() as unknown as McpModuleDeps["agentStatusManager"],
+        serverManager: createMockAgentServerManager() as unknown as McpModuleDeps["serverManager"],
+        selectedAgentType: "opencode",
+        dispatcher: d,
+        logger: SILENT_LOGGER,
+        setMcpServerManager: vi.fn(),
+      });
+
+      wireModules([mcpModule], hookRegistry, d);
+
+      await d.dispatch({
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "ws1" as WorkspaceName,
+          workspacePath: "/workspaces/ws1",
+          projectPath: "/projects/test",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent);
+
+      // Called twice: once from shutdown hook, once from workspace:deleted event
+      expect(msm.unregisterWorkspace).toHaveBeenCalledWith("/workspaces/ws1");
+      expect(msm.unregisterWorkspace).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("app:shutdown / stop hook", () => {
+    it("disposes MCP server and cleans up callbacks", async () => {
+      const { dispatcher, mcpServerManager } = createTestSetup();
+
+      // Start first to wire callbacks
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+      expect(mcpServerManager.onFirstRequest).toHaveBeenCalled();
+
+      // Now shutdown
+      // Wire a quit module to prevent app.quit() error
+      const quitModule: IntentModule = {
+        hooks: {
+          [APP_SHUTDOWN_OPERATION_ID]: {
+            quit: { handler: async () => {} },
+          },
+        },
+      };
+      const hookRegistry = new HookRegistry();
+      const shutdownDispatcher = new Dispatcher(hookRegistry);
+      shutdownDispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+      shutdownDispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+      shutdownDispatcher.registerOperation(INTENT_MCP_ATTACHED, new McpAttachedOperation());
+
+      const msm = createMockMcpServerManager();
+      const mcpModule = createMcpModule({
+        mcpServerManager: msm as unknown as McpModuleDeps["mcpServerManager"],
+        pathProvider: createMockPathProvider() as unknown as McpModuleDeps["pathProvider"],
+        viewManager: createMockViewManager() as unknown as McpModuleDeps["viewManager"],
+        agentStatusManager:
+          createMockAgentStatusManager() as unknown as McpModuleDeps["agentStatusManager"],
+        serverManager: createMockAgentServerManager() as unknown as McpModuleDeps["serverManager"],
+        selectedAgentType: "opencode",
+        dispatcher: shutdownDispatcher,
+        logger: SILENT_LOGGER,
+        setMcpServerManager: vi.fn(),
+      });
+
+      wireModules([mcpModule, quitModule], hookRegistry, shutdownDispatcher);
+
+      // Start to wire callbacks
+      await shutdownDispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      // Shutdown
+      await shutdownDispatcher.dispatch({
+        type: INTENT_APP_SHUTDOWN,
+        payload: {},
+      } as AppShutdownIntent);
+
+      expect(msm.dispose).toHaveBeenCalled();
+      // Callback was cleaned up (capturedFirstRequestCallback nulled by unsubscribe)
+      expect(msm.capturedFirstRequestCallback).toBeNull();
+    });
+  });
+
+  describe("Claude-specific: onWorkspaceReady", () => {
+    it("calls setWorkspaceLoaded when Claude wrapper signals ready", async () => {
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+
+      const mcpServerManager = createMockMcpServerManager();
+      const viewManager = createMockViewManager();
+
+      let capturedReadyCallback: ((workspacePath: string) => void) | null = null;
+      const claudeServerManager = {
+        setMcpConfig: vi.fn(),
+        onWorkspaceReady: vi.fn().mockImplementation((cb: (wp: string) => void) => {
+          capturedReadyCallback = cb;
+          return () => {
+            capturedReadyCallback = null;
+          };
+        }),
+      };
+
+      dispatcher.registerOperation(INTENT_MCP_ATTACHED, new McpAttachedOperation());
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+
+      const mcpModule = createMcpModule({
+        mcpServerManager: mcpServerManager as unknown as McpModuleDeps["mcpServerManager"],
+        pathProvider: createMockPathProvider() as unknown as McpModuleDeps["pathProvider"],
+        viewManager: viewManager as unknown as McpModuleDeps["viewManager"],
+        agentStatusManager:
+          createMockAgentStatusManager() as unknown as McpModuleDeps["agentStatusManager"],
+        serverManager: claudeServerManager as unknown as McpModuleDeps["serverManager"],
+        selectedAgentType: "claude",
+        dispatcher,
+        logger: SILENT_LOGGER,
+        setMcpServerManager: vi.fn(),
+      });
+
+      wireModules([mcpModule], hookRegistry, dispatcher);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(claudeServerManager.onWorkspaceReady).toHaveBeenCalled();
+      expect(capturedReadyCallback).not.toBeNull();
+
+      capturedReadyCallback!("/workspaces/claude-ws");
+      expect(viewManager.setWorkspaceLoaded).toHaveBeenCalledWith("/workspaces/claude-ws");
+    });
+  });
+});

--- a/src/main/modules/mcp-module.ts
+++ b/src/main/modules/mcp-module.ts
@@ -1,0 +1,174 @@
+/**
+ * McpModule - MCP server lifecycle, workspace registration, and event wiring.
+ *
+ * Subscribes to:
+ * - workspace:created: registers workspace with MCP server manager
+ * - workspace:deleted: unregisters workspace from MCP server manager (safety net)
+ * - workspace:mcp-attached: TEMP - calls viewManager.setWorkspaceLoaded() + agentStatusManager.markActive()
+ *   (moves to ViewModule Phase 8b and AgentModule Phase 7c)
+ *
+ * Hook handlers:
+ * - app:start / start: start MCP server, wire callbacks, configure agent ServerManager
+ * - workspace:delete / shutdown: unregister workspace before agent server stops
+ * - app:shutdown / stop: dispose MCP server, cleanup callbacks
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { IDispatcher } from "../intents/infrastructure/dispatcher";
+import type { StartHookResult } from "../operations/app-start";
+import { APP_START_OPERATION_ID } from "../operations/app-start";
+import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
+import type { DeleteWorkspaceIntent, ShutdownHookResult } from "../operations/delete-workspace";
+import { EVENT_WORKSPACE_CREATED } from "../operations/open-workspace";
+import type { WorkspaceCreatedEvent } from "../operations/open-workspace";
+import { EVENT_WORKSPACE_DELETED } from "../operations/delete-workspace";
+import type { WorkspaceDeletedEvent } from "../operations/delete-workspace";
+import { INTENT_MCP_ATTACHED, EVENT_MCP_ATTACHED } from "../operations/mcp-attached";
+import type { McpAttachedIntent, McpAttachedEvent } from "../operations/mcp-attached";
+import type { McpServerManager } from "../../services/mcp-server/mcp-server-manager";
+import type { IViewManager } from "../managers/view-manager.interface";
+import type { AgentStatusManager } from "../../agents/opencode/status-manager";
+import type { AgentServerManager, AgentType } from "../../agents/types";
+import type { ClaudeCodeServerManager } from "../../agents/claude/server-manager";
+import type { OpenCodeServerManager } from "../../agents/opencode/server-manager";
+import type { PathProvider } from "../../services/platform/path-provider";
+import type { Unsubscribe } from "../../shared/api/interfaces";
+import type { WorkspacePath } from "../../shared/ipc";
+import type { Logger } from "../../services/logging";
+
+// =============================================================================
+// Dependencies
+// =============================================================================
+
+export interface McpModuleDeps {
+  readonly mcpServerManager: McpServerManager;
+  readonly pathProvider: PathProvider;
+  readonly viewManager: IViewManager;
+  readonly agentStatusManager: AgentStatusManager;
+  readonly serverManager: AgentServerManager;
+  readonly selectedAgentType: AgentType;
+  readonly dispatcher: IDispatcher;
+  readonly logger: Logger;
+  readonly setMcpServerManager: (manager: McpServerManager) => void;
+}
+
+// =============================================================================
+// Module Factory
+// =============================================================================
+
+export function createMcpModule(deps: McpModuleDeps): IntentModule {
+  let mcpFirstRequestCleanupFn: Unsubscribe | null = null;
+  let wrapperReadyCleanupFn: Unsubscribe | null = null;
+
+  return {
+    events: {
+      [EVENT_WORKSPACE_CREATED]: (event: DomainEvent) => {
+        const payload = (event as WorkspaceCreatedEvent).payload;
+        deps.mcpServerManager.registerWorkspace({
+          projectId: payload.projectId,
+          workspaceName: payload.workspaceName,
+          workspacePath: payload.workspacePath,
+        });
+      },
+      [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
+        const payload = (event as WorkspaceDeletedEvent).payload;
+        deps.mcpServerManager.unregisterWorkspace(payload.workspacePath);
+      },
+      [EVENT_MCP_ATTACHED]: (event: DomainEvent) => {
+        // TEMP: Direct calls until ViewModule (Phase 8b) and AgentModule (Phase 7c) own these
+        const { workspacePath } = (event as McpAttachedEvent).payload;
+        deps.viewManager.setWorkspaceLoaded(workspacePath);
+        deps.agentStatusManager.markActive(workspacePath as WorkspacePath);
+      },
+    },
+    hooks: {
+      [APP_START_OPERATION_ID]: {
+        start: {
+          handler: async (): Promise<StartHookResult> => {
+            const mcpPort = await deps.mcpServerManager.start();
+            deps.logger.info("MCP server started", {
+              port: mcpPort,
+              configPath: deps.pathProvider.opencodeConfig.toString(),
+            });
+
+            // Register callback for first MCP request per workspace — dispatches domain event
+            mcpFirstRequestCleanupFn = deps.mcpServerManager.onFirstRequest((workspacePath) => {
+              const intent: McpAttachedIntent = {
+                type: INTENT_MCP_ATTACHED,
+                payload: { workspacePath },
+              };
+              deps.dispatcher.dispatch(intent);
+            });
+
+            // Register callback for wrapper start (Claude Code only)
+            if (deps.selectedAgentType === "claude" && deps.serverManager) {
+              const claudeServerManager = deps.serverManager as ClaudeCodeServerManager;
+              if (claudeServerManager.onWorkspaceReady) {
+                wrapperReadyCleanupFn = claudeServerManager.onWorkspaceReady((workspacePath) => {
+                  deps.viewManager.setWorkspaceLoaded(workspacePath);
+                });
+              }
+            }
+
+            // Configure server manager to connect to MCP
+            if (deps.serverManager && deps.selectedAgentType === "claude") {
+              const claudeManager = deps.serverManager as ClaudeCodeServerManager;
+              claudeManager.setMcpConfig({
+                port: deps.mcpServerManager.getPort()!,
+              });
+            } else if (deps.serverManager) {
+              const opencodeManager = deps.serverManager as OpenCodeServerManager;
+              opencodeManager.setMcpConfig({
+                configPath: deps.pathProvider.opencodeConfig.toString(),
+                port: deps.mcpServerManager.getPort()!,
+              });
+            }
+
+            // Inject MCP server manager into AppState for onServerStopped cleanup
+            deps.setMcpServerManager(deps.mcpServerManager);
+
+            return { mcpPort };
+          },
+        },
+      },
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        shutdown: {
+          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+            deps.mcpServerManager.unregisterWorkspace(payload.workspacePath);
+            return {};
+          },
+        },
+      },
+      [APP_SHUTDOWN_OPERATION_ID]: {
+        stop: {
+          handler: async () => {
+            try {
+              // Cleanup callbacks
+              if (mcpFirstRequestCleanupFn) {
+                mcpFirstRequestCleanupFn();
+                mcpFirstRequestCleanupFn = null;
+              }
+              if (wrapperReadyCleanupFn) {
+                wrapperReadyCleanupFn();
+                wrapperReadyCleanupFn = null;
+              }
+
+              // Dispose MCP server
+              await deps.mcpServerManager.dispose();
+            } catch (error) {
+              deps.logger.error(
+                "MCP lifecycle shutdown failed (non-fatal)",
+                {},
+                error instanceof Error ? error : undefined
+              );
+            }
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/main/operations/mcp-attached.integration.test.ts
+++ b/src/main/operations/mcp-attached.integration.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+/**
+ * Integration tests for mcp-attached operation through the Dispatcher.
+ *
+ * Tests verify the full dispatch pipeline: intent -> operation -> domain event emission.
+ */
+
+import { describe, it, expect } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { McpAttachedOperation, INTENT_MCP_ATTACHED, EVENT_MCP_ATTACHED } from "./mcp-attached";
+import type { McpAttachedIntent, McpAttachedEvent } from "./mcp-attached";
+import type { DomainEvent } from "../intents/infrastructure/types";
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+function createTestSetup(): { dispatcher: Dispatcher } {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation(INTENT_MCP_ATTACHED, new McpAttachedOperation());
+
+  return { dispatcher };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("McpAttached Operation", () => {
+  it("emits workspace:mcp-attached event with correct workspacePath", async () => {
+    const { dispatcher } = createTestSetup();
+    const receivedEvents: DomainEvent[] = [];
+    dispatcher.subscribe(EVENT_MCP_ATTACHED, (event) => {
+      receivedEvents.push(event);
+    });
+
+    const intent: McpAttachedIntent = {
+      type: INTENT_MCP_ATTACHED,
+      payload: { workspacePath: "/workspace/test" },
+    };
+    await dispatcher.dispatch(intent);
+
+    expect(receivedEvents).toHaveLength(1);
+    const event = receivedEvents[0] as McpAttachedEvent;
+    expect(event.type).toBe(EVENT_MCP_ATTACHED);
+    expect(event.payload.workspacePath).toBe("/workspace/test");
+  });
+
+  it("event handler receives different workspace paths", async () => {
+    const { dispatcher } = createTestSetup();
+    const receivedEvents: DomainEvent[] = [];
+    dispatcher.subscribe(EVENT_MCP_ATTACHED, (event) => {
+      receivedEvents.push(event);
+    });
+
+    await dispatcher.dispatch({
+      type: INTENT_MCP_ATTACHED,
+      payload: { workspacePath: "/workspace/alpha" },
+    } as McpAttachedIntent);
+
+    await dispatcher.dispatch({
+      type: INTENT_MCP_ATTACHED,
+      payload: { workspacePath: "/workspace/beta" },
+    } as McpAttachedIntent);
+
+    expect(receivedEvents).toHaveLength(2);
+    expect((receivedEvents[0] as McpAttachedEvent).payload.workspacePath).toBe("/workspace/alpha");
+    expect((receivedEvents[1] as McpAttachedEvent).payload.workspacePath).toBe("/workspace/beta");
+  });
+});

--- a/src/main/operations/mcp-attached.ts
+++ b/src/main/operations/mcp-attached.ts
@@ -1,0 +1,58 @@
+/**
+ * McpAttachedOperation - Trivial operation that emits a workspace:mcp-attached domain event.
+ *
+ * No hooks -- this operation simply relays the "first MCP request received" signal
+ * through the intent dispatcher so downstream event subscribers (McpModule temporary
+ * handlers for view/agent, future ViewModule and AgentModule) can react.
+ */
+
+import type { Intent, DomainEvent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface McpAttachedPayload {
+  readonly workspacePath: string;
+}
+
+export interface McpAttachedIntent extends Intent<void> {
+  readonly type: "workspace:mcp-attached";
+  readonly payload: McpAttachedPayload;
+}
+
+export const INTENT_MCP_ATTACHED = "workspace:mcp-attached" as const;
+
+// =============================================================================
+// Event Types
+// =============================================================================
+
+export interface McpAttachedEvent extends DomainEvent {
+  readonly type: "workspace:mcp-attached";
+  readonly payload: McpAttachedPayload;
+}
+
+export const EVENT_MCP_ATTACHED = "workspace:mcp-attached" as const;
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export const MCP_ATTACHED_OPERATION_ID = "mcp-attached";
+
+export class McpAttachedOperation implements Operation<McpAttachedIntent, void> {
+  readonly id = MCP_ATTACHED_OPERATION_ID;
+
+  async execute(ctx: OperationContext<McpAttachedIntent>): Promise<void> {
+    const { payload } = ctx.intent;
+
+    const event: McpAttachedEvent = {
+      type: EVENT_MCP_ATTACHED,
+      payload: {
+        workspacePath: payload.workspacePath,
+      },
+    };
+    ctx.emit(event);
+  }
+}


### PR DESCRIPTION
- Extract inline `mcpLifecycleModule` from `bootstrap.ts` into `mcp-module.ts` factory
- Add `mcp-attached` operation/event (`workspace:mcp-attached`) to decouple MCP, view, and agent status concerns
- Wire McpModule in `index.ts` after `McpServerManager` creation to avoid lazy getter timing issue
- Add integration tests for both `McpAttachedOperation` and `McpModule`