### PR TITLE
feat(opencode): decouple status activation from MCP via bridge server

### DIFF
--- a/src/agents/opencode/provider.ts
+++ b/src/agents/opencode/provider.ts
@@ -92,6 +92,7 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
     return {
       CODEHYDRA_OPENCODE_PORT: String(session.port),
       CODEHYDRA_OPENCODE_SESSION_ID: session.sessionId,
+      CODEHYDRA_WORKSPACE_PATH: this.workspacePath,
     };
   }
 

--- a/src/agents/opencode/server-manager.test.ts
+++ b/src/agents/opencode/server-manager.test.ts
@@ -361,7 +361,7 @@ describe("OpenCodeServerManager", () => {
 
       // Create manager with multiple ports
       const multiPortManager = createPortManagerMock([14001, 14002]);
-      const testManager = new OpenCodeServerManager(
+      manager = new OpenCodeServerManager(
         mockProcessRunner,
         multiPortManager,
         mockHttpClient,
@@ -369,10 +369,10 @@ describe("OpenCodeServerManager", () => {
         SILENT_LOGGER
       );
 
-      await testManager.startServer("/project/.worktrees/feature-a");
-      await testManager.startServer("/project/.worktrees/feature-b");
+      await manager.startServer("/project/.worktrees/feature-a");
+      await manager.startServer("/project/.worktrees/feature-b");
 
-      await testManager.stopAllForProject("/project");
+      await manager.stopAllForProject("/project");
 
       expect(mockProcessRunner.$.spawned(0)).toHaveBeenKilled();
       expect(mockProcessRunner.$.spawned(1)).toHaveBeenKilled();
@@ -392,7 +392,7 @@ describe("OpenCodeServerManager", () => {
         }),
       });
 
-      const testManager = new OpenCodeServerManager(
+      manager = new OpenCodeServerManager(
         mockProcessRunner,
         multiPortManager,
         mockHttpClient,
@@ -401,8 +401,8 @@ describe("OpenCodeServerManager", () => {
       );
 
       const [port1, port2] = await Promise.all([
-        testManager.startServer("/workspace/feature-a"),
-        testManager.startServer("/workspace/feature-b"),
+        manager.startServer("/workspace/feature-a"),
+        manager.startServer("/workspace/feature-b"),
       ]);
 
       expect(port1).not.toBe(port2);
@@ -433,7 +433,7 @@ describe("OpenCodeServerManager", () => {
 
       // Create manager with multiple ports
       const multiPortManager = createPortManagerMock([14001, 14002]);
-      const testManager = new OpenCodeServerManager(
+      manager = new OpenCodeServerManager(
         mockProcessRunner,
         multiPortManager,
         mockHttpClient,
@@ -441,10 +441,10 @@ describe("OpenCodeServerManager", () => {
         SILENT_LOGGER
       );
 
-      await testManager.startServer("/workspace/feature-a");
-      await testManager.startServer("/workspace/feature-b");
+      await manager.startServer("/workspace/feature-a");
+      await manager.startServer("/workspace/feature-b");
 
-      await testManager.dispose();
+      await manager.dispose();
 
       expect(mockProcessRunner.$.spawned(0)).toHaveBeenKilled();
       expect(mockProcessRunner.$.spawned(1)).toHaveBeenKilled();

--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -773,8 +773,18 @@ export function initializeBootstrap(deps: BootstrapDeps): BootstrapResult {
         codeServerManager: refs.codeServerManager,
         fileSystemLayer: refs.fileSystemLayer,
         configDataProvider: (workspacePath: string) => {
-          const env =
+          const providerEnv =
             refs.agentStatusManager.getEnvironmentVariables(workspacePath as WorkspacePath) ?? null;
+          const env = providerEnv ? { ...providerEnv } : null;
+          // Add bridge port for OpenCode wrapper notifications (live-lookup path)
+          if (env && refs.selectedAgentType === "opencode") {
+            const bridgePort = (
+              refs.serverManager as import("../agents/opencode/server-manager").OpenCodeServerManager
+            ).getBridgePort();
+            if (bridgePort !== null) {
+              env.CODEHYDRA_BRIDGE_PORT = String(bridgePort);
+            }
+          }
           const agentType = refs.selectedAgentType;
           return { env, agentType };
         },

--- a/src/main/operations/open-workspace.ts
+++ b/src/main/operations/open-workspace.ts
@@ -232,8 +232,13 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
 
     if (setupErrors.length > 0) throw setupErrors[0]!;
 
-    const setup = mergeHookResults(setupResults, "setup");
-    const envVars = setup.envVars ?? {};
+    // Accumulate env vars from all setup hook results (multiple modules can contribute)
+    const envVars: Record<string, string> = {};
+    for (const result of setupResults) {
+      if (result.envVars) {
+        Object.assign(envVars, result.envVars);
+      }
+    }
 
     // Hook 3c: "finalize" — workspace URL (fatal on error)
     const finalizeCtx: FinalizeHookInput = {


### PR DESCRIPTION
- Add bridge HTTP server (port 0) to OpenCodeServerManager for receiving wrapper notifications
- Make wrapper notifyHook async and await before spawnSync (fixes event loop blocking)
- Add CODEHYDRA_WORKSPACE_PATH to OpenCode provider env vars
- Accumulate env vars from multiple setup hook modules in open-workspace
- Wire onWorkspaceReady callback for OpenCode in McpModule
- Propagate CODEHYDRA_BRIDGE_PORT via setup hook and configDataProvider