### PR TITLE
chore(agents): move markActive from agent module callback to server managers

### DIFF
--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -127,6 +127,9 @@ export interface AgentServerManager {
   /** Callback when server stops */
   onServerStopped(callback: (workspacePath: string, ...args: unknown[]) => void): () => void;
 
+  /** Set handler called when workspace becomes active (WrapperStart / first idle) */
+  setMarkActiveHandler(handler: (workspacePath: string) => void): void;
+
   /**
    * Set the initial prompt for a workspace.
    * Optional - only Claude Code implements this method.

--- a/src/main/bootstrap.integration.test.ts
+++ b/src/main/bootstrap.integration.test.ts
@@ -178,6 +178,7 @@ function createMockDeps(): BootstrapDeps {
         serverManager: {
           onServerStarted: vi.fn().mockReturnValue(() => {}),
           onServerStopped: vi.fn().mockReturnValue(() => {}),
+          setMarkActiveHandler: vi.fn(),
           dispose: vi.fn().mockResolvedValue(undefined),
           onWorkspaceReady: vi.fn().mockReturnValue(() => {}),
         },


### PR DESCRIPTION
- Add `setMarkActiveHandler` to `AgentServerManager` interface
- Implement in both `OpenCodeServerManager` (on WrapperStart) and `ClaudeCodeServerManager` (on first idle)
- Wire handler in `wireServerCallbacks` instead of `activate` hook's `onWorkspaceReady`
- Remove `markActiveCleanupFn` closure state from agent module
- Claude Code now also gets markActive support (previously OpenCode only)