### PR TITLE
refactor(api): migrate workspace operations to workspacePath payloads

### DIFF
--- a/src/main/api/registry-types.test.ts
+++ b/src/main/api/registry-types.test.ts
@@ -15,7 +15,7 @@ import type {
   ProjectIdPayload,
   WorkspaceCreatePayload,
   WorkspaceRemovePayload,
-  WorkspaceRefPayload,
+  WorkspacePathPayload,
   WorkspaceSetMetadataPayload,
   UiSwitchWorkspacePayload,
   UiSetModePayload,
@@ -32,7 +32,6 @@ import type {
 import { ALL_METHOD_PATHS } from "./registry-types";
 import type {
   ProjectId,
-  WorkspaceName,
   Project,
   Workspace,
   WorkspaceRef,
@@ -131,22 +130,20 @@ describe("registry-types.payload", () => {
   it("extracts WorkspaceRemovePayload for workspaces.remove", () => {
     expectTypeOf<MethodPayload<"workspaces.remove">>().toEqualTypeOf<WorkspaceRemovePayload>();
     // Verify shape
-    expectTypeOf<MethodPayload<"workspaces.remove">>().toHaveProperty("projectId");
-    expectTypeOf<MethodPayload<"workspaces.remove">>().toHaveProperty("workspaceName");
+    expectTypeOf<MethodPayload<"workspaces.remove">>().toHaveProperty("workspacePath");
     // keepBranch is optional
     type RemovePayload = MethodPayload<"workspaces.remove">;
     expectTypeOf<{
-      projectId: ProjectId;
-      workspaceName: WorkspaceName;
+      workspacePath: string;
     }>().toExtend<RemovePayload>();
   });
 
-  it("extracts WorkspaceRefPayload for workspace ref methods", () => {
-    expectTypeOf<MethodPayload<"workspaces.getStatus">>().toEqualTypeOf<WorkspaceRefPayload>();
+  it("extracts WorkspacePathPayload for workspace path methods", () => {
+    expectTypeOf<MethodPayload<"workspaces.getStatus">>().toEqualTypeOf<WorkspacePathPayload>();
     expectTypeOf<
       MethodPayload<"workspaces.getAgentSession">
-    >().toEqualTypeOf<WorkspaceRefPayload>();
-    expectTypeOf<MethodPayload<"workspaces.getMetadata">>().toEqualTypeOf<WorkspaceRefPayload>();
+    >().toEqualTypeOf<WorkspacePathPayload>();
+    expectTypeOf<MethodPayload<"workspaces.getMetadata">>().toEqualTypeOf<WorkspacePathPayload>();
   });
 
   it("extracts WorkspaceSetMetadataPayload for workspaces.setMetadata", () => {
@@ -164,8 +161,7 @@ describe("registry-types.payload", () => {
     // focus is optional
     type SwitchPayload = MethodPayload<"ui.switchWorkspace">;
     expectTypeOf<{
-      projectId: ProjectId;
-      workspaceName: WorkspaceName;
+      workspacePath: string;
     }>().toExtend<SwitchPayload>();
   });
 

--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -5,7 +5,6 @@
 
 import type {
   ProjectId,
-  WorkspaceName,
   Project,
   Workspace,
   WorkspaceRef,
@@ -48,54 +47,49 @@ export interface ProjectIdPayload {
 
 /** workspaces.create */
 export interface WorkspaceCreatePayload {
-  readonly projectId: ProjectId;
+  readonly projectId?: ProjectId;
   readonly name: string;
   readonly base: string;
   /** Optional initial prompt to send after workspace is created */
   readonly initialPrompt?: InitialPrompt;
   /** If true, don't switch to the new workspace (default: false = switch to it) */
   readonly keepInBackground?: boolean;
+  /** Workspace path of the calling workspace (Plugin API / MCP alternative to projectId) */
+  readonly callerWorkspacePath?: string;
 }
 
 /** workspaces.remove */
 export interface WorkspaceRemovePayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
   readonly keepBranch?: boolean;
   /** If true, don't switch away from this workspace when it's active. Used for retry. */
   readonly skipSwitch?: boolean;
   /** If true, force remove (skip cleanup, ignore errors). Replaces old forceRemove. */
   readonly force?: boolean;
-  /** Workspace path for retry/dismiss signaling. Provided by renderer on retry/dismiss only. */
-  readonly workspacePath?: string;
 }
 
-/** workspaces.getStatus, workspaces.getAgentSession, workspaces.getMetadata */
-export interface WorkspaceRefPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+/** workspaces.getStatus, workspaces.getAgentSession, workspaces.getMetadata, workspaces.restartAgentServer */
+export interface WorkspacePathPayload {
+  readonly workspacePath: string;
 }
 
 /** workspaces.setMetadata */
 export interface WorkspaceSetMetadataPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
   readonly key: string;
   readonly value: string | null;
 }
 
 /** workspaces.executeCommand */
 export interface WorkspaceExecuteCommandPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
   readonly command: string;
   readonly args?: readonly unknown[];
 }
 
 /** ui.switchWorkspace */
 export interface UiSwitchWorkspacePayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
   readonly focus?: boolean;
 }
 
@@ -130,12 +124,12 @@ export interface MethodRegistry {
   // Workspaces
   "workspaces.create": (payload: WorkspaceCreatePayload) => Promise<Workspace>;
   "workspaces.remove": (payload: WorkspaceRemovePayload) => Promise<{ started: boolean }>;
-  "workspaces.getStatus": (payload: WorkspaceRefPayload) => Promise<WorkspaceStatus>;
-  "workspaces.getAgentSession": (payload: WorkspaceRefPayload) => Promise<AgentSession | null>;
-  "workspaces.restartAgentServer": (payload: WorkspaceRefPayload) => Promise<number>;
+  "workspaces.getStatus": (payload: WorkspacePathPayload) => Promise<WorkspaceStatus>;
+  "workspaces.getAgentSession": (payload: WorkspacePathPayload) => Promise<AgentSession | null>;
+  "workspaces.restartAgentServer": (payload: WorkspacePathPayload) => Promise<number>;
   "workspaces.setMetadata": (payload: WorkspaceSetMetadataPayload) => Promise<void>;
   "workspaces.getMetadata": (
-    payload: WorkspaceRefPayload
+    payload: WorkspacePathPayload
   ) => Promise<Readonly<Record<string, string>>>;
   "workspaces.executeCommand": (payload: WorkspaceExecuteCommandPayload) => Promise<unknown>;
 

--- a/src/main/api/registry.test-utils.ts
+++ b/src/main/api/registry.test-utils.ts
@@ -203,27 +203,23 @@ function createMockCodeHydraApi(
     },
     workspaces: {
       create: (projectId, name, base, options) =>
-        get("workspaces.create")({ projectId, name, base, ...options }),
-      remove: (projectId, workspaceName, options) =>
-        get("workspaces.remove")({
-          projectId,
-          workspaceName,
+        get("workspaces.create")({
+          ...(projectId !== undefined && { projectId }),
+          name,
+          base,
           ...options,
         }),
-      getStatus: (projectId, workspaceName) =>
-        get("workspaces.getStatus")({ projectId, workspaceName }),
-      getAgentSession: (projectId, workspaceName) =>
-        get("workspaces.getAgentSession")({ projectId, workspaceName }),
-      restartAgentServer: (projectId, workspaceName) =>
-        get("workspaces.restartAgentServer")({ projectId, workspaceName }),
-      setMetadata: (projectId, workspaceName, key, value) =>
-        get("workspaces.setMetadata")({ projectId, workspaceName, key, value }),
-      getMetadata: (projectId, workspaceName) =>
-        get("workspaces.getMetadata")({ projectId, workspaceName }),
-      executeCommand: (projectId, workspaceName, command, args) =>
+      remove: (workspacePath, options) => get("workspaces.remove")({ workspacePath, ...options }),
+      getStatus: (workspacePath) => get("workspaces.getStatus")({ workspacePath }),
+      getAgentSession: (workspacePath) => get("workspaces.getAgentSession")({ workspacePath }),
+      restartAgentServer: (workspacePath) =>
+        get("workspaces.restartAgentServer")({ workspacePath }),
+      setMetadata: (workspacePath, key, value) =>
+        get("workspaces.setMetadata")({ workspacePath, key, value }),
+      getMetadata: (workspacePath) => get("workspaces.getMetadata")({ workspacePath }),
+      executeCommand: (workspacePath, command, args) =>
         get("workspaces.executeCommand")({
-          projectId,
-          workspaceName,
+          workspacePath,
           command,
           ...(args && { args }),
         }),
@@ -231,10 +227,9 @@ function createMockCodeHydraApi(
     ui: {
       selectFolder: () => get("ui.selectFolder")({}),
       getActiveWorkspace: () => get("ui.getActiveWorkspace")({}),
-      switchWorkspace: (projectId, workspaceName, focus) =>
+      switchWorkspace: (workspacePath, focus) =>
         get("ui.switchWorkspace")({
-          projectId,
-          workspaceName,
+          workspacePath,
           ...(focus !== undefined && { focus }),
         }),
       setMode: (mode) => get("ui.setMode")({ mode }),

--- a/src/main/api/registry.ts
+++ b/src/main/api/registry.ts
@@ -177,27 +177,23 @@ export class ApiRegistry implements IApiRegistry {
       },
       workspaces: {
         create: (projectId, name, base, options) =>
-          get("workspaces.create")({ projectId, name, base, ...options }),
-        remove: (projectId, workspaceName, options) =>
-          get("workspaces.remove")({
-            projectId,
-            workspaceName,
+          get("workspaces.create")({
+            ...(projectId !== undefined && { projectId }),
+            name,
+            base,
             ...options,
           }),
-        getStatus: (projectId, workspaceName) =>
-          get("workspaces.getStatus")({ projectId, workspaceName }),
-        getAgentSession: (projectId, workspaceName) =>
-          get("workspaces.getAgentSession")({ projectId, workspaceName }),
-        restartAgentServer: (projectId, workspaceName) =>
-          get("workspaces.restartAgentServer")({ projectId, workspaceName }),
-        setMetadata: (projectId, workspaceName, key, value) =>
-          get("workspaces.setMetadata")({ projectId, workspaceName, key, value }),
-        getMetadata: (projectId, workspaceName) =>
-          get("workspaces.getMetadata")({ projectId, workspaceName }),
-        executeCommand: (projectId, workspaceName, command, args) =>
+        remove: (workspacePath, options) => get("workspaces.remove")({ workspacePath, ...options }),
+        getStatus: (workspacePath) => get("workspaces.getStatus")({ workspacePath }),
+        getAgentSession: (workspacePath) => get("workspaces.getAgentSession")({ workspacePath }),
+        restartAgentServer: (workspacePath) =>
+          get("workspaces.restartAgentServer")({ workspacePath }),
+        setMetadata: (workspacePath, key, value) =>
+          get("workspaces.setMetadata")({ workspacePath, key, value }),
+        getMetadata: (workspacePath) => get("workspaces.getMetadata")({ workspacePath }),
+        executeCommand: (workspacePath, command, args) =>
           get("workspaces.executeCommand")({
-            projectId,
-            workspaceName,
+            workspacePath,
             command,
             ...(args !== undefined && { args }),
           }),
@@ -205,10 +201,9 @@ export class ApiRegistry implements IApiRegistry {
       ui: {
         selectFolder: () => get("ui.selectFolder")({}),
         getActiveWorkspace: () => get("ui.getActiveWorkspace")({}),
-        switchWorkspace: (projectId, workspaceName, focus) =>
+        switchWorkspace: (workspacePath, focus) =>
           get("ui.switchWorkspace")({
-            projectId,
-            workspaceName,
+            workspacePath,
             ...(focus !== undefined && { focus }),
           }),
         setMode: (mode) => get("ui.setMode")({ mode }),

--- a/src/main/api/wire-plugin-api.ts
+++ b/src/main/api/wire-plugin-api.ts
@@ -3,7 +3,10 @@
  *
  * This module bridges incoming API calls from VS Code extensions to the main
  * application API. The PluginServer provides workspace path from the socket
- * connection, which is resolved to projectId/workspaceName.
+ * connection, which is passed directly to workspacePath-based API methods.
+ *
+ * The `create` handler uses `callerWorkspacePath` so the intent system can
+ * resolve the project from the calling workspace — no external registry needed.
  */
 
 import type { PluginServer, ApiCallHandlers } from "../../services/plugin-server";
@@ -15,97 +18,35 @@ import type {
   PluginResult,
 } from "../../shared/plugin-protocol";
 import type { ICodeHydraApi } from "../../shared/api/interfaces";
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 import type { Logger } from "../../services/logging";
-import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../shared/error-utils";
-
-/**
- * Return type from wirePluginApi — allows callers to register/unregister
- * workspace identities used by Plugin API handlers.
- */
-export interface PluginApiRegistry {
-  registerWorkspace(
-    workspacePath: string,
-    projectId: ProjectId,
-    workspaceName: WorkspaceName
-  ): void;
-  unregisterWorkspace(workspacePath: string): void;
-}
 
 /**
  * Wire PluginServer API handlers to CodeHydraApi.
  *
- * This bridges incoming API calls from VS Code extensions to the main
- * application API. The PluginServer provides workspace path from the
- * socket connection, which is resolved to projectId/workspaceName.
+ * All operations pass workspacePath directly. The `create` handler uses
+ * `callerWorkspacePath` to let the intent system resolve the project.
  *
  * @param pluginServer - The PluginServer instance
  * @param api - The CodeHydra API implementation
  * @param logger - Logger for API call logging
- * @returns Registry for managing workspace identities
  */
 export function wirePluginApi(
   pluginServer: PluginServer,
   api: ICodeHydraApi,
   logger: Logger
-): PluginApiRegistry {
-  const workspaceIdentities = new Map<
-    string,
-    { projectId: ProjectId; workspaceName: WorkspaceName }
-  >();
-
-  function registerWorkspace(
-    workspacePath: string,
-    projectId: ProjectId,
-    workspaceName: WorkspaceName
-  ): void {
-    workspaceIdentities.set(new Path(workspacePath).toString(), { projectId, workspaceName });
-  }
-
-  function unregisterWorkspace(workspacePath: string): void {
-    workspaceIdentities.delete(new Path(workspacePath).toString());
-  }
-
+): void {
   /**
-   * Resolve a workspace path to projectId and workspaceName.
-   * Returns error result if workspace not found.
-   */
-  function resolveWorkspace(
-    workspacePath: string
-  ): { projectId: ProjectId; workspaceName: WorkspaceName } | PluginResult<never> {
-    try {
-      const key = new Path(workspacePath).toString();
-      const identity = workspaceIdentities.get(key);
-      if (identity) {
-        return identity;
-      }
-    } catch {
-      // Path constructor throws on invalid paths
-    }
-    return { success: false, error: "Workspace not found" };
-  }
-
-  /**
-   * Wrap an API call with workspace resolution and error handling.
+   * Wrap an API call with error handling.
    */
   async function handleApiCall<T>(
     workspacePath: string,
     operation: string,
-    fn: (projectId: ProjectId, workspaceName: WorkspaceName) => Promise<T>,
+    fn: () => Promise<T>,
     logContext?: Record<string, unknown>
   ): Promise<PluginResult<T>> {
-    const resolved = resolveWorkspace(workspacePath);
-    if ("success" in resolved && resolved.success === false) {
-      return resolved;
-    }
-    const { projectId, workspaceName } = resolved as {
-      projectId: ProjectId;
-      workspaceName: WorkspaceName;
-    };
-
     try {
-      const result = await fn(projectId, workspaceName);
+      const result = await fn();
       logger.debug(`${operation} success`, { workspace: workspacePath, ...logContext });
       return { success: true, data: result };
     } catch (error) {
@@ -121,27 +62,26 @@ export function wirePluginApi(
 
   const handlers: ApiCallHandlers = {
     async getStatus(workspacePath: string) {
-      return handleApiCall(workspacePath, "getStatus", async (projectId, workspaceName) => {
-        const status = await api.workspaces.getStatus(projectId, workspaceName);
-        return status;
-      });
+      return handleApiCall(workspacePath, "getStatus", () =>
+        api.workspaces.getStatus(workspacePath)
+      );
     },
 
     async getAgentSession(workspacePath: string) {
-      return handleApiCall(workspacePath, "getAgentSession", (projectId, workspaceName) =>
-        api.workspaces.getAgentSession(projectId, workspaceName)
+      return handleApiCall(workspacePath, "getAgentSession", () =>
+        api.workspaces.getAgentSession(workspacePath)
       );
     },
 
     async restartAgentServer(workspacePath: string) {
-      return handleApiCall(workspacePath, "restartAgentServer", (projectId, workspaceName) =>
-        api.workspaces.restartAgentServer(projectId, workspaceName)
+      return handleApiCall(workspacePath, "restartAgentServer", () =>
+        api.workspaces.restartAgentServer(workspacePath)
       );
     },
 
     async getMetadata(workspacePath: string) {
-      return handleApiCall(workspacePath, "getMetadata", async (projectId, workspaceName) => {
-        const metadata = await api.workspaces.getMetadata(projectId, workspaceName);
+      return handleApiCall(workspacePath, "getMetadata", async () => {
+        const metadata = await api.workspaces.getMetadata(workspacePath);
         return metadata as Record<string, string>;
       });
     },
@@ -150,8 +90,8 @@ export function wirePluginApi(
       return handleApiCall(
         workspacePath,
         "setMetadata",
-        async (projectId, workspaceName) => {
-          await api.workspaces.setMetadata(projectId, workspaceName, request.key, request.value);
+        async () => {
+          await api.workspaces.setMetadata(workspacePath, request.key, request.value);
           return undefined;
         },
         { key: request.key }
@@ -162,8 +102,8 @@ export function wirePluginApi(
       return handleApiCall(
         workspacePath,
         "delete",
-        (projectId, workspaceName) =>
-          api.workspaces.remove(projectId, workspaceName, {
+        () =>
+          api.workspaces.remove(workspacePath, {
             ...(request.keepBranch !== undefined && { keepBranch: request.keepBranch }),
           }),
         { keepBranch: !!request.keepBranch }
@@ -174,57 +114,34 @@ export function wirePluginApi(
       return handleApiCall(
         workspacePath,
         "executeCommand",
-        (projectId, workspaceName) =>
-          api.workspaces.executeCommand(projectId, workspaceName, request.command, request.args),
+        () => api.workspaces.executeCommand(workspacePath, request.command, request.args),
         { command: request.command }
       );
     },
 
     async create(workspacePath: string, request: WorkspaceCreateRequest) {
-      // For create, we only need the projectId from the caller's workspace
-      // The new workspace will be created in the same project
-      const resolved = resolveWorkspace(workspacePath);
-      if ("success" in resolved && resolved.success === false) {
-        return resolved;
-      }
-      const { projectId } = resolved as { projectId: ProjectId };
+      return handleApiCall(
+        workspacePath,
+        "create",
+        () => {
+          // Build options object conditionally to satisfy exactOptionalPropertyTypes
+          const options: Record<string, unknown> = {
+            callerWorkspacePath: workspacePath,
+          };
+          if (request.initialPrompt !== undefined) {
+            options.initialPrompt = request.initialPrompt;
+          }
+          if (request.keepInBackground !== undefined) {
+            options.keepInBackground = request.keepInBackground;
+          }
 
-      try {
-        // Build options object conditionally to satisfy exactOptionalPropertyTypes
-        const options =
-          request.initialPrompt !== undefined || request.keepInBackground !== undefined
-            ? {
-                ...(request.initialPrompt !== undefined && {
-                  initialPrompt: request.initialPrompt,
-                }),
-                ...(request.keepInBackground !== undefined && {
-                  keepInBackground: request.keepInBackground,
-                }),
-              }
-            : undefined;
-
-        const workspace = await api.workspaces.create(
-          projectId,
-          request.name,
-          request.base,
-          options
-        );
-        logger.debug("create success", { workspace: workspacePath, name: request.name });
-        return { success: true, data: workspace };
-      } catch (error) {
-        const message = getErrorMessage(error);
-        logger.error("create error", {
-          workspace: workspacePath,
-          name: request.name,
-          error: message,
-        });
-        return { success: false, error: message };
-      }
+          return api.workspaces.create(undefined, request.name, request.base, options);
+        },
+        { name: request.name }
+      );
     },
   };
 
   pluginServer.onApiCall(handlers);
   logger.info("Plugin API handlers registered");
-
-  return { registerWorkspace, unregisterWorkspace };
 }

--- a/src/main/bootstrap.integration.test.ts
+++ b/src/main/bootstrap.integration.test.ts
@@ -586,8 +586,8 @@ function createSetupTestDeps(overrides?: {
     {
       intentType: INTENT_DELETE_WORKSPACE,
       getKey: (p) => {
-        const { projectId, workspaceName } = p as DeleteWorkspacePayload;
-        return `${projectId}/${workspaceName}`;
+        const { workspacePath } = p as DeleteWorkspacePayload;
+        return workspacePath;
       },
       resetOn: EVENT_WORKSPACE_DELETED,
       isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -435,8 +435,8 @@ const idempotencyModule = createIdempotencyModule([
   {
     intentType: INTENT_DELETE_WORKSPACE,
     getKey: (p) => {
-      const { projectId, workspaceName } = p as DeleteWorkspacePayload;
-      return `${projectId}/${workspaceName}`;
+      const { workspacePath } = p as DeleteWorkspacePayload;
+      return workspacePath;
     },
     resetOn: EVENT_WORKSPACE_DELETED,
     isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,

--- a/src/main/modules/agent-module.integration.test.ts
+++ b/src/main/modules/agent-module.integration.test.ts
@@ -238,7 +238,7 @@ class MinimalShutdownOperation implements Operation<DeleteWorkspaceIntent, Shutd
     const { payload } = ctx.intent;
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: payload.projectPath ?? "",
+      projectPath: "/projects/test",
       workspacePath: payload.workspacePath ?? "",
     };
     const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", hookCtx);

--- a/src/main/modules/badge-module.integration.test.ts
+++ b/src/main/modules/badge-module.integration.test.ts
@@ -66,14 +66,13 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
   readonly id = "delete-workspace";
 
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
-    const { payload } = ctx.intent;
     const event: WorkspaceDeletedEvent = {
       type: EVENT_WORKSPACE_DELETED,
       payload: {
-        projectId: payload.projectId,
-        workspaceName: payload.workspaceName,
-        workspacePath: payload.workspacePath ?? "",
-        projectPath: payload.projectPath ?? "",
+        projectId: "test-12345678" as ProjectId,
+        workspaceName: "ws" as WorkspaceName,
+        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        projectPath: "/projects/test",
       },
     };
     ctx.emit(event);
@@ -274,10 +273,7 @@ describe("BadgeModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "ws1" as WorkspaceName,
           workspacePath: "/workspace/1",
-          projectPath: "/projects/test",
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -304,10 +300,7 @@ describe("BadgeModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "ws2" as WorkspaceName,
           workspacePath: "/workspace/2",
-          projectPath: "/projects/test",
           keepBranch: false,
           force: false,
           removeWorktree: true,

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -168,7 +168,7 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteH
     const { payload } = ctx.intent;
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: payload.projectPath ?? "",
+      projectPath: "/projects/test",
       workspacePath: payload.workspacePath ?? "",
     };
     const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);

--- a/src/main/modules/core/index.integration.test.ts
+++ b/src/main/modules/core/index.integration.test.ts
@@ -11,7 +11,7 @@
  * (e.g., workspace execute command, ui.selectFolder).
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { CoreModule, type CoreModuleDeps } from "./index";
 import { createMockRegistry } from "../../api/registry.test-utils";
 import type { MockApiRegistry } from "../../api/registry.test-utils";
@@ -21,7 +21,6 @@ import type { MockApiRegistry } from "../../api/registry.test-utils";
 
 function createMockDeps(overrides: Partial<CoreModuleDeps> = {}): CoreModuleDeps {
   const defaults: CoreModuleDeps = {
-    resolveWorkspace: vi.fn().mockReturnValue("/mock/workspace"),
     codeServerPort: 0,
     wrapperPath: "/mock/bin/claude",
   };

--- a/src/main/modules/core/index.test.ts
+++ b/src/main/modules/core/index.test.ts
@@ -7,7 +7,7 @@
  * - src/main/operations/close-project.integration.test.ts
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { CoreModule, type CoreModuleDeps } from "./index";
 import { createMockRegistry } from "../../api/registry.test-utils";
 import type { MockApiRegistry } from "../../api/registry.test-utils";
@@ -17,7 +17,6 @@ import type { MockApiRegistry } from "../../api/registry.test-utils";
 
 function createMockDeps(overrides: Partial<CoreModuleDeps> = {}): CoreModuleDeps {
   const defaults: CoreModuleDeps = {
-    resolveWorkspace: vi.fn().mockReturnValue("/mock/workspace"),
     codeServerPort: 0,
     wrapperPath: "/mock/bin/claude",
   };

--- a/src/main/modules/core/index.ts
+++ b/src/main/modules/core/index.ts
@@ -20,7 +20,6 @@ import type {
 } from "../../api/registry-types";
 import type { PluginResult } from "../../../shared/plugin-protocol";
 import { ApiIpcChannels } from "../../../shared/ipc";
-import type { ProjectId, WorkspaceName } from "../../../shared/api/types";
 
 // =============================================================================
 // Types
@@ -52,8 +51,6 @@ export interface MinimalDialog {
  * Dependencies for CoreModule.
  */
 export interface CoreModuleDeps {
-  /** Resolves (projectId, workspaceName) → workspacePath. Throws if not found. */
-  readonly resolveWorkspace: (projectId: ProjectId, workspaceName: WorkspaceName) => string;
   /** Code-server port for URL generation (updated by CodeServerLifecycleModule) */
   readonly codeServerPort: number;
   /** Wrapper path for Claude Code wrapper script */
@@ -111,14 +108,12 @@ export class CoreModule implements IApiModule {
   // ===========================================================================
 
   private async workspaceExecuteCommand(payload: WorkspaceExecuteCommandPayload): Promise<unknown> {
-    const workspacePath = this.deps.resolveWorkspace(payload.projectId, payload.workspaceName);
-
     if (!this.deps.pluginServer) {
       throw new Error("Plugin server not available");
     }
 
     const result = await this.deps.pluginServer.sendCommand(
-      workspacePath,
+      payload.workspacePath,
       payload.command,
       payload.args
     );

--- a/src/main/modules/mcp-module.ts
+++ b/src/main/modules/mcp-module.ts
@@ -1,28 +1,19 @@
 /**
- * McpModule - MCP server lifecycle, workspace registration, and event wiring.
- *
- * Subscribes to:
- * - workspace:created: registers workspace with MCP server manager
- * - workspace:deleted: unregisters workspace from MCP server manager (safety net)
+ * McpModule - MCP server lifecycle management.
  *
  * Hook handlers:
  * - app:start / start: start MCP server, return mcpPort
- * - workspace:delete / shutdown: unregister workspace before agent server stops
  * - app:shutdown / stop: dispose MCP server
+ *
+ * Workspace registration is no longer needed — the MCP server passes
+ * workspacePath directly to API methods, and the intent system resolves
+ * workspace identity via hook modules.
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
-import type { DomainEvent } from "../intents/infrastructure/types";
-import type { HookContext } from "../intents/infrastructure/operation";
 import type { StartHookResult } from "../operations/app-start";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
-import type { ShutdownHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
-import { EVENT_WORKSPACE_CREATED } from "../operations/open-workspace";
-import type { WorkspaceCreatedEvent } from "../operations/open-workspace";
-import { EVENT_WORKSPACE_DELETED } from "../operations/delete-workspace";
-import type { WorkspaceDeletedEvent } from "../operations/delete-workspace";
 import type { McpServerManager } from "../../services/mcp-server/mcp-server-manager";
 import type { Logger } from "../../services/logging";
 
@@ -41,20 +32,6 @@ export interface McpModuleDeps {
 
 export function createMcpModule(deps: McpModuleDeps): IntentModule {
   return {
-    events: {
-      [EVENT_WORKSPACE_CREATED]: (event: DomainEvent) => {
-        const payload = (event as WorkspaceCreatedEvent).payload;
-        deps.mcpServerManager.registerWorkspace({
-          projectId: payload.projectId,
-          workspaceName: payload.workspaceName,
-          workspacePath: payload.workspacePath,
-        });
-      },
-      [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
-        const payload = (event as WorkspaceDeletedEvent).payload;
-        deps.mcpServerManager.unregisterWorkspace(payload.workspacePath);
-      },
-    },
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -65,15 +42,6 @@ export function createMcpModule(deps: McpModuleDeps): IntentModule {
             });
 
             return { mcpPort };
-          },
-        },
-      },
-      [DELETE_WORKSPACE_OPERATION_ID]: {
-        shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
-            const { workspacePath } = ctx as DeletePipelineHookInput;
-            deps.mcpServerManager.unregisterWorkspace(workspacePath);
-            return {};
           },
         },
       },

--- a/src/main/modules/windows-file-lock-module.integration.test.ts
+++ b/src/main/modules/windows-file-lock-module.integration.test.ts
@@ -70,7 +70,7 @@ class ReleaseOperation implements Operation<Intent, ReleaseHookResult> {
     const { payload } = ctx.intent as DeleteWorkspaceIntent;
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: payload.projectPath ?? "",
+      projectPath: "/projects/my-app",
       workspacePath: payload.workspacePath ?? "",
     };
     const { results, errors } = await ctx.hooks.collect<ReleaseHookResult>("release", hookCtx);
@@ -89,7 +89,7 @@ class DetectOperation implements Operation<Intent, DetectHookResult> {
     const { payload } = ctx.intent as DeleteWorkspaceIntent;
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: payload.projectPath ?? "",
+      projectPath: "/projects/my-app",
       workspacePath: payload.workspacePath ?? "",
     };
     const { results, errors } = await ctx.hooks.collect<DetectHookResult>("detect", hookCtx);

--- a/src/main/operations/close-project.ts
+++ b/src/main/operations/close-project.ts
@@ -14,10 +14,8 @@
 import type { Intent, DomainEvent } from "../intents/infrastructure/types";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { ProjectId } from "../../shared/api/types";
-import type { WorkspaceName } from "../../shared/api/types";
 import { INTENT_DELETE_WORKSPACE, type DeleteWorkspaceIntent } from "./delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
-import { extractWorkspaceName } from "../../shared/api/id-utils";
 
 // =============================================================================
 // Intent Types
@@ -124,10 +122,7 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
         const deleteIntent: DeleteWorkspaceIntent = {
           type: INTENT_DELETE_WORKSPACE,
           payload: {
-            projectId: payload.projectId,
-            workspaceName: extractWorkspaceName(workspace.path) as WorkspaceName,
             workspacePath: workspace.path,
-            projectPath,
             keepBranch: true,
             force: true,
             removeWorktree: false,

--- a/src/main/operations/open-project.ts
+++ b/src/main/operations/open-project.ts
@@ -26,7 +26,6 @@ import {
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { toIpcWorkspaces } from "../api/workspace-conversion";
 import { Path } from "../../services/platform/path";
-import { extractWorkspaceName } from "../../shared/api/id-utils";
 
 // =============================================================================
 // Intent Types
@@ -227,8 +226,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
         const switchIntent: SwitchWorkspaceIntent = {
           type: INTENT_SWITCH_WORKSPACE,
           payload: {
-            projectId,
-            workspaceName: extractWorkspaceName(firstWorkspace.path),
+            workspacePath: firstWorkspace.path,
           },
         };
         try {

--- a/src/main/operations/set-metadata.ts
+++ b/src/main/operations/set-metadata.ts
@@ -2,8 +2,8 @@
  * SetMetadataOperation - Orchestrates workspace metadata writes.
  *
  * Runs three hook points in sequence:
- * 1. "resolve-project" - Resolves projectId to projectPath
- * 2. "resolve-workspace" - Resolves workspaceName to workspacePath
+ * 1. "resolve" - Validates workspacePath is tracked, returns projectPath + workspaceName
+ * 2. "resolve-project" - Resolves projectPath to projectId (for domain events)
  * 3. "set" - Each handler performs the actual provider write
  *
  * No provider dependencies - hook handlers do the actual work.
@@ -18,8 +18,7 @@ import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 // =============================================================================
 
 export interface SetMetadataPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
   readonly key: string;
   readonly value: string | null;
 }
@@ -50,32 +49,29 @@ export const EVENT_METADATA_CHANGED = "workspace:metadata-changed" as const;
 
 export const SET_METADATA_OPERATION_ID = "set-metadata";
 
-/**
- * Per-handler result contract for the "resolve-project" hook point.
- * Each handler returns projectPath if it owns the project, or `{}` to skip.
- */
-export interface ResolveProjectHookResult {
+/** Input context for "resolve" handlers. */
+export interface ResolveHookInput extends HookContext {
+  readonly workspacePath: string;
+}
+
+/** Per-handler result for "resolve" hook point. */
+export interface ResolveHookResult {
   readonly projectPath?: string;
+  readonly workspaceName?: WorkspaceName;
 }
 
-/**
- * Per-handler result contract for the "resolve-workspace" hook point.
- * Each handler returns workspacePath if it can resolve, or `{}` to skip.
- */
-export interface ResolveWorkspaceHookResult {
-  readonly workspacePath?: string;
-}
-
-/**
- * Input context for "resolve-workspace" handlers — built from resolve-project results.
- */
-export interface ResolveWorkspaceHookInput extends HookContext {
+/** Input context for "resolve-project" handlers. */
+export interface ResolveProjectHookInput extends HookContext {
   readonly projectPath: string;
-  readonly workspaceName: string;
+}
+
+/** Per-handler result for "resolve-project" hook point. */
+export interface ResolveProjectHookResult {
+  readonly projectId?: ProjectId;
 }
 
 /**
- * Input context for "set" handlers — built from resolve-workspace results.
+ * Input context for "set" handlers — built from resolve results.
  */
 export interface SetHookInput extends HookContext {
   readonly workspacePath: string;
@@ -91,47 +87,50 @@ export class SetMetadataOperation implements Operation<SetMetadataIntent, void> 
   async execute(ctx: OperationContext<SetMetadataIntent>): Promise<void> {
     const { payload } = ctx.intent;
 
-    // 1. resolve-project — resolve projectId to projectPath
+    // 1. resolve — validate workspacePath is tracked, get projectPath + workspaceName
+    const resolveCtx: ResolveHookInput = {
+      intent: ctx.intent,
+      workspacePath: payload.workspacePath,
+    };
+    const { results: resolveResults, errors: resolveErrors } =
+      await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+    if (resolveErrors.length > 0) {
+      throw new AggregateError(resolveErrors, "set-metadata resolve failed");
+    }
+
+    let projectPath: string | undefined;
+    let workspaceName: WorkspaceName | undefined;
+    for (const result of resolveResults) {
+      if (result.projectPath !== undefined) projectPath = result.projectPath;
+      if (result.workspaceName !== undefined) workspaceName = result.workspaceName;
+    }
+    if (!projectPath || !workspaceName) {
+      throw new Error(`Workspace not found: ${payload.workspacePath}`);
+    }
+
+    // 2. resolve-project — get projectId from projectPath (for domain events)
+    const resolveProjectCtx: ResolveProjectHookInput = {
+      intent: ctx.intent,
+      projectPath,
+    };
     const { results: resolveProjectResults, errors: resolveProjectErrors } =
-      await ctx.hooks.collect<ResolveProjectHookResult>("resolve-project", {
-        intent: ctx.intent,
-      });
+      await ctx.hooks.collect<ResolveProjectHookResult>("resolve-project", resolveProjectCtx);
     if (resolveProjectErrors.length > 0) {
       throw new AggregateError(resolveProjectErrors, "set-metadata resolve-project failed");
     }
 
-    let projectPath: string | undefined;
+    let projectId: ProjectId | undefined;
     for (const result of resolveProjectResults) {
-      if (result.projectPath !== undefined) projectPath = result.projectPath;
+      if (result.projectId !== undefined) projectId = result.projectId;
     }
-    if (!projectPath) {
-      throw new Error(`Project not found: ${payload.projectId}`);
-    }
-
-    // 2. resolve-workspace — resolve workspaceName to workspacePath
-    const resolveWorkspaceCtx: ResolveWorkspaceHookInput = {
-      intent: ctx.intent,
-      projectPath,
-      workspaceName: payload.workspaceName,
-    };
-    const { results: resolveWorkspaceResults, errors: resolveWorkspaceErrors } =
-      await ctx.hooks.collect<ResolveWorkspaceHookResult>("resolve-workspace", resolveWorkspaceCtx);
-    if (resolveWorkspaceErrors.length > 0) {
-      throw new AggregateError(resolveWorkspaceErrors, "set-metadata resolve-workspace failed");
-    }
-
-    let workspacePath: string | undefined;
-    for (const result of resolveWorkspaceResults) {
-      if (result.workspacePath !== undefined) workspacePath = result.workspacePath;
-    }
-    if (!workspacePath) {
-      throw new Error(`Workspace not found: ${payload.workspaceName}`);
+    if (!projectId) {
+      throw new Error(`Project not found for path: ${projectPath}`);
     }
 
     // 3. set — handler performs the actual provider write
     const setCtx: SetHookInput = {
       intent: ctx.intent,
-      workspacePath,
+      workspacePath: payload.workspacePath,
     };
     const { errors } = await ctx.hooks.collect<void>("set", setCtx);
     if (errors.length > 0) {
@@ -142,8 +141,8 @@ export class SetMetadataOperation implements Operation<SetMetadataIntent, void> 
     const event: MetadataChangedEvent = {
       type: EVENT_METADATA_CHANGED,
       payload: {
-        projectId: payload.projectId,
-        workspaceName: payload.workspaceName,
+        projectId,
+        workspaceName,
         key: payload.key,
         value: payload.value,
       },

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -152,21 +152,16 @@ describe("preload API", () => {
     });
 
     it("workspaces.remove calls api:workspace:remove", async () => {
-      const mockResult = { branchDeleted: false };
+      const mockResult = { started: true };
       mockIpcRenderer.invoke.mockResolvedValue(mockResult);
 
       const workspaces = exposedApi.workspaces as {
-        remove: (
-          projectId: string,
-          workspaceName: string,
-          options?: { keepBranch?: boolean }
-        ) => Promise<unknown>;
+        remove: (workspacePath: string, options?: { keepBranch?: boolean }) => Promise<unknown>;
       };
-      const result = await workspaces.remove("my-app-12345678", "feature", { keepBranch: true });
+      const result = await workspaces.remove("/test/.worktrees/feature", { keepBranch: true });
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:remove", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
         keepBranch: true,
       });
       expect(result).toEqual(mockResult);
@@ -180,13 +175,12 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(mockStatus);
 
       const workspaces = exposedApi.workspaces as {
-        getStatus: (projectId: string, workspaceName: string) => Promise<unknown>;
+        getStatus: (workspacePath: string) => Promise<unknown>;
       };
-      const result = await workspaces.getStatus("my-app-12345678", "feature");
+      const result = await workspaces.getStatus("/test/.worktrees/feature");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:get-status", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
       });
       expect(result).toEqual(mockStatus);
     });
@@ -196,32 +190,28 @@ describe("preload API", () => {
 
       const workspaces = exposedApi.workspaces as {
         getAgentSession: (
-          projectId: string,
-          workspaceName: string
+          workspacePath: string
         ) => Promise<{ port: number; sessionId: string } | null>;
       };
-      await workspaces.getAgentSession("my-app-12345678", "feature");
+      await workspaces.getAgentSession("/test/.worktrees/feature");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:get-agent-session", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
       });
     });
 
-    it("workspaces.getAgentSession should pass projectId and workspaceName parameters", async () => {
+    it("workspaces.getAgentSession should pass workspacePath parameter", async () => {
       mockIpcRenderer.invoke.mockResolvedValue({ port: 54321, sessionId: "ses-456" });
 
       const workspaces = exposedApi.workspaces as {
         getAgentSession: (
-          projectId: string,
-          workspaceName: string
+          workspacePath: string
         ) => Promise<{ port: number; sessionId: string } | null>;
       };
-      await workspaces.getAgentSession("other-project-aaaabbbb", "main-workspace");
+      await workspaces.getAgentSession("/other/.worktrees/main-workspace");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:get-agent-session", {
-        projectId: "other-project-aaaabbbb",
-        workspaceName: "main-workspace",
+        workspacePath: "/other/.worktrees/main-workspace",
       });
     });
 
@@ -230,11 +220,10 @@ describe("preload API", () => {
 
       const workspaces = exposedApi.workspaces as {
         getAgentSession: (
-          projectId: string,
-          workspaceName: string
+          workspacePath: string
         ) => Promise<{ port: number; sessionId: string } | null>;
       };
-      const result = await workspaces.getAgentSession("my-app-12345678", "feature");
+      const result = await workspaces.getAgentSession("/test/.worktrees/feature");
 
       expect(result).toBeNull();
     });
@@ -243,18 +232,12 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(undefined);
 
       const workspaces = exposedApi.workspaces as {
-        setMetadata: (
-          projectId: string,
-          workspaceName: string,
-          key: string,
-          value: string | null
-        ) => Promise<void>;
+        setMetadata: (workspacePath: string, key: string, value: string | null) => Promise<void>;
       };
-      await workspaces.setMetadata("my-app-12345678", "feature", "note", "test value");
+      await workspaces.setMetadata("/test/.worktrees/feature", "note", "test value");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:set-metadata", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
         key: "note",
         value: "test value",
       });
@@ -265,13 +248,12 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(mockMetadata);
 
       const workspaces = exposedApi.workspaces as {
-        getMetadata: (projectId: string, workspaceName: string) => Promise<Record<string, string>>;
+        getMetadata: (workspacePath: string) => Promise<Record<string, string>>;
       };
-      const result = await workspaces.getMetadata("my-app-12345678", "feature");
+      const result = await workspaces.getMetadata("/test/.worktrees/feature");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:get-metadata", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
       });
       expect(result).toEqual(mockMetadata);
     });
@@ -307,17 +289,12 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(undefined);
 
       const ui = exposedApi.ui as {
-        switchWorkspace: (
-          projectId: string,
-          workspaceName: string,
-          focus?: boolean
-        ) => Promise<void>;
+        switchWorkspace: (workspacePath: string, focus?: boolean) => Promise<void>;
       };
-      await ui.switchWorkspace("my-app-12345678", "feature", false);
+      await ui.switchWorkspace("/test/.worktrees/feature", false);
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:ui:switch-workspace", {
-        projectId: "my-app-12345678",
-        workspaceName: "feature",
+        workspacePath: "/test/.worktrees/feature",
         focus: false,
       });
     });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -47,42 +47,35 @@ contextBridge.exposeInMainWorld("api", {
     create: (projectId: string, name: string, base: string) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, { projectId, name, base }),
     remove: (
-      projectId: string,
-      workspaceName: string,
+      workspacePath: string,
       options?: {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
-        workspacePath?: string;
       }
     ): Promise<{ started: boolean }> =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_REMOVE, {
-        projectId,
-        workspaceName,
+        workspacePath,
         ...options,
       }),
-    getStatus: (projectId: string, workspaceName: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_STATUS, { projectId, workspaceName }),
-    getAgentSession: (projectId: string, workspaceName: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_AGENT_SESSION, {
-        projectId,
-        workspaceName,
-      }),
-    setMetadata: (projectId: string, workspaceName: string, key: string, value: string | null) =>
+    getStatus: (workspacePath: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_STATUS, { workspacePath }),
+    getAgentSession: (workspacePath: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_AGENT_SESSION, { workspacePath }),
+    setMetadata: (workspacePath: string, key: string, value: string | null) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_SET_METADATA, {
-        projectId,
-        workspaceName,
+        workspacePath,
         key,
         value,
       }),
-    getMetadata: (projectId: string, workspaceName: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_METADATA, { projectId, workspaceName }),
+    getMetadata: (workspacePath: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_METADATA, { workspacePath }),
   },
   ui: {
     selectFolder: () => ipcRenderer.invoke(ApiIpcChannels.UI_SELECT_FOLDER),
     getActiveWorkspace: () => ipcRenderer.invoke(ApiIpcChannels.UI_GET_ACTIVE_WORKSPACE),
-    switchWorkspace: (projectId: string, workspaceName: string, focus?: boolean) =>
-      ipcRenderer.invoke(ApiIpcChannels.UI_SWITCH_WORKSPACE, { projectId, workspaceName, focus }),
+    switchWorkspace: (workspacePath: string, focus?: boolean) =>
+      ipcRenderer.invoke(ApiIpcChannels.UI_SWITCH_WORKSPACE, { workspacePath, focus }),
     setMode: (mode: string) => ipcRenderer.invoke(ApiIpcChannels.UI_SET_MODE, { mode }),
   },
   lifecycle: {

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -626,9 +626,6 @@ describe("App component", () => {
         expect(getEventCallback("shortcut:key")).toBeDefined();
       });
 
-      // Get actual project ID
-      const actualProjectId = projectsStore.projects.value[0]!.id;
-
       // Set active workspace to second one
       projectsStore.setActiveWorkspace("/test/.worktrees/ws2");
 
@@ -639,8 +636,8 @@ describe("App component", () => {
       fireEvent("shortcut:key", "up");
 
       await waitFor(() => {
-        // Should navigate to first workspace (ws1)
-        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(actualProjectId, "ws1", false);
+        // Should navigate to first workspace (ws1) using workspacePath
+        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/test/.worktrees/ws1", false);
       });
     });
 
@@ -666,9 +663,6 @@ describe("App component", () => {
         expect(getEventCallback("shortcut:key")).toBeDefined();
       });
 
-      // Get actual project ID
-      const actualProjectId = projectsStore.projects.value[0]!.id;
-
       // Set active workspace to first one
       projectsStore.setActiveWorkspace("/test/.worktrees/ws1");
 
@@ -679,8 +673,8 @@ describe("App component", () => {
       fireEvent("shortcut:key", "down");
 
       await waitFor(() => {
-        // Should navigate to second workspace (ws2)
-        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(actualProjectId, "ws2", false);
+        // Should navigate to second workspace (ws2) using workspacePath
+        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/test/.worktrees/ws2", false);
       });
     });
 
@@ -707,8 +701,6 @@ describe("App component", () => {
         expect(getEventCallback("shortcut:key")).toBeDefined();
       });
 
-      const actualProjectId = projectsStore.projects.value[0]!.id;
-
       // Enable shortcut mode
       fireEvent("ui:mode-changed", { mode: "shortcut", previousMode: "workspace" });
 
@@ -716,7 +708,7 @@ describe("App component", () => {
       fireEvent("shortcut:key", "2");
 
       await waitFor(() => {
-        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(actualProjectId, "ws2", false);
+        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/test/.worktrees/ws2", false);
       });
     });
 
@@ -747,8 +739,6 @@ describe("App component", () => {
         expect(getEventCallback("shortcut:key")).toBeDefined();
       });
 
-      const actualProjectId = projectsStore.projects.value[0]!.id;
-
       // Enable shortcut mode
       fireEvent("ui:mode-changed", { mode: "shortcut", previousMode: "workspace" });
 
@@ -756,7 +746,7 @@ describe("App component", () => {
       fireEvent("shortcut:key", "0");
 
       await waitFor(() => {
-        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(actualProjectId, "ws10", false);
+        expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/test/.worktrees/ws10", false);
       });
     });
 
@@ -949,9 +939,9 @@ describe("App component", () => {
       showMainView();
 
       await waitFor(() => {
-        // Should call getStatus for each workspace
-        expect(mockApi.workspaces.getStatus).toHaveBeenCalledWith("test-project-12345678", "ws1");
-        expect(mockApi.workspaces.getStatus).toHaveBeenCalledWith("test-project-12345678", "ws2");
+        // Should call getStatus for each workspace (using workspacePath)
+        expect(mockApi.workspaces.getStatus).toHaveBeenCalledWith("/test/.worktrees/ws1");
+        expect(mockApi.workspaces.getStatus).toHaveBeenCalledWith("/test/.worktrees/ws2");
       });
     });
 
@@ -970,22 +960,20 @@ describe("App component", () => {
       ];
       mockApi.projects.list.mockResolvedValue(mockProjects);
 
-      // Mock different statuses for each workspace
-      mockApi.workspaces.getStatus.mockImplementation(
-        (_projectId: string, workspaceName: string) => {
-          if (workspaceName === "ws1") {
-            return Promise.resolve({
-              isDirty: false,
-              agent: { type: "idle", counts: { idle: 2, busy: 0, total: 2 } },
-            });
-          } else {
-            return Promise.resolve({
-              isDirty: true,
-              agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
-            });
-          }
+      // Mock different statuses for each workspace (uses workspacePath)
+      mockApi.workspaces.getStatus.mockImplementation((workspacePath: string) => {
+        if (workspacePath === "/test/.worktrees/ws1") {
+          return Promise.resolve({
+            isDirty: false,
+            agent: { type: "idle", counts: { idle: 2, busy: 0, total: 2 } },
+          });
+        } else {
+          return Promise.resolve({
+            isDirty: true,
+            agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
+          });
         }
-      );
+      });
 
       render(App);
       showMainView();

--- a/src/renderer/lib/components/CloseProjectDialog.svelte
+++ b/src/renderer/lib/components/CloseProjectDialog.svelte
@@ -53,7 +53,7 @@
       if (removeAll && project && project.workspaces.length > 0) {
         const removalPromises = project.workspaces.map((workspace) =>
           workspaces
-            .remove(projectId, workspace.name, { keepBranch: false })
+            .remove(workspace.path, { keepBranch: false })
             .then(() => ({ name: workspace.name, success: true as const }))
             .catch((error: Error) => ({
               name: workspace.name,

--- a/src/renderer/lib/components/CloseProjectDialog.test.ts
+++ b/src/renderer/lib/components/CloseProjectDialog.test.ts
@@ -340,15 +340,15 @@ describe("CloseProjectDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      // Should call remove for each workspace with keepBranch=false
+      // Should call remove for each workspace with keepBranch=false (using workspace path)
       expect(mockRemoveWorkspace).toHaveBeenCalledTimes(3);
-      expect(mockRemoveWorkspace).toHaveBeenCalledWith(testProjectId, "ws1" as WorkspaceName, {
+      expect(mockRemoveWorkspace).toHaveBeenCalledWith("/test/project/.worktrees/ws1", {
         keepBranch: false,
       });
-      expect(mockRemoveWorkspace).toHaveBeenCalledWith(testProjectId, "ws2" as WorkspaceName, {
+      expect(mockRemoveWorkspace).toHaveBeenCalledWith("/test/project/.worktrees/ws2", {
         keepBranch: false,
       });
-      expect(mockRemoveWorkspace).toHaveBeenCalledWith(testProjectId, "ws3" as WorkspaceName, {
+      expect(mockRemoveWorkspace).toHaveBeenCalledWith("/test/project/.worktrees/ws3", {
         keepBranch: false,
       });
     });

--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -147,7 +147,7 @@
       logger.debug("Dialog submitted", { type: "create-workspace" });
       const workspace = await workspaces.create(selectedProjectId, name, selectedBranch);
       // Switch to the newly created workspace to load its view
-      await ui.switchWorkspace(selectedProjectId, workspace.name);
+      await ui.switchWorkspace(workspace.path);
       closeDialog();
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -703,8 +703,8 @@ describe("CreateWorkspaceDialog component", () => {
 
       await completeAllLoading();
 
-      // Should switch to the newly created workspace
-      expect(mockSwitchWorkspace).toHaveBeenCalledWith(testProjectId, "my-feature");
+      // Should switch to the newly created workspace (uses workspace.path)
+      expect(mockSwitchWorkspace).toHaveBeenCalledWith("/test/project/.worktrees/my-feature");
       expect(mockCloseDialog).toHaveBeenCalled();
     });
   });

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -282,18 +282,14 @@ describe("MainView close project integration", () => {
 
       await vi.runAllTimersAsync();
 
-      // Should call remove for each workspace with keepBranch=false
+      // Should call remove for each workspace with keepBranch=false (using workspace path)
       expect(mockApi.workspaces.remove).toHaveBeenCalledTimes(2);
-      expect(mockApi.workspaces.remove).toHaveBeenCalledWith(
-        projectWithWorkspaces.id,
-        "feature-1",
-        { keepBranch: false }
-      );
-      expect(mockApi.workspaces.remove).toHaveBeenCalledWith(
-        projectWithWorkspaces.id,
-        "feature-2",
-        { keepBranch: false }
-      );
+      expect(mockApi.workspaces.remove).toHaveBeenCalledWith("/test/.worktrees/feature-1", {
+        keepBranch: false,
+      });
+      expect(mockApi.workspaces.remove).toHaveBeenCalledWith("/test/.worktrees/feature-2", {
+        keepBranch: false,
+      });
 
       // Then close the project
       expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -228,7 +228,7 @@
   // Handle switching workspace
   async function handleSwitchWorkspace(workspaceRef: WorkspaceRef): Promise<void> {
     logger.debug("Workspace selected", { workspaceName: workspaceRef.workspaceName });
-    await api.ui.switchWorkspace(workspaceRef.projectId, workspaceRef.workspaceName);
+    await api.ui.switchWorkspace(workspaceRef.path);
   }
 
   // Handle opening create dialog
@@ -250,10 +250,9 @@
       workspaceName: activeDeletionState.workspaceName,
     });
     // Fire-and-forget - signals the waiting pipeline via workspaces.remove handler
-    void api.workspaces.remove(activeDeletionState.projectId, activeDeletionState.workspaceName, {
+    void api.workspaces.remove(activeDeletionState.workspacePath, {
       keepBranch: activeDeletionState.keepBranch,
       skipSwitch: true,
-      workspacePath: activeDeletionState.workspacePath,
     });
   }
 
@@ -261,9 +260,8 @@
   function handleDismiss(): void {
     if (!activeDeletionState) return;
     logger.debug("Dismissing deletion", { workspaceName: activeDeletionState.workspaceName });
-    void api.workspaces.remove(activeDeletionState.projectId, activeDeletionState.workspaceName, {
+    void api.workspaces.remove(activeDeletionState.workspacePath, {
       force: true,
-      workspacePath: activeDeletionState.workspacePath,
     });
     clearDeletion(activeDeletionState.workspacePath);
   }

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
@@ -30,7 +30,7 @@
     isDirty = false;
 
     workspaces
-      .getStatus(workspaceRef.projectId, workspaceRef.workspaceName)
+      .getStatus(workspaceRef.path)
       .then((status) => {
         isDirty = status.isDirty;
       })
@@ -48,7 +48,7 @@
     logger.debug("Dialog submitted", { type: "remove-workspace" });
     // Fire-and-forget: start deletion and close dialog immediately
     // Progress is shown via DeletionProgressView in MainView
-    void workspaces.remove(workspaceRef.projectId, workspaceRef.workspaceName, { keepBranch });
+    void workspaces.remove(workspaceRef.path, { keepBranch });
     closeDialog();
   }
 

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
@@ -120,7 +120,7 @@ describe("RemoveWorkspaceDialog component", () => {
       render(RemoveWorkspaceDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
-      expect(workspaces.getStatus).toHaveBeenCalledWith(testProjectId, testWorkspaceName);
+      expect(workspaces.getStatus).toHaveBeenCalledWith(testWorkspaceRef.path);
     });
 
     it("shows spinner while checking dirty status", async () => {
@@ -213,7 +213,7 @@ describe("RemoveWorkspaceDialog component", () => {
       await vi.runAllTimersAsync();
 
       // API uses keepBranch (inverted from old deleteBranch)
-      expect(workspaces.remove).toHaveBeenCalledWith(testProjectId, testWorkspaceName, {
+      expect(workspaces.remove).toHaveBeenCalledWith(testWorkspaceRef.path, {
         keepBranch: false,
       });
     });
@@ -234,7 +234,7 @@ describe("RemoveWorkspaceDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(workspaces.remove).toHaveBeenCalledWith(testProjectId, testWorkspaceName, {
+      expect(workspaces.remove).toHaveBeenCalledWith(testWorkspaceRef.path, {
         keepBranch: true,
       });
     });

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -172,11 +172,7 @@ async function handleNavigation(key: NavigationKey): Promise<void> {
   _switchingWorkspace = true;
   try {
     // Pass false to keep UI focused (shortcut mode active)
-    await api.ui.switchWorkspace(
-      targetWorkspaceRef.projectId,
-      targetWorkspaceRef.workspaceName,
-      false
-    );
+    await api.ui.switchWorkspace(targetWorkspaceRef.path, false);
   } catch (error) {
     logWorkspaceSwitchError("switch workspace", error);
   } finally {
@@ -207,11 +203,7 @@ async function handleIdleNavigation(direction: -1 | 1): Promise<void> {
 
   _switchingWorkspace = true;
   try {
-    await api.ui.switchWorkspace(
-      targetWorkspaceRef.projectId,
-      targetWorkspaceRef.workspaceName,
-      false
-    );
+    await api.ui.switchWorkspace(targetWorkspaceRef.path, false);
   } catch (error) {
     logWorkspaceSwitchError("navigate to idle workspace", error);
   } finally {
@@ -255,7 +247,7 @@ async function handleJump(key: JumpKey): Promise<void> {
   _switchingWorkspace = true;
   try {
     // Pass false to keep UI focused (shortcut mode active)
-    await api.ui.switchWorkspace(workspaceRef.projectId, workspaceRef.workspaceName, false);
+    await api.ui.switchWorkspace(workspaceRef.path, false);
   } catch (error) {
     logWorkspaceSwitchError("jump to workspace", error);
   } finally {

--- a/src/renderer/lib/stores/shortcuts.test.ts
+++ b/src/renderer/lib/stores/shortcuts.test.ts
@@ -423,12 +423,8 @@ describe("shortcuts store", () => {
 
         // Wait for async action to complete
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws2",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws2", false);
         });
       });
 
@@ -448,12 +444,8 @@ describe("shortcuts store", () => {
         handleShortcutKey("up");
 
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws1",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws1", false);
         });
       });
 
@@ -471,12 +463,8 @@ describe("shortcuts store", () => {
         handleShortcutKey("up");
 
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws3",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws3", false);
         });
       });
 
@@ -494,12 +482,8 @@ describe("shortcuts store", () => {
         handleShortcutKey("down");
 
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws1",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws1", false);
         });
       });
 
@@ -544,11 +528,7 @@ describe("shortcuts store", () => {
         handleShortcutKey("left");
 
         await vi.waitFor(() => {
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws1",
-            false
-          );
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws1", false);
         });
       });
 
@@ -574,11 +554,7 @@ describe("shortcuts store", () => {
 
         await vi.waitFor(() => {
           // Should skip ws2 (busy) and go to ws3 (idle)
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws3",
-            false
-          );
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws3", false);
         });
       });
 
@@ -641,11 +617,7 @@ describe("shortcuts store", () => {
         handleShortcutKey("right");
 
         await vi.waitFor(() => {
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws2",
-            false
-          );
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws2", false);
         });
       });
 
@@ -715,12 +687,8 @@ describe("shortcuts store", () => {
         handleShortcutKey("5");
 
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws5",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws5", false);
         });
       });
 
@@ -736,12 +704,8 @@ describe("shortcuts store", () => {
         handleShortcutKey("0");
 
         await vi.waitFor(() => {
-          // Should pass projectId, workspaceName, false to keep shortcut mode active
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws10",
-            false
-          );
+          // Should pass workspacePath and false to keep shortcut mode active
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws10", false);
         });
       });
 
@@ -894,11 +858,7 @@ describe("shortcuts store", () => {
 
         // Verify the call was attempted with correct parameters
         await vi.waitFor(() => {
-          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith(
-            "test-project-12345678",
-            "ws2",
-            false
-          );
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws2", false);
         });
         // Logging is an implementation detail - we just verify the call was made
         // and no unhandled rejection occurs

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -41,9 +41,9 @@ export function createMockApi(): Api {
       create: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.workspace),
       remove: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.removeResult),
       getStatus: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.status),
+      getAgentSession: vi.fn().mockResolvedValue(null),
       setMetadata: vi.fn().mockResolvedValue(undefined),
       getMetadata: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.metadata),
-      getOpencodePort: vi.fn().mockResolvedValue(null),
     },
     ui: {
       selectFolder: vi.fn().mockResolvedValue(null),

--- a/src/renderer/lib/utils/initialize-app.ts
+++ b/src/renderer/lib/utils/initialize-app.ts
@@ -25,7 +25,7 @@ export interface InitializeAppOptions {
 
 export interface InitializeAppApi {
   lifecycle: { ready(): Promise<void> };
-  workspaces: { getStatus(projectId: string, name: string): Promise<WorkspaceStatus> };
+  workspaces: { getStatus(workspacePath: string): Promise<WorkspaceStatus> };
 }
 
 /**
@@ -56,7 +56,7 @@ async function fetchAllAgentStatuses(
     for (const workspace of project.workspaces) {
       promises.push(
         apiImpl.workspaces
-          .getStatus(project.id, workspace.name)
+          .getStatus(workspace.path)
           .then((status) => {
             result[workspace.path] = status.agent;
           })

--- a/src/services/mcp-server/index.ts
+++ b/src/services/mcp-server/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Types
-export type { McpResolvedWorkspace, McpErrorCode, McpError, IMcpServer } from "./types";
+export type { McpErrorCode, McpError, IMcpServer } from "./types";
 export type { IDisposable } from "../../shared/types";
 
 // MCP Server

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -11,7 +11,6 @@ import type { ICoreApi } from "../../shared/api/interfaces";
 import { createMockLogger } from "../logging";
 import { createMockCoreApi } from "../test-utils";
 import { delay } from "@shared/test-fixtures";
-import { generateProjectId, extractWorkspaceName } from "../../shared/api/id-utils";
 
 /**
  * Find a free port for testing.
@@ -39,7 +38,6 @@ describe("McpServer Boundary Tests", () => {
   let logger: ReturnType<typeof createMockLogger>;
 
   const testWorkspacePath = "/home/user/projects/my-app/.worktrees/feature-branch";
-  const testProjectPath = "/home/user/projects/my-app";
 
   beforeEach(async () => {
     port = await findFreePort();
@@ -47,11 +45,6 @@ describe("McpServer Boundary Tests", () => {
     logger = createMockLogger();
 
     server = new McpServer(mockApi, createDefaultMcpServer, logger);
-    server.registerWorkspace({
-      projectId: generateProjectId(testProjectPath),
-      workspaceName: extractWorkspaceName(testWorkspacePath),
-      workspacePath: testWorkspacePath,
-    });
     await server.start(port);
   });
 

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -10,7 +10,7 @@ import {
   type McpServerFactory,
 } from "./mcp-server";
 import type { ICoreApi, IWorkspaceApi, IProjectApi } from "../../shared/api/interfaces";
-import { type ProjectId, type WorkspaceName, initialPromptSchema } from "../../shared/api/types";
+import { type ProjectId, initialPromptSchema } from "../../shared/api/types";
 import { createMockLogger } from "../logging";
 
 /**
@@ -147,17 +147,10 @@ describe("McpServer", () => {
     });
 
     it("workspace_restart_agent_server tool calls API and returns port", async () => {
-      // Set up workspace identity via register
       const workspacePath = "/project/workspaces/test-workspace";
-      const projectPath = "/project";
 
-      // Create server and register workspace
+      // Create server
       const server = new McpServer(mockApi, mockFactory, mockLogger);
-      server.registerWorkspace({
-        projectId: `${projectPath}-12345678` as ProjectId,
-        workspaceName: "test-workspace" as WorkspaceName,
-        workspacePath,
-      });
 
       await server.start(0);
       await server.stop();

--- a/src/services/mcp-server/types.ts
+++ b/src/services/mcp-server/types.ts
@@ -2,22 +2,7 @@
  * Type definitions for the MCP Server.
  */
 
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 import type { IDisposable } from "../../shared/types";
-
-// =============================================================================
-// Resolved Workspace
-// =============================================================================
-
-/**
- * A workspace resolved from an MCP workspace path.
- * Contains all identifiers needed to call ICoreApi methods.
- */
-export interface McpResolvedWorkspace {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-}
 
 // =============================================================================
 // MCP Error Types

--- a/src/shared/api/interfaces.test.ts
+++ b/src/shared/api/interfaces.test.ts
@@ -57,79 +57,55 @@ describe("IProjectApi Interface", () => {
 describe("IWorkspaceApi Interface", () => {
   it("should have correct method signatures", () => {
     const api: IWorkspaceApi = {
-      async create(projectId: ProjectId, name: string, base: string): Promise<Workspace> {
+      async create(
+        projectId: ProjectId | undefined,
+        name: string,
+        base: string
+      ): Promise<Workspace> {
         void projectId;
         void name;
         void base;
         throw new Error("mock");
       },
       async remove(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName,
+        workspacePath: string,
         options?: {
           keepBranch?: boolean;
           skipSwitch?: boolean;
           force?: boolean;
-          unblock?: "kill" | "close" | "ignore";
-          isRetry?: boolean;
         }
       ): Promise<{ started: boolean }> {
-        void projectId;
-        void workspaceName;
+        void workspacePath;
         void options;
         return { started: true };
       },
-      async getStatus(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName
-      ): Promise<WorkspaceStatus> {
-        void projectId;
-        void workspaceName;
+      async getStatus(workspacePath: string): Promise<WorkspaceStatus> {
+        void workspacePath;
         return { isDirty: false, agent: { type: "none" } };
       },
-      async setMetadata(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName,
-        key: string,
-        value: string | null
-      ): Promise<void> {
-        void projectId;
-        void workspaceName;
+      async setMetadata(workspacePath: string, key: string, value: string | null): Promise<void> {
+        void workspacePath;
         void key;
         void value;
       },
-      async getMetadata(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName
-      ): Promise<Readonly<Record<string, string>>> {
-        void projectId;
-        void workspaceName;
+      async getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>> {
+        void workspacePath;
         return { base: "main" };
       },
-      async getAgentSession(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName
-      ): Promise<AgentSession | null> {
-        void projectId;
-        void workspaceName;
+      async getAgentSession(workspacePath: string): Promise<AgentSession | null> {
+        void workspacePath;
         return null;
       },
-      async restartAgentServer(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName
-      ): Promise<number> {
-        void projectId;
-        void workspaceName;
+      async restartAgentServer(workspacePath: string): Promise<number> {
+        void workspacePath;
         return 14001;
       },
       async executeCommand(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName,
+        workspacePath: string,
         command: string,
         args?: readonly unknown[]
       ): Promise<unknown> {
-        void projectId;
-        void workspaceName;
+        void workspacePath;
         void command;
         void args;
         return undefined;
@@ -157,13 +133,8 @@ describe("IUiApi Interface", () => {
       async getActiveWorkspace(): Promise<WorkspaceRef | null> {
         return null;
       },
-      async switchWorkspace(
-        projectId: ProjectId,
-        workspaceName: WorkspaceName,
-        focus?: boolean
-      ): Promise<void> {
-        void projectId;
-        void workspaceName;
+      async switchWorkspace(workspacePath: string, focus?: boolean): Promise<void> {
+        void workspacePath;
         void focus;
       },
       async setMode(mode: UIMode): Promise<void> {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -44,43 +44,26 @@ export interface Api {
      * Progress is emitted via workspace:deletion-progress events.
      * Returns { started: true } on success, { started: false } if blocked by idempotency.
      *
-     * @param projectId Project containing the workspace
-     * @param workspaceName Name of the workspace to remove
+     * @param workspacePath Absolute path to the workspace to remove
      * @param options Optional removal options
      */
     remove(
-      projectId: string,
-      workspaceName: string,
+      workspacePath: string,
       options?: {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
-        workspacePath?: string;
       }
     ): Promise<{ started: boolean }>;
-    getStatus(projectId: string, workspaceName: string): Promise<WorkspaceStatus>;
-    /**
-     * Get the OpenCode server port for a workspace.
-     * @param projectId Project containing the workspace
-     * @param workspaceName Name of the workspace
-     * @returns Port number if server is running, null if not running or not initialized
-     */
-    getOpencodePort(projectId: string, workspaceName: string): Promise<number | null>;
-    setMetadata(
-      projectId: string,
-      workspaceName: string,
-      key: string,
-      value: string | null
-    ): Promise<void>;
-    getMetadata(
-      projectId: string,
-      workspaceName: string
-    ): Promise<Readonly<Record<string, string>>>;
+    getStatus(workspacePath: string): Promise<WorkspaceStatus>;
+    getAgentSession(workspacePath: string): Promise<unknown>;
+    setMetadata(workspacePath: string, key: string, value: string | null): Promise<void>;
+    getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>>;
   };
   ui: {
     selectFolder(): Promise<string | null>;
     getActiveWorkspace(): Promise<WorkspaceRef | null>;
-    switchWorkspace(projectId: string, workspaceName: string, focus?: boolean): Promise<void>;
+    switchWorkspace(workspacePath: string, focus?: boolean): Promise<void>;
     setMode(mode: UIMode): Promise<void>;
   };
   lifecycle: {


### PR DESCRIPTION
- Replace `(projectId, workspaceName)` pairs with `workspacePath` as primary workspace identifier across all operations, APIs, and transports
- Eliminate 4 duplicate workspace registries: Plugin API `workspaceIdentities`, MCP server `workspaces` Map, MCP manager `pendingRegistrations`, bootstrap `workspacesByKey`
- External callers (Plugin API, MCP server) pass `workspacePath` directly; resolution to `projectId`/`workspaceName` happens once in hook system via resolve handlers
- Add `callerWorkspacePath` field on `open-workspace` intent for Plugin/MCP workspace creation without per-transport registries
- Update `IWorkspaceApi`, `IUiApi`, preload, and renderer to use `workspacePath`-based signatures