### PR TITLE
chore(operations): move path resolution from bridge handlers to intent operations

### DIFF
--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -66,6 +66,8 @@ export interface WorkspaceRemovePayload {
   readonly skipSwitch?: boolean;
   /** If true, force remove (skip cleanup, ignore errors). Replaces old forceRemove. */
   readonly force?: boolean;
+  /** Workspace path for retry/dismiss signaling. Provided by renderer on retry/dismiss only. */
+  readonly workspacePath?: string;
 }
 
 /** workspaces.getStatus, workspaces.getAgentSession, workspaces.getMetadata */

--- a/src/main/modules/agent-module.integration.test.ts
+++ b/src/main/modules/agent-module.integration.test.ts
@@ -36,7 +36,11 @@ import type {
   OpenWorkspaceIntent,
 } from "../operations/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
-import type { DeleteWorkspaceIntent, ShutdownHookResult } from "../operations/delete-workspace";
+import type {
+  DeleteWorkspaceIntent,
+  DeletePipelineHookInput,
+  ShutdownHookResult,
+} from "../operations/delete-workspace";
 import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../operations/get-workspace-status";
 import type { GetStatusHookInput, GetStatusHookResult } from "../operations/get-workspace-status";
 import { GET_AGENT_SESSION_OPERATION_ID } from "../operations/get-agent-session";
@@ -206,9 +210,13 @@ class MinimalShutdownOperation implements Operation<DeleteWorkspaceIntent, Shutd
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<ShutdownHookResult> {
-    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", {
+    const { payload } = ctx.intent;
+    const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-    });
+      projectPath: payload.projectPath ?? "",
+      workspacePath: payload.workspacePath ?? "",
+    };
+    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
   }

--- a/src/main/modules/badge-module.integration.test.ts
+++ b/src/main/modules/badge-module.integration.test.ts
@@ -72,8 +72,8 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
       payload: {
         projectId: payload.projectId,
         workspaceName: payload.workspaceName,
-        workspacePath: payload.workspacePath,
-        projectPath: payload.projectPath,
+        workspacePath: payload.workspacePath ?? "",
+        projectPath: payload.projectPath ?? "",
       },
     };
     ctx.emit(event);

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -25,7 +25,11 @@ import type {
   OpenWorkspaceIntent,
 } from "../operations/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
-import type { DeleteWorkspaceIntent, DeleteHookResult } from "../operations/delete-workspace";
+import type {
+  DeleteWorkspaceIntent,
+  DeletePipelineHookInput,
+  DeleteHookResult,
+} from "../operations/delete-workspace";
 import {
   createCodeServerModule,
   type CodeServerModuleDeps,
@@ -154,9 +158,13 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteH
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<DeleteHookResult> {
-    const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", {
+    const { payload } = ctx.intent;
+    const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-    });
+      projectPath: payload.projectPath ?? "",
+      workspacePath: payload.workspacePath ?? "",
+    };
+    const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
   }

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -26,7 +26,7 @@ import type { CheckDepsResult, StartHookResult } from "../operations/app-start";
 import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
 import type { FinalizeHookInput, FinalizeHookResult } from "../operations/open-workspace";
 import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
-import type { DeleteHookResult } from "../operations/delete-workspace";
+import type { DeleteHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { SETUP_OPERATION_ID } from "../operations/setup";
@@ -340,11 +340,12 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
           handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+            const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             const workspace = deps.getWorkspaceDeps();
 
             try {
-              const workspacePath = new Path(payload.workspacePath);
+              const workspacePath = new Path(wsPath);
               const workspaceName = workspacePath.basename;
               const projectWorkspacesDir = workspacePath.dirname;
               await workspace.workspaceFileService.deleteWorkspaceFile(

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -137,8 +137,8 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
       payload: {
         projectId: payload.projectId,
         workspaceName: payload.workspaceName,
-        workspacePath: payload.workspacePath,
-        projectPath: payload.projectPath,
+        workspacePath: payload.workspacePath ?? "",
+        projectPath: payload.projectPath ?? "",
       },
     };
     ctx.emit(event);

--- a/src/main/modules/mcp-module.ts
+++ b/src/main/modules/mcp-module.ts
@@ -18,7 +18,7 @@ import type { StartHookResult } from "../operations/app-start";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
-import type { DeleteWorkspaceIntent, ShutdownHookResult } from "../operations/delete-workspace";
+import type { ShutdownHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
 import { EVENT_WORKSPACE_CREATED } from "../operations/open-workspace";
 import type { WorkspaceCreatedEvent } from "../operations/open-workspace";
 import { EVENT_WORKSPACE_DELETED } from "../operations/delete-workspace";
@@ -71,8 +71,8 @@ export function createMcpModule(deps: McpModuleDeps): IntentModule {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
-            const { payload } = ctx.intent as DeleteWorkspaceIntent;
-            deps.mcpServerManager.unregisterWorkspace(payload.workspacePath);
+            const { workspacePath } = ctx as DeletePipelineHookInput;
+            deps.mcpServerManager.unregisterWorkspace(workspacePath);
             return {};
           },
         },

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -54,7 +54,11 @@ import {
   INTENT_DELETE_WORKSPACE,
   DELETE_WORKSPACE_OPERATION_ID,
 } from "../operations/delete-workspace";
-import type { DeleteWorkspaceIntent, ShutdownHookResult } from "../operations/delete-workspace";
+import type {
+  DeleteWorkspaceIntent,
+  DeletePipelineHookInput,
+  ShutdownHookResult,
+} from "../operations/delete-workspace";
 import { INTENT_OPEN_WORKSPACE, EVENT_WORKSPACE_CREATED } from "../operations/open-workspace";
 import type { OpenWorkspaceIntent, WorkspaceCreatedEvent } from "../operations/open-workspace";
 import { EVENT_PROJECT_OPENED } from "../operations/open-project";
@@ -209,9 +213,13 @@ class MinimalSwitchOperation implements Operation<SwitchWorkspaceIntent, void> {
 class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, ShutdownHookResult> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<ShutdownHookResult> {
-    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", {
+    const { payload } = ctx.intent;
+    const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-    });
+      projectPath: payload.projectPath ?? "",
+      workspacePath: payload.workspacePath ?? "",
+    };
+    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     const merged: ShutdownHookResult = {};
     for (const r of results) {

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -38,7 +38,11 @@ import type {
   ActivateHookInput,
   WorkspaceSwitchedEvent,
 } from "../operations/switch-workspace";
-import type { DeleteWorkspaceIntent, ShutdownHookResult } from "../operations/delete-workspace";
+import type {
+  DeleteWorkspaceIntent,
+  ShutdownHookResult,
+  DeletePipelineHookInput,
+} from "../operations/delete-workspace";
 import type { WorkspaceCreatedEvent } from "../operations/open-workspace";
 import type { ProjectOpenedEvent } from "../operations/open-project";
 import type { AgentStatusUpdatedEvent } from "../operations/update-agent-status";
@@ -235,12 +239,13 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
-            const isActive = viewManager.getActiveWorkspacePath() === payload.workspacePath;
+            const isActive = viewManager.getActiveWorkspacePath() === workspacePath;
 
             try {
-              await viewManager.destroyWorkspaceView(payload.workspacePath);
+              await viewManager.destroyWorkspaceView(workspacePath);
               return { ...(isActive && { wasActive: true }) };
             } catch (error) {
               if (payload.force) {

--- a/src/main/modules/windows-file-lock-module.integration.test.ts
+++ b/src/main/modules/windows-file-lock-module.integration.test.ts
@@ -10,11 +10,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 import { wireModules } from "../intents/infrastructure/wire";
-import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
   type DeleteWorkspaceIntent,
+  type DeletePipelineHookInput,
   type ReleaseHookResult,
   type DetectHookResult,
   type FlushHookResult,
@@ -66,7 +67,12 @@ class ReleaseOperation implements Operation<Intent, ReleaseHookResult> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<Intent>): Promise<ReleaseHookResult> {
-    const hookCtx: HookContext = { intent: ctx.intent };
+    const { payload } = ctx.intent as DeleteWorkspaceIntent;
+    const hookCtx: DeletePipelineHookInput = {
+      intent: ctx.intent,
+      projectPath: payload.projectPath ?? "",
+      workspacePath: payload.workspacePath ?? "",
+    };
     const { results, errors } = await ctx.hooks.collect<ReleaseHookResult>("release", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
@@ -80,7 +86,12 @@ class DetectOperation implements Operation<Intent, DetectHookResult> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<Intent>): Promise<DetectHookResult> {
-    const hookCtx: HookContext = { intent: ctx.intent };
+    const { payload } = ctx.intent as DeleteWorkspaceIntent;
+    const hookCtx: DeletePipelineHookInput = {
+      intent: ctx.intent,
+      projectPath: payload.projectPath ?? "",
+      workspacePath: payload.workspacePath ?? "",
+    };
     const { results, errors } = await ctx.hooks.collect<DetectHookResult>("detect", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};

--- a/src/main/operations/close-project.integration.test.ts
+++ b/src/main/operations/close-project.integration.test.ts
@@ -47,6 +47,7 @@ import type {
   WorkspaceDeletedEvent,
   DeletionProgressCallback,
   ShutdownHookResult,
+  DeletePipelineHookInput,
   ResolveProjectHookResult,
   ResolveWorkspaceHookResult,
   ResolveWorkspaceHookInput,
@@ -255,13 +256,14 @@ function createTestHarness(options?: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             // Track that skipSwitch is set
             if (!payload.skipSwitch) {
               // Not expected for project:close -- would indicate a bug
               viewManager.setActiveWorkspace(null, false);
             }
-            await viewManager.destroyWorkspaceView(payload.workspacePath);
+            await viewManager.destroyWorkspaceView(workspacePath);
             return {};
           },
         },
@@ -274,10 +276,10 @@ function createTestHarness(options?: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
-            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+            const { workspacePath } = ctx as DeletePipelineHookInput;
             const serverManager = appState.getServerManager();
             if (serverManager) {
-              await serverManager.stopServer(payload.workspacePath);
+              await serverManager.stopServer(workspacePath);
             }
             return {};
           },

--- a/src/main/operations/open-workspace.ts
+++ b/src/main/operations/open-workspace.ts
@@ -62,7 +62,11 @@ export interface OpenWorkspacePayload {
 
 export type OpenWorkspaceResult =
   | Workspace
-  | { bases: readonly { name: string; isRemote: boolean }[]; defaultBaseBranch?: string };
+  | {
+      bases: readonly { name: string; isRemote: boolean }[];
+      defaultBaseBranch?: string;
+      projectPath: string;
+    };
 
 export interface OpenWorkspaceIntent extends Intent<OpenWorkspaceResult> {
   readonly type: "workspace:open";
@@ -203,6 +207,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
         ...(fetchBases.defaultBaseBranch !== undefined && {
           defaultBaseBranch: fetchBases.defaultBaseBranch,
         }),
+        projectPath,
       };
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,8 +53,7 @@ contextBridge.exposeInMainWorld("api", {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
-        unblock?: "kill" | "close" | "ignore";
-        isRetry?: boolean;
+        workspacePath?: string;
       }
     ): Promise<{ started: boolean }> =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_REMOVE, {

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -253,6 +253,7 @@
     void api.workspaces.remove(activeDeletionState.projectId, activeDeletionState.workspaceName, {
       keepBranch: activeDeletionState.keepBranch,
       skipSwitch: true,
+      workspacePath: activeDeletionState.workspacePath,
     });
   }
 
@@ -262,6 +263,7 @@
     logger.debug("Dismissing deletion", { workspaceName: activeDeletionState.workspaceName });
     void api.workspaces.remove(activeDeletionState.projectId, activeDeletionState.workspaceName, {
       force: true,
+      workspacePath: activeDeletionState.workspacePath,
     });
     clearDeletion(activeDeletionState.workspacePath);
   }

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -1140,6 +1140,7 @@ describe("MainView component", () => {
         expect(mockApi.workspaces.remove).toHaveBeenCalledWith("test-project-12345678", "feature", {
           keepBranch: false, // from the stored progress
           skipSwitch: true, // retry keeps user on this workspace
+          workspacePath: "/test/.worktrees/feature", // for retry/dismiss signaling
         });
       });
     });
@@ -1200,6 +1201,7 @@ describe("MainView component", () => {
       await waitFor(() => {
         expect(mockApi.workspaces.remove).toHaveBeenCalledWith("test-project-12345678", "feature", {
           force: true,
+          workspacePath: "/test/.worktrees/feature", // for retry/dismiss signaling
         });
       });
 

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -55,8 +55,7 @@ export interface Api {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
-        unblock?: "kill" | "close" | "ignore";
-        isRetry?: boolean;
+        workspacePath?: string;
       }
     ): Promise<{ started: boolean }>;
     getStatus(projectId: string, workspaceName: string): Promise<WorkspaceStatus>;


### PR DESCRIPTION
- Remove redundant `projectsById`/`workspacesByKey` map lookups from `workspaces.remove` and `projects.fetchBases` bridge handlers
- Make `workspacePath`/`projectPath` optional in `DeleteWorkspacePayload`; resolve hooks provide paths authoritatively
- Update all hook modules (agent, code-server, view, mcp, git-worktree, bootstrap inline) to read from enriched `DeletePipelineHookInput` context
- Key idempotency interceptor by `projectId/workspaceName` instead of `workspacePath`
- Add `projectPath` to `OpenWorkspaceResult` bases variant for `fetchBases` bridge handler
- Pass `workspacePath` through preload/renderer for delete retry/dismiss signaling