### PR TITLE
feat(mcp): add server instructions and enrich workspace_create tool description

### DIFF
--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { McpServer, createDefaultMcpServer, type McpServerFactory } from "./mcp-server";
+import {
+  McpServer,
+  createDefaultMcpServer,
+  SERVER_INSTRUCTIONS,
+  type McpServerFactory,
+} from "./mcp-server";
 import type { ICoreApi, IWorkspaceApi, IProjectApi } from "../../shared/api/interfaces";
 import { type ProjectId, type WorkspaceName, initialPromptSchema } from "../../shared/api/types";
 import { createMockLogger } from "../logging";
@@ -198,6 +203,15 @@ describe("createDefaultMcpServer", () => {
     expect(typeof sdk.registerTool).toBe("function");
     expect(typeof sdk.connect).toBe("function");
     expect(typeof sdk.close).toBe("function");
+  });
+});
+
+describe("SERVER_INSTRUCTIONS", () => {
+  it("includes workspace creation guidance", () => {
+    expect(SERVER_INSTRUCTIONS).toContain("workspace_create");
+    expect(SERVER_INSTRUCTIONS).toContain('"plan"');
+    expect(SERVER_INSTRUCTIONS).toContain("read-only");
+    expect(SERVER_INSTRUCTIONS).toContain("full permissions");
   });
 });
 

--- a/src/services/mcp-server/mcp-server.ts
+++ b/src/services/mcp-server/mcp-server.ts
@@ -53,8 +53,26 @@ export type McpServerFactory = () => McpServerSdk;
 /**
  * Default factory that creates an MCP SDK server instance.
  */
+/**
+ * Server-level instructions surfaced to AI agents via MCP initialize response.
+ * Guides agents on how to use CodeHydra tools effectively.
+ */
+export const SERVER_INSTRUCTIONS = [
+  "CodeHydra manages workspaces as git worktrees, each with its own AI agent session.",
+  "",
+  "When creating a workspace with workspace_create, the initialPrompt parameter controls what the new workspace's agent will do.",
+  "Use the object form { prompt, agent } to control the agent's permission mode:",
+  '- agent: "plan" — the agent starts in read-only/plan mode. Use this when the task requires planning, research, or exploration before making changes.',
+  "- No agent field — the agent starts with full permissions. Use this when the task should proceed directly to implementation.",
+  "",
+  "The model is automatically propagated from your current session — you do not need to specify it.",
+].join("\n");
+
 export function createDefaultMcpServer(): McpServerSdk {
-  return new McpServerSdk({ name: "codehydra", version: "1.0.0" }, { capabilities: { tools: {} } });
+  return new McpServerSdk(
+    { name: "codehydra", version: "1.0.0" },
+    { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS }
+  );
 }
 
 /**
@@ -388,7 +406,10 @@ export class McpServer implements IMcpServer {
             initialPrompt: initialPromptSchema
               .optional()
               .describe(
-                "Optional initial prompt to send after workspace is created. Can be a string or { prompt, agent? }"
+                "Optional initial prompt to send after workspace is created. " +
+                  "Can be a string or { prompt, agent? }. " +
+                  'Set agent to "plan" for read-only/planning mode, ' +
+                  "or omit agent for full-permission implementation mode."
               ),
             keepInBackground: z
               .boolean()


### PR DESCRIPTION
- Add MCP server-level `instructions` field to guide agents on workspace creation patterns
- Enrich `initialPrompt` parameter description with agent mode guidance (`"plan"` = read-only, omit = full permissions)
- Add test coverage for server instructions content