### PR TITLE
fix(startup): show error dialog and quit on startup failure

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -787,7 +787,12 @@ async function bootstrap(): Promise<void> {
         { error: getErrorMessage(error) },
         error instanceof Error ? error : undefined
       );
-      // Error is already emitted to renderer via the setup error handler
+
+      if (dialogLayer) {
+        dialogLayer.showErrorBox("Startup Failed", getErrorMessage(error));
+      }
+
+      app.quit();
     });
 
   // 10. Open DevTools in development only


### PR DESCRIPTION
- Show native error dialog via `dialogLayer.showErrorBox()` when `app:start` dispatch fails
- Call `app.quit()` after dialog instead of leaving user stuck on starting screen
- Remove misleading comment about setup error handler