### PR TITLE
chore(modules): absorb badgeLifecycleModule into BadgeModule

### DIFF
--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -1036,28 +1036,6 @@ function wireDispatcher(
     },
   };
 
-  // BadgeLifecycleModule: start → (badgeManager already created, just needs to exist).
-  // stop → dispose BadgeManager.
-  const badgeLifecycleModule: IntentModule = {
-    hooks: {
-      [APP_SHUTDOWN_OPERATION_ID]: {
-        stop: {
-          handler: async () => {
-            try {
-              badgeManager.dispose();
-            } catch (error) {
-              lifecycleLogger.error(
-                "Badge lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
-            }
-          },
-        },
-      },
-    },
-  };
-
   const telemetryLifecycleModule = createTelemetryModule({
     telemetryService: lifecycleRefs.telemetryService,
     platformInfo: lifecycleRefs.platformInfo,
@@ -1212,7 +1190,7 @@ function wireDispatcher(
   // Wire IpcEventBridge, BadgeModule, and hook handler modules
   // Note: shutdownIdempotencyModule and quitModule are wired early in initializeBootstrap()
   const ipcEventBridge = createIpcEventBridge(registry);
-  const badgeModule = createBadgeModule(badgeManager);
+  const badgeModule = createBadgeModule(badgeManager, lifecycleLogger);
   wireModules(
     [
       // Workspace index (must be first to receive events before other modules)
@@ -1239,7 +1217,6 @@ function wireDispatcher(
       windowTitleModule,
       // App lifecycle modules
       wrapperReadyViewModule,
-      badgeLifecycleModule,
       telemetryLifecycleModule,
       autoUpdaterLifecycleModule,
       ipcBridgeLifecycleModule,


### PR DESCRIPTION
- Move shutdown hook from inline `badgeLifecycleModule` in `bootstrap.ts` into `createBadgeModule`, combining events and hooks in a single `IntentModule`
- Add `Logger` parameter to `createBadgeModule` for shutdown error reporting
- Add shutdown disposal and non-fatal error handling tests