### PR TITLE
fix(security): bind all servers to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/src/services/code-server/code-server-manager.test.ts
+++ b/src/services/code-server/code-server-manager.test.ts
@@ -480,8 +480,8 @@ describe("CodeServerManager (with full DI)", () => {
         {
           command: config.binaryPath,
           args: expect.arrayContaining([
-            "--port",
-            String(CODE_SERVER_PORT),
+            "--bind-addr",
+            `127.0.0.1:${CODE_SERVER_PORT}`,
             "--auth",
             "none",
           ]) as unknown as string[],

--- a/src/services/code-server/code-server-manager.ts
+++ b/src/services/code-server/code-server-manager.ts
@@ -347,8 +347,8 @@ export class CodeServerManager {
 
     // Build command arguments
     const args = [
-      "--port",
-      port.toString(),
+      "--bind-addr",
+      `127.0.0.1:${port}`,
       "--auth",
       "none",
       "--disable-workspace-trust",

--- a/src/services/platform/network.boundary.test.ts
+++ b/src/services/platform/network.boundary.test.ts
@@ -178,7 +178,7 @@ describe("DefaultNetworkLayer boundary tests", () => {
 
       await new Promise<void>((resolve, reject) => {
         server.on("error", reject);
-        server.listen(port, () => {
+        server.listen(port, "127.0.0.1", () => {
           server.close(() => resolve());
         });
       });

--- a/src/services/platform/network.ts
+++ b/src/services/platform/network.ts
@@ -164,7 +164,7 @@ export class DefaultNetworkLayer implements HttpClient, PortManager {
   async findFreePort(): Promise<number> {
     return new Promise((resolve, reject) => {
       const server = createServer();
-      server.listen(0, () => {
+      server.listen(0, "127.0.0.1", () => {
         const address = server.address();
         if (address && typeof address === "object") {
           const { port } = address;


### PR DESCRIPTION
- Bind `findFreePort()` probe server to `127.0.0.1` (was defaulting to `0.0.0.0`)
- Add `--bind-addr 127.0.0.1:<port>` to code-server spawn args (replaces `--port`)
- Fix boundary test probe server to bind to `127.0.0.1`
- Update code-server test assertion for new `--bind-addr` flag