### PR TITLE
fix(delete): keep spinner visible during delete hook after release

### DIFF
--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -1257,6 +1257,12 @@ describe("DeleteWorkspaceOperation.inProgressSpinner", () => {
       "in-progress"
     );
     expect(postShutdown.operations.find((op) => op.id === "kill-terminals")?.status).toBe("done");
+
+    // Post-release: cleanup-workspace still in-progress (delete hook about to run)
+    const postRelease = harness.progressCaptures[2]!;
+    expect(postRelease.operations.find((op) => op.id === "cleanup-workspace")?.status).toBe(
+      "in-progress"
+    );
   });
 
   it("test 26: retry loop emits in-progress for detecting-blockers, killing-blockers, and cleanup-workspace", async () => {

--- a/src/main/operations/delete-workspace.ts
+++ b/src/main/operations/delete-workspace.ts
@@ -499,7 +499,14 @@ export class DeleteWorkspaceOperation implements Operation<
     const { results: releaseResults, errors: releaseCollectErrors } =
       await ctx.hooks.collect<ReleaseHookResult>("release", pipelineCtx);
     const release = mergeRelease(releaseResults, releaseCollectErrors);
-    this.emitPipelineProgress(payload, resolvedWorkspacePath, { shutdown, release });
+    this.emitPipelineProgress(
+      payload,
+      resolvedWorkspacePath,
+      { shutdown, release },
+      false,
+      false,
+      "cleanup-workspace"
+    );
 
     // --- Delete ---
     const { results: deleteResults, errors: deleteCollectErrors } =


### PR DESCRIPTION
- Pass `currentStep: "cleanup-workspace"` to post-release progress emission so the spinner stays visible while the delete hook runs
- Add test assertion verifying post-release emission keeps cleanup-workspace as in-progress