### PR TITLE
refactor(plugin-server): replace ConfigDataProvider closure with per-workspace config storage

### DIFF
--- a/src/main/bootstrap.integration.test.ts
+++ b/src/main/bootstrap.integration.test.ts
@@ -208,7 +208,6 @@ function createMockDeps(): BootstrapDeps {
     fileSystemLayer: {
       mkdir: vi.fn().mockResolvedValue(undefined),
     } as never,
-    configDataProviderFn: () => vi.fn().mockReturnValue({ env: null, agentType: null }),
     viewLayer: null,
     windowLayer: null,
     sessionLayer: null,

--- a/src/main/bootstrap.test.ts
+++ b/src/main/bootstrap.test.ts
@@ -146,7 +146,6 @@ function createMockDeps(): BootstrapDeps {
       port: vi.fn().mockReturnValue(9090),
     } as never,
     fileSystemLayer: { mkdir: vi.fn().mockResolvedValue(undefined) } as never,
-    configDataProviderFn: () => vi.fn().mockReturnValue({ env: null, agentType: null }),
     viewLayer: null,
     windowLayer: null,
     sessionLayer: null,

--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -209,8 +209,6 @@ export interface BootstrapDeps {
   readonly codeServerManager: import("../services").CodeServerManager;
   /** FileSystemLayer for directory creation */
   readonly fileSystemLayer: import("../services").FileSystemLayer;
-  /** Lazy getter for ConfigDataProvider (depends on agent fields from start hook) */
-  readonly configDataProviderFn: () => import("../services/plugin-server/plugin-server").ConfigDataProvider;
   /** ViewLayer for shell layer disposal (nullable for testing) */
   readonly viewLayer: import("../services/shell/view").ViewLayer | null;
   /** WindowLayer for shell layer disposal (nullable for testing) */
@@ -438,7 +436,6 @@ export function initializeBootstrap(deps: BootstrapDeps): BootstrapResult {
       pluginServer: deps.pluginServer,
       codeServerManager: deps.codeServerManager,
       fileSystemLayer: deps.fileSystemLayer,
-      configDataProvider: deps.configDataProviderFn(),
       onPortChanged: (port: number) => {
         deps.viewManagerFn().updateCodeServerPort(port);
       },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,7 +56,7 @@ import {
 } from "../services/binary-download";
 import { ExtensionManager } from "../services/vscode-setup/extension-manager";
 import type { AgentStatusManager, AgentType, AgentServerManager } from "../agents";
-import { PluginServer, type ConfigDataProvider } from "../services/plugin-server";
+import { PluginServer } from "../services/plugin-server";
 import { McpServerManager } from "../services/mcp-server";
 import { WindowManager } from "./managers/window-manager";
 import { ViewManager } from "./managers/view-manager";
@@ -208,7 +208,6 @@ function createCodeServerConfig(): CodeServerConfig {
 // Global state
 let windowManager: WindowManager | null = null;
 let viewManager: ViewManager | null = null;
-let selectedAgentTypeValue: AgentType | null = null;
 let codeServerManager: CodeServerManager | null = null;
 let agentStatusManager: AgentStatusManager | null = null;
 let badgeManager: BadgeManager | null = null;
@@ -563,7 +562,6 @@ async function bootstrap(): Promise<void> {
     selectedAgentType: AgentType;
   }) => {
     agentStatusManager = services.agentStatusManager;
-    selectedAgentTypeValue = services.selectedAgentType;
   };
 
   // 8. Initialize bootstrap with API registry and all modules
@@ -706,15 +704,6 @@ async function bootstrap(): Promise<void> {
     agentStatusManagerFn: () => agentStatusManager!,
     codeServerManager: codeServerManager!,
     fileSystemLayer,
-    configDataProviderFn: (): ConfigDataProvider => {
-      return (workspacePath: string) => {
-        const env =
-          agentStatusManager
-            ?.getProvider(workspacePath as import("../shared/ipc").WorkspacePath)
-            ?.getEnvironmentVariables() ?? null;
-        return { env, agentType: selectedAgentTypeValue! };
-      };
-    },
     // Shell layers for ViewModule (available immediately from bootstrap)
     viewLayer,
     windowLayer,
@@ -856,7 +845,6 @@ async function cleanup(): Promise<void> {
   // Clear module-level references
   windowManager = null;
   viewManager = null;
-  selectedAgentTypeValue = null;
   codeServerManager = null;
   agentStatusManager = null;
   badgeManager = null;

--- a/src/main/modules/agent-module.integration.test.ts
+++ b/src/main/modules/agent-module.integration.test.ts
@@ -859,6 +859,7 @@ describe("AgentModule", () => {
       expect(mockSM.startServer).toHaveBeenCalledWith("/test/project/.worktrees/feature-1");
       expect(result.envVars).toBeDefined();
       expect(result.envVars!.OPENCODE_PORT).toBe("8080");
+      expect(result.agentType).toBe("opencode");
     });
 
     it("sets initial prompt when provided", async () => {

--- a/src/main/modules/agent-module.ts
+++ b/src/main/modules/agent-module.ts
@@ -631,7 +631,7 @@ export function createAgentModule(deps: AgentModuleDeps): IntentModule {
               }
             }
 
-            return { envVars };
+            return { envVars, agentType };
           },
         },
       },

--- a/src/services/plugin-server/index.ts
+++ b/src/services/plugin-server/index.ts
@@ -2,5 +2,5 @@
  * Plugin server module - Socket.IO server for VS Code extension communication.
  */
 
-export { PluginServer, type ApiCallHandlers, type ConfigDataProvider } from "./plugin-server";
+export { PluginServer, type ApiCallHandlers } from "./plugin-server";
 export { SHUTDOWN_DISCONNECT_TIMEOUT_MS } from "../../shared/plugin-protocol";

--- a/src/services/plugin-server/plugin-server.test.ts
+++ b/src/services/plugin-server/plugin-server.test.ts
@@ -22,7 +22,7 @@ describe("PluginServer", () => {
   // Note: normalizeWorkspacePath tests moved to Path class tests (path.test.ts)
   // The PluginServer now uses Path internally for cross-platform normalization
 
-  describe("onConfigData", () => {
+  describe("setWorkspaceConfig / removeWorkspaceConfig", () => {
     let server: PluginServer;
     let mockPortManager: ReturnType<typeof createPortManagerMock>;
 
@@ -35,29 +35,28 @@ describe("PluginServer", () => {
       await server.close();
     });
 
-    it("accepts provider registration without throwing", () => {
-      // Should not throw when registering a config data provider
+    it("stores config without throwing", () => {
       expect(() =>
-        server.onConfigData(() => ({
-          env: null,
-          agentType: null,
-        }))
+        server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode")
       ).not.toThrow();
     });
 
-    it("allows provider to be replaced", () => {
-      server.onConfigData(() => ({
-        env: null,
-        agentType: null,
-      }));
+    it("allows config to be overwritten", () => {
+      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode");
 
-      // Should not throw when replacing provider
       expect(() =>
-        server.onConfigData(() => ({
-          env: { TEST: "value" },
-          agentType: "opencode",
-        }))
+        server.setWorkspaceConfig("/test/workspace", { PORT: "9090" }, "claude")
       ).not.toThrow();
+    });
+
+    it("removes config without throwing", () => {
+      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode");
+
+      expect(() => server.removeWorkspaceConfig("/test/workspace")).not.toThrow();
+    });
+
+    it("remove is idempotent for non-existent workspaces", () => {
+      expect(() => server.removeWorkspaceConfig("/nonexistent")).not.toThrow();
     });
   });
 


### PR DESCRIPTION
- Flow envVars and agentType through the hook pipeline instead of re-querying them via a closure
- CodeServerModule now pushes config into PluginServer during finalize and cleans up during delete