### PR TITLE
refactor(bootstrap): hoist service construction to module level

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,23 @@
 /**
  * Electron main process entry point.
  * Initializes all components and manages the application lifecycle.
+ *
+ * File layout:
+ * 1. Pre-import setup (fontconfig fix)
+ * 2. Imports
+ * 3. Helper function definitions
+ * 4. Core initializations (buildInfo, platformInfo, pathProvider, logging)
+ * 5. Electron layers (all constructors are pure)
+ * 6. Service construction (hoisted from bootstrap)
+ * 7. Manager construction (two-phase: constructor only, no Electron resources)
+ * 8. Intent modules (all at module level)
+ * 9. Pre-ready calls (applyElectronFlags, redirectElectronDataPaths)
+ * 10. Mutable state
+ * 11. bootstrap() — focused on Electron lifecycle
+ * 12. App lifecycle handlers
  */
 
+// 1. Pre-import setup
 // Fix fontconfig for AppImage builds.
 // Must be set BEFORE any Electron/Chromium code runs.
 // AppImage sets APPIMAGE or APPDIR environment variables.
@@ -11,6 +26,7 @@ if (process.env.APPIMAGE || process.env.APPDIR) {
   process.env.FONTCONFIG_PATH = "/etc/fonts";
 }
 
+// 2. Imports
 import { app } from "electron";
 import { fileURLToPath } from "node:url";
 import nodePath from "node:path";
@@ -96,6 +112,8 @@ import { ElectronBuildInfo } from "./build-info";
 import { NodePlatformInfo } from "./platform-info";
 import { getErrorMessage } from "../shared/error-utils";
 
+// 3. Helper function definitions
+
 /**
  * Parses Electron command-line flags from a string.
  * @param flags - Space-separated flags string (e.g., "--disable-gpu --use-gl=swiftshader")
@@ -133,26 +151,6 @@ function parseElectronFlags(flags: string | undefined): { name: string; value?: 
   return result;
 }
 
-// Module-level instances - created IMMEDIATELY after imports.
-// These are created early because:
-// 1. applyElectronFlags() needs to log
-// 2. redirectElectronDataPaths() needs pathProvider
-const buildInfo: BuildInfo = new ElectronBuildInfo();
-
-// Disable ASAR virtual filesystem when not packaged.
-// Prevents file handle issues on Windows when deleting workspaces
-// that contain node_modules/electron directories.
-if (!buildInfo.isPackaged) {
-  process.noAsar = true;
-}
-
-const platformInfo = new NodePlatformInfo();
-const pathProvider: PathProvider = new DefaultPathProvider(buildInfo, platformInfo);
-
-// Create logging service - must be before any code that needs to log
-const loggingService: LoggingService = new ElectronLogService(buildInfo, pathProvider);
-const appLogger = loggingService.createLogger("app");
-
 /**
  * Applies Electron command-line flags from environment variable.
  * Must be called BEFORE app.whenReady().
@@ -179,14 +177,6 @@ function applyElectronFlags(): void {
   }
 }
 
-// Apply Electron command-line flags IMMEDIATELY after logging is available.
-// CRITICAL: Must be before app.whenReady() and any code that might trigger GPU initialization.
-applyElectronFlags();
-
-const __dirname = nodePath.dirname(fileURLToPath(import.meta.url));
-
-const fileSystemLayer = new DefaultFileSystemLayer(loggingService.createLogger("fs"));
-
 /**
  * Redirect Electron's data paths to isolate from system defaults.
  * This prevents conflicts when running nested CodeHydra instances
@@ -201,424 +191,411 @@ function redirectElectronDataPaths(): void {
   });
 }
 
+// 4. Core initializations
+
+const buildInfo: BuildInfo = new ElectronBuildInfo();
+
+const platformInfo = new NodePlatformInfo();
+const pathProvider: PathProvider = new DefaultPathProvider(buildInfo, platformInfo);
+const loggingService: LoggingService = new ElectronLogService(buildInfo, pathProvider);
+const appLogger = loggingService.createLogger("app");
+const __dirname = nodePath.dirname(fileURLToPath(import.meta.url));
+const fileSystemLayer = new DefaultFileSystemLayer(loggingService.createLogger("fs"));
+
+// 5. Electron layers (all constructors are pure — just store deps)
+
+const dialogLayer = new DefaultDialogLayer(loggingService.createLogger("dialog"));
+const menuLayer = new DefaultMenuLayer(loggingService.createLogger("menu"));
+const imageLayer = new DefaultImageLayer(loggingService.createLogger("window"));
+const windowLayer = new DefaultWindowLayer(
+  imageLayer,
+  platformInfo,
+  loggingService.createLogger("window")
+);
+const viewLayer = new DefaultViewLayer(windowLayer, loggingService.createLogger("view"));
+const sessionLayer = new DefaultSessionLayer(loggingService.createLogger("view"));
+const appLayer = new DefaultAppLayer(loggingService.createLogger("badge"));
+const ipcLayer = new DefaultIpcLayer(loggingService.createLogger("api"));
+
+// 6. Service construction (hoisted from bootstrap)
+
+const configService = new ConfigService({
+  fileSystem: fileSystemLayer,
+  pathProvider,
+  logger: loggingService.createLogger("config"),
+});
+
+const telemetryService = new PostHogTelemetryService({
+  buildInfo,
+  platformInfo,
+  configService,
+  logger: loggingService.createLogger("telemetry"),
+  apiKey: typeof __POSTHOG_API_KEY__ !== "undefined" ? __POSTHOG_API_KEY__ : undefined,
+  host: typeof __POSTHOG_HOST__ !== "undefined" ? __POSTHOG_HOST__ : undefined,
+});
+
+// Register global error handlers for uncaught exceptions
+// Use prependListener to capture errors before other handlers
+process.prependListener("uncaughtException", (error: Error) => {
+  telemetryService?.captureError(error);
+  // Re-throw to let default handler take over
+  throw error;
+});
+process.prependListener("unhandledRejection", (reason: unknown) => {
+  const error = reason instanceof Error ? reason : new Error(String(reason));
+  telemetryService?.captureError(error);
+  // Re-throw to let default handler take over
+  throw error;
+});
+
+// Process runner uses platform-native tree killing (taskkill on Windows, process.kill on Unix)
+const processRunner = new ExecaProcessRunner(loggingService.createLogger("process"));
+const networkLayer = new DefaultNetworkLayer(loggingService.createLogger("network"));
+
+const binaryDownloadService: BinaryDownloadService = new DefaultBinaryDownloadService(
+  networkLayer,
+  fileSystemLayer,
+  new DefaultArchiveExtractor(),
+  pathProvider,
+  platformInfo,
+  loggingService.createLogger("binary-download")
+);
+
+const codeServerConfig: CodeServerConfig = {
+  port: getCodeServerPort(buildInfo),
+  binaryPath: pathProvider.getBinaryPath("code-server", CODE_SERVER_VERSION).toNative(),
+  runtimeDir: nodePath.join(pathProvider.dataRootDir.toNative(), "runtime"),
+  extensionsDir: pathProvider.vscodeExtensionsDir.toNative(),
+  userDataDir: pathProvider.vscodeUserDataDir.toNative(),
+  binDir: pathProvider.binDir.toNative(),
+  codeServerDir: pathProvider.getBinaryDir("code-server", CODE_SERVER_VERSION).toNative(),
+  opencodeDir: pathProvider.getBinaryDir("opencode", OPENCODE_VERSION).toNative(),
+};
+
+const codeServerManager = new CodeServerManager(
+  codeServerConfig,
+  processRunner,
+  networkLayer,
+  networkLayer,
+  loggingService.createLogger("code-server"),
+  binaryDownloadService
+);
+
+// AgentBinaryManager factory - creates manager for specific agent type
+const getAgentBinaryManager = (agentType: ConfigAgentType): AgentBinaryManager => {
+  return new AgentBinaryManager(
+    agentType,
+    binaryDownloadService,
+    loggingService.createLogger("agent-binary")
+  );
+};
+
+// ExtensionManager for extension preflight/install
+const setupExtensionManager = new ExtensionManager(
+  pathProvider,
+  fileSystemLayer,
+  processRunner,
+  loggingService.createLogger("ext-manager")
+);
+
+const hookRegistry = new HookRegistry();
+const dispatcher = new Dispatcher(hookRegistry);
+
+// Runtime services (non-agent, used by lifecycle modules)
+const pluginServer = new PluginServer(networkLayer, loggingService.createLogger("plugin"), {
+  isDevelopment: buildInfo.isDevelopment,
+  extensionLogger: loggingService.createLogger("extension"),
+});
+
+const projectStore = new ProjectStore(
+  pathProvider.projectsDir.toString(),
+  fileSystemLayer,
+  pathProvider.remotesDir.toString()
+);
+const gitClient = new SimpleGitClient(loggingService.createLogger("git"));
+const globalWorktreeProvider = new GitWorktreeProvider(
+  gitClient,
+  fileSystemLayer,
+  loggingService.createLogger("worktree")
+);
+const workspaceFileConfig = createWorkspaceFileConfig();
+const workspaceFileService = new WorkspaceFileService(
+  fileSystemLayer,
+  workspaceFileConfig,
+  loggingService.createLogger("workspace-file")
+);
+
+const autoUpdater = new AutoUpdater({
+  logger: loggingService.createLogger("updater"),
+  isDevelopment: buildInfo.isDevelopment,
+});
+
+// Agent services (both server managers + status manager)
+// Both constructors are pure field assignment (no I/O)
+const serverManagerDeps = {
+  processRunner,
+  portManager: networkLayer,
+  httpClient: networkLayer,
+  pathProvider,
+  fileSystem: fileSystemLayer,
+  logger: loggingService.createLogger("agent"),
+};
+const agentServerManagers = {
+  claude: createAgentServerManager("claude", serverManagerDeps),
+  opencode: createAgentServerManager("opencode", serverManagerDeps),
+};
+const agentStatusManager = new AgentStatusManager(loggingService.createLogger("agent"));
+
+const keepFilesService = new KeepFilesService(
+  fileSystemLayer,
+  loggingService.createLogger("keepfiles")
+);
+
+// Wrap DialogLayer to match MinimalDialog interface (converts Path to string)
+const dialog = {
+  showOpenDialog: async (options: { properties: string[] }) => {
+    const result = await dialogLayer.showOpenDialog({
+      properties: options.properties as import("../services/platform/dialog").OpenDialogProperty[],
+    });
+    return {
+      canceled: result.canceled,
+      filePaths: result.filePaths.map((p) => p.toString()),
+    };
+  },
+};
+
+const workspaceLockHandler = createWorkspaceLockHandler(
+  processRunner,
+  platformInfo,
+  loggingService.createLogger("process"),
+  nodePath.join(pathProvider.scriptsRuntimeDir.toNative(), "blocking-processes.ps1")
+);
+
+const apiLogger = loggingService.createLogger("api");
+const lifecycleLogger = loggingService.createLogger("lifecycle");
+
+// 7. Manager construction (two-phase: constructor only, no Electron resources)
+
+const windowTitle =
+  !buildInfo.isPackaged && buildInfo.gitBranch ? `CodeHydra (${buildInfo.gitBranch})` : "CodeHydra";
+
+const windowManager = new WindowManager(
+  {
+    windowLayer,
+    imageLayer,
+    logger: loggingService.createLogger("window"),
+    platformInfo,
+  },
+  windowTitle,
+  pathProvider.appIconPath.toNative()
+);
+
+const viewManager = new ViewManager({
+  windowManager,
+  windowLayer,
+  viewLayer,
+  sessionLayer,
+  config: {
+    uiPreloadPath: nodePath.join(__dirname, "../preload/index.cjs"),
+    codeServerPort: 0,
+  },
+  logger: loggingService.createLogger("view"),
+  setModeFn: (mode) => {
+    void dispatcher.dispatch({
+      type: INTENT_SET_MODE,
+      payload: { mode },
+    } as SetModeIntent);
+  },
+});
+
+const badgeManager = new BadgeManager(
+  platformInfo,
+  appLayer,
+  imageLayer,
+  windowManager,
+  loggingService.createLogger("badge")
+);
+
+// Mutable reference: set after initializeBootstrap(), read by lazy closures
+let codeHydraApi: ICodeHydraApi | null = null;
+
+// McpServerManager with lazy API factory (API is not available until after bootstrap)
+const mcpServerManager = new McpServerManager(
+  networkLayer,
+  pathProvider,
+  () => {
+    if (!codeHydraApi) {
+      throw new Error("API not initialized");
+    }
+    return codeHydraApi;
+  },
+  loggingService.createLogger("mcp")
+);
+
+// 8. Intent modules (all at module level)
+
+const idempotencyModule = createIdempotencyModule([
+  { intentType: INTENT_APP_SHUTDOWN },
+  { intentType: INTENT_SETUP, resetOn: EVENT_SETUP_ERROR },
+  {
+    intentType: INTENT_DELETE_WORKSPACE,
+    getKey: (p) => {
+      const { projectId, workspaceName } = p as DeleteWorkspacePayload;
+      return `${projectId}/${workspaceName}`;
+    },
+    resetOn: EVENT_WORKSPACE_DELETED,
+    isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,
+  },
+]);
+
+const { module: viewModule, mountSignal } = createViewModule({
+  viewManager,
+  logger: apiLogger,
+  viewLayer,
+  windowLayer,
+  sessionLayer,
+});
+
+const codeServerModule = createCodeServerModule({
+  codeServerManager,
+  extensionManager: setupExtensionManager,
+  logger: apiLogger,
+  getLifecycleDeps: () => ({
+    pluginServer,
+    codeServerManager,
+    fileSystemLayer,
+    onPortChanged: (port: number) => {
+      viewManager.updateCodeServerPort(port);
+    },
+  }),
+  getWorkspaceDeps: () => ({
+    workspaceFileService,
+    wrapperPath: pathProvider.claudeCodeWrapperPath.toString(),
+  }),
+});
+
+const agentModule = createAgentModule({
+  configService,
+  getAgentBinaryManager,
+  ipcLayer,
+  getUIWebContentsFn: () => viewManager.getUIWebContents(),
+  logger: apiLogger,
+  loggingService,
+  dispatcher,
+  killTerminalsCallback: async (workspacePath: string) => {
+    await pluginServer.sendExtensionHostShutdown(workspacePath);
+  },
+  agentServerManagers,
+  agentStatusManager,
+});
+
+const metadataModule = createMetadataModule({
+  globalProvider: globalWorktreeProvider,
+});
+const keepFilesModule = createKeepFilesModule({
+  keepFilesService,
+  logger: apiLogger,
+});
+const deleteWindowsLockModule = createWindowsFileLockModule({
+  workspaceLockHandler,
+  logger: apiLogger,
+});
+const windowTitleModule = createWindowTitleModule(
+  (title: string) => windowManager.setTitle(title),
+  buildInfo.gitBranch ?? buildInfo.version
+);
+const telemetryLifecycleModule = createTelemetryModule({
+  telemetryService,
+  platformInfo,
+  buildInfo,
+  configService,
+  logger: lifecycleLogger,
+});
+const autoUpdaterLifecycleModule = createAutoUpdaterModule({
+  autoUpdater,
+  dispatcher,
+  logger: lifecycleLogger,
+});
+const localProjectModule = createLocalProjectModule({
+  projectStore,
+  globalProvider: globalWorktreeProvider,
+});
+const remoteProjectModule = createRemoteProjectModule({
+  projectStore,
+  gitClient,
+  pathProvider,
+  logger: lifecycleLogger,
+});
+const gitWorktreeWorkspaceModule = createGitWorktreeWorkspaceModule(
+  globalWorktreeProvider,
+  pathProvider,
+  apiLogger
+);
+const badgeModule = createBadgeModule(badgeManager, lifecycleLogger);
+const mcpModule = createMcpModule({
+  mcpServerManager,
+  logger: lifecycleLogger,
+});
+
+// 9. Pre-ready calls
+
+// Disable ASAR virtual filesystem when not packaged.
+// Prevents file handle issues on Windows when deleting workspaces
+// that contain node_modules/electron directories.
+if (!buildInfo.isPackaged) {
+  process.noAsar = true;
+}
+
+// Apply Electron command-line flags IMMEDIATELY after logging is available.
+// CRITICAL: Must be before app.whenReady() and any code that might trigger GPU initialization.
+applyElectronFlags();
+
 // Redirect Electron data paths before app is ready
 redirectElectronDataPaths();
 
-/**
- * Creates the code-server configuration using pathProvider.
- */
-function createCodeServerConfig(): CodeServerConfig {
-  return {
-    port: getCodeServerPort(buildInfo),
-    binaryPath: pathProvider.getBinaryPath("code-server", CODE_SERVER_VERSION).toNative(),
-    runtimeDir: nodePath.join(pathProvider.dataRootDir.toNative(), "runtime"),
-    extensionsDir: pathProvider.vscodeExtensionsDir.toNative(),
-    userDataDir: pathProvider.vscodeUserDataDir.toNative(),
-    binDir: pathProvider.binDir.toNative(),
-    codeServerDir: pathProvider.getBinaryDir("code-server", CODE_SERVER_VERSION).toNative(),
-    opencodeDir: pathProvider.getBinaryDir("opencode", OPENCODE_VERSION).toNative(),
-  };
-}
+// 10. Mutable state
 
 /** Cleanup function — defined as a closure inside bootstrap() to capture local variables. */
 let cleanup: (() => Promise<void>) | null = null;
 
+// 11. bootstrap() — focused on Electron lifecycle
+
 /**
  * Bootstraps the application.
  *
- * Creates all services, wires the intent dispatcher, loads UI, and dispatches app:start.
- *
- * The initialization flow is:
+ * All services and modules are constructed at module level. This function
+ * handles only Electron lifecycle operations:
  * 1. Initialize logging and disable application menu
- * 2. Create BinaryDownloadService and setup managers
- * 3. Regenerate wrapper scripts (cheap operation on every startup)
- * 4. Create WindowManager and ViewManager
- * 5. Initialize bootstrap with ApiRegistry and lifecycle handlers
- * 6. Load UI
- * 7. Dispatch app:start intent (checks setup, runs app:setup if needed, starts services)
+ * 2. Regenerate wrapper scripts
+ * 3. Create window and views (two-phase init: create())
+ * 4. Initialize bootstrap with ApiRegistry and lifecycle handlers
+ * 5. Load UI
+ * 6. Dispatch app:start intent
  */
 async function bootstrap(): Promise<void> {
-  // Mutable reference: set after initializeBootstrap(), read by lazy closures
-  let codeHydraApi: ICodeHydraApi | null = null;
-
-  // 0. Initialize logging service (enables renderer logging via IPC)
+  // Initialize logging service (enables renderer logging via IPC)
   loggingService.initialize();
   registerLogHandlers(loggingService);
-  const appLogger = loggingService.createLogger("app");
   appLogger.info("Bootstrap starting", {
     version: buildInfo.version,
     isDev: buildInfo.isDevelopment,
   });
 
-  // 1. Create platform layers and disable application menu
-  const dialogLayer = new DefaultDialogLayer(loggingService.createLogger("dialog"));
-  const menuLayer = new DefaultMenuLayer(loggingService.createLogger("menu"));
+  // Disable application menu
   menuLayer.setApplicationMenu(null);
 
-  // 2. Create ConfigService first to load agent selection
-  const configService = new ConfigService({
-    fileSystem: fileSystemLayer,
-    pathProvider,
-    logger: loggingService.createLogger("config"),
-  });
-
-  // 2b. Create TelemetryService for PostHog analytics
-  // Uses build-time injected API key and host (see vite.config)
-  // Operates in no-op mode if API key is missing or telemetry is disabled
-  const telemetryService = new PostHogTelemetryService({
-    buildInfo,
-    platformInfo,
-    configService,
-    logger: loggingService.createLogger("telemetry"),
-    apiKey: typeof __POSTHOG_API_KEY__ !== "undefined" ? __POSTHOG_API_KEY__ : undefined,
-    host: typeof __POSTHOG_HOST__ !== "undefined" ? __POSTHOG_HOST__ : undefined,
-  });
-
-  // Register global error handlers for uncaught exceptions
-  // Use prependListener to capture errors before other handlers
-  process.prependListener("uncaughtException", (error: Error) => {
-    telemetryService?.captureError(error);
-    // Re-throw to let default handler take over
-    throw error;
-  });
-  process.prependListener("unhandledRejection", (reason: unknown) => {
-    const error = reason instanceof Error ? reason : new Error(String(reason));
-    telemetryService?.captureError(error);
-    // Re-throw to let default handler take over
-    throw error;
-  });
-
-  // 3. Create platform layers and setup services
-
-  // Process runner uses platform-native tree killing (taskkill on Windows, process.kill on Unix)
-  const processRunner = new ExecaProcessRunner(loggingService.createLogger("process"));
-
-  // Create network layer for binary downloads
-  const networkLayerForSetup = new DefaultNetworkLayer(loggingService.createLogger("network"));
-
-  // Create BinaryDownloadService for downloading code-server and opencode
-  const binaryDownloadService: BinaryDownloadService = new DefaultBinaryDownloadService(
-    networkLayerForSetup,
-    fileSystemLayer,
-    new DefaultArchiveExtractor(),
-    pathProvider,
-    platformInfo,
-    loggingService.createLogger("binary-download")
-  );
-
-  // 3. Regenerate wrapper scripts (cheap operation, ensures they always exist)
+  // Regenerate wrapper scripts (cheap operation, ensures they always exist)
   await setupBinDirectory(fileSystemLayer, pathProvider);
 
-  // 3b. Create setup managers for app:setup hook modules
-  // CodeServerManager for setup (preflight + download only, not runtime)
-  const codeServerConfig = createCodeServerConfig();
-  const setupCodeServerManager = new CodeServerManager(
-    codeServerConfig,
-    processRunner,
-    networkLayerForSetup,
-    networkLayerForSetup,
-    loggingService.createLogger("code-server"),
-    binaryDownloadService
-  );
+  // Two-phase init: create Electron resources
+  windowManager.create();
+  viewManager.create();
 
-  // AgentBinaryManager factory - creates manager for specific agent type
-  const getAgentBinaryManager = (agentType: ConfigAgentType): AgentBinaryManager => {
-    return new AgentBinaryManager(
-      agentType,
-      binaryDownloadService,
-      loggingService.createLogger("agent-binary")
-    );
-  };
-
-  // ExtensionManager for extension preflight/install
-  const setupExtensionManager = new ExtensionManager(
-    pathProvider,
-    fileSystemLayer,
-    processRunner,
-    loggingService.createLogger("ext-manager")
-  );
-
-  // 4. Create WindowManager with appropriate title and icon
-  // When not packaged, show branch name: "CodeHydra (branch-name)"
-  const windowTitle =
-    !buildInfo.isPackaged && buildInfo.gitBranch
-      ? `CodeHydra (${buildInfo.gitBranch})`
-      : "CodeHydra";
-
-  // Create ImageLayer (shared between WindowLayer and BadgeManager)
-  // Must be a single instance so ImageHandles are resolvable across components
-  const imageLayer = new DefaultImageLayer(loggingService.createLogger("window"));
-
-  // Create WindowLayer for WindowManager
-  const windowLogger = loggingService.createLogger("window");
-  const windowLayer = new DefaultWindowLayer(imageLayer, platformInfo, windowLogger);
-
-  const windowManager = WindowManager.create(
-    {
-      windowLayer,
-      imageLayer,
-      logger: windowLogger,
-      platformInfo,
-    },
-    windowTitle,
-    pathProvider.appIconPath.toNative()
-  );
-
-  // 5. Create ViewLayer and SessionLayer for ViewManager
-  const viewLogger = loggingService.createLogger("view");
-  const sessionLayer = new DefaultSessionLayer(viewLogger);
-  const viewLayer = new DefaultViewLayer(windowLayer, viewLogger);
-
-  // 6. Create dispatcher early so ShortcutController can dispatch intents
-  const hookRegistry = new HookRegistry();
-  const dispatcher = new Dispatcher(hookRegistry);
-
-  // 6b. Create ViewManager with port=0 initially
-  // Port will be updated when startServices() runs
-  const viewManager = ViewManager.create({
-    windowManager,
-    windowLayer,
-    viewLayer,
-    sessionLayer,
-    config: {
-      uiPreloadPath: nodePath.join(__dirname, "../preload/index.cjs"),
-      codeServerPort: 0,
-    },
-    logger: viewLogger,
-    setModeFn: (mode) => {
-      void dispatcher.dispatch({
-        type: INTENT_SET_MODE,
-        payload: { mode },
-      } as SetModeIntent);
-    },
-  });
-
-  // 6c. Maximize window after ViewManager subscription is active
+  // Maximize window after ViewManager subscription is active
   // On Linux, maximize() is async - wait for it to complete before loading UI
   await windowManager.maximizeAsync();
 
-  // Capture viewManager for closure (TypeScript narrow refinement doesn't persist)
-  const viewManagerRef = viewManager;
-
-  // 7. Create runtime services (non-agent, used by lifecycle modules)
-  // Agent services are created lazily by AgentModule during its start hook.
-  const networkLayer = new DefaultNetworkLayer(loggingService.createLogger("network"));
-
-  const pluginLogger = loggingService.createLogger("plugin");
-  const extensionLogger = loggingService.createLogger("extension");
-  const pluginServer = new PluginServer(networkLayer, pluginLogger, {
-    isDevelopment: buildInfo.isDevelopment,
-    extensionLogger,
-  });
-
-  const runtimeCodeServerConfig = createCodeServerConfig();
-  const codeServerManager = new CodeServerManager(
-    runtimeCodeServerConfig,
-    processRunner,
-    networkLayer,
-    networkLayer,
-    loggingService.createLogger("code-server")
-  );
-
-  const projectStore = new ProjectStore(
-    pathProvider.projectsDir.toString(),
-    fileSystemLayer,
-    pathProvider.remotesDir.toString()
-  );
-  const gitClient = new SimpleGitClient(loggingService.createLogger("git"));
-  const globalWorktreeProvider = new GitWorktreeProvider(
-    gitClient,
-    fileSystemLayer,
-    loggingService.createLogger("worktree")
-  );
-  const workspaceFileConfig = createWorkspaceFileConfig();
-  const workspaceFileService = new WorkspaceFileService(
-    fileSystemLayer,
-    workspaceFileConfig,
-    loggingService.createLogger("workspace-file")
-  );
-
-  const appLayer = new DefaultAppLayer(loggingService.createLogger("badge"));
-  const badgeManager = new BadgeManager(
-    platformInfo,
-    appLayer,
-    imageLayer,
-    windowManager,
-    loggingService.createLogger("badge")
-  );
-
-  const autoUpdater = new AutoUpdater({
-    logger: loggingService.createLogger("updater"),
-    isDevelopment: buildInfo.isDevelopment,
-  });
-
-  // 7a. Create agent services upfront (both server managers + status manager).
-  // Both constructors are pure field assignment (no I/O). Agent type is selected at runtime
-  // by AgentModule during its start hook.
-  const serverManagerDeps = {
-    processRunner,
-    portManager: networkLayer,
-    httpClient: networkLayer,
-    pathProvider,
-    fileSystem: fileSystemLayer,
-    logger: loggingService.createLogger("agent"),
-  };
-  const agentServerManagers = {
-    claude: createAgentServerManager("claude", serverManagerDeps),
-    opencode: createAgentServerManager("opencode", serverManagerDeps),
-  };
-  const agentStatusManager = new AgentStatusManager(loggingService.createLogger("agent"));
-
-  // 7b. Create McpServerManager with lazy API factory (API is not available until after bootstrap)
-  const mcpServerManager = new McpServerManager(
-    networkLayer,
-    pathProvider,
-    () => {
-      if (!codeHydraApi) {
-        throw new Error("API not initialized");
-      }
-      return codeHydraApi;
-    },
-    loggingService.createLogger("mcp")
-  );
-
-  // 7c. Create services needed for BootstrapDeps
-  const keepFilesService = new KeepFilesService(
-    fileSystemLayer,
-    loggingService.createLogger("keepfiles")
-  );
-
-  // Wrap DialogLayer to match MinimalDialog interface (converts Path to string)
-  const dialog = {
-    showOpenDialog: async (options: { properties: string[] }) => {
-      const result = await dialogLayer.showOpenDialog({
-        properties:
-          options.properties as import("../services/platform/dialog").OpenDialogProperty[],
-      });
-      return {
-        canceled: result.canceled,
-        filePaths: result.filePaths.map((p) => p.toString()),
-      };
-    },
-  };
-
-  const workspaceLockHandler = createWorkspaceLockHandler(
-    processRunner,
-    platformInfo,
-    loggingService.createLogger("process"),
-    nodePath.join(pathProvider.scriptsRuntimeDir.toNative(), "blocking-processes.ps1")
-  );
-
-  // 8. Create factory modules at the composition root
-  // Modules are created here where their deps already exist as local variables.
-  // Bootstrap receives pre-created modules instead of raw service deps.
-  const ipcLayer = new DefaultIpcLayer(loggingService.createLogger("api"));
-  const apiLogger = loggingService.createLogger("api");
-  const lifecycleLogger = loggingService.createLogger("lifecycle");
-
-  const { module: viewModule, mountSignal } = createViewModule({
-    viewManager,
-    logger: apiLogger,
-    viewLayer,
-    windowLayer,
-    sessionLayer,
-  });
-
-  const codeServerModule = createCodeServerModule({
-    codeServerManager: setupCodeServerManager,
-    extensionManager: setupExtensionManager,
-    logger: apiLogger,
-    getLifecycleDeps: () => ({
-      pluginServer,
-      codeServerManager,
-      fileSystemLayer,
-      onPortChanged: (port: number) => {
-        viewManagerRef.updateCodeServerPort(port);
-      },
-    }),
-    getWorkspaceDeps: () => ({
-      workspaceFileService,
-      wrapperPath: pathProvider.claudeCodeWrapperPath.toString(),
-    }),
-  });
-
-  const agentModule = createAgentModule({
-    configService,
-    getAgentBinaryManager,
-    ipcLayer,
-    getUIWebContentsFn: () => viewManager?.getUIWebContents() ?? null,
-    logger: apiLogger,
-    loggingService,
-    dispatcher,
-    killTerminalsCallback: async (workspacePath: string) => {
-      await pluginServer.sendExtensionHostShutdown(workspacePath);
-    },
-    agentServerManagers,
-    agentStatusManager,
-  });
-
-  const metadataModule = createMetadataModule({
-    globalProvider: globalWorktreeProvider,
-  });
-  const keepFilesModule = createKeepFilesModule({
-    keepFilesService,
-    logger: apiLogger,
-  });
-  const deleteWindowsLockModule = createWindowsFileLockModule({
-    workspaceLockHandler,
-    logger: apiLogger,
-  });
-  const windowTitleModule = createWindowTitleModule(
-    (title: string) => windowManager?.setTitle(title),
-    buildInfo.gitBranch ?? buildInfo.version
-  );
-  const telemetryLifecycleModule = createTelemetryModule({
-    telemetryService,
-    platformInfo,
-    buildInfo,
-    configService,
-    logger: lifecycleLogger,
-  });
-  const autoUpdaterLifecycleModule = createAutoUpdaterModule({
-    autoUpdater,
-    dispatcher,
-    logger: lifecycleLogger,
-  });
-  const localProjectModule = createLocalProjectModule({
-    projectStore,
-    globalProvider: globalWorktreeProvider,
-  });
-  const remoteProjectModule = createRemoteProjectModule({
-    projectStore,
-    gitClient,
-    pathProvider,
-    logger: lifecycleLogger,
-  });
-  const gitWorktreeWorkspaceModule = createGitWorktreeWorkspaceModule(
-    globalWorktreeProvider,
-    pathProvider,
-    apiLogger
-  );
-  const badgeModule = createBadgeModule(badgeManager, lifecycleLogger);
-  const mcpModule = createMcpModule({
-    mcpServerManager,
-    logger: lifecycleLogger,
-  });
-  const idempotencyModule = createIdempotencyModule([
-    { intentType: INTENT_APP_SHUTDOWN },
-    { intentType: INTENT_SETUP, resetOn: EVENT_SETUP_ERROR },
-    {
-      intentType: INTENT_DELETE_WORKSPACE,
-      getKey: (p) => {
-        const { projectId, workspaceName } = p as DeleteWorkspacePayload;
-        return `${projectId}/${workspaceName}`;
-      },
-      resetOn: EVENT_WORKSPACE_DELETED,
-      isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,
-    },
-  ]);
-
-  // 9. Initialize bootstrap with API registry and pre-created modules
+  // Initialize bootstrap with API registry and pre-created modules
   const bootstrapResult = initializeBootstrap({
     logger: apiLogger,
     ipcLayer,
@@ -632,12 +609,10 @@ async function bootstrap(): Promise<void> {
       return codeHydraApi;
     },
     pluginServer,
-    getUIWebContentsFn: () => viewManager?.getUIWebContents() ?? null,
+    getUIWebContentsFn: () => viewManager.getUIWebContents(),
     emitDeletionProgress: (progress: import("../shared/api/types").DeletionProgress) => {
       try {
-        viewManagerRef
-          ?.getUIWebContents()
-          ?.send(ApiIpcChannels.WORKSPACE_DELETION_PROGRESS, progress);
+        viewManager.getUIWebContents()?.send(ApiIpcChannels.WORKSPACE_DELETION_PROGRESS, progress);
       } catch {
         // Log but don't throw - deletion continues even if UI disconnected
       }
@@ -669,19 +644,15 @@ async function bootstrap(): Promise<void> {
   // Get the typed API interface (all methods are now registered)
   codeHydraApi = bootstrapResult.getInterface();
 
-  // Note: lifecycle:setup-progress and lifecycle:setup-error are handled by
-  // IpcEventBridge domain event subscriptions (wired during wireModules in bootstrap).
-
-  // 8. Load UI layer HTML
+  // Load UI layer HTML
   // Renderer starts in "initializing" mode and waits for IPC events
-  // Use file:// URL to load local HTML file
   const uiHtmlPath = `file://${nodePath.join(__dirname, "../renderer/index.html")}`;
   await viewLayer.loadURL(viewManager.getUIViewHandle(), uiHtmlPath);
 
   // Focus UI layer so keyboard shortcuts (Alt+X) work immediately on startup
   viewManager.focusUI();
 
-  // Define cleanup as a closure capturing local variables
+  // Define cleanup as a closure capturing bootstrapResult
   cleanup = async () => {
     const shutdownLogger = loggingService.createLogger("app");
     shutdownLogger.info("Shutdown initiated");
@@ -706,9 +677,7 @@ async function bootstrap(): Promise<void> {
     shutdownLogger.info("Cleanup complete");
   };
 
-  // 9. Dispatch app:start to orchestrate the startup flow
-  // This shows the starting screen, checks if setup is needed, and dispatches app:setup if required.
-  // After setup (if any), it runs start and activate hooks to complete startup.
+  // Dispatch app:start to orchestrate the startup flow
   appLogger.info("Dispatching app:start");
   void dispatcher
     .dispatch({
@@ -727,7 +696,7 @@ async function bootstrap(): Promise<void> {
       app.quit();
     });
 
-  // 10. Open DevTools in development only
+  // Open DevTools in development only
   // Note: DevTools not auto-opened to avoid z-order issues on Linux.
   // Use Ctrl+Shift+I to open manually when needed (opens detached).
   if (buildInfo.isDevelopment) {
@@ -747,12 +716,12 @@ async function bootstrap(): Promise<void> {
   }
 }
 
-// App lifecycle handlers
+// 12. App lifecycle handlers
+
 app
   .whenReady()
   .then(bootstrap)
   .catch((error: unknown) => {
-    const appLogger = loggingService.createLogger("app");
     appLogger.error(
       "Fatal error",
       { error: getErrorMessage(error) },
@@ -769,7 +738,6 @@ app.on("window-all-closed", () => {
 app.on("activate", () => {
   if (cleanup === null) {
     void bootstrap().catch((error: unknown) => {
-      const appLogger = loggingService.createLogger("app");
       appLogger.error(
         "Bootstrap failed on activate",
         { error: getErrorMessage(error) },

--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -116,6 +116,15 @@ function createViewManagerDeps(): ViewManagerDeps & {
   };
 }
 
+/**
+ * Creates a ViewManager with two-phase init (constructor + create).
+ */
+function createViewManager(deps: ViewManagerDeps): ViewManager {
+  const manager = new ViewManager(deps);
+  manager.create();
+  return manager;
+}
+
 describe("ViewManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -134,14 +143,14 @@ describe("ViewManager", () => {
   describe("create", () => {
     it("creates a ViewManager instance", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       expect(manager).toBeInstanceOf(ViewManager);
     });
 
     it("creates UI layer view with security settings", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const uiHandle = manager.getUIViewHandle();
       expect(uiHandle.id).toMatch(/^view-\d+$/);
@@ -150,7 +159,7 @@ describe("ViewManager", () => {
 
     it("sets transparent background on UI layer", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const uiHandle = manager.getUIViewHandle();
       expect(deps.viewLayer).toHaveView(uiHandle.id, { backgroundColor: "#00000000" });
@@ -158,7 +167,7 @@ describe("ViewManager", () => {
 
     it("attaches UI layer to window", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const uiHandle = manager.getUIViewHandle();
       expect(deps.viewLayer).toHaveView(uiHandle.id, {
@@ -168,7 +177,7 @@ describe("ViewManager", () => {
 
     it("subscribes to window resize events", () => {
       const deps = createViewManagerDeps();
-      ViewManager.create(deps);
+      createViewManager(deps);
 
       expect(deps.windowManager.onResize).toHaveBeenCalledWith(expect.any(Function));
     });
@@ -177,7 +186,7 @@ describe("ViewManager", () => {
   describe("getUIViewHandle", () => {
     it("returns the UI layer ViewHandle", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const handle = manager.getUIViewHandle();
 
@@ -189,7 +198,7 @@ describe("ViewManager", () => {
   describe("createWorkspaceView", () => {
     it("creates a workspace view (not attached)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -207,7 +216,7 @@ describe("ViewManager", () => {
 
     it("does not load URL on creation (lazy loading)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -221,7 +230,7 @@ describe("ViewManager", () => {
 
     it("stores view accessible via getWorkspaceView", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const createdHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -236,7 +245,7 @@ describe("ViewManager", () => {
 
     it("sets dark background color", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -249,7 +258,7 @@ describe("ViewManager", () => {
 
     it("returns a ViewHandle", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const handle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -263,7 +272,7 @@ describe("ViewManager", () => {
 
     it("registers dom-ready handler that disables EditContext", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -282,7 +291,7 @@ describe("ViewManager", () => {
 
     it("loads URL on first activation", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -300,7 +309,7 @@ describe("ViewManager", () => {
 
     it("does not reload URL on subsequent activations", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const ws1Handle = manager.createWorkspaceView(
         "/path/to/workspace1",
@@ -331,7 +340,7 @@ describe("ViewManager", () => {
   describe("preloadWorkspaceUrl", () => {
     it("loads URL without attaching view", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -350,7 +359,7 @@ describe("ViewManager", () => {
 
     it("is idempotent - multiple calls only load URL once", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -371,7 +380,7 @@ describe("ViewManager", () => {
 
     it("does nothing for nonexistent workspace", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Should not throw
       expect(() => manager.preloadWorkspaceUrl("/nonexistent/workspace")).not.toThrow();
@@ -381,7 +390,7 @@ describe("ViewManager", () => {
   describe("shared session model", () => {
     it("all workspaces share the same session (same SessionHandle.id)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace1",
@@ -408,7 +417,7 @@ describe("ViewManager", () => {
 
     it("session data persists after workspace deletion", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Create two workspaces
       manager.createWorkspaceView(
@@ -434,7 +443,7 @@ describe("ViewManager", () => {
 
     it("uses global partition constant for all workspaces", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Create workspaces in different projects
       manager.createWorkspaceView(
@@ -458,7 +467,7 @@ describe("ViewManager", () => {
   describe("destroyWorkspaceView", () => {
     it("removes view from internal map", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -473,7 +482,7 @@ describe("ViewManager", () => {
 
     it("clears active workspace path when destroying active workspace", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -490,7 +499,7 @@ describe("ViewManager", () => {
 
     it("is idempotent - multiple calls don't throw", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -505,14 +514,14 @@ describe("ViewManager", () => {
 
     it("handles workspace that never existed", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       await expect(manager.destroyWorkspaceView("/nonexistent/workspace")).resolves.not.toThrow();
     });
 
     it("returns a Promise", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -528,7 +537,7 @@ describe("ViewManager", () => {
 
     it("does not clear session storage (shared across workspaces)", async () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -553,7 +562,7 @@ describe("ViewManager", () => {
   describe("getWorkspaceView", () => {
     it("returns the view handle for existing workspace", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const createdHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -568,7 +577,7 @@ describe("ViewManager", () => {
 
     it("returns undefined for non-existent workspace", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const view = manager.getWorkspaceView("/path/to/nonexistent");
 
@@ -580,7 +589,7 @@ describe("ViewManager", () => {
     it("only updates active workspace bounds (O(1) not O(n))", () => {
       const deps = createViewManagerDeps();
       vi.mocked(deps.windowManager.getBounds).mockReturnValue({ width: 1400, height: 900 });
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const ws1Handle = manager.createWorkspaceView(
         "/path/to/workspace1",
@@ -613,7 +622,7 @@ describe("ViewManager", () => {
     it("sets UI layer bounds to full window", () => {
       const deps = createViewManagerDeps();
       vi.mocked(deps.windowManager.getBounds).mockReturnValue({ width: 1400, height: 900 });
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.updateBounds();
 
@@ -626,7 +635,7 @@ describe("ViewManager", () => {
     it("sets active workspace bounds with sidebar offset", () => {
       const deps = createViewManagerDeps();
       vi.mocked(deps.windowManager.getBounds).mockReturnValue({ width: 1400, height: 900 });
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -650,7 +659,7 @@ describe("ViewManager", () => {
       const deps = createViewManagerDeps();
       // Smaller than minimum 800x600
       vi.mocked(deps.windowManager.getBounds).mockReturnValue({ width: 600, height: 400 });
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -675,7 +684,7 @@ describe("ViewManager", () => {
   describe("setActiveWorkspace", () => {
     it("loads URL and attaches view on first activation (when not loading)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -696,7 +705,7 @@ describe("ViewManager", () => {
 
     it("detaches previous workspace when switching", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const ws1Handle = manager.createWorkspaceView(
         "/path/to/workspace1",
@@ -728,7 +737,7 @@ describe("ViewManager", () => {
 
     it("is idempotent - same workspace doesn't re-attach", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -749,7 +758,7 @@ describe("ViewManager", () => {
 
     it("keeps UI view at index 0 in workspace mode (DirectComposition workaround)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
       const windowId = deps.windowLayer._createdWindowHandle.id;
 
       manager.createWorkspaceView(
@@ -768,7 +777,7 @@ describe("ViewManager", () => {
 
     it("null workspace detaches current", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -786,7 +795,7 @@ describe("ViewManager", () => {
 
     it("focuses UI when setting active workspace to null", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -806,7 +815,7 @@ describe("ViewManager", () => {
 
     it("updates active workspace path", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -823,7 +832,7 @@ describe("ViewManager", () => {
   describe("focusActiveWorkspace", () => {
     it("focuses UI when no active workspace", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.focusActiveWorkspace();
 
@@ -836,7 +845,7 @@ describe("ViewManager", () => {
   describe("focusUI", () => {
     it("does not throw", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Should not throw (focus is a no-op in behavioral mock)
       expect(() => manager.focusUI()).not.toThrow();
@@ -846,7 +855,7 @@ describe("ViewManager", () => {
   describe("setMode", () => {
     it("changes mode from workspace to shortcut", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       expect(manager.getMode()).toBe("workspace");
 
@@ -857,7 +866,7 @@ describe("ViewManager", () => {
 
     it("is idempotent - same mode is no-op", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       manager.onModeChange(callback);
@@ -870,7 +879,7 @@ describe("ViewManager", () => {
 
     it("emits mode change event", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       manager.onModeChange(callback);
@@ -887,7 +896,7 @@ describe("ViewManager", () => {
   describe("getMode", () => {
     it("returns current mode", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       expect(manager.getMode()).toBe("workspace");
 
@@ -899,7 +908,7 @@ describe("ViewManager", () => {
   describe("onModeChange", () => {
     it("returns unsubscribe function", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       const unsubscribe = manager.onModeChange(callback);
@@ -914,7 +923,7 @@ describe("ViewManager", () => {
   describe("onWorkspaceChange", () => {
     it("is called when active workspace changes", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       manager.onWorkspaceChange(callback);
@@ -931,7 +940,7 @@ describe("ViewManager", () => {
 
     it("is called with null when workspace deactivated", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -950,7 +959,7 @@ describe("ViewManager", () => {
 
     it("returns unsubscribe function", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       const unsubscribe = manager.onWorkspaceChange(callback);
@@ -971,7 +980,7 @@ describe("ViewManager", () => {
   describe("isWorkspaceLoading", () => {
     it("returns true for newly created workspace with isNew=true", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -985,7 +994,7 @@ describe("ViewManager", () => {
 
     it("returns false for workspace with isNew=false (default)", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -998,7 +1007,7 @@ describe("ViewManager", () => {
 
     it("returns false after setWorkspaceLoaded called", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -1016,7 +1025,7 @@ describe("ViewManager", () => {
   describe("setWorkspaceLoaded", () => {
     it("attaches view if workspace is active", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -1040,7 +1049,7 @@ describe("ViewManager", () => {
 
     it("is idempotent", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -1061,7 +1070,7 @@ describe("ViewManager", () => {
   describe("onLoadingChange", () => {
     it("is called when workspace starts loading", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       manager.onLoadingChange(callback);
@@ -1078,7 +1087,7 @@ describe("ViewManager", () => {
 
     it("is called when workspace finishes loading", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",
@@ -1097,7 +1106,7 @@ describe("ViewManager", () => {
 
     it("returns unsubscribe function", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       const callback = vi.fn();
       const unsubscribe = manager.onLoadingChange(callback);
@@ -1118,7 +1127,7 @@ describe("ViewManager", () => {
       vi.useFakeTimers();
 
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Create workspace that finishes loading BEFORE callback is wired
       manager.createWorkspaceView(
@@ -1146,7 +1155,7 @@ describe("ViewManager", () => {
   describe("updateCodeServerPort", () => {
     it("updates the port", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       // Should not throw
       expect(() => manager.updateCodeServerPort(9090)).not.toThrow();
@@ -1156,7 +1165,7 @@ describe("ViewManager", () => {
   describe("destroy", () => {
     it("destroys all views", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace1",
@@ -1178,7 +1187,7 @@ describe("ViewManager", () => {
 
     it("disposes shortcut controller", () => {
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.destroy();
 
@@ -1191,7 +1200,7 @@ describe("ViewManager", () => {
       vi.useFakeTimers();
 
       const deps = createViewManagerDeps();
-      const manager = ViewManager.create(deps);
+      const manager = createViewManager(deps);
 
       manager.createWorkspaceView(
         "/path/to/workspace",

--- a/src/main/managers/window-manager.integration.test.ts
+++ b/src/main/managers/window-manager.integration.test.ts
@@ -34,6 +34,19 @@ function createWindowManagerDeps(
   };
 }
 
+/**
+ * Creates a WindowManager with two-phase init (constructor + create).
+ */
+function createWindowManager(
+  deps: WindowManagerDeps,
+  title?: string,
+  iconPath?: string
+): WindowManager {
+  const manager = new WindowManager(deps, title, iconPath);
+  manager.create();
+  return manager;
+}
+
 describe("WindowManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,7 +55,7 @@ describe("WindowManager", () => {
   describe("create", () => {
     it("creates a window with default title", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       expect(deps.windowLayer).toHaveWindowCount(1);
       expect(deps.windowLayer).toHaveWindowTitle(manager.getWindowHandle().id, "CodeHydra");
@@ -50,7 +63,7 @@ describe("WindowManager", () => {
 
     it("creates a window with custom title", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps, "CodeHydra (feature-branch)");
+      const manager = createWindowManager(deps, "CodeHydra (feature-branch)");
 
       expect(deps.windowLayer).toHaveWindowTitle(
         manager.getWindowHandle().id,
@@ -60,14 +73,14 @@ describe("WindowManager", () => {
 
     it("returns a WindowManager instance", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       expect(manager).toBeInstanceOf(WindowManager);
     });
 
     it("creates window with correct dimensions", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       expect(deps.windowLayer).toHaveWindowBounds(manager.getWindowHandle().id, {
         width: 1200,
@@ -86,7 +99,7 @@ describe("WindowManager", () => {
       };
       const depsWithMockImage = { ...deps, imageLayer: mockImageLayer };
 
-      WindowManager.create(depsWithMockImage, "CodeHydra", "/app/resources/icon.png");
+      createWindowManager(depsWithMockImage, "CodeHydra", "/app/resources/icon.png");
 
       expect(mockImageLayer.createFromPath).toHaveBeenCalledWith("/app/resources/icon.png");
       expect(mockImageLayer.release).toHaveBeenCalled();
@@ -104,7 +117,7 @@ describe("WindowManager", () => {
 
       // Should not throw
       expect(() =>
-        WindowManager.create(depsWithMockImage, "CodeHydra", "/app/resources/icon.png")
+        createWindowManager(depsWithMockImage, "CodeHydra", "/app/resources/icon.png")
       ).not.toThrow();
     });
 
@@ -120,7 +133,7 @@ describe("WindowManager", () => {
 
       // Should not throw
       expect(() =>
-        WindowManager.create(depsWithMockImage, "CodeHydra", "/app/resources/icon.png")
+        createWindowManager(depsWithMockImage, "CodeHydra", "/app/resources/icon.png")
       ).not.toThrow();
     });
 
@@ -132,7 +145,7 @@ describe("WindowManager", () => {
       };
       const depsWithMockImage = { ...deps, imageLayer: mockImageLayer };
 
-      WindowManager.create(depsWithMockImage, "CodeHydra");
+      createWindowManager(depsWithMockImage, "CodeHydra");
 
       expect(mockImageLayer.createFromPath).not.toHaveBeenCalled();
     });
@@ -142,7 +155,7 @@ describe("WindowManager", () => {
     it("maximizes the window and notifies resize callbacks after delay", async () => {
       vi.useFakeTimers();
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const callback = vi.fn();
       manager.onResize(callback);
       callback.mockClear();
@@ -166,7 +179,7 @@ describe("WindowManager", () => {
   describe("getWindow", () => {
     it("returns the underlying BaseWindow", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       // The behavioral mock doesn't have _getRawWindow, so this will throw
       // In production, this returns the real BaseWindow
@@ -177,7 +190,7 @@ describe("WindowManager", () => {
   describe("getWindowHandle", () => {
     it("returns the WindowHandle", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       const handle = manager.getWindowHandle();
 
@@ -189,7 +202,7 @@ describe("WindowManager", () => {
   describe("getBounds", () => {
     it("returns window content bounds", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       const bounds = manager.getBounds();
 
@@ -201,7 +214,7 @@ describe("WindowManager", () => {
   describe("onResize", () => {
     it("calls callback when resize is triggered", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const callback = vi.fn();
 
       manager.onResize(callback);
@@ -216,7 +229,7 @@ describe("WindowManager", () => {
 
     it("returns unsubscribe function that removes listener", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const callback = vi.fn();
 
       const unsubscribe = manager.onResize(callback);
@@ -237,7 +250,7 @@ describe("WindowManager", () => {
   describe("setTitle", () => {
     it("sets the window title", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       manager.setTitle("CodeHydra - my-app / feature - (main)");
 
@@ -253,7 +266,7 @@ describe("WindowManager", () => {
     it("calls windowLayer.setOverlayIcon on Windows", () => {
       const platformInfo = createMockPlatformInfo({ platform: "win32" });
       const deps = createWindowManagerDeps({ platformInfo });
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const imageHandle: ImageHandle = { id: "image-1", __brand: "ImageHandle" };
 
       // Should not throw - overlay icon is handled by WindowLayer
@@ -263,7 +276,7 @@ describe("WindowManager", () => {
     it("clears overlay when null passed on Windows", () => {
       const platformInfo = createMockPlatformInfo({ platform: "win32" });
       const deps = createWindowManagerDeps({ platformInfo });
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
 
       // Should not throw
       expect(() => manager.setOverlayIcon(null, "")).not.toThrow();
@@ -272,7 +285,7 @@ describe("WindowManager", () => {
     it("no-ops on macOS", () => {
       const platformInfo = createMockPlatformInfo({ platform: "darwin" });
       const deps = createWindowManagerDeps({ platformInfo });
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const imageHandle: ImageHandle = { id: "image-1", __brand: "ImageHandle" };
 
       // Should not throw and not call windowLayer (no-op)
@@ -282,7 +295,7 @@ describe("WindowManager", () => {
     it("no-ops on Linux", () => {
       const platformInfo = createMockPlatformInfo({ platform: "linux" });
       const deps = createWindowManagerDeps({ platformInfo });
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const imageHandle: ImageHandle = { id: "image-1", __brand: "ImageHandle" };
 
       // Should not throw and not call windowLayer (no-op)
@@ -293,7 +306,7 @@ describe("WindowManager", () => {
   describe("close", () => {
     it("closes the window", () => {
       const deps = createWindowManagerDeps();
-      const manager = WindowManager.create(deps);
+      const manager = createWindowManager(deps);
       const handle = manager.getWindowHandle();
 
       manager.close();


### PR DESCRIPTION
- Convert WindowManager and ViewManager from static factory pattern to two-phase init (constructor + create())
- Hoist all service and module construction from bootstrap() to module level
- Slim bootstrap() to only Electron lifecycle operations (logging init, menu, window create, UI load, app:start)
- Eliminate viewManagerHolder circular-dependency hack in ViewManager