### PR TITLE
refactor(bootstrap): consolidate project index into LocalProjectModule

### DIFF
--- a/src/main/modules/local-project-module.ts
+++ b/src/main/modules/local-project-module.ts
@@ -411,7 +411,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               }
             }
 
-            return {};
+            return { otherProjectsExist: projects.size > 0 };
           },
         },
       },


### PR DESCRIPTION
- Move `otherProjectsExist` computation from bootstrap's shadow `projectsById` map into LocalProjectModule's close hook, which already maintains the canonical projects map
- Remove `indexModule`, `projectCloseIndexModule`, and `projectsById` from bootstrap.ts (-60 lines)
- Clean up unused imports (`EVENT_PROJECT_OPENED`, `ProjectOpenedEvent`, `EVENT_PROJECT_CLOSED`, `ProjectClosedEvent`, `CLOSE_PROJECT_OPERATION_ID`, `CloseHookResult`, `DomainEvent`, `HookContext`)