### PR TITLE
refactor(operations): unify resolve hooks via workspace:resolve and project:resolve intents

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -137,6 +137,11 @@ import {
   INTENT_UPDATE_AGENT_STATUS,
 } from "./operations/update-agent-status";
 import { UpdateAvailableOperation, INTENT_UPDATE_AVAILABLE } from "./operations/update-available";
+import {
+  ResolveWorkspaceOperation,
+  INTENT_RESOLVE_WORKSPACE,
+} from "./operations/resolve-workspace";
+import { ResolveProjectOperation, INTENT_RESOLVE_PROJECT } from "./operations/resolve-project";
 import type { ICodeHydraApi } from "../shared/api/interfaces";
 import { ApiIpcChannels } from "../shared/ipc";
 import { ElectronBuildInfo } from "./build-info";
@@ -511,6 +516,8 @@ const registry = new ApiRegistry({
 
 dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation());
+dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 dispatcher.registerOperation(INTENT_SETUP, new SetupOperation());
 dispatcher.registerOperation(INTENT_SET_MODE, new SetModeOperation());
 dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -23,16 +23,24 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import {
   UpdateAgentStatusOperation,
-  UPDATE_AGENT_STATUS_OPERATION_ID,
   INTENT_UPDATE_AGENT_STATUS,
 } from "../operations/update-agent-status";
+import type { UpdateAgentStatusIntent } from "../operations/update-agent-status";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "../operations/resolve-workspace";
 import type {
-  UpdateAgentStatusIntent,
-  ResolveHookResult,
-  ResolveProjectHookResult,
-  ResolveHookInput,
-  ResolveProjectHookInput,
-} from "../operations/update-agent-status";
+  ResolveHookResult as ResolveWorkspaceHookResult,
+  ResolveHookInput as ResolveWorkspaceHookInput,
+} from "../operations/resolve-workspace";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "../operations/resolve-project";
+import type { ResolveHookResult as ResolveProjectHookResult } from "../operations/resolve-project";
 import {
   INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETED,
@@ -177,19 +185,20 @@ const TEST_WORKSPACE_PATH = "/projects/test/workspaces/feature-branch";
 function createMockResolveModule(): IntentModule {
   return {
     hooks: {
-      [UPDATE_AGENT_STATUS_OPERATION_ID]: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            void (ctx as ResolveHookInput);
+          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
+            void (ctx as ResolveWorkspaceHookInput);
             return {
               projectPath: TEST_PROJECT_PATH,
               workspaceName: TEST_WORKSPACE_NAME,
             };
           },
         },
-        "resolve-project": {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            void (ctx as ResolveProjectHookInput);
+      },
+      [RESOLVE_PROJECT_OPERATION_ID]: {
+        resolve: {
+          handler: async (): Promise<ResolveProjectHookResult> => {
             return { projectId: TEST_PROJECT_ID };
           },
         },
@@ -203,6 +212,8 @@ function createStatusTestSetup(): StatusTestSetup {
   const dispatcher = new Dispatcher(hookRegistry);
 
   dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
   const mockApiRegistry = createMockApiRegistry();
   const ipcEventBridge = createIpcEventBridge({

--- a/src/main/modules/workspace-selection-module.integration.test.ts
+++ b/src/main/modules/workspace-selection-module.integration.test.ts
@@ -21,14 +21,24 @@ import {
 } from "../operations/switch-workspace";
 import type {
   SwitchWorkspaceIntent,
-  ResolveHookResult,
-  ResolveProjectHookResult,
   SwitchWorkspaceHookResult,
   FindCandidatesHookResult,
   WorkspaceCandidate,
   WorkspaceSwitchedEvent,
 } from "../operations/switch-workspace";
 import { SWITCH_WORKSPACE_OPERATION_ID } from "../operations/switch-workspace";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "../operations/resolve-workspace";
+import type { ResolveHookResult as ResolveWorkspaceHookResult } from "../operations/resolve-workspace";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "../operations/resolve-project";
+import type { ResolveHookResult as ResolveProjectHookResult } from "../operations/resolve-project";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { DomainEvent } from "../intents/infrastructure/types";
@@ -87,15 +97,17 @@ function createTestSetup(opts: {
   const dispatcher = new Dispatcher(hookRegistry);
 
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
   let activeWorkspacePath: string | null = null;
 
   // Resolve module: workspace path → project path + workspace name
   const resolveModule: IntentModule = {
     hooks: {
-      [SWITCH_WORKSPACE_OPERATION_ID]: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
             const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
             const found = opts.candidates.find((c) => c.workspacePath === wsPath);
             if (!found) return {};
@@ -112,8 +124,8 @@ function createTestSetup(opts: {
   // Resolve project module
   const resolveProjectModule: IntentModule = {
     hooks: {
-      [SWITCH_WORKSPACE_OPERATION_ID]: {
-        "resolve-project": {
+      [RESOLVE_PROJECT_OPERATION_ID]: {
+        resolve: {
           handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
             const { projectPath } = ctx as { projectPath: string } & HookContext;
             if (projectPath === PROJECT_PATH) {

--- a/src/main/operations/get-agent-session.integration.test.ts
+++ b/src/main/operations/get-agent-session.integration.test.ts
@@ -24,8 +24,13 @@ import type {
   GetAgentSessionIntent,
   GetAgentSessionHookInput,
   GetAgentSessionHookResult,
-  ResolveHookResult,
 } from "./get-agent-session";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "./resolve-workspace";
+import type { ResolveHookResult } from "./resolve-workspace";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
@@ -80,14 +85,15 @@ function createTestSetup(opts: { agentStatusManager?: MockAgentStatusManager | n
   const dispatcher = new Dispatcher(hookRegistry);
 
   dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 
   // Resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
     hooks: {
-      [GET_AGENT_SESSION_OPERATION_ID]: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
           handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            const intent = ctx.intent as GetAgentSessionIntent;
+            const intent = ctx.intent as { payload: { workspacePath: string } };
             if (intent.payload.workspacePath === WORKSPACE_PATH) {
               return { projectPath: PROJECT_ROOT, workspaceName };
             }

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -19,24 +19,28 @@ import {
   SET_METADATA_OPERATION_ID,
   INTENT_SET_METADATA,
 } from "./set-metadata";
-import type {
-  SetMetadataIntent,
-  ResolveHookResult as SetResolveHookResult,
-  ResolveProjectHookResult as SetResolveProjectHookResult,
-  ResolveProjectHookInput as SetResolveProjectHookInput,
-  SetHookInput,
-} from "./set-metadata";
+import type { SetMetadataIntent, SetHookInput } from "./set-metadata";
 import {
   GetMetadataOperation,
   GET_METADATA_OPERATION_ID,
   INTENT_GET_METADATA,
 } from "./get-metadata";
+import type { GetMetadataIntent, GetMetadataHookResult, GetHookInput } from "./get-metadata";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "./resolve-workspace";
+import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "./resolve-project";
 import type {
-  GetMetadataIntent,
-  GetMetadataHookResult,
-  ResolveHookResult as GetResolveHookResult,
-  GetHookInput,
-} from "./get-metadata";
+  ResolveHookInput as ResolveProjectHookInput,
+  ResolveHookResult as ResolveProjectHookResult,
+} from "./resolve-project";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
 import { createMockGitClient } from "../../services/git/git-client.state-mock";
 import { createFileSystemMock, directory } from "../../services/platform/filesystem.state-mock";
@@ -129,25 +133,16 @@ function createTestSetup(): TestSetup {
   // Register operations
   dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
   dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
   // resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
     hooks: {
-      [SET_METADATA_OPERATION_ID]: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<SetResolveHookResult> => {
-            const intent = ctx.intent as SetMetadataIntent;
-            if (intent.payload.workspacePath === workspacePath.toString()) {
-              return { projectPath: PROJECT_ROOT.toString(), workspaceName };
-            }
-            return {};
-          },
-        },
-      },
-      [GET_METADATA_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<GetResolveHookResult> => {
-            const intent = ctx.intent as GetMetadataIntent;
+          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
+            const intent = ctx.intent as { payload: { workspacePath: string } };
             if (intent.payload.workspacePath === workspacePath.toString()) {
               return { projectPath: PROJECT_ROOT.toString(), workspaceName };
             }
@@ -158,13 +153,13 @@ function createTestSetup(): TestSetup {
     },
   };
 
-  // resolve-project module: resolves projectPath → projectId (only for set-metadata commands)
+  // resolve-project module: resolves projectPath → projectId
   const resolveProjectModule: IntentModule = {
     hooks: {
-      [SET_METADATA_OPERATION_ID]: {
-        "resolve-project": {
-          handler: async (ctx: HookContext): Promise<SetResolveProjectHookResult> => {
-            const { projectPath } = ctx as SetResolveProjectHookInput;
+      [RESOLVE_PROJECT_OPERATION_ID]: {
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+            const { projectPath } = ctx as ResolveProjectHookInput;
             if (projectPath === PROJECT_ROOT.toString()) {
               return { projectId };
             }

--- a/src/main/operations/get-metadata.ts
+++ b/src/main/operations/get-metadata.ts
@@ -1,9 +1,9 @@
 /**
  * GetMetadataOperation - Orchestrates workspace metadata reads.
  *
- * Runs two hook points in sequence:
- * 1. "resolve" - Validates workspacePath is tracked, returns projectPath + workspaceName
- * 2. "get" - Each handler performs the actual provider read
+ * Runs two steps:
+ * 1. Dispatch workspace:resolve to validate workspacePath
+ * 2. "get" hook — each handler performs the actual provider read
  *
  * No provider dependencies - hook handlers do the actual work.
  * No domain events - this is a query operation.
@@ -11,7 +11,7 @@
 
 import type { Intent } from "../intents/infrastructure/types";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
-import type { WorkspaceName } from "../../shared/api/types";
+import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 
 // =============================================================================
 // Intent Types
@@ -33,17 +33,6 @@ export const INTENT_GET_METADATA = "workspace:get-metadata" as const;
 // =============================================================================
 
 export const GET_METADATA_OPERATION_ID = "get-metadata";
-
-/** Input context for "resolve" handlers. */
-export interface ResolveHookInput extends HookContext {
-  readonly workspacePath: string;
-}
-
-/** Per-handler result for "resolve" hook point. */
-export interface ResolveHookResult {
-  readonly projectPath?: string;
-  readonly workspaceName?: WorkspaceName;
-}
 
 /**
  * Input context for "get" handlers — built from resolve results.
@@ -75,24 +64,11 @@ export class GetMetadataOperation implements Operation<
   ): Promise<Readonly<Record<string, string>>> {
     const { payload } = ctx.intent;
 
-    // 1. resolve — validate workspacePath is tracked
-    const resolveCtx: ResolveHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results: resolveResults, errors: resolveErrors } =
-      await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-    if (resolveErrors.length > 0) {
-      throw new AggregateError(resolveErrors, "get-metadata resolve failed");
-    }
-
-    let found = false;
-    for (const result of resolveResults) {
-      if (result.projectPath !== undefined) found = true;
-    }
-    if (!found) {
-      throw new Error(`Workspace not found: ${payload.workspacePath}`);
-    }
+    // 1. Dispatch shared workspace resolution
+    await ctx.dispatch({
+      type: INTENT_RESOLVE_WORKSPACE,
+      payload: { workspacePath: payload.workspacePath },
+    } as ResolveWorkspaceIntent);
 
     // 2. get — handler performs the actual provider read
     const getCtx: GetHookInput = {

--- a/src/main/operations/get-workspace-status.integration.test.ts
+++ b/src/main/operations/get-workspace-status.integration.test.ts
@@ -22,10 +22,15 @@ import {
 } from "./get-workspace-status";
 import type {
   GetWorkspaceStatusIntent,
-  ResolveHookResult,
   GetStatusHookResult,
   GetStatusHookInput,
 } from "./get-workspace-status";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "./resolve-workspace";
+import type { ResolveHookResult } from "./resolve-workspace";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
@@ -93,14 +98,15 @@ function createTestSetup(opts: {
   const dispatcher = new Dispatcher(hookRegistry);
 
   dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 
   // resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
     hooks: {
-      [GET_WORKSPACE_STATUS_OPERATION_ID]: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
           handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            const intent = ctx.intent as GetWorkspaceStatusIntent;
+            const intent = ctx.intent as { payload: { workspacePath: string } };
             if (intent.payload.workspacePath === WORKSPACE_PATH) {
               return { projectPath: PROJECT_ROOT, workspaceName };
             }

--- a/src/main/operations/resolve-project.integration.test.ts
+++ b/src/main/operations/resolve-project.integration.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+/**
+ * Integration tests for resolve-project operation through the Dispatcher.
+ *
+ * Tests verify the full dispatch pipeline: intent -> operation -> hooks -> result.
+ *
+ * Test plan items covered:
+ * #1: resolves projectPath → projectId + projectName
+ * #2: throws when no handler returns projectId
+ * #3: defaults projectName to empty string when not provided
+ * #4: propagates hook handler errors
+ */
+
+import { describe, it, expect } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "./resolve-project";
+import type { ResolveProjectIntent, ResolveHookResult } from "./resolve-project";
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { ProjectId } from "../../shared/api/types";
+
+// =============================================================================
+// Test Constants
+// =============================================================================
+
+const PROJECT_PATH = "/projects/my-app";
+const PROJECT_ID = "my-app-12345678" as ProjectId;
+const PROJECT_NAME = "my-app";
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveHookResult>): {
+  dispatcher: Dispatcher;
+} {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+
+  if (resolveHandler) {
+    const module: IntentModule = {
+      hooks: {
+        [RESOLVE_PROJECT_OPERATION_ID]: {
+          resolve: { handler: resolveHandler },
+        },
+      },
+    };
+    dispatcher.registerModule(module);
+  }
+
+  return { dispatcher };
+}
+
+function resolveIntent(projectPath: string): ResolveProjectIntent {
+  return {
+    type: INTENT_RESOLVE_PROJECT,
+    payload: { projectPath },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ResolveProjectOperation Integration", () => {
+  describe("success", () => {
+    it("resolves projectPath to projectId + projectName (#1)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectId: PROJECT_ID,
+          projectName: PROJECT_NAME,
+        })
+      );
+
+      const result = await dispatcher.dispatch(resolveIntent(PROJECT_PATH));
+
+      expect(result).toEqual({
+        projectId: PROJECT_ID,
+        projectName: PROJECT_NAME,
+      });
+    });
+
+    it("defaults projectName to empty string when not provided (#3)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectId: PROJECT_ID,
+        })
+      );
+
+      const result = await dispatcher.dispatch(resolveIntent(PROJECT_PATH));
+
+      expect(result).toEqual({
+        projectId: PROJECT_ID,
+        projectName: "",
+      });
+    });
+  });
+
+  describe("failure", () => {
+    it("throws when no handler returns projectId (#2)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectName: PROJECT_NAME,
+        })
+      );
+
+      await expect(dispatcher.dispatch(resolveIntent(PROJECT_PATH))).rejects.toThrow(
+        `Project not found for path: ${PROJECT_PATH}`
+      );
+    });
+
+    it("throws when no handler is registered", async () => {
+      const { dispatcher } = createTestSetup();
+
+      await expect(dispatcher.dispatch(resolveIntent(PROJECT_PATH))).rejects.toThrow(
+        `Project not found for path: ${PROJECT_PATH}`
+      );
+    });
+
+    it("propagates hook handler errors (#4)", async () => {
+      const { dispatcher } = createTestSetup(async () => {
+        throw new Error("storage error");
+      });
+
+      await expect(dispatcher.dispatch(resolveIntent(PROJECT_PATH))).rejects.toThrow(
+        "storage error"
+      );
+    });
+  });
+});

--- a/src/main/operations/resolve-project.ts
+++ b/src/main/operations/resolve-project.ts
@@ -1,0 +1,93 @@
+/**
+ * ResolveProjectOperation - Shared project resolution.
+ *
+ * Centralizes the projectPath → (projectId, projectName) lookup
+ * used by multiple operations. Each consuming operation dispatches this
+ * intent instead of running its own resolve-project hook.
+ *
+ * Single hook point:
+ * 1. "resolve" — collected from modules (e.g., localProjectModule)
+ *
+ * Throws if no handler returns projectId.
+ */
+
+import type { Intent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { ProjectId } from "../../shared/api/types";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface ResolveProjectPayload {
+  readonly projectPath: string;
+}
+
+export interface ResolveProjectResult {
+  readonly projectId: ProjectId;
+  readonly projectName: string;
+}
+
+export interface ResolveProjectIntent extends Intent<ResolveProjectResult> {
+  readonly type: "project:resolve";
+  readonly payload: ResolveProjectPayload;
+}
+
+export const INTENT_RESOLVE_PROJECT = "project:resolve" as const;
+
+// =============================================================================
+// Hook Types
+// =============================================================================
+
+export const RESOLVE_PROJECT_OPERATION_ID = "resolve-project";
+
+/** Input context for "resolve" handlers. */
+export interface ResolveHookInput extends HookContext {
+  readonly projectPath: string;
+}
+
+/** Per-handler result for "resolve" hook point. */
+export interface ResolveHookResult {
+  readonly projectId?: ProjectId;
+  readonly projectName?: string;
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class ResolveProjectOperation implements Operation<
+  ResolveProjectIntent,
+  ResolveProjectResult
+> {
+  readonly id = RESOLVE_PROJECT_OPERATION_ID;
+
+  async execute(ctx: OperationContext<ResolveProjectIntent>): Promise<ResolveProjectResult> {
+    const { payload } = ctx.intent;
+
+    const resolveCtx: ResolveHookInput = {
+      intent: ctx.intent,
+      projectPath: payload.projectPath,
+    };
+    const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+    if (errors.length === 1) {
+      throw errors[0]!;
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "project:resolve hooks failed");
+    }
+
+    let projectId: ProjectId | undefined;
+    let projectName: string | undefined;
+    for (const r of results) {
+      if (r.projectId !== undefined) projectId = r.projectId;
+      if (r.projectName !== undefined) projectName = r.projectName;
+    }
+
+    if (!projectId) {
+      throw new Error(`Project not found for path: ${payload.projectPath}`);
+    }
+
+    return { projectId, projectName: projectName ?? "" };
+  }
+}

--- a/src/main/operations/resolve-workspace.integration.test.ts
+++ b/src/main/operations/resolve-workspace.integration.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+/**
+ * Integration tests for resolve-workspace operation through the Dispatcher.
+ *
+ * Tests verify the full dispatch pipeline: intent -> operation -> hooks -> result.
+ *
+ * Test plan items covered:
+ * #1: resolves workspacePath → projectPath + workspaceName
+ * #2: throws when no handler returns projectPath
+ * #3: throws when no handler returns workspaceName
+ * #4: propagates hook handler errors
+ */
+
+import { describe, it, expect } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "./resolve-workspace";
+import type { ResolveWorkspaceIntent, ResolveHookResult } from "./resolve-workspace";
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { WorkspaceName } from "../../shared/api/types";
+
+// =============================================================================
+// Test Constants
+// =============================================================================
+
+const PROJECT_PATH = "/projects/my-app";
+const WORKSPACE_PATH = "/workspaces/feature-x";
+const WORKSPACE_NAME = "feature-x" as WorkspaceName;
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveHookResult>): {
+  dispatcher: Dispatcher;
+} {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+
+  if (resolveHandler) {
+    const module: IntentModule = {
+      hooks: {
+        [RESOLVE_WORKSPACE_OPERATION_ID]: {
+          resolve: { handler: resolveHandler },
+        },
+      },
+    };
+    dispatcher.registerModule(module);
+  }
+
+  return { dispatcher };
+}
+
+function resolveIntent(workspacePath: string): ResolveWorkspaceIntent {
+  return {
+    type: INTENT_RESOLVE_WORKSPACE,
+    payload: { workspacePath },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ResolveWorkspaceOperation Integration", () => {
+  describe("success", () => {
+    it("resolves workspacePath to projectPath + workspaceName (#1)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectPath: PROJECT_PATH,
+          workspaceName: WORKSPACE_NAME,
+        })
+      );
+
+      const result = await dispatcher.dispatch(resolveIntent(WORKSPACE_PATH));
+
+      expect(result).toEqual({
+        projectPath: PROJECT_PATH,
+        workspaceName: WORKSPACE_NAME,
+      });
+    });
+  });
+
+  describe("failure", () => {
+    it("throws when no handler returns projectPath (#2)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          workspaceName: WORKSPACE_NAME,
+        })
+      );
+
+      await expect(dispatcher.dispatch(resolveIntent(WORKSPACE_PATH))).rejects.toThrow(
+        `Workspace not found: ${WORKSPACE_PATH}`
+      );
+    });
+
+    it("throws when no handler returns workspaceName (#3)", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectPath: PROJECT_PATH,
+        })
+      );
+
+      await expect(dispatcher.dispatch(resolveIntent(WORKSPACE_PATH))).rejects.toThrow(
+        `Workspace not found: ${WORKSPACE_PATH}`
+      );
+    });
+
+    it("throws when no handler is registered", async () => {
+      const { dispatcher } = createTestSetup();
+
+      await expect(dispatcher.dispatch(resolveIntent(WORKSPACE_PATH))).rejects.toThrow(
+        `Workspace not found: ${WORKSPACE_PATH}`
+      );
+    });
+
+    it("propagates hook handler errors (#4)", async () => {
+      const { dispatcher } = createTestSetup(async () => {
+        throw new Error("provider error");
+      });
+
+      await expect(dispatcher.dispatch(resolveIntent(WORKSPACE_PATH))).rejects.toThrow(
+        "provider error"
+      );
+    });
+  });
+});

--- a/src/main/operations/resolve-workspace.ts
+++ b/src/main/operations/resolve-workspace.ts
@@ -1,0 +1,93 @@
+/**
+ * ResolveWorkspaceOperation - Shared workspace resolution.
+ *
+ * Centralizes the workspacePath → (projectPath, workspaceName) lookup
+ * used by multiple operations. Each consuming operation dispatches this
+ * intent instead of running its own resolve hook.
+ *
+ * Single hook point:
+ * 1. "resolve" — collected from modules (e.g., gitWorktreeWorkspaceModule)
+ *
+ * Throws if no handler returns projectPath or workspaceName.
+ */
+
+import type { Intent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { WorkspaceName } from "../../shared/api/types";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface ResolveWorkspacePayload {
+  readonly workspacePath: string;
+}
+
+export interface ResolveWorkspaceResult {
+  readonly projectPath: string;
+  readonly workspaceName: WorkspaceName;
+}
+
+export interface ResolveWorkspaceIntent extends Intent<ResolveWorkspaceResult> {
+  readonly type: "workspace:resolve";
+  readonly payload: ResolveWorkspacePayload;
+}
+
+export const INTENT_RESOLVE_WORKSPACE = "workspace:resolve" as const;
+
+// =============================================================================
+// Hook Types
+// =============================================================================
+
+export const RESOLVE_WORKSPACE_OPERATION_ID = "resolve-workspace";
+
+/** Input context for "resolve" handlers. */
+export interface ResolveHookInput extends HookContext {
+  readonly workspacePath: string;
+}
+
+/** Per-handler result for "resolve" hook point. */
+export interface ResolveHookResult {
+  readonly projectPath?: string;
+  readonly workspaceName?: WorkspaceName;
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class ResolveWorkspaceOperation implements Operation<
+  ResolveWorkspaceIntent,
+  ResolveWorkspaceResult
+> {
+  readonly id = RESOLVE_WORKSPACE_OPERATION_ID;
+
+  async execute(ctx: OperationContext<ResolveWorkspaceIntent>): Promise<ResolveWorkspaceResult> {
+    const { payload } = ctx.intent;
+
+    const resolveCtx: ResolveHookInput = {
+      intent: ctx.intent,
+      workspacePath: payload.workspacePath,
+    };
+    const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+    if (errors.length === 1) {
+      throw errors[0]!;
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "workspace:resolve hooks failed");
+    }
+
+    let projectPath: string | undefined;
+    let workspaceName: WorkspaceName | undefined;
+    for (const r of results) {
+      if (r.projectPath !== undefined) projectPath = r.projectPath;
+      if (r.workspaceName !== undefined) workspaceName = r.workspaceName;
+    }
+
+    if (!projectPath || !workspaceName) {
+      throw new Error(`Workspace not found: ${payload.workspacePath}`);
+    }
+
+    return { projectPath, workspaceName };
+  }
+}

--- a/src/main/operations/set-metadata.ts
+++ b/src/main/operations/set-metadata.ts
@@ -1,10 +1,10 @@
 /**
  * SetMetadataOperation - Orchestrates workspace metadata writes.
  *
- * Runs three hook points in sequence:
- * 1. "resolve" - Validates workspacePath is tracked, returns projectPath + workspaceName
- * 2. "resolve-project" - Resolves projectPath to projectId (for domain events)
- * 3. "set" - Each handler performs the actual provider write
+ * Runs three steps:
+ * 1. Dispatch workspace:resolve — validates workspacePath, returns projectPath + workspaceName
+ * 2. Dispatch project:resolve — resolves projectPath to projectId (for domain events)
+ * 3. "set" hook — each handler performs the actual provider write
  *
  * No provider dependencies - hook handlers do the actual work.
  */
@@ -12,6 +12,8 @@
 import type { Intent, DomainEvent } from "../intents/infrastructure/types";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 
 // =============================================================================
 // Intent + Event Types
@@ -49,27 +51,6 @@ export const EVENT_METADATA_CHANGED = "workspace:metadata-changed" as const;
 
 export const SET_METADATA_OPERATION_ID = "set-metadata";
 
-/** Input context for "resolve" handlers. */
-export interface ResolveHookInput extends HookContext {
-  readonly workspacePath: string;
-}
-
-/** Per-handler result for "resolve" hook point. */
-export interface ResolveHookResult {
-  readonly projectPath?: string;
-  readonly workspaceName?: WorkspaceName;
-}
-
-/** Input context for "resolve-project" handlers. */
-export interface ResolveProjectHookInput extends HookContext {
-  readonly projectPath: string;
-}
-
-/** Per-handler result for "resolve-project" hook point. */
-export interface ResolveProjectHookResult {
-  readonly projectId?: ProjectId;
-}
-
 /**
  * Input context for "set" handlers — built from resolve results.
  */
@@ -87,45 +68,17 @@ export class SetMetadataOperation implements Operation<SetMetadataIntent, void> 
   async execute(ctx: OperationContext<SetMetadataIntent>): Promise<void> {
     const { payload } = ctx.intent;
 
-    // 1. resolve — validate workspacePath is tracked, get projectPath + workspaceName
-    const resolveCtx: ResolveHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results: resolveResults, errors: resolveErrors } =
-      await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-    if (resolveErrors.length > 0) {
-      throw new AggregateError(resolveErrors, "set-metadata resolve failed");
-    }
+    // 1. Dispatch shared workspace resolution
+    const { projectPath, workspaceName } = await ctx.dispatch({
+      type: INTENT_RESOLVE_WORKSPACE,
+      payload: { workspacePath: payload.workspacePath },
+    } as ResolveWorkspaceIntent);
 
-    let projectPath: string | undefined;
-    let workspaceName: WorkspaceName | undefined;
-    for (const result of resolveResults) {
-      if (result.projectPath !== undefined) projectPath = result.projectPath;
-      if (result.workspaceName !== undefined) workspaceName = result.workspaceName;
-    }
-    if (!projectPath || !workspaceName) {
-      throw new Error(`Workspace not found: ${payload.workspacePath}`);
-    }
-
-    // 2. resolve-project — get projectId from projectPath (for domain events)
-    const resolveProjectCtx: ResolveProjectHookInput = {
-      intent: ctx.intent,
-      projectPath,
-    };
-    const { results: resolveProjectResults, errors: resolveProjectErrors } =
-      await ctx.hooks.collect<ResolveProjectHookResult>("resolve-project", resolveProjectCtx);
-    if (resolveProjectErrors.length > 0) {
-      throw new AggregateError(resolveProjectErrors, "set-metadata resolve-project failed");
-    }
-
-    let projectId: ProjectId | undefined;
-    for (const result of resolveProjectResults) {
-      if (result.projectId !== undefined) projectId = result.projectId;
-    }
-    if (!projectId) {
-      throw new Error(`Project not found for path: ${projectPath}`);
-    }
+    // 2. Dispatch shared project resolution
+    const { projectId } = await ctx.dispatch({
+      type: INTENT_RESOLVE_PROJECT,
+      payload: { projectPath },
+    } as ResolveProjectIntent);
 
     // 3. set — handler performs the actual provider write
     const setCtx: SetHookInput = {


### PR DESCRIPTION
- Add shared `workspace:resolve` and `project:resolve` operations that centralize workspace path resolution and project path resolution
- Replace ~13 duplicated per-operation resolve hook registrations in `git-worktree-workspace-module` and `local-project-module` with single registrations on the new operations
- Update 9 consuming operations to dispatch to shared resolve intents instead of running inline `collect()` calls
- Net reduction: 1058 insertions vs 1057 deletions across 32 files, eliminating ~8 copies of resolve type definitions