### PR TITLE
chore(code-server-module): flatten deps, publish port via hook context

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -410,19 +410,11 @@ const { module: viewModule, mountSignal } = createViewModule({
 const codeServerModule = createCodeServerModule({
   codeServerManager,
   extensionManager: setupExtensionManager,
+  pluginServer,
+  fileSystemLayer,
+  workspaceFileService,
+  wrapperPath: pathProvider.claudeCodeWrapperPath.toString(),
   logger: apiLogger,
-  getLifecycleDeps: () => ({
-    pluginServer,
-    codeServerManager,
-    fileSystemLayer,
-    onPortChanged: (port: number) => {
-      viewManager.updateCodeServerPort(port);
-    },
-  }),
-  getWorkspaceDeps: () => ({
-    workspaceFileService,
-    wrapperPath: pathProvider.claudeCodeWrapperPath.toString(),
-  }),
 });
 
 const agentModule = createAgentModule({

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -34,6 +34,7 @@ import type { SetModeIntent, SetModeHookResult } from "../operations/set-mode";
 import type {
   ConfigureResult,
   ShowUIHookResult,
+  ActivateHookContext,
   ActivateHookResult,
 } from "../operations/app-start";
 import type { GetActiveWorkspaceHookResult } from "../operations/get-active-workspace";
@@ -274,7 +275,13 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
           },
         },
         activate: {
-          handler: async (): Promise<ActivateHookResult> => {
+          handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
+            // Update code-server port from start results
+            const { codeServerPort } = ctx as ActivateHookContext;
+            if (codeServerPort !== null) {
+              viewManager.updateCodeServerPort(codeServerPort);
+            }
+
             // Wire loading state changes to IPC
             loadingChangeCleanupFn = viewManager.onLoadingChange(
               (path: string, loading: boolean) => {

--- a/src/main/operations/app-start.integration.test.ts
+++ b/src/main/operations/app-start.integration.test.ts
@@ -830,6 +830,58 @@ describe("AppStart Operation", () => {
 
       expect(receivedMcpPort).toBeNull();
     });
+
+    it("passes codeServerPort from CodeServer start handler to activate handlers", async () => {
+      const state = createTestState();
+      let receivedCodeServerPort: number | null | undefined;
+
+      const portReaderModule: IntentModule = {
+        hooks: {
+          [APP_START_OPERATION_ID]: {
+            activate: {
+              handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
+                receivedCodeServerPort = (ctx as ActivateHookContext).codeServerPort;
+                return {};
+              },
+            },
+          },
+        },
+      };
+
+      const { dispatcher } = createTestSetup([
+        createCodeServerModule(state),
+        createMcpModule(state),
+        portReaderModule,
+      ]);
+
+      await dispatcher.dispatch(appStartIntent());
+
+      expect(receivedCodeServerPort).toBe(8080);
+    });
+
+    it("passes null codeServerPort when no start handler returns codeServerPort", async () => {
+      const state = createTestState();
+      let receivedCodeServerPort: number | null | undefined;
+
+      const portReaderModule: IntentModule = {
+        hooks: {
+          [APP_START_OPERATION_ID]: {
+            activate: {
+              handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
+                receivedCodeServerPort = (ctx as ActivateHookContext).codeServerPort;
+                return {};
+              },
+            },
+          },
+        },
+      };
+
+      const { dispatcher } = createTestSetup([createMcpModule(state), portReaderModule]);
+
+      await dispatcher.dispatch(appStartIntent());
+
+      expect(receivedCodeServerPort).toBeNull();
+    });
   });
 
   // ===========================================================================

--- a/src/main/operations/app-start.ts
+++ b/src/main/operations/app-start.ts
@@ -124,9 +124,10 @@ export interface StartHookResult {
   readonly mcpPort?: number;
 }
 
-/** Input context for "activate" -- carries mcpPort from start results. */
+/** Input context for "activate" -- carries ports from start results. */
 export interface ActivateHookContext extends HookContext {
   readonly mcpPort: number | null;
+  readonly codeServerPort: number | null;
 }
 
 /**
@@ -244,11 +245,13 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       throw startErrors[0]!;
     }
 
-    // Extract mcpPort from start results for activate handlers
+    // Extract ports from start results for activate handlers
     const mcpPort = startResults.find((r) => r.mcpPort !== undefined)?.mcpPort ?? null;
+    const codeServerPort =
+      startResults.find((r) => r.codeServerPort !== undefined)?.codeServerPort ?? null;
 
     // Hook 8: "activate" -- Wire callbacks, gather project paths, mount renderer
-    const activateCtx: ActivateHookContext = { ...hookCtx, mcpPort };
+    const activateCtx: ActivateHookContext = { ...hookCtx, mcpPort, codeServerPort };
     const { results: activateResults, errors: activateErrors } =
       await ctx.hooks.collect<ActivateHookResult>("activate", activateCtx);
     if (activateErrors.length > 0) {


### PR DESCRIPTION
## Summary
- Replaced nested `CodeServerLifecycleDeps`/`CodeServerWorkspaceDeps` with a single flat `CodeServerModuleDeps` interface
- Removed `onPortChanged` callback — code-server port now flows through `ActivateHookContext` (matching existing `mcpPort` pattern)
- View module reads `codeServerPort` from activate context and calls `viewManager.updateCodeServerPort()`

## Test plan
- [x] All 3570 existing tests pass
- [x] New tests for `codeServerPort` in `ActivateHookContext` (app-start integration tests)
- [x] New tests for `updateCodeServerPort` called from view module activate hook
- [x] `pnpm validate:fix` passes (lint, types, tests, build)
- [x] Manual `pnpm preview` verified app starts correctly