### PR TITLE
fix(projects): restore remoteUrl for remote projects on startup

### DIFF
--- a/src/main/modules/local-project-module.integration.test.ts
+++ b/src/main/modules/local-project-module.integration.test.ts
@@ -231,6 +231,54 @@ describe("LocalProjectModule Integration", () => {
       expect(errors[0]!.message).toBe("Not a git repository");
     });
 
+    it("returns remoteUrl from persisted config on startup (#18)", async () => {
+      const setup = createTestSetup();
+
+      // Pre-populate config with remoteUrl (simulates saved remote project)
+      writeConfig(setup.fs, PROJECT_PATH, "https://github.com/user/repo.git");
+
+      // Resolve with local path only (no git URL) — like app startup
+      const { results, errors } = await setup.openHooks.collect<ResolveHookResult>("resolve", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        projectPath: new Path(PROJECT_PATH).toString(),
+        remoteUrl: "https://github.com/user/repo.git",
+      });
+    });
+
+    it("returns remoteUrl with alreadyOpen when project is in state (#19)", async () => {
+      const setup = createTestSetup();
+
+      // Pre-populate config with remoteUrl
+      writeConfig(setup.fs, PROJECT_PATH, "https://github.com/user/repo.git");
+
+      // Register so project is in internal state
+      const registerCtx: RegisterHookInput = {
+        intent: openLocalIntent(PROJECT_PATH),
+        projectPath: new Path(PROJECT_PATH).toString(),
+        remoteUrl: "https://github.com/user/repo.git",
+      };
+      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+
+      // Resolve again — should return alreadyOpen AND remoteUrl
+      const { results, errors } = await setup.openHooks.collect<ResolveHookResult>("resolve", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        projectPath: new Path(PROJECT_PATH).toString(),
+        alreadyOpen: true,
+        remoteUrl: "https://github.com/user/repo.git",
+      });
+      expect(setup.globalProvider.validateRepository).not.toHaveBeenCalled();
+    });
+
     it("returns alreadyOpen when path is in internal state (#14)", async () => {
       const setup = createTestSetup();
 

--- a/src/main/modules/local-project-module.ts
+++ b/src/main/modules/local-project-module.ts
@@ -326,14 +326,25 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               return {};
             }
 
+            // Check persisted config for remoteUrl (restores icon on startup)
+            const config = await getProjectConfig(fs, projectsDir, path.toString());
+            const remoteUrl = config?.remoteUrl;
+
             // Already open — skip validation, signal short-circuit
             if (projects.has(path.toString())) {
-              return { projectPath: path.toString(), alreadyOpen: true };
+              return {
+                projectPath: path.toString(),
+                alreadyOpen: true,
+                ...(remoteUrl !== undefined && { remoteUrl }),
+              };
             }
 
             await globalProvider.validateRepository(path);
 
-            return { projectPath: path.toString() };
+            return {
+              projectPath: path.toString(),
+              ...(remoteUrl !== undefined && { remoteUrl }),
+            };
           },
         },
 


### PR DESCRIPTION
- Read persisted config in LocalProjectModule resolve hook to restore remoteUrl for remote projects reopened at app startup
- Without this, remote projects lost their git icon in the sidebar after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)