### PR TITLE
chore(operations): pass projectPath from renderer, eliminate reverse-direction resolve hooks

### DIFF
--- a/src/main/api/registry-types.test.ts
+++ b/src/main/api/registry-types.test.ts
@@ -12,7 +12,7 @@ import type {
   MethodResult,
   EmptyPayload,
   ProjectOpenPayload,
-  ProjectIdPayload,
+  ProjectPathPayload,
   WorkspaceCreatePayload,
   WorkspaceRemovePayload,
   WorkspacePathPayload,
@@ -31,7 +31,6 @@ import type {
 } from "./registry-types";
 import { ALL_METHOD_PATHS } from "./registry-types";
 import type {
-  ProjectId,
   Project,
   Workspace,
   WorkspaceRef,
@@ -103,23 +102,23 @@ describe("registry-types.payload", () => {
     expectTypeOf<MethodPayload<"projects.open">>().toHaveProperty("path");
   });
 
-  it("extracts ProjectIdPayload for project ID methods", () => {
-    expectTypeOf<MethodPayload<"projects.fetchBases">>().toEqualTypeOf<ProjectIdPayload>();
+  it("extracts ProjectPathPayload for project path methods", () => {
+    expectTypeOf<MethodPayload<"projects.fetchBases">>().toEqualTypeOf<ProjectPathPayload>();
     // Verify shape
-    expectTypeOf<MethodPayload<"projects.fetchBases">>().toHaveProperty("projectId");
-    expectTypeOf<MethodPayload<"projects.fetchBases">["projectId"]>().toEqualTypeOf<ProjectId>();
+    expectTypeOf<MethodPayload<"projects.fetchBases">>().toHaveProperty("projectPath");
+    expectTypeOf<MethodPayload<"projects.fetchBases">["projectPath"]>().toEqualTypeOf<string>();
   });
 
   it("extracts ProjectClosePayload for projects.close", () => {
     // projects.close has optional removeLocalRepo parameter
-    expectTypeOf<MethodPayload<"projects.close">>().toHaveProperty("projectId");
-    expectTypeOf<MethodPayload<"projects.close">["projectId"]>().toEqualTypeOf<ProjectId>();
+    expectTypeOf<MethodPayload<"projects.close">>().toHaveProperty("projectPath");
+    expectTypeOf<MethodPayload<"projects.close">["projectPath"]>().toEqualTypeOf<string>();
   });
 
   it("extracts WorkspaceCreatePayload for workspaces.create", () => {
     expectTypeOf<MethodPayload<"workspaces.create">>().toEqualTypeOf<WorkspaceCreatePayload>();
     // Verify shape
-    expectTypeOf<MethodPayload<"workspaces.create">>().toHaveProperty("projectId");
+    expectTypeOf<MethodPayload<"workspaces.create">>().toHaveProperty("projectPath");
     expectTypeOf<MethodPayload<"workspaces.create">>().toHaveProperty("name");
     expectTypeOf<MethodPayload<"workspaces.create">>().toHaveProperty("base");
   });

--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -4,7 +4,6 @@
  */
 
 import type {
-  ProjectId,
   Project,
   Workspace,
   WorkspaceRef,
@@ -30,7 +29,7 @@ export interface ProjectOpenPayload {
 
 /** projects.close */
 export interface ProjectClosePayload {
-  readonly projectId: ProjectId;
+  readonly projectPath: string;
   /** If true and project has remoteUrl, delete the entire project directory including cloned repo */
   readonly removeLocalRepo?: boolean;
 }
@@ -40,14 +39,14 @@ export interface ProjectClonePayload {
   readonly url: string;
 }
 
-/** projects.get, projects.fetchBases */
-export interface ProjectIdPayload {
-  readonly projectId: ProjectId;
+/** projects.fetchBases */
+export interface ProjectPathPayload {
+  readonly projectPath: string;
 }
 
 /** workspaces.create */
 export interface WorkspaceCreatePayload {
-  readonly projectId?: ProjectId;
+  readonly projectPath?: string;
   readonly name: string;
   readonly base: string;
   /** Optional initial prompt to send after workspace is created */
@@ -118,7 +117,7 @@ export interface MethodRegistry {
   "projects.close": (payload: ProjectClosePayload) => Promise<void>;
   "projects.clone": (payload: ProjectClonePayload) => Promise<Project>;
   "projects.fetchBases": (
-    payload: ProjectIdPayload
+    payload: ProjectPathPayload
   ) => Promise<{ readonly bases: readonly BaseInfo[] }>;
 
   // Workspaces

--- a/src/main/api/registry.test-utils.ts
+++ b/src/main/api/registry.test-utils.ts
@@ -197,14 +197,14 @@ function createMockCodeHydraApi(
   return {
     projects: {
       open: (path) => get("projects.open")({ ...(path !== undefined && { path }) }),
-      close: (projectId, options) => get("projects.close")({ projectId, ...options }),
+      close: (projectPath, options) => get("projects.close")({ projectPath, ...options }),
       clone: (url) => get("projects.clone")({ url }),
-      fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),
+      fetchBases: (projectPath) => get("projects.fetchBases")({ projectPath }),
     },
     workspaces: {
-      create: (projectId, name, base, options) =>
+      create: (projectPath, name, base, options) =>
         get("workspaces.create")({
-          ...(projectId !== undefined && { projectId }),
+          ...(projectPath !== undefined && { projectPath }),
           name,
           base,
           ...options,

--- a/src/main/api/registry.ts
+++ b/src/main/api/registry.ts
@@ -171,14 +171,14 @@ export class ApiRegistry implements IApiRegistry {
     return {
       projects: {
         open: (path) => get("projects.open")({ ...(path !== undefined && { path }) }),
-        close: (projectId, options) => get("projects.close")({ projectId, ...options }),
+        close: (projectPath, options) => get("projects.close")({ projectPath, ...options }),
         clone: (url) => get("projects.clone")({ url }),
-        fetchBases: (projectId) => get("projects.fetchBases")({ projectId }),
+        fetchBases: (projectPath) => get("projects.fetchBases")({ projectPath }),
       },
       workspaces: {
-        create: (projectId, name, base, options) =>
+        create: (projectPath, name, base, options) =>
           get("workspaces.create")({
-            ...(projectId !== undefined && { projectId }),
+            ...(projectPath !== undefined && { projectPath }),
             name,
             base,
             ...options,

--- a/src/main/ipc/api-handlers.integration.test.ts
+++ b/src/main/ipc/api-handlers.integration.test.ts
@@ -162,10 +162,15 @@ describe("API → IPC → Renderer event flow", () => {
 
   it("should forward project:bases-updated event to renderer", () => {
     const bases = [{ name: "main", isRemote: false }];
-    emitEvent("project:bases-updated", { projectId: TEST_PROJECT_ID, bases });
+    emitEvent("project:bases-updated", {
+      projectId: TEST_PROJECT_ID,
+      projectPath: "/test/project",
+      bases,
+    });
 
     expect(sendToUI).toHaveBeenCalledWith("api:project:bases-updated", {
       projectId: TEST_PROJECT_ID,
+      projectPath: "/test/project",
       bases,
     });
   });

--- a/src/main/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/main/modules/git-worktree-workspace-module.integration.test.ts
@@ -38,7 +38,6 @@ import { createGitWorktreeWorkspaceModule } from "./git-worktree-workspace-modul
 import type { FetchBasesHookResult } from "./git-worktree-workspace-module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { Path } from "../../services/platform/path";
-import type { ProjectId } from "../../shared/api/types";
 
 // =============================================================================
 // Mock Dependencies
@@ -471,7 +470,6 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const createIntent: OpenWorkspaceIntent = {
           type: "workspace:open",
           payload: {
-            projectId: "my-app-12345678" as ProjectId,
             workspaceName: "new-feature",
             base: "origin/main",
             projectPath,
@@ -506,7 +504,6 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const createIntent: OpenWorkspaceIntent = {
           type: "workspace:open",
           payload: {
-            projectId: "my-app-12345678" as ProjectId,
             workspaceName: "existing-ws",
             base: "origin/main",
             projectPath,

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -18,7 +18,7 @@ import type {
   ProjectOpenPayload,
   ProjectClosePayload,
   ProjectClonePayload,
-  ProjectIdPayload,
+  ProjectPathPayload,
   WorkspaceCreatePayload,
   WorkspaceRemovePayload,
   WorkspaceSetMetadataPayload,
@@ -258,7 +258,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          ...(payload.projectId !== undefined && { projectId: payload.projectId }),
+          ...(payload.projectPath !== undefined && { projectPath: payload.projectPath }),
           workspaceName: payload.name,
           base: payload.base,
           ...(payload.initialPrompt !== undefined && { initialPrompt: payload.initialPrompt }),
@@ -505,7 +505,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
       const intent: CloseProjectIntent = {
         type: INTENT_CLOSE_PROJECT,
         payload: {
-          projectId: payload.projectId,
+          projectPath: payload.projectPath,
           ...(payload.removeLocalRepo !== undefined && {
             removeLocalRepo: payload.removeLocalRepo,
           }),
@@ -518,13 +518,13 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
 
   apiRegistry.register(
     "projects.fetchBases",
-    async (payload: ProjectIdPayload) => {
+    async (payload: ProjectPathPayload) => {
       // Dispatch workspace:open with incomplete payload (missing workspaceName/base)
-      // This triggers the resolve-project + fetch-bases path
+      // This triggers the project:resolve + fetch-bases path
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: payload.projectId,
+          projectPath: payload.projectPath,
         },
       };
       const result = await dispatcher.dispatch(intent);
@@ -535,6 +535,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
         bases: readonly { name: string; isRemote: boolean }[];
         defaultBaseBranch?: string;
         projectPath: string;
+        projectId: import("../../shared/api/types").ProjectId;
       };
 
       // Fire-and-forget background update
@@ -544,13 +545,14 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
           await deps.globalWorktreeProvider.updateBases(projectRoot);
           const updatedBases = await deps.globalWorktreeProvider.listBases(projectRoot);
           apiRegistry.emit("project:bases-updated", {
-            projectId: payload.projectId,
+            projectId: basesResult.projectId,
+            projectPath: basesResult.projectPath,
             bases: updatedBases,
           });
         } catch (error) {
           logger.error(
             "Failed to fetch bases for project",
-            { projectId: payload.projectId },
+            { projectPath: payload.projectPath },
             error instanceof Error ? error : undefined
           );
         }

--- a/src/main/modules/local-project-module.integration.test.ts
+++ b/src/main/modules/local-project-module.integration.test.ts
@@ -12,8 +12,8 @@
  * #4: register generates ID and persists new local projects
  * #5: register registers remote project (saves with remoteUrl from context)
  * #6: register skips save when project config already exists
- * #7: close resolve finds project by ID in internal state
- * #8: close resolve returns empty for unknown project ID
+ * #7: close resolve returns config for known project path
+ * #8: close resolve returns empty for unknown project path
  * #9: close removes from state and config
  * #10: close removes remote project from state and config
  * #11: activate returns all project paths including remote
@@ -166,10 +166,10 @@ function openGitIntent(url: string): OpenProjectIntent {
   };
 }
 
-function closeIntent(projectId: ProjectId): CloseProjectIntent {
+function closeIntent(projectPath: string): CloseProjectIntent {
   return {
     type: INTENT_CLOSE_PROJECT,
-    payload: { projectId },
+    payload: { projectPath },
   };
 }
 
@@ -420,36 +420,34 @@ describe("LocalProjectModule Integration", () => {
   // ---------------------------------------------------------------------------
 
   describe("project:close resolve", () => {
-    it("finds project by ID in internal state (#7)", async () => {
+    it("returns config for known project path (#7)", async () => {
       const setup = createTestSetup();
 
-      // First, register a project so it's in internal state
+      // Register a project so config is written to disk
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
         projectPath: new Path(PROJECT_PATH).toString(),
       };
       await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
 
-      // Now resolve by projectId
+      // Now resolve by projectPath - should return config data (empty for local projects without remoteUrl)
       const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        { intent: closeIntent(PROJECT_ID) }
+        "resolve",
+        { intent: closeIntent(PROJECT_PATH) }
       );
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
-      expect(results[0]!.projectPath).toBe(new Path(PROJECT_PATH).toString());
+      // Local project has no remoteUrl, so result is empty
+      expect(results[0]).toEqual({});
     });
 
-    it("returns empty for unknown project ID (#8)", async () => {
+    it("returns empty for unknown project path (#8)", async () => {
       const { closeHooks } = createTestSetup();
 
-      const { results, errors } = await closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        {
-          intent: closeIntent("unknown-00000000" as ProjectId),
-        }
-      );
+      const { results, errors } = await closeHooks.collect<CloseResolveHookResult>("resolve", {
+        intent: closeIntent("/unknown/project"),
+      });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -472,13 +470,12 @@ describe("LocalProjectModule Integration", () => {
 
       // Resolve — should include remoteUrl from config
       const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        { intent: closeIntent(PROJECT_ID) }
+        "resolve",
+        { intent: closeIntent(PROJECT_PATH) }
       );
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
-      expect(results[0]!.projectPath).toBe(new Path(PROJECT_PATH).toString());
       expect(results[0]!.remoteUrl).toBe("https://github.com/user/repo.git");
     });
   });
@@ -500,7 +497,7 @@ describe("LocalProjectModule Integration", () => {
 
       // Close the project
       const closeCtx: CloseHookInput = {
-        intent: closeIntent(PROJECT_ID),
+        intent: closeIntent(PROJECT_PATH),
         projectPath: new Path(PROJECT_PATH).toString(),
         removeLocalRepo: false,
       };
@@ -510,8 +507,8 @@ describe("LocalProjectModule Integration", () => {
 
       // Verify it's gone from internal state (close resolve should return empty)
       const { results: resolveResults } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        { intent: closeIntent(PROJECT_ID) }
+        "resolve",
+        { intent: closeIntent(PROJECT_PATH) }
       );
       expect(resolveResults[0]).toEqual({});
     });
@@ -532,7 +529,7 @@ describe("LocalProjectModule Integration", () => {
 
       // Close with remoteUrl present
       const closeCtx: CloseHookInput = {
-        intent: closeIntent(PROJECT_ID),
+        intent: closeIntent(PROJECT_PATH),
         projectPath: new Path(PROJECT_PATH).toString(),
         remoteUrl: "https://github.com/user/repo.git",
         removeLocalRepo: false,
@@ -543,8 +540,8 @@ describe("LocalProjectModule Integration", () => {
 
       // Verify it's gone from internal state
       const { results: resolveResults } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        { intent: closeIntent(PROJECT_ID) }
+        "resolve",
+        { intent: closeIntent(PROJECT_PATH) }
       );
       expect(resolveResults[0]).toEqual({});
     });
@@ -565,7 +562,7 @@ describe("LocalProjectModule Integration", () => {
 
       // Close with removeLocalRepo=true and remoteUrl
       const closeCtx: CloseHookInput = {
-        intent: closeIntent(PROJECT_ID),
+        intent: closeIntent(PROJECT_PATH),
         projectPath: new Path(PROJECT_PATH).toString(),
         remoteUrl: "https://github.com/user/repo.git",
         removeLocalRepo: true,
@@ -626,14 +623,16 @@ describe("LocalProjectModule Integration", () => {
         intent: appStartIntent(),
       });
 
-      // activate should NOT populate state — close-resolve should return empty
+      // activate should NOT populate internal state — resolve reads config from disk,
+      // so it returns {} for a local project (no remoteUrl)
       const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve-project",
-        { intent: closeIntent(PROJECT_ID) }
+        "resolve",
+        { intent: closeIntent(PROJECT_PATH) }
       );
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
+      // Local project config has no remoteUrl, so result is empty
       expect(results[0]).toEqual({});
     });
   });

--- a/src/main/modules/local-project-module.ts
+++ b/src/main/modules/local-project-module.ts
@@ -8,10 +8,8 @@
  * - resolve-project: shared project resolution (projectPath → projectId + projectName)
  * - project:open  → resolve:  validate .git exists for local paths
  * - project:open  → register: generate ID, persist, add to internal state (all projects)
- * - project:close → resolve-project:  look up projectId in internal state + config
+ * - project:close → resolve:  look up projectPath in config to get remoteUrl
  * - project:close → close:    remove from internal state and config (all projects)
- * - workspace:open → resolve-project: resolve projectId to path
- * - workspace:open → resolve-caller-project: resolve projectPath → projectId (caller flow)
  * - app:start     → activate: load ALL saved project configs
  */
 
@@ -47,13 +45,6 @@ import {
   type ResolveHookInput as ResolveProjectHookInput,
   type ResolveHookResult as ResolveProjectHookResult,
 } from "../operations/resolve-project";
-import {
-  OPEN_WORKSPACE_OPERATION_ID,
-  type OpenWorkspaceIntent,
-  type ResolveProjectHookResult as OpenWorkspaceResolveProjectHookResult,
-  type ResolveCallerProjectHookInput,
-  type ResolveCallerProjectHookResult,
-} from "../operations/open-workspace";
 
 // =============================================================================
 // Types
@@ -381,29 +372,18 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       },
 
       [CLOSE_PROJECT_OPERATION_ID]: {
-        // resolve-project: look up projectId in internal state + load config for remoteUrl
-        "resolve-project": {
+        // resolve: look up projectPath in config to get remoteUrl
+        resolve: {
           handler: async (ctx: HookContext): Promise<CloseResolveHookResult> => {
             const intent = ctx.intent as CloseProjectIntent;
-            const { projectId } = intent.payload;
+            const { projectPath } = intent.payload;
 
-            // Find project by ID in our state
-            for (const project of projects.values()) {
-              if (project.id === projectId) {
-                const projectPath = project.path.toString();
+            // Look up config to get remoteUrl
+            const config = await getProjectConfig(fs, projectsDir, projectPath);
 
-                // Look up config to get remoteUrl
-                const config = await getProjectConfig(fs, projectsDir, projectPath);
-
-                return {
-                  projectPath,
-                  ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
-                };
-              }
-            }
-
-            // Not found — return empty
-            return {};
+            return {
+              ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
+            };
           },
         },
 
@@ -444,40 +424,6 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
           handler: async (): Promise<ActivateHookResult> => {
             const configs = await loadAllProjectConfigs(fs, projectsDir);
             return { projectPaths: configs.map((c) => c.path) };
-          },
-        },
-      },
-
-      [OPEN_WORKSPACE_OPERATION_ID]: {
-        // resolve-project: resolve projectId to path from project state (sole handler)
-        "resolve-project": {
-          handler: async (ctx: HookContext): Promise<OpenWorkspaceResolveProjectHookResult> => {
-            const intent = ctx.intent as OpenWorkspaceIntent;
-            const { projectId, projectPath: payloadPath } = intent.payload;
-
-            // Short-circuit: authoritative path already provided
-            if (payloadPath) {
-              return { projectPath: payloadPath };
-            }
-
-            // Look up projectId in project state
-            if (!projectId) return {};
-            for (const project of projects.values()) {
-              if (project.id === projectId) {
-                return { projectPath: project.path.toString() };
-              }
-            }
-
-            return {};
-          },
-        },
-        // resolve-caller-project: resolve projectPath → projectId (for callerWorkspacePath flow)
-        "resolve-caller-project": {
-          handler: async (ctx: HookContext): Promise<ResolveCallerProjectHookResult> => {
-            const { projectPath } = ctx as ResolveCallerProjectHookInput;
-            const normalizedKey = new Path(projectPath).toString();
-            const project = projects.get(normalizedKey);
-            return project ? { projectId: project.id } : {};
           },
         },
       },

--- a/src/main/modules/remote-project-module.integration.test.ts
+++ b/src/main/modules/remote-project-module.integration.test.ts
@@ -68,7 +68,7 @@ function openProjectIntent(payload: { git?: string; path?: Path }): OpenProjectI
 }
 
 function closeProjectIntent(payload: {
-  projectId: string;
+  projectPath: string;
   removeLocalRepo?: boolean;
 }): CloseProjectIntent {
   return {
@@ -193,7 +193,10 @@ describe("RemoteProjectModule Integration", () => {
       fs.$.setEntry(projectPath, { type: "directory" });
 
       const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
-      const closeIntnt = closeProjectIntent({ projectId: "test-id", removeLocalRepo: true });
+      const closeIntnt = closeProjectIntent({
+        projectPath: "/test/project",
+        removeLocalRepo: true,
+      });
 
       const closeCtx: CloseHookInput = {
         intent: closeIntnt,
@@ -218,7 +221,10 @@ describe("RemoteProjectModule Integration", () => {
       fs.$.setEntry(projectPath, { type: "directory" });
 
       const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
-      const closeIntnt = closeProjectIntent({ projectId: "test-id", removeLocalRepo: false });
+      const closeIntnt = closeProjectIntent({
+        projectPath: "/test/project",
+        removeLocalRepo: false,
+      });
 
       const closeCtx: CloseHookInput = {
         intent: closeIntnt,
@@ -242,7 +248,10 @@ describe("RemoteProjectModule Integration", () => {
       const projectPath = "/home/user/projects/local";
 
       const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
-      const closeIntnt = closeProjectIntent({ projectId: "test-id", removeLocalRepo: true });
+      const closeIntnt = closeProjectIntent({
+        projectPath: "/test/project",
+        removeLocalRepo: true,
+      });
 
       const closeCtx: CloseHookInput = {
         intent: closeIntnt,

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -362,7 +362,7 @@ class MinimalOpenOperation implements Operation<OpenWorkspaceIntent, unknown> {
     const event: WorkspaceCreatedEvent = {
       type: EVENT_WORKSPACE_CREATED,
       payload: {
-        projectId: payload.projectId as unknown as ProjectId,
+        projectId: "test-12345678" as unknown as ProjectId,
         workspaceName: payload.workspaceName as unknown as WorkspaceName,
         workspacePath: `/workspaces/${payload.workspaceName}`,
         projectPath: `/projects/test`,
@@ -593,9 +593,9 @@ describe("ViewModule Integration", () => {
       await dispatcher.dispatch({
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: "test-project" as unknown as ProjectId,
-          workspaceName: "ws1" as unknown as WorkspaceName,
+          workspaceName: "ws1",
           base: "main",
+          projectPath: "/projects/test",
         },
       } as OpenWorkspaceIntent);
 

--- a/src/main/operations/close-project.integration.test.ts
+++ b/src/main/operations/close-project.integration.test.ts
@@ -12,7 +12,7 @@
  * #10: Close with removeLocalRepo deletes cloned dir
  * #11: Close with removeLocalRepo skips for local projects
  * #12: project:closed event emitted after close
- * #13: Close with unknown projectId throws
+ * #13: Close with unknown projectPath throws
  * #14: skipSwitch prevents intermediate switches during close
  */
 
@@ -319,26 +319,26 @@ function createTestHarness(options?: {
     },
   };
 
-  // ProjectResolveModule: "resolve-project" hook -- resolves projectId to path/config/workspaces
+  // ProjectResolveModule: "resolve" hook -- resolves projectPath to config/workspaces
   const projectResolveModule: IntentModule = {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
-        "resolve-project": {
+        resolve: {
           handler: async (ctx: HookContext): Promise<CloseResolveHookResult> => {
             const intent = ctx.intent as CloseProjectIntent;
+            const { projectPath: payloadPath } = intent.payload;
 
             // Resolve using appState (mirrors bootstrap pattern)
             const allProjects: Project[] = await appState.getAllProjects();
-            const found = allProjects.find((p) => p.id === intent.payload.projectId);
+            const found = allProjects.find((p) => p.path === payloadPath);
             if (!found) {
-              throw new Error(`Project not found: ${intent.payload.projectId}`);
+              throw new Error(`Project not found for path: ${payloadPath}`);
             }
 
             const store = appState.getProjectStore();
             const config = await store.getProjectConfig(found.path);
 
             return {
-              projectPath: found.path,
               workspaces: found.workspaces ?? [],
               ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
             };
@@ -468,7 +468,7 @@ function buildCloseIntent(overrides?: Partial<CloseProjectIntent["payload"]>): C
   return {
     type: INTENT_CLOSE_PROJECT,
     payload: {
-      projectId: PROJECT_ID,
+      projectPath: PROJECT_PATH,
       ...overrides,
     },
   };
@@ -539,10 +539,10 @@ describe("CloseProjectOperation", () => {
     expect(event.payload.projectId).toBe(PROJECT_ID);
   });
 
-  it("test 13: close with unknown projectId throws", async () => {
+  it("test 13: close with unknown projectPath throws", async () => {
     const harness = createTestHarness({ projectNotFound: true });
     const intent = buildCloseIntent({
-      projectId: "nonexistent-12345678" as ProjectId,
+      projectPath: "/nonexistent/project",
     });
 
     await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Project not found");

--- a/src/main/operations/close-project.ts
+++ b/src/main/operations/close-project.ts
@@ -1,10 +1,11 @@
 /**
  * CloseProjectOperation - Orchestrates project closing.
  *
- * Runs two hook points in sequence:
- * 1. "resolve-project" - Resolves projectId to projectPath, loads config, gets workspace list
- * 2. Dispatches workspace:delete per workspace (removeWorktree=false, skipSwitch=true)
- * 3. "close" - Disposes provider, removes state + store, clears active workspace
+ * Steps:
+ * 1. Dispatches project:resolve to get projectId from projectPath
+ * 2. "resolve" hook - Loads config (remoteUrl), gets workspace list
+ * 3. Dispatches workspace:delete per workspace (removeWorktree=false, skipSwitch=true)
+ * 4. "close" - Disposes provider, removes state + store, clears active workspace
  *
  * Emits project:closed after close hook completes.
  *
@@ -16,13 +17,14 @@ import type { Operation, OperationContext, HookContext } from "../intents/infras
 import type { ProjectId } from "../../shared/api/types";
 import { INTENT_DELETE_WORKSPACE, type DeleteWorkspaceIntent } from "./delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
+import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 
 // =============================================================================
 // Intent Types
 // =============================================================================
 
 export interface CloseProjectPayload {
-  readonly projectId: ProjectId;
+  readonly projectPath: string;
   readonly removeLocalRepo?: boolean;
 }
 
@@ -55,10 +57,9 @@ export const EVENT_PROJECT_CLOSED = "project:closed" as const;
 export const CLOSE_PROJECT_OPERATION_ID = "close-project";
 
 /**
- * Per-handler result contract for the "resolve-project" hook point.
+ * Per-handler result contract for the "resolve" hook point.
  */
 export interface CloseResolveHookResult {
-  readonly projectPath?: string;
   readonly remoteUrl?: string;
   readonly workspaces?: ReadonlyArray<{ path: string }>;
 }
@@ -89,34 +90,35 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
 
   async execute(ctx: OperationContext<CloseProjectIntent>): Promise<void> {
     const { payload } = ctx.intent;
+    const projectPath = payload.projectPath;
 
+    // 1. Dispatch project:resolve to get projectId from projectPath
+    const projResolved = await ctx.dispatch({
+      type: INTENT_RESOLVE_PROJECT,
+      payload: { projectPath },
+    } as ResolveProjectIntent);
+    const projectId = projResolved.projectId;
+
+    // 2. Run "resolve" hook -- returns remoteUrl, workspaces
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
-
-    // 1. Run "resolve-project" hook -- returns projectPath, remoteUrl, workspaces
     const { results: resolveResults, errors: resolveErrors } =
-      await ctx.hooks.collect<CloseResolveHookResult>("resolve-project", hookCtx);
+      await ctx.hooks.collect<CloseResolveHookResult>("resolve", hookCtx);
     if (resolveErrors.length > 0) {
       throw resolveErrors[0]!;
     }
 
     // Merge resolve results — last-write-wins
-    let projectPath: string | undefined;
     let remoteUrl: string | undefined;
     const removeLocalRepo = payload.removeLocalRepo ?? false;
     let workspaces: ReadonlyArray<{ path: string }> = [];
     for (const result of resolveResults) {
-      if (result.projectPath !== undefined) projectPath = result.projectPath;
       if (result.remoteUrl !== undefined) remoteUrl = result.remoteUrl;
       if (result.workspaces !== undefined) workspaces = result.workspaces;
     }
 
-    if (!projectPath) {
-      throw new Error("Resolve hook did not provide projectPath");
-    }
-
-    // 2. Dispatch workspace:delete per workspace (removeWorktree=false, skipSwitch=true)
+    // 3. Dispatch workspace:delete per workspace (removeWorktree=false, skipSwitch=true)
     for (const workspace of workspaces) {
       try {
         const deleteIntent: DeleteWorkspaceIntent = {
@@ -135,7 +137,7 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
       }
     }
 
-    // 3. Run "close" hook (dispose provider, remove state + store, clear active workspace)
+    // 4. Run "close" hook (dispose provider, remove state + store, clear active workspace)
     const closeHookInput: CloseHookInput = {
       intent: ctx.intent,
       projectPath,
@@ -156,7 +158,7 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
       if (result.otherProjectsExist !== undefined) otherProjectsExist = result.otherProjectsExist;
     }
 
-    // 4. Emit workspace:switched(null) if no other projects remain
+    // 5. Emit workspace:switched(null) if no other projects remain
     if (otherProjectsExist === false) {
       const nullEvent: WorkspaceSwitchedEvent = {
         type: EVENT_WORKSPACE_SWITCHED,
@@ -165,10 +167,10 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
       ctx.emit(nullEvent);
     }
 
-    // 5. Emit project:closed event
+    // 6. Emit project:closed event
     const event: ProjectClosedEvent = {
       type: EVENT_PROJECT_CLOSED,
-      payload: { projectId: payload.projectId },
+      payload: { projectId },
     };
     ctx.emit(event);
   }

--- a/src/main/operations/open-project.integration.test.ts
+++ b/src/main/operations/open-project.integration.test.ts
@@ -53,7 +53,6 @@ import type {
   FinalizeHookResult,
   OpenWorkspaceIntent,
   WorkspaceCreatedEvent,
-  ResolveProjectHookResult,
 } from "./open-workspace";
 import type { IViewManager } from "../managers/view-manager.interface";
 import type { Project, ProjectId } from "../../shared/api/types";
@@ -495,23 +494,6 @@ function createTestHarness(options?: {
   // Workspace:open modules
   // ---------------------------------------------------------------------------
 
-  // ResolveProjectModule for workspace:open (resolves projectPath from payload)
-  const resolveProjectModule: IntentModule = {
-    hooks: {
-      [OPEN_WORKSPACE_OPERATION_ID]: {
-        "resolve-project": {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const intent = ctx.intent as OpenWorkspaceIntent;
-            if (intent.payload.projectPath) {
-              return { projectPath: intent.payload.projectPath };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
-
   // WorktreeModule for workspace:open (handles existingWorkspace)
   const worktreeModule: IntentModule = {
     hooks: {
@@ -666,7 +648,6 @@ function createTestHarness(options?: {
     localRegisterModule,
     appStateRegisterModule,
     discoverModule,
-    resolveProjectModule,
     worktreeModule,
     codeServerModule,
     stateModule,

--- a/src/main/operations/open-project.ts
+++ b/src/main/operations/open-project.ts
@@ -231,7 +231,6 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
           const openWsIntent: OpenWorkspaceIntent = {
             type: INTENT_OPEN_WORKSPACE,
             payload: {
-              projectId,
               workspaceName: workspace.name,
               base: workspace.metadata.base ?? "",
               existingWorkspace,

--- a/src/main/operations/open-workspace.integration.test.ts
+++ b/src/main/operations/open-workspace.integration.test.ts
@@ -22,7 +22,7 @@
  * #15: existingWorkspace skips worktree creation
  * #16: existingWorkspace uses projectPath directly
  * #17: Incomplete payload returns bases
- * #18: Resolve-project failure propagates error
+ * #18: project:resolve failure propagates error
  *
  * Regression coverage (APP_LIFECYCLE_INTENTS #10):
  * The agentModule's setup hook behavior (starting per-workspace server) is tested
@@ -54,7 +54,6 @@ import type {
   FinalizeHookResult,
   WorkspaceCreatedEvent,
   ExistingWorkspaceData,
-  ResolveProjectHookResult,
 } from "./open-workspace";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
@@ -81,7 +80,10 @@ import {
   RESOLVE_PROJECT_OPERATION_ID,
   INTENT_RESOLVE_PROJECT,
 } from "./resolve-project";
-import type { ResolveHookResult as ResolveProjectResolveHookResult } from "./resolve-project";
+import type {
+  ResolveHookResult as ResolveProjectResolveHookResult,
+  ResolveHookInput as ResolveProjectHookInput,
+} from "./resolve-project";
 
 // =============================================================================
 // Test Constants
@@ -201,6 +203,8 @@ interface TestSetup {
   dispatcher: Dispatcher;
   projectId: ProjectId;
   keepFilesService: MockKeepFilesService;
+  /** Set of project paths recognized by the resolve module. Add paths here for custom project tests. */
+  knownProjectPaths: Set<string>;
 }
 
 function createTestSetup(opts?: TestSetupOptions): TestSetup {
@@ -237,12 +241,19 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
       },
     },
   };
+  // Tracks known project paths for project:resolve resolution.
+  // Only PROJECT_ROOT is known by default; tests can add more.
+  const knownProjectPaths = new Set<string>([PROJECT_ROOT]);
   const resolveProjectResolveModule: IntentModule = {
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (): Promise<ResolveProjectResolveHookResult> => {
-            return { projectId: PROJECT_ID, projectName: "test" };
+          handler: async (ctx: HookContext): Promise<ResolveProjectResolveHookResult> => {
+            const { projectPath } = ctx as ResolveProjectHookInput;
+            if (knownProjectPaths.has(projectPath)) {
+              return { projectId: PROJECT_ID, projectName: "test" };
+            }
+            return {};
           },
         },
       },
@@ -255,28 +266,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
             const { workspacePath } = ctx as ActivateHookInput;
             return { resolvedPath: workspacePath };
-          },
-        },
-      },
-    },
-  };
-
-  // ResolveProjectModule: "resolve-project" hook — resolves projectId to project path
-  const resolveProjectModule: IntentModule = {
-    hooks: {
-      [OPEN_WORKSPACE_OPERATION_ID]: {
-        "resolve-project": {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const intent = ctx.intent as OpenWorkspaceIntent;
-            // Short-circuit: if projectPath is in payload, use it
-            if (intent.payload.projectPath) {
-              return { projectPath: intent.payload.projectPath };
-            }
-            // Check projectId
-            if (intent.payload.projectId === projectId) {
-              return { projectPath: PROJECT_ROOT };
-            }
-            return {};
           },
         },
       },
@@ -324,10 +313,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
                 branch: existing.branch ?? existing.name,
                 metadata: existing.metadata,
               };
-            }
-
-            if (intent.payload.projectId !== projectId) {
-              throw new Error(`Project not found: ${intent.payload.projectId}`);
             }
 
             if (opts?.throwOnCreate) {
@@ -437,7 +422,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     resolveWorkspaceModule,
     resolveProjectResolveModule,
     switchViewModule,
-    resolveProjectModule,
     fetchBasesModule,
     worktreeModule,
     keepFilesModule,
@@ -450,7 +434,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
   }
   for (const m of modules) dispatcher.registerModule(m);
 
-  return { dispatcher, projectId, keepFilesService };
+  return { dispatcher, projectId, keepFilesService, knownProjectPaths };
 }
 
 // =============================================================================
@@ -458,13 +442,14 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 // =============================================================================
 
 function createIntent(
-  projectId: ProjectId,
+  _projectId: ProjectId,
   overrides?: Partial<OpenWorkspacePayload>
 ): OpenWorkspaceIntent {
+  void _projectId; // projectId no longer in payload; kept in signature for test compat
   return {
     type: INTENT_OPEN_WORKSPACE,
     payload: {
-      projectId,
+      projectPath: PROJECT_ROOT,
       workspaceName: "feature-x",
       base: "main",
       ...overrides,
@@ -584,9 +569,18 @@ describe("OpenWorkspace Operation", () => {
     it("throws Project not found error", async () => {
       const setup = createTestSetup();
 
-      await expect(
-        setup.dispatcher.dispatch(createIntent("nonexistent-12345678" as ProjectId))
-      ).rejects.toThrow("resolve-project hook did not provide projectPath");
+      const intent: OpenWorkspaceIntent = {
+        type: INTENT_OPEN_WORKSPACE,
+        payload: {
+          projectPath: "/nonexistent/project",
+          workspaceName: "feature-x",
+          base: "main",
+        },
+      };
+
+      await expect(setup.dispatcher.dispatch(intent)).rejects.toThrow(
+        "Project not found for path: /nonexistent/project"
+      );
     });
   });
 
@@ -763,7 +757,6 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: setup.projectId,
           workspaceName: "feature-y",
           base: "main",
           existingWorkspace,
@@ -791,6 +784,7 @@ describe("OpenWorkspace Operation", () => {
     it("populates context without projectId resolution", async () => {
       const setup = createTestSetup();
       const customProjectPath = "/custom/project/path";
+      setup.knownProjectPaths.add(customProjectPath);
 
       const existingWorkspace: ExistingWorkspaceData = {
         path: "/custom/workspace/my-ws",
@@ -807,7 +801,6 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: setup.projectId,
           workspaceName: "my-ws",
           base: "develop",
           existingWorkspace,
@@ -836,7 +829,7 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: setup.projectId,
+          projectPath: PROJECT_ROOT,
           // No workspaceName or base
         },
       };
@@ -862,7 +855,7 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: setup.projectId,
+          projectPath: PROJECT_ROOT,
           workspaceName: "feature-x",
           // No base
         },
@@ -877,21 +870,21 @@ describe("OpenWorkspace Operation", () => {
     });
   });
 
-  describe("resolve-project failure propagates error (#18)", () => {
-    it("throws when resolve-project provides no projectPath", async () => {
+  describe("project:resolve failure propagates error (#18)", () => {
+    it("throws when project:resolve finds no project for path", async () => {
       const setup = createTestSetup();
 
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectId: "nonexistent-12345678" as ProjectId,
+          projectPath: "/nonexistent/project",
           workspaceName: "feature-x",
           base: "main",
         },
       };
 
       await expect(setup.dispatcher.dispatch(intent)).rejects.toThrow(
-        "resolve-project hook did not provide projectPath"
+        "Project not found for path: /nonexistent/project"
       );
     });
   });
@@ -961,17 +954,6 @@ describe("OpenWorkspace Operation", () => {
           },
         },
       };
-      const resolveProjectModule: IntentModule = {
-        hooks: {
-          [OPEN_WORKSPACE_OPERATION_ID]: {
-            "resolve-project": {
-              handler: async (): Promise<ResolveProjectHookResult> => {
-                return { projectPath: PROJECT_ROOT };
-              },
-            },
-          },
-        },
-      };
       const fetchBasesModule: IntentModule = {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
@@ -1026,7 +1008,6 @@ describe("OpenWorkspace Operation", () => {
       dispatcher.registerModule(resolveWorkspaceModule);
       dispatcher.registerModule(resolveProjectResolveModule);
       dispatcher.registerModule(switchViewModule);
-      dispatcher.registerModule(resolveProjectModule);
       dispatcher.registerModule(fetchBasesModule);
       dispatcher.registerModule(worktreeModule);
       dispatcher.registerModule(agentModule);

--- a/src/main/operations/open-workspace.ts
+++ b/src/main/operations/open-workspace.ts
@@ -9,8 +9,8 @@
  *
  * Steps:
  * 0. If callerWorkspacePath:
- *    Dispatch workspace:resolve + project:resolve to get projectPath + projectId
- * 1. "resolve-project" hook → ResolveProjectHookResult — resolves projectId to path (fatal)
+ *    Dispatch workspace:resolve to get projectPath
+ * 1. Dispatch project:resolve to get projectId from projectPath
  * 2. If incomplete (missing workspaceName or base):
  *    "fetch-bases" → FetchBasesHookResult — returns bases for dialog (fatal, early return)
  * 3. If complete:
@@ -54,11 +54,10 @@ export interface ExistingWorkspaceData {
 }
 
 export interface OpenWorkspacePayload {
-  readonly projectId?: ProjectId;
   /**
    * Workspace path of the calling workspace.
-   * Used by Plugin API / MCP server as an alternative to projectId.
-   * When present, resolved via dispatch to determine projectId and projectPath.
+   * Used by Plugin API / MCP server as an alternative to projectPath.
+   * When present, resolved via dispatch to determine projectPath.
    */
   readonly callerWorkspacePath?: string;
   readonly workspaceName?: string;
@@ -67,7 +66,7 @@ export interface OpenWorkspacePayload {
   readonly keepInBackground?: boolean;
   /** When set, skip worktree creation and populate context from existing workspace data. */
   readonly existingWorkspace?: ExistingWorkspaceData;
-  /** Authoritative project path when existingWorkspace is set (avoids re-resolution from projectId). */
+  /** Authoritative project path. */
   readonly projectPath?: string;
 }
 
@@ -77,6 +76,7 @@ export type OpenWorkspaceResult =
       bases: readonly { name: string; isRemote: boolean }[];
       defaultBaseBranch?: string;
       projectPath: string;
+      projectId: ProjectId;
     };
 
 export interface OpenWorkspaceIntent extends Intent<OpenWorkspaceResult> {
@@ -120,11 +120,6 @@ export const OPEN_WORKSPACE_OPERATION_ID = "open-workspace";
 // Per-hook-point types
 // =============================================================================
 
-/** Result from the "resolve-project" hook point (projectId → projectPath). */
-export interface ResolveProjectHookResult {
-  readonly projectPath?: string;
-}
-
 /** Input context for the "resolve-caller" hook point (callerWorkspacePath resolution). */
 export interface ResolveCallerHookInput extends HookContext {
   readonly callerWorkspacePath: string;
@@ -134,16 +129,6 @@ export interface ResolveCallerHookInput extends HookContext {
 export interface ResolveCallerHookResult {
   readonly projectPath?: string;
   readonly workspaceName?: WorkspaceName;
-}
-
-/** Input context for the "resolve-caller-project" hook point. */
-export interface ResolveCallerProjectHookInput extends HookContext {
-  readonly projectPath: string;
-}
-
-/** Result from the "resolve-caller-project" hook point. */
-export interface ResolveCallerProjectHookResult {
-  readonly projectId?: ProjectId;
 }
 
 /** Input context for the "fetch-bases" hook point (enriched with resolved project path). */
@@ -207,45 +192,32 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<OpenWorkspaceResult> {
-    let projectPath: string | undefined;
-    let resolvedProjectId: ProjectId | undefined = ctx.intent.payload.projectId;
+    let projectPath: string | undefined = ctx.intent.payload.projectPath;
 
     // If callerWorkspacePath provided (Plugin API / MCP), resolve via dispatch
-    if (ctx.intent.payload.callerWorkspacePath && !resolvedProjectId) {
-      // Dispatch workspace:resolve to get projectPath from callerWorkspacePath
+    if (ctx.intent.payload.callerWorkspacePath && !projectPath) {
       const wsResolved = await ctx.dispatch({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: ctx.intent.payload.callerWorkspacePath },
       } as ResolveWorkspaceIntent);
       projectPath = wsResolved.projectPath;
-
-      // Dispatch project:resolve to get projectId from projectPath
-      const projResolved = await ctx.dispatch({
-        type: INTENT_RESOLVE_PROJECT,
-        payload: { projectPath },
-      } as ResolveProjectIntent);
-      resolvedProjectId = projResolved.projectId;
     }
 
-    // Hook 1: "resolve-project" — resolve projectId to projectPath (skip if already resolved)
     if (!projectPath) {
-      const resolveCtx: HookContext = { intent: ctx.intent };
-      const { results: resolveResults, errors: resolveErrors } =
-        await ctx.hooks.collect<ResolveProjectHookResult>("resolve-project", resolveCtx);
-
-      if (resolveErrors.length > 0) throw resolveErrors[0]!;
-
-      const resolve = mergeHookResults(resolveResults, "resolve-project");
-      projectPath = resolve.projectPath;
-      if (projectPath === undefined) {
-        throw new Error("resolve-project hook did not provide projectPath");
-      }
+      throw new Error("projectPath is required");
     }
+
+    // Dispatch project:resolve to get projectId from projectPath
+    const projResolved = await ctx.dispatch({
+      type: INTENT_RESOLVE_PROJECT,
+      payload: { projectPath },
+    } as ResolveProjectIntent);
+    const resolvedProjectId = projResolved.projectId;
 
     // Check if payload is incomplete (missing workspaceName or base)
     const { workspaceName, base } = ctx.intent.payload;
     if (workspaceName === undefined || base === undefined) {
-      // Hook 2: "fetch-bases" — return bases for dialog (fatal, early return)
+      // Hook: "fetch-bases" — return bases for dialog (fatal, early return)
       const fetchBasesCtx: FetchBasesHookInput = {
         intent: ctx.intent,
         projectPath,
@@ -264,6 +236,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
           defaultBaseBranch: fetchBases.defaultBaseBranch,
         }),
         projectPath,
+        projectId: resolvedProjectId,
       };
     }
 
@@ -328,9 +301,6 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
 
     // Build Workspace return value
     const resolvedWorkspaceName = extractWorkspaceName(workspacePath);
-    if (!resolvedProjectId) {
-      throw new Error("projectId is required for complete workspace creation");
-    }
     const projectId = resolvedProjectId;
 
     const workspace: Workspace = {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -101,28 +101,28 @@ describe("preload API", () => {
       expect(result).toEqual(mockProject);
     });
 
-    it("projects.close calls api:project:close with projectId", async () => {
+    it("projects.close calls api:project:close with projectPath", async () => {
       mockIpcRenderer.invoke.mockResolvedValue(undefined);
 
-      const projects = exposedApi.projects as { close: (projectId: string) => Promise<void> };
-      await projects.close("my-app-12345678");
+      const projects = exposedApi.projects as { close: (projectPath: string) => Promise<void> };
+      await projects.close("/test/my-app");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:project:close", {
-        projectId: "my-app-12345678",
+        projectPath: "/test/my-app",
       });
     });
 
-    it("projects.fetchBases calls api:project:fetch-bases with projectId", async () => {
+    it("projects.fetchBases calls api:project:fetch-bases with projectPath", async () => {
       const mockBases = { bases: [{ name: "main", isRemote: false }] };
       mockIpcRenderer.invoke.mockResolvedValue(mockBases);
 
       const projects = exposedApi.projects as {
-        fetchBases: (projectId: string) => Promise<unknown>;
+        fetchBases: (projectPath: string) => Promise<unknown>;
       };
-      const result = await projects.fetchBases("my-app-12345678");
+      const result = await projects.fetchBases("/test/my-app");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:project:fetch-bases", {
-        projectId: "my-app-12345678",
+        projectPath: "/test/my-app",
       });
       expect(result).toEqual(mockBases);
     });
@@ -144,7 +144,7 @@ describe("preload API", () => {
       const result = await workspaces.create("my-app-12345678", "feature", "main");
 
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:create", {
-        projectId: "my-app-12345678",
+        projectPath: "my-app-12345678",
         name: "feature",
         base: "main",
       });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,15 +40,15 @@ contextBridge.exposeInMainWorld("api", {
       ipcRenderer.invoke(ApiIpcChannels.PROJECT_OPEN, {
         ...(path !== undefined && { path }),
       }),
-    close: (projectId: string, options?: { removeLocalRepo?: boolean }) =>
-      ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLOSE, { projectId, ...options }),
+    close: (projectPath: string, options?: { removeLocalRepo?: boolean }) =>
+      ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLOSE, { projectPath, ...options }),
     clone: (url: string) => ipcRenderer.invoke(ApiIpcChannels.PROJECT_CLONE, { url }),
-    fetchBases: (projectId: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.PROJECT_FETCH_BASES, { projectId }),
+    fetchBases: (projectPath: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.PROJECT_FETCH_BASES, { projectPath }),
   },
   workspaces: {
-    create: (projectId: string, name: string, base: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, { projectId, name, base }),
+    create: (projectPath: string, name: string, base: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, { projectPath, name, base }),
     remove: (
       workspacePath: string,
       options?: {

--- a/src/renderer/lib/components/BranchDropdown.svelte
+++ b/src/renderer/lib/components/BranchDropdown.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import { projects, on, type ProjectId, type BaseInfo } from "$lib/api";
+  import { projects, on, type BaseInfo } from "$lib/api";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
   import Icon from "./Icon.svelte";
 
   interface BranchDropdownProps {
-    projectId: ProjectId;
+    projectPath: string;
     value: string;
     onSelect: (branch: string) => void;
     disabled?: boolean;
   }
 
-  let { projectId, value, onSelect, disabled = false }: BranchDropdownProps = $props();
+  let { projectPath, value, onSelect, disabled = false }: BranchDropdownProps = $props();
 
   // State
   let branches = $state<readonly BaseInfo[]>([]);
@@ -20,13 +20,13 @@
 
   // Load cached branches immediately, then wait for bases-updated event
   $effect(() => {
-    const currentProjectId = projectId;
+    const currentProjectPath = projectPath;
     loading = true;
     error = null;
 
     // Fetch cached branches immediately for display
     projects
-      .fetchBases(currentProjectId)
+      .fetchBases(currentProjectPath)
       .then((result: { bases: readonly BaseInfo[] }) => {
         branches = result.bases;
         // Keep loading=true until bases-updated event arrives
@@ -37,10 +37,10 @@
       });
 
     // Subscribe to bases-updated event for when fresh data arrives
-    const unsubscribe = on<{ projectId: ProjectId; bases: readonly BaseInfo[] }>(
+    const unsubscribe = on<{ projectPath: string; bases: readonly BaseInfo[] }>(
       "project:bases-updated",
       (event) => {
-        if (event.projectId === currentProjectId) {
+        if (event.projectPath === currentProjectPath) {
           branches = event.bases;
           loading = false;
         }
@@ -133,7 +133,7 @@
       {disabled}
       placeholder="Select branch..."
       filterOption={filterBranch}
-      id={`branch-dropdown-${projectId}`}
+      id={`branch-dropdown-${projectPath}`}
     >
       {#snippet optionSnippet(option)}
         {#if option.type === "header"}

--- a/src/renderer/lib/components/BranchDropdown.test.ts
+++ b/src/renderer/lib/components/BranchDropdown.test.ts
@@ -6,7 +6,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 import type { BaseInfo } from "@shared/api/types";
-import type { ProjectId } from "@shared/api/types";
 
 // Mock branches data
 const mockLocalBranches: BaseInfo[] = [
@@ -25,7 +24,7 @@ const allBranches = [...mockLocalBranches, ...mockRemoteBranches];
 const { mockFetchBases, basesUpdatedHandlers } = vi.hoisted(() => ({
   mockFetchBases: vi.fn(),
   // Store handlers to trigger bases-updated events in tests
-  basesUpdatedHandlers: new Set<(event: { projectId: string; bases: BaseInfo[] }) => void>(),
+  basesUpdatedHandlers: new Set<(event: { projectPath: string; bases: BaseInfo[] }) => void>(),
 }));
 
 // Mock $lib/api module
@@ -49,7 +48,7 @@ vi.mock("$lib/api", () => ({
     fetchBases: mockFetchBases,
   },
   // Event subscription mock - directly return the implementation
-  on: (event: string, handler: (event: { projectId: string; bases: BaseInfo[] }) => void) => {
+  on: (event: string, handler: (event: { projectPath: string; bases: BaseInfo[] }) => void) => {
     if (event === "project:bases-updated") {
       basesUpdatedHandlers.add(handler);
       return () => basesUpdatedHandlers.delete(handler);
@@ -59,17 +58,17 @@ vi.mock("$lib/api", () => ({
 }));
 
 // Helper to emit bases-updated event in tests
-function emitBasesUpdated(projectId: string, bases: BaseInfo[]): void {
-  basesUpdatedHandlers.forEach((handler) => handler({ projectId, bases }));
+function emitBasesUpdated(projectPath: string, bases: BaseInfo[]): void {
+  basesUpdatedHandlers.forEach((handler) => handler({ projectPath, bases }));
 }
 
 // Helper to complete loading: run timers then emit bases-updated event
 async function completeLoading(
-  projectId: string = testProjectId,
+  projectPath: string = testProjectPath,
   bases: BaseInfo[] = allBranches
 ): Promise<void> {
   await vi.runAllTimersAsync();
-  emitBasesUpdated(projectId, bases);
+  emitBasesUpdated(projectPath, bases);
   await tick();
 }
 
@@ -77,12 +76,12 @@ async function completeLoading(
 import BranchDropdown from "./BranchDropdown.svelte";
 import { projects } from "$lib/api";
 
-// Test project ID
-const testProjectId = "test-project-12345678" as ProjectId;
+// Test project path
+const testProjectPath = "/test/project";
 
 describe("BranchDropdown component", () => {
   const defaultProps = {
-    projectId: testProjectId,
+    projectPath: testProjectPath,
     value: "",
     onSelect: vi.fn(),
   };
@@ -160,12 +159,12 @@ describe("BranchDropdown component", () => {
   });
 
   describe("loading", () => {
-    it("loads branches using projects.fetchBases(projectId) on mount", async () => {
+    it("loads branches using projects.fetchBases(projectPath) on mount", async () => {
       render(BranchDropdown, { props: defaultProps });
 
       await completeLoading();
 
-      expect(projects.fetchBases).toHaveBeenCalledWith(testProjectId);
+      expect(projects.fetchBases).toHaveBeenCalledWith(testProjectPath);
     });
 
     it("shows spinner while loading", async () => {
@@ -183,7 +182,7 @@ describe("BranchDropdown component", () => {
       expect(screen.getByRole("status", { name: /loading branches/i })).toBeInTheDocument();
 
       // Emit bases-updated event (simulating background refresh completing)
-      emitBasesUpdated(testProjectId, allBranches);
+      emitBasesUpdated(testProjectPath, allBranches);
       await tick();
 
       // Spinner should be gone after bases-updated event
@@ -718,7 +717,7 @@ describe("BranchDropdown component", () => {
 
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading(testProjectId, mockLocalBranches);
+      await completeLoading(testProjectPath, mockLocalBranches);
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -732,7 +731,7 @@ describe("BranchDropdown component", () => {
 
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading(testProjectId, mockRemoteBranches);
+      await completeLoading(testProjectPath, mockRemoteBranches);
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -782,7 +781,7 @@ describe("BranchDropdown component", () => {
       expect(basesUpdatedHandlers.size).toBeGreaterThan(0);
     });
 
-    it("updates branches when project:bases-updated event is received for matching projectId", async () => {
+    it("updates branches when project:bases-updated event is received for matching projectPath", async () => {
       render(BranchDropdown, { props: defaultProps });
       await completeLoading();
 
@@ -797,7 +796,7 @@ describe("BranchDropdown component", () => {
         { name: "main", isRemote: false },
         { name: "origin/main", isRemote: true },
       ];
-      emitBasesUpdated(testProjectId, updatedBases);
+      emitBasesUpdated(testProjectPath, updatedBases);
       await tick();
 
       // origin/feature should be gone
@@ -805,7 +804,7 @@ describe("BranchDropdown component", () => {
       expect(screen.getByText("main")).toBeInTheDocument();
     });
 
-    it("ignores project:bases-updated event for different projectId", async () => {
+    it("ignores project:bases-updated event for different projectPath", async () => {
       render(BranchDropdown, { props: defaultProps });
       await completeLoading();
 
@@ -813,7 +812,7 @@ describe("BranchDropdown component", () => {
       await fireEvent.focus(input);
 
       // Simulate event for different project
-      emitBasesUpdated("different-project" as ProjectId, []);
+      emitBasesUpdated("/different/project", []);
       await tick();
 
       // Should still have original branches

--- a/src/renderer/lib/components/CloseProjectDialog.svelte
+++ b/src/renderer/lib/components/CloseProjectDialog.svelte
@@ -81,7 +81,10 @@
 
       // Always close the project (even if some removals failed)
       // Pass removeLocalRepo option if checked (and project is remote)
-      await projectsApi.close(projectId, deleteLocalRepo ? { removeLocalRepo: true } : undefined);
+      await projectsApi.close(
+        project!.path,
+        deleteLocalRepo ? { removeLocalRepo: true } : undefined
+      );
       closeDialog();
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/renderer/lib/components/CloseProjectDialog.test.ts
+++ b/src/renderer/lib/components/CloseProjectDialog.test.ts
@@ -198,7 +198,7 @@ describe("CloseProjectDialog component", () => {
       await vi.runAllTimersAsync();
 
       // Should only call close, not remove
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, undefined);
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", undefined);
       expect(mockRemoveWorkspace).not.toHaveBeenCalled();
       expect(mockCloseDialog).toHaveBeenCalled();
     });
@@ -308,7 +308,7 @@ describe("CloseProjectDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, undefined);
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", undefined);
       expect(mockRemoveWorkspace).not.toHaveBeenCalled();
     });
 
@@ -366,7 +366,7 @@ describe("CloseProjectDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, undefined);
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", undefined);
     });
   });
 
@@ -411,7 +411,7 @@ describe("CloseProjectDialog component", () => {
       await vi.runAllTimersAsync();
 
       // Should still close the project
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, undefined);
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", undefined);
     });
 
     it("error display uses role='alert'", async () => {
@@ -627,7 +627,9 @@ describe("CloseProjectDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, { removeLocalRepo: true });
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", {
+        removeLocalRepo: true,
+      });
     });
 
     it("does not pass removeLocalRepo when delete is unchecked", async () => {
@@ -639,7 +641,7 @@ describe("CloseProjectDialog component", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(mockCloseProject).toHaveBeenCalledWith(testProjectId, undefined);
+      expect(mockCloseProject).toHaveBeenCalledWith("/test/projects/test-project", undefined);
     });
   });
 });

--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -138,15 +138,15 @@
 
   // Handle form submission
   async function handleSubmit(): Promise<void> {
-    // isFormValid includes hasProject check, so selectedProjectId is defined
-    if (!isFormValid || isSubmitting || !selectedProjectId) return;
+    // isFormValid includes hasProject check, so selectedProject is defined
+    if (!isFormValid || isSubmitting || !selectedProject) return;
 
     submitError = null;
     isSubmitting = true;
 
     try {
       logger.debug("Dialog submitted", { type: "create-workspace" });
-      const workspace = await workspaces.create(selectedProjectId, name, selectedBranch);
+      const workspace = await workspaces.create(selectedProject.path, name, selectedBranch);
       // Switch to the newly created workspace to load its view
       await ui.switchWorkspace(workspace.path);
       closeDialog();
@@ -253,10 +253,10 @@
 
     <div class="ch-form-field">
       <label for="workspace-name" class="ch-form-label">Name</label>
-      {#if selectedProjectId}
+      {#if selectedProject}
         <NameBranchDropdown
           id="workspace-name"
-          projectId={selectedProjectId}
+          projectPath={selectedProject.path}
           value={name}
           onSelect={handleNameSelect}
           onInput={handleNameInput}
@@ -277,9 +277,9 @@
 
     <div class="ch-form-field">
       <label for="branch-select" class="ch-form-label">Base Branch</label>
-      {#if selectedProjectId}
+      {#if selectedProject}
         <BranchDropdown
-          projectId={selectedProjectId}
+          projectPath={selectedProject.path}
           value={selectedBranch}
           onSelect={handleBranchSelect}
           disabled={isSubmitting || isOpeningProject}

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -26,7 +26,7 @@ const {
   mockGetProjectById: vi.fn(),
   mockSwitchWorkspace: vi.fn(),
   // Store handlers to trigger bases-updated events in tests
-  basesUpdatedHandlers: new Set<(event: { projectId: string; bases: BaseInfo[] }) => void>(),
+  basesUpdatedHandlers: new Set<(event: { projectPath: string; bases: BaseInfo[] }) => void>(),
 }));
 
 // Mock $lib/api - using v2 API
@@ -57,7 +57,7 @@ vi.mock("$lib/api", () => ({
     switchWorkspace: mockSwitchWorkspace,
   },
   // Event subscription mock for BranchDropdown
-  on: (event: string, handler: (event: { projectId: string; bases: BaseInfo[] }) => void) => {
+  on: (event: string, handler: (event: { projectPath: string; bases: BaseInfo[] }) => void) => {
     if (event === "project:bases-updated") {
       basesUpdatedHandlers.add(handler);
       return () => basesUpdatedHandlers.delete(handler);
@@ -155,21 +155,21 @@ describe("CreateWorkspaceDialog component", () => {
 
   // Helper to emit bases-updated event
   function emitBasesUpdated(
-    projectId: string,
+    projectPath: string,
     bases: BaseInfo[] = [
       { name: "main", isRemote: false },
       { name: "develop", isRemote: false },
     ]
   ): void {
-    basesUpdatedHandlers.forEach((handler) => handler({ projectId, bases }));
+    basesUpdatedHandlers.forEach((handler) => handler({ projectPath, bases }));
   }
 
   // Helper to complete loading for all known projects
   async function completeAllLoading(): Promise<void> {
     await vi.runAllTimersAsync();
-    // Emit bases-updated for both test projects
-    emitBasesUpdated(testProjectId);
-    emitBasesUpdated(otherProjectId);
+    // Emit bases-updated for both test projects (using their paths)
+    emitBasesUpdated("/test/project");
+    emitBasesUpdated("/test/other-project");
     await tick();
   }
 
@@ -191,11 +191,11 @@ describe("CreateWorkspaceDialog component", () => {
       ],
     });
     // Return a workspace object with the name that was passed in
-    mockCreateWorkspace.mockImplementation(async (_projectId, name) => ({
+    mockCreateWorkspace.mockImplementation(async (_projectPath, name) => ({
       name,
       path: `/test/project/.worktrees/${name}`,
       branch: name,
-      projectId: _projectId,
+      projectId: testProjectId,
     }));
     mockSwitchWorkspace.mockResolvedValue(undefined);
   });
@@ -496,7 +496,7 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
 
       expect(mockCreateWorkspace).toHaveBeenCalledWith(
-        defaultProps.projectId,
+        "/test/project",
         "valid-name",
         expect.any(String)
       );
@@ -538,7 +538,7 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
 
       // Form should submit because name is valid and branch is pre-selected
-      expect(mockCreateWorkspace).toHaveBeenCalledWith(testProjectId, "my-feature", "main");
+      expect(mockCreateWorkspace).toHaveBeenCalledWith("/test/project", "my-feature", "main");
     });
 
     it("form does not submit while already submitting", async () => {
@@ -686,7 +686,7 @@ describe("CreateWorkspaceDialog component", () => {
 
       await completeAllLoading();
 
-      expect(workspaces.create).toHaveBeenCalledWith(testProjectId, "my-feature", "main");
+      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main");
     });
 
     it("success switches to new workspace and closes dialog", async () => {
@@ -800,8 +800,8 @@ describe("CreateWorkspaceDialog component", () => {
 
     it("changing project clears branch selection", async () => {
       // Setup mock to return different branches per project ID
-      mockFetchBases.mockImplementation((projectId: ProjectId) => {
-        if (projectId === testProjectId) {
+      mockFetchBases.mockImplementation((projectPath: string) => {
+        if (projectPath === "/test/project") {
           return Promise.resolve({
             bases: [
               { name: "main", isRemote: false },
@@ -844,7 +844,7 @@ describe("CreateWorkspaceDialog component", () => {
     });
 
     it("branch dropdown shows new project's branches after project change", async () => {
-      // Setup mock to return different branches per project ID
+      // Setup mock to return different branches per project path
       const testBranches: BaseInfo[] = [
         { name: "main", isRemote: false },
         { name: "develop", isRemote: false },
@@ -853,8 +853,8 @@ describe("CreateWorkspaceDialog component", () => {
         { name: "feature-branch", isRemote: false },
         { name: "release", isRemote: false },
       ];
-      mockFetchBases.mockImplementation((projectId: ProjectId) => {
-        if (projectId === testProjectId) {
+      mockFetchBases.mockImplementation((projectPath: string) => {
+        if (projectPath === "/test/project") {
           return Promise.resolve({ bases: testBranches });
         } else {
           return Promise.resolve({ bases: otherBranches });
@@ -864,8 +864,8 @@ describe("CreateWorkspaceDialog component", () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       // Complete loading with correct branches for each project
       await vi.runAllTimersAsync();
-      emitBasesUpdated(testProjectId, testBranches);
-      emitBasesUpdated(otherProjectId, otherBranches);
+      emitBasesUpdated("/test/project", testBranches);
+      emitBasesUpdated("/test/other-project", otherBranches);
       await tick();
 
       // Initial branches should be from test-project
@@ -887,7 +887,7 @@ describe("CreateWorkspaceDialog component", () => {
       await fireEvent.focus(branchDropdown);
       // Emit bases-updated for other-project
       await vi.runAllTimersAsync();
-      emitBasesUpdated(otherProjectId, otherBranches);
+      emitBasesUpdated("/test/other-project", otherBranches);
       await tick();
 
       expect(screen.getByText("feature-branch")).toBeInTheDocument();
@@ -1114,7 +1114,7 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
 
       // Form should be submitted because name is valid and branch is pre-selected
-      expect(mockCreateWorkspace).toHaveBeenCalledWith(testProjectId, "my-feature", "main");
+      expect(mockCreateWorkspace).toHaveBeenCalledWith("/test/project", "my-feature", "main");
     });
   });
 

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -243,7 +243,7 @@ describe("MainView close project integration", () => {
 
       // Should only call close, not remove
       expect(mockApi.workspaces.remove).not.toHaveBeenCalled();
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.path, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");
@@ -291,7 +291,7 @@ describe("MainView close project integration", () => {
       });
 
       // Then close the project
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.path, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");
@@ -332,7 +332,7 @@ describe("MainView close project integration", () => {
       expect(mockApi.workspaces.remove).toHaveBeenCalledTimes(2);
 
       // Project should still be closed despite partial failure
-      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.id, undefined);
+      expect(mockApi.projects.close).toHaveBeenCalledWith(projectWithWorkspaces.path, undefined);
 
       // Dialog should be closed
       expect(dialogsStore.dialogState.value.type).toBe("closed");

--- a/src/renderer/lib/components/NameBranchDropdown.svelte
+++ b/src/renderer/lib/components/NameBranchDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { projects, type ProjectId, type BaseInfo } from "$lib/api";
+  import { projects, type BaseInfo } from "$lib/api";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
 
   /**
@@ -15,7 +15,7 @@
   }
 
   interface NameBranchDropdownProps {
-    projectId: ProjectId;
+    projectPath: string;
     value: string;
     onSelect: (selection: NameBranchSelection) => void;
     disabled?: boolean;
@@ -32,7 +32,7 @@
   }
 
   let {
-    projectId,
+    projectPath,
     value,
     onSelect,
     disabled = false,
@@ -52,7 +52,7 @@
     error = null;
 
     projects
-      .fetchBases(projectId)
+      .fetchBases(projectPath)
       .then((result: { bases: readonly BaseInfo[] }) => {
         branches = result.bases;
       })
@@ -169,7 +169,7 @@
       {disabled}
       placeholder="Enter name or select branch..."
       filterOption={filterBranch}
-      id={id ?? `name-branch-dropdown-${projectId}`}
+      id={id ?? `name-branch-dropdown-${projectPath}`}
       allowFreeText={true}
       {onEnter}
       {onInput}

--- a/src/renderer/lib/components/NameBranchDropdown.test.ts
+++ b/src/renderer/lib/components/NameBranchDropdown.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
-import type { BaseInfo, ProjectId } from "@shared/api/types";
+import type { BaseInfo } from "@shared/api/types";
 
 // Create mock functions with vi.hoisted - required for vitest mocking pattern
 const { mockFetchBases } = vi.hoisted(() => ({
@@ -23,10 +23,10 @@ vi.mock("$lib/api", () => ({
 import NameBranchDropdown, { type NameBranchSelection } from "./NameBranchDropdown.svelte";
 
 describe("NameBranchDropdown component", () => {
-  const testProjectId = "test-project-12345678" as ProjectId;
+  const testProjectPath = "/test/project";
 
   const defaultProps = {
-    projectId: testProjectId,
+    projectPath: testProjectPath,
     value: "",
     onSelect: vi.fn(),
   };

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -325,9 +325,9 @@ describe("Integration tests", () => {
       const confirmButton = within(dialog).getByRole("button", { name: /close project/i });
       await fireEvent.click(confirmButton);
 
-      // Verify closeProject was called (v2 API uses projectId)
+      // Verify closeProject was called with project path
       await waitFor(() => {
-        expect(mockApi.projects.close).toHaveBeenCalledWith(actualProjectId, undefined);
+        expect(mockApi.projects.close).toHaveBeenCalledWith(project.path, undefined);
       });
 
       // Simulate project:closed event (v2 format uses projectId not path)

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -35,7 +35,7 @@ export interface ProjectCloseOptions {
 
 export interface IProjectApi {
   open(path?: string): Promise<Project | null>;
-  close(projectId: ProjectId, options?: ProjectCloseOptions): Promise<void>;
+  close(projectPath: string, options?: ProjectCloseOptions): Promise<void>;
   /**
    * Clone a git repository and create a new project.
    * If the URL has already been cloned, returns the existing project.
@@ -45,7 +45,7 @@ export interface IProjectApi {
    * @throws Error if clone fails (network, auth, invalid URL)
    */
   clone(url: string): Promise<Project>;
-  fetchBases(projectId: ProjectId): Promise<{ readonly bases: readonly BaseInfo[] }>;
+  fetchBases(projectPath: string): Promise<{ readonly bases: readonly BaseInfo[] }>;
 }
 
 /**
@@ -68,13 +68,13 @@ export interface IWorkspaceApi {
   /**
    * Create a new workspace.
    *
-   * @param projectId Project to create the workspace in
+   * @param projectPath Project path to create the workspace in
    * @param name Name of the new workspace
    * @param base Base branch to create the workspace from
    * @param options Optional creation options (initialPrompt, keepInBackground)
    */
   create(
-    projectId: ProjectId | undefined,
+    projectPath: string | undefined,
     name: string,
     base: string,
     options?: WorkspaceCreateOptions
@@ -192,6 +192,7 @@ export interface ApiEvents {
   "project:closed": (event: { readonly projectId: ProjectId }) => void;
   "project:bases-updated": (event: {
     readonly projectId: ProjectId;
+    readonly projectPath: string;
     readonly bases: readonly BaseInfo[];
   }) => void;
   "workspace:created": (event: {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -33,12 +33,12 @@ export interface Api {
 
   projects: {
     open(path?: string): Promise<Project | null>;
-    close(projectId: string, options?: { removeLocalRepo?: boolean }): Promise<void>;
+    close(projectPath: string, options?: { removeLocalRepo?: boolean }): Promise<void>;
     clone(url: string): Promise<Project>;
-    fetchBases(projectId: string): Promise<{ readonly bases: readonly ApiBaseInfo[] }>;
+    fetchBases(projectPath: string): Promise<{ readonly bases: readonly ApiBaseInfo[] }>;
   };
   workspaces: {
-    create(projectId: string, name: string, base: string): Promise<Workspace>;
+    create(projectPath: string, name: string, base: string): Promise<Workspace>;
     /**
      * Start workspace removal (fire-and-forget).
      * Progress is emitted via workspace:deletion-progress events.


### PR DESCRIPTION
- IPC API (`close`, `fetchBases`, `create`) now accepts `projectPath` instead of `projectId`, since the renderer already has `project.path` available
- `open-workspace` removes the reverse-direction `"resolve-project"` hook and dispatches `project:resolve` intent instead
- `close-project` payload changes from `projectId` to `projectPath`, dispatches `project:resolve` for ID resolution
- `local-project-module` removes 3 reverse-direction handlers (`resolve-project` on open-workspace, `resolve-caller-project` on open-workspace, `resolve-project` on close-project)
- Renderer components (`CreateWorkspaceDialog`, `CloseProjectDialog`, `BranchDropdown`, `NameBranchDropdown`) updated to pass `projectPath`
- All operations now use the unified `project:resolve` intent for `projectPath → projectId` resolution