### PR TITLE
fix(view): disable EditContext via dom-ready JS injection for Linux keyboard input

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -170,11 +170,6 @@ function applyElectronFlags(): void {
 // CRITICAL: Must be before app.whenReady() and any code that might trigger GPU initialization.
 applyElectronFlags();
 
-// Disable EditContext API at the Blink level. Code-server's web context
-// doesn't reliably support EditContext, and configurationDefaults for
-// editor.editContext don't always apply before the editor initializes.
-app.commandLine.appendSwitch("disable-blink-features", "EditContext");
-
 const __dirname = nodePath.dirname(fileURLToPath(import.meta.url));
 
 const fileSystemLayer = new DefaultFileSystemLayer(loggingService.createLogger("fs"));

--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -261,6 +261,25 @@ describe("ViewManager", () => {
       expect(handle.__brand).toBe("ViewHandle");
     });
 
+    it("registers dom-ready handler that disables EditContext", () => {
+      const deps = createViewManagerDeps();
+      const manager = ViewManager.create(deps);
+
+      const wsHandle = manager.createWorkspaceView(
+        "/path/to/workspace",
+        "http://127.0.0.1:8080/?folder=/path",
+        "/path/to/project"
+      );
+
+      // Spy on executeJavaScript to verify it's called on dom-ready
+      const executeJsSpy = vi.spyOn(deps.viewLayer, "executeJavaScript");
+
+      // Trigger dom-ready event on the workspace view
+      deps.viewLayer.$.triggerDomReady(wsHandle);
+
+      expect(executeJsSpy).toHaveBeenCalledWith(wsHandle, "delete globalThis.EditContext");
+    });
+
     it("loads URL on first activation", () => {
       const deps = createViewManagerDeps();
       const manager = ViewManager.create(deps);

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -406,6 +406,14 @@ export class ViewManager implements IViewManager {
       return true; // Allow navigation within code-server
     });
 
+    // Disable EditContext API before VS Code editor initializes.
+    // EditContext (Chromium 121+) is incompatible with code-server's web context,
+    // causing the editor to ignore all keyboard input. Removing it from the JS
+    // context at dom-ready ensures VS Code falls back to the legacy input method.
+    this.viewLayer.onDomReady(viewHandle, () => {
+      void this.viewLayer.executeJavaScript(viewHandle, "delete globalThis.EditContext");
+    });
+
     // Store workspace state
     this.workspaceStates.set(workspacePath, {
       handle: viewHandle,

--- a/src/services/shell/view.integration.test.ts
+++ b/src/services/shell/view.integration.test.ts
@@ -244,6 +244,42 @@ describe("ViewLayer (integration)", () => {
     });
   });
 
+  describe("onDomReady", () => {
+    it("registers callback", () => {
+      const handle = viewLayer.createView({});
+      const callback = vi.fn();
+
+      viewLayer.onDomReady(handle, callback);
+      viewLayer.$.triggerDomReady(handle);
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it("unsubscribes from callback", () => {
+      const handle = viewLayer.createView({});
+      const callback = vi.fn();
+
+      const unsubscribe = viewLayer.onDomReady(handle, callback);
+      unsubscribe();
+      viewLayer.$.triggerDomReady(handle);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("supports multiple callbacks", () => {
+      const handle = viewLayer.createView({});
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      viewLayer.onDomReady(handle, callback1);
+      viewLayer.onDomReady(handle, callback2);
+      viewLayer.$.triggerDomReady(handle);
+
+      expect(callback1).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+  });
+
   describe("onWillNavigate", () => {
     it("registers callback with URL", () => {
       const handle = viewLayer.createView({});
@@ -283,6 +319,20 @@ describe("ViewLayer (integration)", () => {
       viewLayer.setWindowOpenHandler(handle, null);
 
       expect(viewLayer).toHaveView(handle.id, { hasWindowOpenHandler: false });
+    });
+  });
+
+  describe("executeJavaScript", () => {
+    it("resolves for valid view", async () => {
+      const handle = viewLayer.createView({});
+
+      await expect(viewLayer.executeJavaScript(handle, "1 + 1")).resolves.toBeUndefined();
+    });
+
+    it("throws VIEW_NOT_FOUND for non-existent view", async () => {
+      const fakeHandle = { id: "view-999", __brand: "ViewHandle" as const };
+
+      await expect(viewLayer.executeJavaScript(fakeHandle, "1")).rejects.toThrow(ShellError);
     });
   });
 

--- a/src/services/vscode-workspace/workspace-file-service.test.ts
+++ b/src/services/vscode-workspace/workspace-file-service.test.ts
@@ -174,7 +174,7 @@ describe("WorkspaceFileService", () => {
         new Path("/project/workspaces/my-feature.code-workspace")
       );
       const parsed = JSON.parse(content) as CodeWorkspaceFile;
-      expect(parsed.settings).toEqual({}); // Default empty settings from config
+      expect(parsed.settings).toEqual({});
     });
 
     it("creates file if it does not exist", async () => {
@@ -303,9 +303,7 @@ describe("createWorkspaceFileConfig", () => {
       "editor.fontSize": 14,
     });
 
-    expect(config.defaultSettings).toEqual({
-      "editor.fontSize": 14,
-    });
+    expect(config.defaultSettings).toEqual({ "editor.fontSize": 14 });
   });
 
   it("omits recommendedExtensions when none provided", () => {


### PR DESCRIPTION
- Remove `disable-blink-features=EditContext` Chromium flag (ineffective on Linux)
- Remove `editor.editContext: false` workspace setting (doesn't apply before editor init)
- Add `onDomReady` and `executeJavaScript` methods to ViewLayer interface and mock
- Wire `delete globalThis.EditContext` at dom-ready in workspace view creation, forcing VS Code to fall back to legacy textarea input