### PR TITLE
chore(modules): absorb worktree hooks from bootstrap into GitWorktreeWorkspaceModule

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -38,14 +38,9 @@ import { GetMetadataOperation, INTENT_GET_METADATA } from "./operations/get-meta
 import type { GetMetadataIntent } from "./operations/get-metadata";
 import {
   GetWorkspaceStatusOperation,
-  GET_WORKSPACE_STATUS_OPERATION_ID,
   INTENT_GET_WORKSPACE_STATUS,
 } from "./operations/get-workspace-status";
-import type {
-  GetWorkspaceStatusIntent,
-  GetStatusHookResult,
-  GetStatusHookInput,
-} from "./operations/get-workspace-status";
+import type { GetWorkspaceStatusIntent } from "./operations/get-workspace-status";
 import { GetAgentSessionOperation, INTENT_GET_AGENT_SESSION } from "./operations/get-agent-session";
 import type { GetAgentSessionIntent } from "./operations/get-agent-session";
 import { RestartAgentOperation, INTENT_RESTART_AGENT } from "./operations/restart-agent";
@@ -91,7 +86,6 @@ import {
 } from "./operations/close-project";
 import type {
   CloseProjectIntent,
-  CloseHookInput,
   CloseHookResult,
   ProjectClosedEvent,
 } from "./operations/close-project";
@@ -821,21 +815,6 @@ function wireDispatcher(
 
   const metadataModule = createMetadataModule({ globalProvider });
 
-  // Workspace status hook handler module (get hook only — resolve handled by extracted modules)
-  const workspaceStatusModule: IntentModule = {
-    hooks: {
-      [GET_WORKSPACE_STATUS_OPERATION_ID]: {
-        get: {
-          handler: async (ctx: HookContext): Promise<GetStatusHookResult> => {
-            const { workspacePath } = ctx as GetStatusHookInput;
-            const isDirty = await globalProvider.isDirty(new Path(workspacePath));
-            return { isDirty };
-          },
-        },
-      },
-    },
-  };
-
   // ---------------------------------------------------------------------------
   // Open-workspace hook modules
   // ---------------------------------------------------------------------------
@@ -951,21 +930,6 @@ function wireDispatcher(
               }
             }
             return { otherProjectsExist: otherExists };
-          },
-        },
-      },
-    },
-  };
-
-  // ProjectWorktreeCloseModule: "close" hook -- unregister project from global git provider
-  const projectWorktreeCloseModule: IntentModule = {
-    hooks: {
-      [CLOSE_PROJECT_OPERATION_ID]: {
-        close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
-            const { projectPath } = ctx as CloseHookInput;
-            globalProvider.unregisterProject(new Path(projectPath));
-            return {};
           },
         },
       },
@@ -1187,7 +1151,6 @@ function wireDispatcher(
       ipcEventBridge,
       badgeModule,
       metadataModule,
-      workspaceStatusModule,
       // Open-workspace hook modules (kept inline)
       keepFilesModule,
       // Delete-workspace modules
@@ -1201,7 +1164,6 @@ function wireDispatcher(
       gitWorktreeWorkspaceModule,
       // Project:close modules
       projectCloseIndexModule,
-      projectWorktreeCloseModule,
       // Workspace:switch modules
       windowTitleModule,
       // App lifecycle modules

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -48,6 +48,8 @@ import {
 import {
   GET_WORKSPACE_STATUS_OPERATION_ID,
   type ResolveWorkspaceHookInput as GetStatusResolveWorkspaceInput,
+  type GetStatusHookInput,
+  type GetStatusHookResult,
 } from "../operations/get-workspace-status";
 import {
   UPDATE_AGENT_STATUS_OPERATION_ID,
@@ -385,13 +387,20 @@ export function createGitWorktreeWorkspaceModule(
         },
       },
 
-      // get-workspace-status -> resolve-workspace
+      // get-workspace-status -> resolve-workspace + get
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         "resolve-workspace": {
           handler: async (ctx: HookContext): Promise<ResolveWorkspaceResult> => {
             const { projectPath, workspaceName } = ctx as GetStatusResolveWorkspaceInput;
             const workspacePath = resolveWorkspacePath(projectPath, workspaceName);
             return workspacePath ? { workspacePath } : {};
+          },
+        },
+        get: {
+          handler: async (ctx: HookContext): Promise<GetStatusHookResult> => {
+            const { workspacePath } = ctx as GetStatusHookInput;
+            const isDirty = await globalProvider.isDirty(new Path(workspacePath));
+            return { isDirty };
           },
         },
       },


### PR DESCRIPTION
- Move get-workspace-status `get` hook into GitWorktreeWorkspaceModule (was inline in bootstrap.ts)
- Remove redundant project:close `close` hook that called `unregisterProject()` a second time
- Clean up unused bootstrap imports (GetStatusHookResult, GetStatusHookInput, GET_WORKSPACE_STATUS_OPERATION_ID, CloseHookInput)
- Add integration tests for the get-workspace-status `get` hook