### PR TITLE
refactor(modules): route setup:error through IPC event bridge

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -895,12 +895,18 @@ async function bootstrap(): Promise<void> {
   // Called by app:start intent after setup completes, before running start/activate hooks
   bootstrapResult.setBeforeAppStart(createServicesAndWireDispatcher);
 
-  // Wire lifecycle:setup-progress events to IPC immediately (before UI loads)
-  // This is needed because setup runs before services are created
+  // Wire lifecycle events to IPC immediately (before UI loads)
+  // These are needed because setup runs before services are created
   bootstrapResult.registry.on("lifecycle:setup-progress", (payload) => {
     const webContents = viewManager?.getUIWebContents();
     if (webContents && !webContents.isDestroyed()) {
       webContents.send(ApiIpcChannels.LIFECYCLE_SETUP_PROGRESS, payload);
+    }
+  });
+  bootstrapResult.registry.on("lifecycle:setup-error", (payload) => {
+    const webContents = viewManager?.getUIWebContents();
+    if (webContents && !webContents.isDestroyed()) {
+      webContents.send(ApiIpcChannels.LIFECYCLE_SETUP_ERROR, payload);
     }
   });
 

--- a/src/main/ipc/api-handlers.test.ts
+++ b/src/main/ipc/api-handlers.test.ts
@@ -169,6 +169,8 @@ describe("wireApiEvents", () => {
     expect(mockApi.on).toHaveBeenCalledWith("workspace:status-changed", expect.any(Function));
     expect(mockApi.on).toHaveBeenCalledWith("workspace:metadata-changed", expect.any(Function));
     expect(mockApi.on).toHaveBeenCalledWith("ui:mode-changed", expect.any(Function));
+    expect(mockApi.on).toHaveBeenCalledWith("lifecycle:setup-progress", expect.any(Function));
+    expect(mockApi.on).toHaveBeenCalledWith("lifecycle:setup-error", expect.any(Function));
   });
 
   it("forwards project:opened events to webContents", () => {
@@ -203,6 +205,18 @@ describe("wireApiEvents", () => {
     expect(mockWebContents.send).toHaveBeenCalledWith("api:ui:mode-changed", {
       mode: "shortcut",
       previousMode: "workspace",
+    });
+  });
+
+  it("forwards lifecycle:setup-error events to webContents", () => {
+    wireApiEvents(mockApi, () => mockWebContents as never);
+
+    const handler = eventHandlers.get("lifecycle:setup-error");
+    handler?.({ message: "Download failed", code: "NETWORK_ERROR" });
+
+    expect(mockWebContents.send).toHaveBeenCalledWith("api:lifecycle:setup-error", {
+      message: "Download failed",
+      code: "NETWORK_ERROR",
     });
   });
 

--- a/src/main/ipc/api-handlers.ts
+++ b/src/main/ipc/api-handlers.ts
@@ -137,6 +137,12 @@ export function wireApiEvents(
     })
   );
 
+  unsubscribers.push(
+    api.on("lifecycle:setup-error", (event) => {
+      send(ApiIpcChannels.LIFECYCLE_SETUP_ERROR, event);
+    })
+  );
+
   // Return cleanup function
   return () => {
     for (const unsubscribe of unsubscribers) {

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -37,6 +37,9 @@ import type { WorkspaceSwitchedEvent } from "../operations/switch-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../operations/switch-workspace";
 import type { AgentStatusUpdatedEvent } from "../operations/update-agent-status";
 import { EVENT_AGENT_STATUS_UPDATED } from "../operations/update-agent-status";
+import { EVENT_SETUP_ERROR } from "../operations/setup";
+import type { SetupErrorEvent } from "../operations/setup";
+import type { SetupErrorPayload } from "../../shared/ipc";
 import type { WorkspaceStatus } from "../../shared/api/types";
 
 /**
@@ -125,6 +128,14 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
           path: payload.path,
         });
       }
+    },
+    [EVENT_SETUP_ERROR]: (event: DomainEvent) => {
+      const { message, code } = (event as SetupErrorEvent).payload;
+      const payload: SetupErrorPayload = {
+        message,
+        ...(code !== undefined && { code }),
+      };
+      apiRegistry.emit("lifecycle:setup-error", payload);
     },
     [EVENT_AGENT_STATUS_UPDATED]: (event: DomainEvent) => {
       const {

--- a/src/shared/api/interfaces.test.ts
+++ b/src/shared/api/interfaces.test.ts
@@ -24,7 +24,7 @@ import type {
   AgentSession,
   SetupScreenProgress,
 } from "./types";
-import type { UIMode, UIModeChangedEvent } from "../ipc";
+import type { UIMode, UIModeChangedEvent, SetupErrorPayload } from "../ipc";
 
 describe("IProjectApi Interface", () => {
   it("should have correct method signatures", () => {
@@ -241,10 +241,13 @@ describe("ApiEvents Interface", () => {
       "lifecycle:setup-progress": (event: SetupScreenProgress) => {
         void event;
       },
+      "lifecycle:setup-error": (event: SetupErrorPayload) => {
+        void event;
+      },
     };
 
     expect(handlers).toBeDefined();
-    expect(Object.keys(handlers)).toHaveLength(10);
+    expect(Object.keys(handlers)).toHaveLength(11);
   });
 });
 

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -15,7 +15,7 @@ import type {
   AgentSession,
   SetupScreenProgress,
 } from "./types";
-import type { UIMode, UIModeChangedEvent } from "../ipc";
+import type { UIMode, UIModeChangedEvent, SetupErrorPayload } from "../ipc";
 import type { IDisposable, Unsubscribe } from "../types";
 
 // Re-export for consumers that import from this module
@@ -222,6 +222,7 @@ export interface ApiEvents {
   }) => void;
   "ui:mode-changed": (event: UIModeChangedEvent) => void;
   "lifecycle:setup-progress": (event: SetupScreenProgress) => void;
+  "lifecycle:setup-error": (event: SetupErrorPayload) => void;
 }
 
 // =============================================================================


### PR DESCRIPTION
- Wire IPC event bridge early in `initializeBootstrap()` so it receives `setup:error` domain events during setup
- Add `setup:error` handler to IPC event bridge (domain event → `registry.emit("lifecycle:setup-error")`)
- Add early `registry.on("lifecycle:setup-error")` subscriber in `index.ts` (matching `setup-progress` pattern)
- Add `lifecycle:setup-error` to `ApiEvents` interface and `wireApiEvents()`
- Merge idempotency reset into `setupIdempotencyModule` and remove `setupErrorModule`