### PR TITLE
chore(view-manager): replace setModeFn callback with direct dispatcher reference

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -109,7 +109,6 @@ import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "./operations/app-shut
 import type { AppShutdownIntent } from "./operations/app-shutdown";
 import { SetupOperation, INTENT_SETUP, EVENT_SETUP_ERROR } from "./operations/setup";
 import { SetModeOperation, INTENT_SET_MODE } from "./operations/set-mode";
-import type { SetModeIntent } from "./operations/set-mode";
 import { SetMetadataOperation, INTENT_SET_METADATA } from "./operations/set-metadata";
 import { GetMetadataOperation, INTENT_GET_METADATA } from "./operations/get-metadata";
 import {
@@ -335,12 +334,7 @@ const viewManager = new ViewManager({
     codeServerPort: 0,
   },
   logger: loggingService.createLogger("view"),
-  setModeFn: (mode) => {
-    void dispatcher.dispatch({
-      type: INTENT_SET_MODE,
-      payload: { mode },
-    } as SetModeIntent);
-  },
+  dispatcher,
 });
 
 const badgeManager = new BadgeManager(

--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -21,6 +21,7 @@ import {
   type MockWindowLayerInternal,
 } from "../../services/shell/window.state-mock";
 import type { WindowHandle } from "../../services/shell/types";
+import type { IDispatcher } from "../intents/infrastructure";
 
 // Mock ShortcutController before imports
 const mockShortcutController = vi.hoisted(() => ({
@@ -113,6 +114,7 @@ function createViewManagerDeps(): ViewManagerDeps & {
       codeServerPort: 8080,
     },
     logger: SILENT_LOGGER,
+    dispatcher: { dispatch: vi.fn() } as unknown as IDispatcher,
   };
 }
 


### PR DESCRIPTION
- Replace optional `setModeFn` callback with required `IDispatcher` dependency on `ViewManagerDeps`
- ShortcutController now always dispatches `ui:set-mode` intents through the intent pipeline
- Remove conditional fallback that bypassed domain events when `setModeFn` was not provided
- Remove unused `SetModeIntent` type import from `index.ts`