### PR TITLE
chore: convert unnecessary dynamic imports to static imports

### DIFF
--- a/src/services/code-server/code-server-manager.boundary.test.ts
+++ b/src/services/code-server/code-server-manager.boundary.test.ts
@@ -16,9 +16,11 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { execa } from "execa";
 import { CodeServerManager } from "./code-server-manager";
 import { ExecaProcessRunner } from "../platform/process";
 import { DefaultNetworkLayer } from "../platform/network";
+import { SILENT_LOGGER } from "../logging";
 import { createTempDir } from "../test-utils";
 import { delay } from "@shared/test-fixtures";
 import {
@@ -95,7 +97,6 @@ function createTestConfig(baseDir: string, port: number): CodeServerConfig {
  * On Unix, uses pkill -P to kill children first, then SIGKILL.
  */
 async function forceKillPid(pid: number): Promise<void> {
-  const { execa } = await import("execa");
   if (isWindows) {
     try {
       await execa("taskkill", ["/pid", String(pid), "/t", "/f"]);
@@ -136,7 +137,6 @@ describe("CodeServerManager (boundary)", () => {
     cleanup = temp.cleanup;
 
     // Real dependencies - no mocks
-    const { SILENT_LOGGER } = await import("../logging");
     const logger = SILENT_LOGGER;
     const runner = new ExecaProcessRunner(logger);
     const networkLayer = new DefaultNetworkLayer(logger);

--- a/src/services/git/git-worktree-provider.integration.test.ts
+++ b/src/services/git/git-worktree-provider.integration.test.ts
@@ -9,6 +9,7 @@ import { GitWorktreeProvider } from "./git-worktree-provider";
 import { createMockGitClient } from "./git-client.state-mock";
 import { createFileSystemMock, directory } from "../platform/filesystem.state-mock";
 import { SILENT_LOGGER } from "../logging";
+import { WorkspaceError } from "../errors";
 import { Path } from "../platform/path";
 
 describe("GitWorktreeProvider integration", () => {
@@ -291,7 +292,6 @@ describe("GitWorktreeProvider integration", () => {
       );
       const workspace = await provider.createWorkspace(PROJECT_ROOT, "feature-x", "main");
 
-      const { WorkspaceError } = await import("../errors");
       try {
         await provider.setMetadata(workspace.path, "my_key", "value");
         expect.fail("Should have thrown");

--- a/src/services/git/simple-git-client.boundary.test.ts
+++ b/src/services/git/simple-git-client.boundary.test.ts
@@ -563,8 +563,7 @@ describe("SimpleGitClient", () => {
         await client.clone(sourceRepo.path, targetPath);
 
         // Verify it's a bare repo by checking for typical bare repo structure
-        const { readdir, stat } = await import("fs/promises");
-        const entries = await readdir(targetPath.toNative());
+        const entries = await fs.readdir(targetPath.toNative());
         // Bare repos have HEAD, config, objects, refs at root (not in .git subdir)
         expect(entries).toContain("HEAD");
         expect(entries).toContain("config");
@@ -574,7 +573,7 @@ describe("SimpleGitClient", () => {
         expect(entries).not.toContain(".git");
 
         // Verify HEAD exists (bare repos have it at root)
-        const headStat = await stat(nodePath.join(targetPath.toNative(), "HEAD"));
+        const headStat = await fs.stat(nodePath.join(targetPath.toNative(), "HEAD"));
         expect(headStat.isFile()).toBe(true);
       } finally {
         await sourceRepo.cleanup();

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -4,6 +4,7 @@
  * These tests verify actual HTTP transport behavior using real SDK and HTTP.
  */
 
+import { createServer } from "node:net";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { McpServer, createDefaultMcpServer } from "./mcp-server";
 import type { ICoreApi } from "../../shared/api/interfaces";
@@ -16,7 +17,6 @@ import { generateProjectId, extractWorkspaceName } from "../../shared/api/id-uti
  * Find a free port for testing.
  */
 async function findFreePort(): Promise<number> {
-  const { createServer } = await import("node:net");
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.listen(0, "127.0.0.1", () => {

--- a/src/services/platform/filesystem.boundary.test.ts
+++ b/src/services/platform/filesystem.boundary.test.ts
@@ -6,7 +6,15 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
-import { symlink, writeFile as nodeWriteFile, mkdir as nodeMkdir } from "node:fs/promises";
+import {
+  symlink,
+  writeFile as nodeWriteFile,
+  mkdir as nodeMkdir,
+  readFile as nodeReadFile,
+  chmod,
+  stat,
+  lstat,
+} from "node:fs/promises";
 import { DefaultFileSystemLayer } from "./filesystem";
 import { SILENT_LOGGER } from "../logging";
 import { FileSystemError } from "../errors";
@@ -447,7 +455,6 @@ describe("DefaultFileSystemLayer", () => {
       await fs.copyTree(srcPath, destPath);
 
       // Verify byte-for-byte
-      const { readFile: nodeReadFile } = await import("node:fs/promises");
       const destBuffer = await nodeReadFile(destPath);
       expect(Buffer.compare(destBuffer, binaryContent)).toBe(0);
     });
@@ -467,7 +474,6 @@ describe("DefaultFileSystemLayer", () => {
 
       await fs.copyTree(srcPath, destPath);
 
-      const { readFile: nodeReadFile } = await import("node:fs/promises");
       const destBuffer = await nodeReadFile(destPath);
       expect(Buffer.compare(destBuffer, pngHeader)).toBe(0);
     });
@@ -502,7 +508,6 @@ describe("DefaultFileSystemLayer", () => {
         await nodeWriteFile(srcPath, "#!/bin/bash\necho hello", "utf-8");
 
         // Make file executable
-        const { chmod, stat } = await import("node:fs/promises");
         await chmod(srcPath, 0o755);
 
         await fs.copyTree(srcPath, destPath);
@@ -533,7 +538,6 @@ describe("DefaultFileSystemLayer", () => {
         expect(await fs.readFile(join(destDir, "file.txt"))).toBe("content");
 
         // Verify symlink exists at destination (as a symlink)
-        const { lstat } = await import("node:fs/promises");
         const destLinkStat = await lstat(join(destDir, "link.txt"));
         expect(destLinkStat.isSymbolicLink()).toBe(true);
       }
@@ -586,7 +590,6 @@ describe("DefaultFileSystemLayer", () => {
         await fs.copyTree(linkPath, destPath);
 
         // Verify symlink was copied as symlink
-        const { lstat } = await import("node:fs/promises");
         const destStat = await lstat(destPath);
         expect(destStat.isSymbolicLink()).toBe(true);
       }
@@ -606,7 +609,6 @@ describe("DefaultFileSystemLayer", () => {
       await fs.makeExecutable(filePath);
 
       // Verify permissions include execute bits for all (owner, group, other)
-      const { stat } = await import("node:fs/promises");
       const stats = await stat(filePath);
       expect(stats.mode & 0o755).toBe(0o755);
     });

--- a/src/services/platform/filesystem.test.ts
+++ b/src/services/platform/filesystem.test.ts
@@ -13,6 +13,7 @@ import {
   writeFile as nodeWriteFile,
   mkdir as nodeMkdir,
   readFile as nodeReadFile,
+  stat,
 } from "node:fs/promises";
 import { DefaultFileSystemLayer } from "./filesystem";
 import { SILENT_LOGGER } from "../logging";
@@ -137,7 +138,6 @@ describe("DefaultFileSystemLayer.makeExecutable", () => {
     await fs.makeExecutable(filePath);
 
     // Verify permissions
-    const { stat } = await import("node:fs/promises");
     const stats = await stat(filePath);
     // Check that execute bits are set (owner, group, other)
     expect(stats.mode & 0o111).toBe(0o111);

--- a/src/services/platform/filesystem.ts
+++ b/src/services/platform/filesystem.ts
@@ -12,6 +12,7 @@
  * - This enables gradual migration to Path objects while maintaining backward compatibility
  */
 
+import { tmpdir } from "node:os";
 import { Path } from "./path";
 
 /** Type for paths accepted by FileSystemLayer (Path object or string) */
@@ -583,7 +584,7 @@ export class DefaultFileSystemLayer implements FileSystemLayer {
   async mkdtemp(prefix: string): Promise<Path> {
     this.logger.debug("Mkdtemp", { prefix });
     try {
-      const tmpDir = await import("node:os").then((os) => os.tmpdir());
+      const tmpDir = tmpdir();
       const created = await fs.mkdtemp(`${tmpDir}/${prefix}`);
       this.logger.debug("Mkdtemp created", { path: created });
       return new Path(created);

--- a/src/services/platform/network.test-utils.ts
+++ b/src/services/platform/network.test-utils.ts
@@ -15,6 +15,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "http";
+import { createConnection } from "net";
 import { delay } from "@shared/test-fixtures";
 
 // ============================================================================
@@ -235,8 +236,6 @@ export async function waitForPort(port: number, timeoutMs?: number): Promise<voi
  * @returns true if port is accepting connections
  */
 async function isPortOpen(port: number): Promise<boolean> {
-  const { createConnection } = await import("net");
-
   return new Promise((resolve) => {
     const socket = createConnection({ port, host: "127.0.0.1" }, () => {
       socket.destroy();

--- a/src/services/platform/network.ts
+++ b/src/services/platform/network.ts
@@ -9,6 +9,7 @@
  * removed in favor of the @opencode-ai/sdk which handles SSE internally.
  */
 
+import { createServer } from "net";
 import type { Logger } from "../logging";
 import { getErrorMessage } from "../errors";
 
@@ -161,8 +162,6 @@ export class DefaultNetworkLayer implements HttpClient, PortManager {
 
   // PortManager implementation
   async findFreePort(): Promise<number> {
-    const { createServer } = await import("net");
-
     return new Promise((resolve, reject) => {
       const server = createServer();
       server.listen(0, () => {
@@ -180,8 +179,6 @@ export class DefaultNetworkLayer implements HttpClient, PortManager {
   }
 
   async isPortAvailable(port: number): Promise<boolean> {
-    const { createServer } = await import("net");
-
     return new Promise((resolve) => {
       const server = createServer();
       server.once("error", (err: NodeJS.ErrnoException) => {

--- a/src/services/telemetry/posthog-telemetry-service.ts
+++ b/src/services/telemetry/posthog-telemetry-service.ts
@@ -12,6 +12,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { PostHog } from "posthog-node";
 import type {
   TelemetryService,
   TelemetryServiceDeps,
@@ -28,22 +29,11 @@ const MAX_STACK_FRAMES = 10;
 /** Maximum stack string length */
 const MAX_STACK_LENGTH = 2000;
 
-/** Cached PostHog constructor for lazy loading */
-let PostHogConstructor: typeof import("posthog-node").PostHog | null = null;
-
 /**
  * Create the default PostHog client using posthog-node SDK.
- * Uses cached constructor to avoid repeated dynamic imports.
  */
-async function createDefaultPostHogClient(
-  apiKey: string,
-  options: { host: string }
-): Promise<PostHogClient> {
-  if (!PostHogConstructor) {
-    const posthogModule = await import("posthog-node");
-    PostHogConstructor = posthogModule.PostHog;
-  }
-  return new PostHogConstructor(apiKey, options);
+function createDefaultPostHogClient(apiKey: string, options: { host: string }): PostHogClient {
+  return new PostHog(apiKey, options);
 }
 
 /**

--- a/src/services/test-utils.ts
+++ b/src/services/test-utils.ts
@@ -4,7 +4,7 @@
  * with automatic cleanup.
  */
 
-import { mkdtemp, rm, realpath } from "fs/promises";
+import { mkdtemp, rm, realpath, writeFile, mkdir } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { simpleGit } from "simple-git";
@@ -67,7 +67,6 @@ export async function createTestGitRepo(options: CreateTestGitRepoOptions = {}):
   await git.addConfig("user.name", "Test User");
 
   // Create initial commit (required for worktrees)
-  const { writeFile } = await import("fs/promises");
   await writeFile(join(path, "README.md"), "# Test Repository\n");
   await git.add("README.md");
   await git.commit("Initial commit");
@@ -162,8 +161,6 @@ export async function createTestGitRepoWithRemote(): Promise<TestRepoWithRemoteR
   const repoPath = join(parent, "repo");
   const remotePath = join(parent, "remote.git");
 
-  const { mkdir, writeFile } = await import("fs/promises");
-
   // Create bare remote first
   await mkdir(remotePath);
   const remoteGit = simpleGit(remotePath);
@@ -212,7 +209,6 @@ export async function createCommitInRemote(remotePath: string, message: string):
     await git.addConfig("user.email", "test@test.com");
     await git.addConfig("user.name", "Test User");
 
-    const { writeFile } = await import("fs/promises");
     const filename = `file-${Date.now()}.txt`;
     await writeFile(join(tempClone, filename), `Content: ${message}\n`);
     await git.add(filename);


### PR DESCRIPTION
- Replace ~20 `await import()` calls with static imports across 12 files (4 production, 8 test/utility)
- Remove async overhead where lazy-loading provided no benefit
- Simplify PostHog telemetry service by removing constructor cache pattern
- Use existing `fs` import aliases in test files instead of inline imports