### PR TITLE
fix(ui): change "Press Alt+X" to "Tip: Alt+X" on setup screens

### DIFF
--- a/src/renderer/lib/components/SetupComplete.svelte
+++ b/src/renderer/lib/components/SetupComplete.svelte
@@ -31,7 +31,7 @@
   </span>
   <p>Setup complete!</p>
   <p class="hint">
-    Press <vscode-badge>Alt+X</vscode-badge> for keyboard shortcuts
+    Tip: <vscode-badge>Alt+X</vscode-badge> for keyboard shortcuts
   </p>
 </div>
 

--- a/src/renderer/lib/components/SetupScreen.svelte
+++ b/src/renderer/lib/components/SetupScreen.svelte
@@ -153,7 +153,7 @@
     <p class="subtitle">{subtitle}</p>
   {/if}
   <p class="hint">
-    Press <vscode-badge>Alt+X</vscode-badge> for keyboard shortcuts
+    Tip: <vscode-badge>Alt+X</vscode-badge> for keyboard shortcuts
   </p>
 
   {#if !hideProgress}


### PR DESCRIPTION
- Change hint text from "Press Alt+X" to "Tip: Alt+X" on SetupScreen and SetupComplete components
- Reframes the shortcut hint as informational guidance rather than an immediate instruction during startup