### PR TITLE
chore(window-title): move initial title construction into WindowTitleModule

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -310,9 +310,6 @@ const lifecycleLogger = loggingService.createLogger("lifecycle");
 
 // 6. Manager construction (two-phase: constructor only, no Electron resources)
 
-const windowTitle =
-  !buildInfo.isPackaged && buildInfo.gitBranch ? `CodeHydra (${buildInfo.gitBranch})` : "CodeHydra";
-
 const windowManager = new WindowManager(
   {
     windowLayer,
@@ -320,7 +317,7 @@ const windowManager = new WindowManager(
     logger: loggingService.createLogger("window"),
     platformInfo,
   },
-  windowTitle,
+  "CodeHydra",
   pathProvider.appIconPath.toNative()
 );
 

--- a/src/main/modules/window-title-module.ts
+++ b/src/main/modules/window-title-module.ts
@@ -1,5 +1,8 @@
 /**
- * WindowTitleModule - Event subscriber module for updating the window title.
+ * WindowTitleModule - Lifecycle and event subscriber module for the window title.
+ *
+ * Hooks:
+ * - app:start → "start": sets the initial window title via updateTitle()
  *
  * Subscribes to:
  * - workspace:switched: updates internal project/workspace names, calls updateTitle()
@@ -13,14 +16,16 @@ import type { DomainEvent } from "../intents/infrastructure/types";
 import type { WorkspaceSwitchedEvent } from "../operations/switch-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../operations/switch-workspace";
 import { EVENT_UPDATE_AVAILABLE } from "../operations/update-available";
+import { APP_START_OPERATION_ID, type StartHookResult } from "../operations/app-start";
 import { formatWindowTitle } from "../ipc/api-handlers";
 
 /**
- * Create a window title module that subscribes to workspace switch and update-available events.
+ * Create a window title module that sets the initial title on startup and
+ * subscribes to workspace switch and update-available events.
  *
  * @param setTitle - Callback to set the window title
  * @param titleVersion - Version suffix (branch in dev, version in packaged), or undefined
- * @returns IntentModule with event subscriptions
+ * @returns IntentModule with hooks and event subscriptions
  */
 export function createWindowTitleModule(
   setTitle: (title: string) => void,
@@ -41,6 +46,16 @@ export function createWindowTitleModule(
   }
 
   return {
+    hooks: {
+      [APP_START_OPERATION_ID]: {
+        start: {
+          handler: async (): Promise<StartHookResult> => {
+            updateTitle();
+            return {};
+          },
+        },
+      },
+    },
     events: {
       [EVENT_WORKSPACE_SWITCHED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceSwitchedEvent).payload;


### PR DESCRIPTION
- Move initial window title construction from `index.ts` into `WindowTitleModule` via an `app:start → start` hook
- Fix inconsistent title format: was `CodeHydra (branch)`, now uses `formatWindowTitle()` producing `CodeHydra - (branch)`
- Pass plain `"CodeHydra"` to `WindowManager` constructor instead of pre-formatted title
- Add integration tests for the new start hook (version, dev branch, undefined version)