### PR TITLE
refactor(bootstrap): eliminate startServicesFn two-phase startup

### DIFF
--- a/src/main/modules/telemetry-module.integration.test.ts
+++ b/src/main/modules/telemetry-module.integration.test.ts
@@ -31,7 +31,6 @@ import { createMockPlatformInfo } from "../../services/platform/platform-info.te
 import { SILENT_LOGGER } from "../../services/logging";
 import type { TelemetryService } from "../../services/telemetry/types";
 import type { Logger } from "../../services/logging/types";
-import type { AgentType } from "../../agents/types";
 
 // =============================================================================
 // Minimal Start Operation
@@ -112,7 +111,7 @@ interface TestSetup {
 
 function createTestSetup(overrides?: {
   telemetryService?: TelemetryService | null;
-  selectedAgentType?: AgentType;
+  configAgent?: string;
   logger?: Logger;
 }): TestSetup {
   const tracking = createTrackingTelemetryService();
@@ -124,7 +123,9 @@ function createTestSetup(overrides?: {
       overrides?.telemetryService !== undefined ? overrides.telemetryService : tracking.service,
     platformInfo,
     buildInfo,
-    selectedAgentType: overrides?.selectedAgentType ?? "opencode",
+    configService: {
+      load: async () => ({ agent: overrides?.configAgent ?? "opencode" }) as never,
+    },
     logger: overrides?.logger ?? SILENT_LOGGER,
   });
 

--- a/src/main/modules/telemetry-module.ts
+++ b/src/main/modules/telemetry-module.ts
@@ -12,14 +12,14 @@ import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import type { TelemetryService } from "../../services/telemetry/types";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { BuildInfo } from "../../services/platform/build-info";
-import type { AgentType } from "../../agents/types";
+import type { ConfigService } from "../../services/config/config-service";
 import type { Logger } from "../../services/logging/types";
 
 interface TelemetryModuleDeps {
   readonly telemetryService: TelemetryService | null;
   readonly platformInfo: PlatformInfo;
   readonly buildInfo: BuildInfo;
-  readonly selectedAgentType: AgentType;
+  readonly configService: Pick<ConfigService, "load">;
   readonly logger: Logger;
 }
 
@@ -29,11 +29,12 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
       [APP_START_OPERATION_ID]: {
         start: {
           handler: async (): Promise<StartHookResult> => {
+            const config = await deps.configService.load();
             deps.telemetryService?.capture("app_launched", {
               platform: deps.platformInfo.platform,
               arch: deps.platformInfo.arch,
               isDevelopment: deps.buildInfo.isDevelopment,
-              agent: deps.selectedAgentType,
+              agent: config.agent ?? "unknown",
             });
             return {};
           },

--- a/src/main/operations/app-start.ts
+++ b/src/main/operations/app-start.ts
@@ -5,10 +5,9 @@
  * 1. "show-ui" - Show starting screen
  * 2. "check-config" - Load configuration (collect, isolated contexts)
  * 3. "check-deps" - Check binaries and extensions (collect, isolated contexts)
- * 4. "wire" - Wire services (after setup completes if dispatched)
- * 5. "start" - Start servers and wire services (CodeServer, Agent, Badge, MCP,
+ * 4. "start" - Start servers and wire services (CodeServer, Agent, Badge, MCP,
  *              Telemetry, AutoUpdater, IpcBridge)
- * 6. "activate" - Wire callbacks, gather project paths, mount renderer (Data, View, Mount)
+ * 5. "activate" - Wire callbacks, gather project paths, mount renderer (Data, View, Mount)
  *
  * After "activate", dispatches project:open for each saved project path
  * (best-effort, skips invalid projects). The mount handler in activate
@@ -187,13 +186,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       }
     }
 
-    // Hook 4: "wire" -- Wire services (after setup completes)
-    const { errors: wireErrors } = await ctx.hooks.collect<void>("wire", hookCtx);
-    if (wireErrors.length > 0) {
-      throw wireErrors[0]!;
-    }
-
-    // Hook 5: "start" -- Start servers and wire services
+    // Hook 4: "start" -- Start servers and wire services
     const { results: startResults, errors: startErrors } = await ctx.hooks.collect<StartHookResult>(
       "start",
       hookCtx
@@ -205,7 +198,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // Extract mcpPort from start results for activate handlers
     const mcpPort = startResults.find((r) => r.mcpPort !== undefined)?.mcpPort ?? null;
 
-    // Hook 6: "activate" -- Wire callbacks, gather project paths, mount renderer
+    // Hook 5: "activate" -- Wire callbacks, gather project paths, mount renderer
     const activateCtx: ActivateHookContext = { ...hookCtx, mcpPort };
     const { results: activateResults, errors: activateErrors } =
       await ctx.hooks.collect<ActivateHookResult>("activate", activateCtx);
@@ -234,7 +227,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       }
     }
 
-    // Hook 7: "loaded" — Signal that initial project:open dispatches are complete.
+    // Hook 6: "loaded" — Signal that initial project:open dispatches are complete.
     // lifecycle.ready awaits this before returning to the renderer.
     await ctx.hooks.collect<void>("loaded", hookCtx);
   }


### PR DESCRIPTION
- Remove deferred `startServicesFn` / `setBeforeAppStart` / `createServicesAndWireDispatcher` callback pattern
- Inline `wireDispatcher()` and `CoreModule` creation into `initializeBootstrap()` directly
- Move `AgentModule` to own `ServerManager` and `AgentStatusManager` creation in its `start` hook via closure state
- Change `TelemetryModule` to read agent config at hook time via `configService.load()` instead of receiving `selectedAgentType` at construction
- Remove "wire" hook point from `AppStartOperation` pipeline
- Update tests for new `BootstrapDeps` shape (`serverManagerDeps`, `onAgentInitialized`)