### PR TITLE
refactor(mcp): decouple McpModule from agent/view concerns

### DIFF
--- a/src/main/app-state.integration.test.ts
+++ b/src/main/app-state.integration.test.ts
@@ -41,16 +41,6 @@ describe("AppState Integration", () => {
     });
   });
 
-  describe("MCP server manager lifecycle", () => {
-    it("injects and retrieves MCP server manager", () => {
-      const mockMcpManager = {};
-
-      appState.setMcpServerManager(mockMcpManager as never);
-
-      expect(appState.getMcpServerManager()).toBe(mockMcpManager);
-    });
-  });
-
   describe("waitForProvider", () => {
     it("resolves immediately when no pending promise exists", async () => {
       await expect(appState.waitForProvider("/some/path")).resolves.toBeUndefined();

--- a/src/main/app-state.test.ts
+++ b/src/main/app-state.test.ts
@@ -55,18 +55,6 @@ describe("AppState", () => {
     });
   });
 
-  describe("MCP server manager", () => {
-    it("returns null when not set", () => {
-      expect(appState.getMcpServerManager()).toBeNull();
-    });
-
-    it("returns manager after set", () => {
-      const mockManager = { mock: true };
-      appState.setMcpServerManager(mockManager as never);
-      expect(appState.getMcpServerManager()).toBe(mockManager);
-    });
-  });
-
   describe("waitForProvider", () => {
     it("resolves immediately when no pending promise", async () => {
       await expect(appState.waitForProvider("/some/path")).resolves.toBeUndefined();

--- a/src/main/app-state.ts
+++ b/src/main/app-state.ts
@@ -16,8 +16,6 @@ import { createAgentProvider, type AgentType } from "../agents";
 import type { AgentServerManager } from "../agents/types";
 import type { ClaudeCodeServerManager } from "../agents/claude/server-manager";
 import type { PendingPrompt } from "../agents/opencode/server-manager";
-import type { McpServerManager } from "../services/mcp-server";
-
 /**
  * Manages application state for agent lifecycle and server coordination.
  */
@@ -26,7 +24,6 @@ export class AppState {
   private readonly agentType: AgentType;
   private agentStatusManager: AgentStatusManager | null = null;
   private serverManager: AgentServerManager | null = null;
-  private mcpServerManager: McpServerManager | null = null;
   /**
    * Tracks pending handleServerStarted() promises so callers can await provider registration.
    */
@@ -212,20 +209,5 @@ export class AppState {
    */
   getServerManager(): AgentServerManager | null {
     return this.serverManager;
-  }
-
-  /**
-   * Set the MCP server manager.
-   * Called from main process after creating services.
-   */
-  setMcpServerManager(manager: McpServerManager): void {
-    this.mcpServerManager = manager;
-  }
-
-  /**
-   * Get the MCP server manager.
-   */
-  getMcpServerManager(): McpServerManager | null {
-    return this.mcpServerManager;
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -511,12 +511,7 @@ async function createServicesAndWireDispatcher(): Promise<void> {
   // (must happen before app:start's "start" hook collects handlers)
   const mcpModule = createMcpModule({
     mcpServerManager,
-    viewManager: viewManager!,
-    agentStatusManager: agentStatusManager!,
-    serverManager: serverManager!,
-    selectedAgentType: appState!.getAgentType(),
     logger: loggingService.createLogger("mcp"),
-    setMcpServerManager: (mgr) => appState!.setMcpServerManager(mgr),
   });
   wireModules([mcpModule], hookRegistryInstance!, dispatcherInstance!);
 

--- a/src/main/operations/close-project.integration.test.ts
+++ b/src/main/operations/close-project.integration.test.ts
@@ -201,7 +201,6 @@ function createTestHarness(options?: {
         return { success: true };
       }),
     }),
-    getMcpServerManager: vi.fn().mockReturnValue({}),
     getAgentStatusManager: vi.fn().mockReturnValue({
       clearTuiTracking: vi.fn(),
     }),

--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -208,7 +208,6 @@ function createTestAppState(initial?: Partial<TestAppState>): {
         return { success: true };
       }),
     }),
-    getMcpServerManager: vi.fn().mockReturnValue({}),
     getAgentStatusManager: vi.fn().mockReturnValue({
       clearTuiTracking: vi.fn().mockImplementation(() => {
         state.tuiCleared = true;


### PR DESCRIPTION
- Slim McpModule to pure MCP lifecycle (only mcpServerManager + logger deps)
- Relocate onWorkspaceReady and setMcpConfig wiring to agentLifecycleModule activate handler
- Relocate CODEHYDRA_BRIDGE_PORT env var contribution to agentModule setup handler
- Add ActivateHookContext to flow mcpPort from start to activate hooks
- Remove mcpServerManager from AppState (field, setter, getter)
- Update tests: simplify mcp-module tests, add activate hook context tests