### PR TITLE
refactor(shutdown): remove cleanup closure, dispatch app:shutdown directly

### DIFF
--- a/src/main/managers/view-manager.interface.ts
+++ b/src/main/managers/view-manager.interface.ts
@@ -226,4 +226,10 @@ export interface IViewManager {
    * @param workspacePath - Absolute path to the workspace directory
    */
   preloadWorkspaceUrl(workspacePath: string): void;
+
+  /**
+   * Destroys all views and cleans up resources.
+   * Called during application shutdown.
+   */
+  destroy(): void;
 }

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -617,6 +617,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
                 apiEventCleanupFn();
                 apiEventCleanupFn = null;
               }
+              await deps.apiRegistry.dispose();
             } catch (error) {
               deps.logger.error(
                 "IpcBridge lifecycle shutdown failed (non-fatal)",

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -149,6 +149,7 @@ function createMockViewManager() {
     isWorkspaceLoading: vi.fn(),
     setWorkspaceLoaded: vi.fn(),
     create: vi.fn(),
+    destroy: vi.fn(),
     // Test accessors
     _webContents: mockWebContents,
     _setActivePath: (p: string | null) => {
@@ -920,10 +921,10 @@ describe("ViewModule Integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Test 15: app-shutdown/stop → layers disposed
+  // Test 15: app-shutdown/stop → viewManager.destroy() + layers disposed
   // -------------------------------------------------------------------------
   describe("app-shutdown/stop", () => {
-    it("disposes shell layers", async () => {
+    it("calls viewManager.destroy() and disposes shell layers", async () => {
       // Need a quit module to prevent missing handler error
       const quitModule: IntentModule = {
         hooks: {
@@ -955,6 +956,7 @@ describe("ViewModule Integration", () => {
         payload: {},
       } as AppShutdownIntent);
 
+      expect(viewManager.destroy).toHaveBeenCalled();
       expect(layers.viewLayer.dispose).toHaveBeenCalled();
       expect(layers.windowLayer.dispose).toHaveBeenCalled();
       expect(layers.sessionLayer.dispose).toHaveBeenCalled();

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -437,6 +437,9 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
                 loadingChangeCleanupFn = null;
               }
 
+              // Destroy all views before disposing layers (uses viewLayer internally)
+              viewManager.destroy();
+
               // Dispose layers in reverse initialization order
               if (deps.viewLayer) {
                 await deps.viewLayer.dispose();


### PR DESCRIPTION
- Move `viewManager.destroy()` into view-module's `app-shutdown/stop` hook (before layer disposal)
- Move `apiRegistry.dispose()` into ipc-event-bridge's `app-shutdown/stop` hook (after event cleanup)
- Add `destroy()` to `IViewManager` interface (was missing, method existed on class)
- Remove cleanup closure and null-assignment idempotency pattern from `index.ts`
- Event handlers (`window-all-closed`, `before-quit`) now dispatch `app:shutdown` directly
- Shutdown idempotency interceptor (singleton mode) ensures only one dispatch proceeds