### PR TITLE
fix(paths): use isDevelopment for app-data path selection

### DIFF
--- a/src/services/platform/path-provider.test.ts
+++ b/src/services/platform/path-provider.test.ts
@@ -283,6 +283,21 @@ describe("DefaultPathProvider", () => {
       expect(pathProvider.scriptsDir.toString()).toBe("/dev/project/out/main/assets/scripts");
     });
 
+    it("uses ./app-data/ for packaged dev builds", () => {
+      const buildInfo = createMockBuildInfo({
+        isDevelopment: true,
+        isPackaged: true,
+        appPath: "/opt/codehydra/resources/app.asar",
+        resourcesPath: "/opt/codehydra/resources",
+      });
+      const platformInfo = createMockPlatformInfo({ platform: "linux", homeDir: "/home/testuser" });
+      const pathProvider = new DefaultPathProvider(buildInfo, platformInfo);
+
+      // Packaged dev builds should still use ./app-data/ (not system paths)
+      expect(pathProvider.dataRootDir.toString()).toMatch(/app-data$/);
+      expect(pathProvider.projectsDir.toString()).toMatch(/app-data\/projects$/);
+    });
+
     it("ignores platform in development mode", () => {
       const buildInfo = createMockBuildInfo({ isDevelopment: true, appPath: "/test/app" });
 

--- a/src/services/platform/path-provider.ts
+++ b/src/services/platform/path-provider.ts
@@ -130,7 +130,7 @@ export interface PathProvider {
  * Computes paths based on BuildInfo (dev/prod mode) and PlatformInfo (OS/home).
  *
  * Path structure:
- * - Development: `./app-data/` (relative to process.cwd())
+ * - Development (isDevelopment=true): `./app-data/` (relative to process.cwd())
  * - Production Linux: `~/.local/share/codehydra/`
  * - Production macOS: `~/Library/Application Support/Codehydra/`
  * - Production Windows: `<home>/AppData/Roaming/Codehydra/`
@@ -298,7 +298,7 @@ export class DefaultPathProvider implements PathProvider {
    * Compute the data root directory based on build mode and platform.
    */
   private computeDataRootDir(buildInfo: BuildInfo, platformInfo: PlatformInfo): string {
-    if (!buildInfo.isPackaged) {
+    if (buildInfo.isDevelopment) {
       return join(process.cwd(), "app-data");
     }
 


### PR DESCRIPTION
- Use `isDevelopment` instead of `!isPackaged` in `computeDataRootDir` so packaged dev builds use `./app-data` instead of system paths
- Add test for `isDevelopment=true, isPackaged=true` scenario