### PR TITLE
refactor(open-project): move folder selection dialog into intent system

### DIFF
--- a/src/main/api/registry-types.test.ts
+++ b/src/main/api/registry-types.test.ts
@@ -46,7 +46,7 @@ describe("registry-types.paths", () => {
     // This test is compile-time verified by the `satisfies` constraint in registry-types.ts
     // At runtime, we verify the count matches
     // Note: lifecycle methods (getState, setAgent, setup, startServices) were removed in app:setup migration
-    const registryKeyCount = 18; // Count of all methods in MethodRegistry
+    const registryKeyCount = 17; // Count of all methods in MethodRegistry
     expect(ALL_METHOD_PATHS.length).toBe(registryKeyCount);
   });
 
@@ -62,7 +62,7 @@ describe("registry-types.paths", () => {
     expectTypeOf<"lifecycle.quit">().toExtend<MethodPath>();
     expectTypeOf<"projects.open">().toExtend<MethodPath>();
     expectTypeOf<"workspaces.create">().toExtend<MethodPath>();
-    expectTypeOf<"ui.selectFolder">().toExtend<MethodPath>();
+    expectTypeOf<"ui.getActiveWorkspace">().toExtend<MethodPath>();
   });
 
   it("grouped paths match their expected values", () => {
@@ -84,7 +84,6 @@ describe("registry-types.paths", () => {
     expectTypeOf<"workspaces.getMetadata">().toExtend<WorkspacePath>();
 
     // UI paths
-    expectTypeOf<"ui.selectFolder">().toExtend<UiPath>();
     expectTypeOf<"ui.getActiveWorkspace">().toExtend<UiPath>();
     expectTypeOf<"ui.switchWorkspace">().toExtend<UiPath>();
     expectTypeOf<"ui.setMode">().toExtend<UiPath>();
@@ -95,15 +94,13 @@ describe("registry-types.payload", () => {
   it("extracts EmptyPayload for no-arg methods", () => {
     // Note: lifecycle.getState, lifecycle.setup removed in app:setup migration
     expectTypeOf<MethodPayload<"lifecycle.quit">>().toEqualTypeOf<EmptyPayload>();
-    expectTypeOf<MethodPayload<"ui.selectFolder">>().toEqualTypeOf<EmptyPayload>();
     expectTypeOf<MethodPayload<"ui.getActiveWorkspace">>().toEqualTypeOf<EmptyPayload>();
   });
 
   it("extracts ProjectOpenPayload for projects.open", () => {
     expectTypeOf<MethodPayload<"projects.open">>().toEqualTypeOf<ProjectOpenPayload>();
-    // Verify shape
+    // Verify shape - path is optional
     expectTypeOf<MethodPayload<"projects.open">>().toHaveProperty("path");
-    expectTypeOf<MethodPayload<"projects.open">["path"]>().toBeString();
   });
 
   it("extracts ProjectIdPayload for project ID methods", () => {
@@ -174,11 +171,11 @@ describe("registry-types.payload", () => {
 
 describe("registry-types.handler", () => {
   it("MethodHandler extracts correct function type", () => {
-    // Handler for projects.open should accept ProjectOpenPayload and return Promise<Project>
+    // Handler for projects.open should accept ProjectOpenPayload and return Promise<Project | null>
     type OpenHandler = MethodHandler<"projects.open">;
     expectTypeOf<OpenHandler>().toBeFunction();
     expectTypeOf<OpenHandler>().parameter(0).toEqualTypeOf<ProjectOpenPayload>();
-    expectTypeOf<OpenHandler>().returns.resolves.toEqualTypeOf<Project>();
+    expectTypeOf<OpenHandler>().returns.resolves.toEqualTypeOf<Project | null>();
   });
 
   it("MethodHandler matches MethodRegistry definition", () => {
@@ -201,7 +198,7 @@ describe("registry-types.result", () => {
     expectTypeOf<MethodResult<"lifecycle.quit">>().toEqualTypeOf<void>();
 
     // Project methods
-    expectTypeOf<MethodResult<"projects.open">>().toEqualTypeOf<Project>();
+    expectTypeOf<MethodResult<"projects.open">>().toEqualTypeOf<Project | null>();
     expectTypeOf<MethodResult<"projects.close">>().toEqualTypeOf<void>();
     expectTypeOf<MethodResult<"projects.fetchBases">>().toEqualTypeOf<{
       readonly bases: readonly BaseInfo[];
@@ -218,7 +215,6 @@ describe("registry-types.result", () => {
     >();
 
     // UI methods
-    expectTypeOf<MethodResult<"ui.selectFolder">>().toEqualTypeOf<string | null>();
     expectTypeOf<MethodResult<"ui.getActiveWorkspace">>().toEqualTypeOf<WorkspaceRef | null>();
     expectTypeOf<MethodResult<"ui.switchWorkspace">>().toEqualTypeOf<void>();
     expectTypeOf<MethodResult<"ui.setMode">>().toEqualTypeOf<void>();

--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -25,7 +25,7 @@ export type EmptyPayload = object;
 
 /** projects.open */
 export interface ProjectOpenPayload {
-  readonly path: string;
+  readonly path?: string;
 }
 
 /** projects.close */
@@ -114,7 +114,7 @@ export interface MethodRegistry {
   "lifecycle.quit": (payload: EmptyPayload) => Promise<void>;
 
   // Projects
-  "projects.open": (payload: ProjectOpenPayload) => Promise<Project>;
+  "projects.open": (payload: ProjectOpenPayload) => Promise<Project | null>;
   "projects.close": (payload: ProjectClosePayload) => Promise<void>;
   "projects.clone": (payload: ProjectClonePayload) => Promise<Project>;
   "projects.fetchBases": (
@@ -134,7 +134,6 @@ export interface MethodRegistry {
   "workspaces.executeCommand": (payload: WorkspaceExecuteCommandPayload) => Promise<unknown>;
 
   // UI
-  "ui.selectFolder": (payload: EmptyPayload) => Promise<string | null>;
   "ui.getActiveWorkspace": (payload: EmptyPayload) => Promise<WorkspaceRef | null>;
   "ui.switchWorkspace": (payload: UiSwitchWorkspacePayload) => Promise<void>;
   "ui.setMode": (payload: UiSetModePayload) => Promise<void>;
@@ -172,11 +171,7 @@ export type WorkspacePath =
   | "workspaces.getMetadata"
   | "workspaces.executeCommand";
 /** @internal Exported for testing only */
-export type UiPath =
-  | "ui.selectFolder"
-  | "ui.getActiveWorkspace"
-  | "ui.switchWorkspace"
-  | "ui.setMode";
+export type UiPath = "ui.getActiveWorkspace" | "ui.switchWorkspace" | "ui.setMode";
 
 /**
  * Get the handler signature for a method path.
@@ -212,7 +207,6 @@ export const ALL_METHOD_PATHS = [
   "workspaces.setMetadata",
   "workspaces.getMetadata",
   "workspaces.executeCommand",
-  "ui.selectFolder",
   "ui.getActiveWorkspace",
   "ui.switchWorkspace",
   "ui.setMode",

--- a/src/main/api/registry.integration.test.ts
+++ b/src/main/api/registry.integration.test.ts
@@ -293,7 +293,7 @@ describe("registry.getInterface", () => {
     // Verify methods exist
     expect(typeof api.projects.open).toBe("function");
     expect(typeof api.workspaces.create).toBe("function");
-    expect(typeof api.ui.selectFolder).toBe("function");
+    expect(typeof api.ui.getActiveWorkspace).toBe("function");
     expect(typeof api.lifecycle.quit).toBe("function");
   });
 });
@@ -509,7 +509,6 @@ function registerAllMethodsWithStubs(
     "workspaces.setMetadata": async () => {},
     "workspaces.getMetadata": async () => ({}),
     "workspaces.executeCommand": async () => undefined,
-    "ui.selectFolder": async () => null,
     "ui.getActiveWorkspace": async () => null,
     "ui.switchWorkspace": async () => {},
     "ui.setMode": async () => {},

--- a/src/main/api/registry.test-utils.ts
+++ b/src/main/api/registry.test-utils.ts
@@ -196,7 +196,7 @@ function createMockCodeHydraApi(
 
   return {
     projects: {
-      open: (path) => get("projects.open")({ path }),
+      open: (path) => get("projects.open")({ ...(path !== undefined && { path }) }),
       close: (projectId, options) => get("projects.close")({ projectId, ...options }),
       clone: (url) => get("projects.clone")({ url }),
       fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),
@@ -225,7 +225,6 @@ function createMockCodeHydraApi(
         }),
     },
     ui: {
-      selectFolder: () => get("ui.selectFolder")({}),
       getActiveWorkspace: () => get("ui.getActiveWorkspace")({}),
       switchWorkspace: (workspacePath, focus) =>
         get("ui.switchWorkspace")({
@@ -266,7 +265,6 @@ export function registerAllMethodsWithStubs(
     "workspaces.setMetadata": async () => {},
     "workspaces.getMetadata": async () => ({}),
     "workspaces.executeCommand": async () => undefined,
-    "ui.selectFolder": async () => null,
     "ui.getActiveWorkspace": async () => null,
     "ui.switchWorkspace": async () => {},
     "ui.setMode": async () => {},

--- a/src/main/api/registry.ts
+++ b/src/main/api/registry.ts
@@ -170,7 +170,7 @@ export class ApiRegistry implements IApiRegistry {
     // Build facade that converts positional args to payload objects
     return {
       projects: {
-        open: (path) => get("projects.open")({ path }),
+        open: (path) => get("projects.open")({ ...(path !== undefined && { path }) }),
         close: (projectId, options) => get("projects.close")({ projectId, ...options }),
         clone: (url) => get("projects.clone")({ url }),
         fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),
@@ -199,7 +199,6 @@ export class ApiRegistry implements IApiRegistry {
           }),
       },
       ui: {
-        selectFolder: () => get("ui.selectFolder")({}),
         getActiveWorkspace: () => get("ui.getActiveWorkspace")({}),
         switchWorkspace: (workspacePath, focus) =>
           get("ui.switchWorkspace")({

--- a/src/main/api/wire-plugin-api.test.ts
+++ b/src/main/api/wire-plugin-api.test.ts
@@ -43,7 +43,6 @@ function createMockApi(): ICodeHydraApi {
       executeCommand: vi.fn().mockResolvedValue(undefined),
     },
     ui: {
-      selectFolder: vi.fn().mockResolvedValue(null),
       getActiveWorkspace: vi.fn().mockResolvedValue(null),
       switchWorkspace: vi.fn(),
       setMode: vi.fn(),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -285,19 +285,6 @@ const keepFilesService = new KeepFilesService(
   loggingService.createLogger("keepfiles")
 );
 
-// Wrap DialogLayer for IPC bridge (converts Path to string)
-const dialog = {
-  showOpenDialog: async (options: { properties: string[] }) => {
-    const result = await dialogLayer.showOpenDialog({
-      properties: options.properties as import("../services/platform/dialog").OpenDialogProperty[],
-    });
-    return {
-      canceled: result.canceled,
-      filePaths: result.filePaths.map((p) => p.toString()),
-    };
-  },
-};
-
 const workspaceLockHandler = createWorkspaceLockHandler(
   processRunner,
   platformInfo,
@@ -382,6 +369,7 @@ const { module: viewModule, mountSignal } = createViewModule({
   viewLayer,
   windowLayer,
   sessionLayer,
+  dialogLayer,
   menuLayer,
   windowManager,
   buildInfo,
@@ -563,7 +551,6 @@ const ipcEventBridge = createIpcEventBridge({
   dispatcher,
   agentStatusManager,
   globalWorktreeProvider,
-  dialog,
   deleteOp,
 });
 

--- a/src/main/ipc/api-handlers.integration.test.ts
+++ b/src/main/ipc/api-handlers.integration.test.ts
@@ -85,7 +85,6 @@ function createMockApiWithEvents(): {
       restartAgentServer: vi.fn().mockResolvedValue(3000),
     },
     ui: {
-      selectFolder: vi.fn().mockResolvedValue(null),
       getActiveWorkspace: vi.fn().mockResolvedValue(null),
       switchWorkspace: vi.fn().mockResolvedValue(undefined),
       setMode: vi.fn().mockResolvedValue(undefined),

--- a/src/main/ipc/api-handlers.test.ts
+++ b/src/main/ipc/api-handlers.test.ts
@@ -31,7 +31,6 @@ function createMockApi(): ICodeHydraApi {
       restartAgentServer: vi.fn().mockResolvedValue(3000),
     },
     ui: {
-      selectFolder: vi.fn().mockResolvedValue(null),
       getActiveWorkspace: vi.fn().mockResolvedValue(null),
       switchWorkspace: vi.fn(),
       setMode: vi.fn(),

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -92,7 +92,7 @@ describe("preload API", () => {
       };
       mockIpcRenderer.invoke.mockResolvedValue(mockProject);
 
-      const projects = exposedApi.projects as { open: (path: string) => Promise<unknown> };
+      const projects = exposedApi.projects as { open: (path?: string) => Promise<unknown> };
       const result = await projects.open("/test/path");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:project:open", {
@@ -260,16 +260,6 @@ describe("preload API", () => {
   });
 
   describe("ui", () => {
-    it("ui.selectFolder calls api:ui:select-folder", async () => {
-      mockIpcRenderer.invoke.mockResolvedValue("/selected/path");
-
-      const ui = exposedApi.ui as { selectFolder: () => Promise<string | null> };
-      const result = await ui.selectFolder();
-
-      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:ui:select-folder");
-      expect(result).toBe("/selected/path");
-    });
-
     it("ui.getActiveWorkspace calls api:ui:get-active-workspace", async () => {
       const mockRef = {
         projectId: "my-app-12345678",

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,7 +36,10 @@ contextBridge.exposeInMainWorld("api", {
   // Lifecycle handlers are registered in bootstrap(), others in startServices().
 
   projects: {
-    open: (path: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_OPEN, { path }),
+    open: (path?: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.PROJECT_OPEN, {
+        ...(path !== undefined && { path }),
+      }),
     close: (projectId: string, options?: { removeLocalRepo?: boolean }) =>
       ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLOSE, { projectId, ...options }),
     clone: (url: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLONE, { url }),
@@ -72,7 +75,6 @@ contextBridge.exposeInMainWorld("api", {
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_METADATA, { workspacePath }),
   },
   ui: {
-    selectFolder: () => ipcRenderer.invoke(ApiIpcChannels.UI_SELECT_FOLDER),
     getActiveWorkspace: () => ipcRenderer.invoke(ApiIpcChannels.UI_GET_ACTIVE_WORKSPACE),
     switchWorkspace: (workspacePath: string, focus?: boolean) =>
       ipcRenderer.invoke(ApiIpcChannels.UI_SWITCH_WORKSPACE, { workspacePath, focus }),

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -29,7 +29,6 @@ const { mockApi, eventCallbacks } = vi.hoisted(() => {
         fetchBases: vi.fn().mockResolvedValue({ bases: [] }),
       },
       ui: {
-        selectFolder: vi.fn().mockResolvedValue(null),
         getActiveWorkspace: vi.fn().mockResolvedValue(null),
         switchWorkspace: vi.fn().mockResolvedValue(undefined),
         setMode: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/lib/api/index.test.ts
+++ b/src/renderer/lib/api/index.test.ts
@@ -91,14 +91,6 @@ describe("renderer API layer", () => {
       expect(result).toHaveProperty("name");
     });
 
-    it("ui.selectFolder returns path or null", async () => {
-      const api = await import("$lib/api");
-      const result = await api.ui.selectFolder();
-
-      expect(mockApi.ui.selectFolder).toHaveBeenCalled();
-      expect(result).toBeNull();
-    });
-
     // Note: lifecycle.getState removed in app:setup migration
     it("lifecycle.quit calls quit", async () => {
       const api = await import("$lib/api");

--- a/src/renderer/lib/components/BranchDropdown.test.ts
+++ b/src/renderer/lib/components/BranchDropdown.test.ts
@@ -30,7 +30,6 @@ const { mockFetchBases, basesUpdatedHandlers } = vi.hoisted(() => ({
 
 // Mock $lib/api module
 vi.mock("$lib/api", () => ({
-  selectFolder: vi.fn().mockResolvedValue(null),
   openProject: vi.fn().mockResolvedValue(undefined),
   closeProject: vi.fn().mockResolvedValue(undefined),
   listProjects: vi.fn().mockResolvedValue({ projects: [], activeWorkspacePath: null }),

--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -10,6 +10,7 @@
     projects as projectsApi,
     type Workspace,
     type ProjectId,
+    type Project,
   } from "$lib/api";
   import { closeDialog, openGitCloneDialog } from "$lib/stores/dialogs.svelte.js";
   import { getProjectById, projects } from "$lib/stores/projects.svelte.js";
@@ -172,26 +173,18 @@
     submitError = null;
 
     try {
-      const path = await ui.selectFolder();
-      if (!path) {
+      const project: Project | null = await projectsApi.open();
+      if (!project) {
         // User cancelled folder picker
         return;
       }
-
-      try {
-        await projectsApi.open(path);
-        // Find the newly opened project (it will be the one with the matching path)
-        const newProject = projects.value.find((p) => p.path === path);
-        if (newProject) {
-          handleProjectSelect(newProject.id);
-          // Focus name input for efficient form completion
-          setTimeout(() => nameInputRef?.focus(), 0);
-        }
-      } catch (error) {
-        const message = getErrorMessage(error);
-        logger.warn("Failed to open project from dialog", { path, error: message });
-        submitError = message;
-      }
+      handleProjectSelect(project.id);
+      // Focus name input for efficient form completion
+      setTimeout(() => nameInputRef?.focus(), 0);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.warn("Failed to open project from dialog", { error: message });
+      submitError = message;
     } finally {
       isOpeningProject = false;
     }

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -31,7 +31,6 @@ const {
 
 // Mock $lib/api - using v2 API
 vi.mock("$lib/api", () => ({
-  selectFolder: vi.fn().mockResolvedValue(null),
   openProject: vi.fn().mockResolvedValue(undefined),
   closeProject: vi.fn().mockResolvedValue(undefined),
   listProjects: vi.fn().mockResolvedValue({ projects: [], activeWorkspacePath: null }),

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -34,7 +34,6 @@ const mockApi = vi.hoisted(() => ({
   },
   // Flat API structure - ui namespace
   ui: {
-    selectFolder: vi.fn().mockResolvedValue(null),
     getActiveWorkspace: vi.fn().mockResolvedValue(null),
     switchWorkspace: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -189,20 +189,17 @@
     // Prevent sidebar collapse while native dialog is open (Windows focus issue)
     setDialogOpen(true);
     try {
-      const path = await api.ui.selectFolder();
-      if (!path) {
+      const project = await api.projects.open();
+      if (!project) {
         // User cancelled folder picker - keep dialog open with original error
         return;
       }
-      // Clear error and try opening the new path
+      // Clear error on success
       openProjectError = null;
-      try {
-        await api.projects.open(path);
-      } catch (error) {
-        const message = getErrorMessage(error);
-        logger.warn("Failed to open project", { path, error: message });
-        openProjectError = message;
-      }
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.warn("Failed to open project", { error: message });
+      openProjectError = message;
     } finally {
       setDialogOpen(false);
     }

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -40,7 +40,6 @@ const mockApi = vi.hoisted(() => ({
   },
   // Flat API structure - ui namespace
   ui: {
-    selectFolder: vi.fn().mockResolvedValue(null),
     getActiveWorkspace: vi.fn().mockResolvedValue(null),
     switchWorkspace: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),
@@ -667,8 +666,8 @@ describe("MainView component", () => {
         expect(screen.getByText("Create Workspace")).toBeInTheDocument();
       });
 
-      // Verify folder picker was NOT automatically called
-      expect(mockApi.ui.selectFolder).not.toHaveBeenCalled();
+      // Verify projects.open was NOT automatically called (no folder picker)
+      expect(mockApi.projects.open).not.toHaveBeenCalled();
     });
 
     it("auto-opens create dialog when projects exist but no workspaces", async () => {
@@ -688,8 +687,8 @@ describe("MainView component", () => {
         expect(screen.getByText("Create Workspace")).toBeInTheDocument();
       });
 
-      // Verify folder picker was NOT automatically called
-      expect(mockApi.ui.selectFolder).not.toHaveBeenCalled();
+      // Verify projects.open was NOT automatically called (no folder picker)
+      expect(mockApi.projects.open).not.toHaveBeenCalled();
     });
   });
 

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
@@ -15,7 +15,6 @@ const { mockRemoveWorkspace, mockGetStatus, mockCloseDialog } = vi.hoisted(() =>
 
 // Mock $lib/api - using v2 API
 vi.mock("$lib/api", () => ({
-  selectFolder: vi.fn().mockResolvedValue(null),
   openProject: vi.fn().mockResolvedValue(undefined),
   closeProject: vi.fn().mockResolvedValue(undefined),
   listProjects: vi.fn().mockResolvedValue({ projects: [], activeWorkspacePath: null }),

--- a/src/renderer/lib/stores/shortcuts.test.ts
+++ b/src/renderer/lib/stores/shortcuts.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockApi = vi.hoisted(() => ({
   ui: {
     switchWorkspace: vi.fn().mockResolvedValue(undefined),
-    selectFolder: vi.fn().mockResolvedValue(null),
     setMode: vi.fn().mockResolvedValue(undefined),
   },
   projects: {

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -46,7 +46,6 @@ export function createMockApi(): Api {
       getMetadata: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.metadata),
     },
     ui: {
-      selectFolder: vi.fn().mockResolvedValue(null),
       getActiveWorkspace: vi.fn().mockResolvedValue(null),
       switchWorkspace: vi.fn().mockResolvedValue(undefined),
       setMode: vi.fn().mockResolvedValue(undefined),

--- a/src/shared/api/interfaces.test.ts
+++ b/src/shared/api/interfaces.test.ts
@@ -30,7 +30,7 @@ describe("IProjectApi Interface", () => {
   it("should have correct method signatures", () => {
     // Type-level test: this compiles if interface is correct
     const api: IProjectApi = {
-      async open(path: string): Promise<Project> {
+      async open(path?: string): Promise<Project | null> {
         void path;
         throw new Error("mock");
       },
@@ -127,9 +127,6 @@ describe("IWorkspaceApi Interface", () => {
 describe("IUiApi Interface", () => {
   it("should have correct method signatures", () => {
     const api: IUiApi = {
-      async selectFolder(): Promise<string | null> {
-        return null;
-      },
       async getActiveWorkspace(): Promise<WorkspaceRef | null> {
         return null;
       },
@@ -143,7 +140,6 @@ describe("IUiApi Interface", () => {
     };
 
     expect(api).toBeDefined();
-    expect(typeof api.selectFolder).toBe("function");
     expect(typeof api.getActiveWorkspace).toBe("function");
     expect(typeof api.switchWorkspace).toBe("function");
     expect(typeof api.setMode).toBe("function");

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -34,7 +34,7 @@ export interface ProjectCloseOptions {
 }
 
 export interface IProjectApi {
-  open(path: string): Promise<Project>;
+  open(path?: string): Promise<Project | null>;
   close(projectId: ProjectId, options?: ProjectCloseOptions): Promise<void>;
   /**
    * Clone a git repository and create a new project.
@@ -155,7 +155,6 @@ export interface IWorkspaceApi {
 }
 
 export interface IUiApi {
-  selectFolder(): Promise<string | null>;
   getActiveWorkspace(): Promise<WorkspaceRef | null>;
   switchWorkspace(workspacePath: string, focus?: boolean): Promise<void>;
   /**

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -32,7 +32,7 @@ export interface Api {
   // Lifecycle handlers are registered in bootstrap(), others in startServices().
 
   projects: {
-    open(path: string): Promise<Project>;
+    open(path?: string): Promise<Project | null>;
     close(projectId: string, options?: { removeLocalRepo?: boolean }): Promise<void>;
     clone(url: string): Promise<Project>;
     fetchBases(projectId: string): Promise<{ readonly bases: readonly ApiBaseInfo[] }>;
@@ -61,7 +61,6 @@ export interface Api {
     getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>>;
   };
   ui: {
-    selectFolder(): Promise<string | null>;
     getActiveWorkspace(): Promise<WorkspaceRef | null>;
     switchWorkspace(workspacePath: string, focus?: boolean): Promise<void>;
     setMode(mode: UIMode): Promise<void>;

--- a/src/shared/ipc.test.ts
+++ b/src/shared/ipc.test.ts
@@ -58,12 +58,6 @@ describe("ApiIpcChannels (v2 API)", () => {
     });
   });
 
-  describe("UI commands", () => {
-    it("has UI_SELECT_FOLDER channel", () => {
-      expect(ApiIpcChannels.UI_SELECT_FOLDER).toBe("api:ui:select-folder");
-    });
-  });
-
   describe("Events", () => {
     it("has PROJECT_OPENED event channel", () => {
       expect(ApiIpcChannels.PROJECT_OPENED).toBe("api:project:opened");

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -91,7 +91,6 @@ export const ApiIpcChannels = {
   WORKSPACE_SET_METADATA: "api:workspace:set-metadata",
   WORKSPACE_GET_METADATA: "api:workspace:get-metadata",
   // UI commands
-  UI_SELECT_FOLDER: "api:ui:select-folder",
   UI_GET_ACTIVE_WORKSPACE: "api:ui:get-active-workspace",
   UI_SWITCH_WORKSPACE: "api:ui:switch-workspace",
   UI_SET_MODE: "api:ui:set-mode",


### PR DESCRIPTION
- Eliminate standalone `ui.selectFolder` IPC handler that bypassed the intent system
- Add `"select-folder"` hook point to `OpenProjectOperation`, invoked when no path/git provided
- View module registers hook handler that shows native folder dialog via `dialogLayer`
- Simplify renderer from two IPC calls (`selectFolder` + `open`) to single `projects.open()`
- Update `projects.open` signature to `open(path?: string): Promise<Project | null>` across all layers
- Remove `UI_SELECT_FOLDER` IPC channel and all `selectFolder` references from API types, preload, and tests
- Add 6 new tests covering select-folder hook behavior (view-module + open-project)