### PR TITLE
chore(ship): add rebase onto main before push

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -105,6 +105,21 @@ If a PR already exists for this branch:
 - If state is MERGED: skip to step 6 (delete workspace) with exit code 0
 - If state is CLOSED: continue to create new PR
 
+### 1.5. Rebase onto main
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+If rebase fails, abort and report:
+
+```
+Rebase onto main failed (conflicts?).
+
+Resolve conflicts manually, then run `/ship` again.
+```
+
 ### 2. Push
 
 ```bash


### PR DESCRIPTION
- Add rebase step (fetch + rebase origin/main) before push in /ship command
- Ensures PRs are created on a fresh base, reducing conflicts and unnecessary CI reruns
- Rebase failures abort with a clear message directing the user to resolve conflicts