### PR TITLE
refactor(delete-workspace): emit deletion progress via domain events

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -529,14 +529,7 @@ dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
 dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
 
-const emitDeletionProgress = (progress: import("../shared/api/types").DeletionProgress) => {
-  try {
-    viewManager.getUIWebContents()?.send(ApiIpcChannels.WORKSPACE_DELETION_PROGRESS, progress);
-  } catch {
-    // Ignore - deletion continues even if UI disconnected
-  }
-};
-const deleteOp = new DeleteWorkspaceOperation(emitDeletionProgress);
+const deleteOp = new DeleteWorkspaceOperation();
 dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOp);
 
 dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
@@ -571,7 +564,6 @@ const ipcEventBridge = createIpcEventBridge({
   agentStatusManager,
   globalWorktreeProvider,
   dialog,
-  emitDeletionProgress,
   deleteOp,
 });
 

--- a/src/main/operations/close-project.integration.test.ts
+++ b/src/main/operations/close-project.integration.test.ts
@@ -45,7 +45,6 @@ import {
 import type {
   DeleteWorkspaceIntent,
   WorkspaceDeletedEvent,
-  DeletionProgressCallback,
   ShutdownHookResult,
   DeletePipelineHookInput,
   ResolveHookInput,
@@ -210,9 +209,8 @@ function createTestHarness(options?: {
   };
 
   // Register operations
-  const emitProgress: DeletionProgressCallback = () => {};
   dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation(emitProgress));
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
 
   // Delete-workspace resolve modules
   const deleteResolveModule: IntentModule = {

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -221,7 +221,6 @@ function createTestSetup(): TestSetup {
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-    emitDeletionProgress: vi.fn(),
     deleteOp: {
       hasPendingRetry: vi.fn().mockReturnValue(false),
       signalDismiss: vi.fn(),

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -229,7 +229,6 @@ function createTestSetup(): TestSetup {
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-    emitDeletionProgress: vi.fn(),
     deleteOp: {
       hasPendingRetry: vi.fn().mockReturnValue(false),
       signalDismiss: vi.fn(),

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -128,7 +128,6 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-      emitDeletionProgress: vi.fn(),
       deleteOp: {
         hasPendingRetry: vi.fn().mockReturnValue(false),
         signalDismiss: vi.fn(),

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -328,7 +328,6 @@ function createTestSetup(opts?: {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-      emitDeletionProgress: vi.fn(),
       deleteOp: {
         hasPendingRetry: vi.fn().mockReturnValue(false),
         signalDismiss: vi.fn(),


### PR DESCRIPTION
- Replace `DeletionProgressCallback` constructor parameter with domain event emission via `ctx.emit()`
- Add `EVENT_WORKSPACE_DELETION_PROGRESS` domain event and `WorkspaceDeletionProgressEvent` type
- Subscribe to the new event in IPC event bridge, forwarding to renderer via `webContents.send()`
- Remove `emitDeletionProgress` from `IpcEventBridgeDeps` and composition root
- Update 8 test files to use event-based progress capture instead of callback