### PR TITLE
feat(ui): invert CloseProjectDialog defaults for remote projects

### DIFF
--- a/src/renderer/lib/components/CloseProjectDialog.svelte
+++ b/src/renderer/lib/components/CloseProjectDialog.svelte
@@ -19,7 +19,7 @@
 
   // Form state
   let removeAll = $state(false);
-  let deleteLocalRepo = $state(false);
+  let keepLocalRepo = $state(false);
   let submitError = $state<string | null>(null);
   let isSubmitting = $state(false);
 
@@ -30,11 +30,12 @@
     workspaceCount === 1 ? "1 workspace" : `${workspaceCount} workspaces`
   );
   const isRemoteProject = $derived(Boolean(project?.remoteUrl));
+  const shouldDeleteRepo = $derived(isRemoteProject && !keepLocalRepo);
 
   // Dynamic button label
   const buttonLabel = $derived.by(() => {
     if (isSubmitting) return "Closing...";
-    if (deleteLocalRepo) return "Delete & Close";
+    if (shouldDeleteRepo) return "Delete & Close";
     if (removeAll) return "Remove & Close";
     return "Close Project";
   });
@@ -49,8 +50,8 @@
     logger.debug("Dialog submitted", { type: "close-project" });
 
     try {
-      // If removeAll is checked, remove all workspaces first
-      if (removeAll && project && project.workspaces.length > 0) {
+      // If removeAll or shouldDeleteRepo, remove all workspaces first
+      if ((shouldDeleteRepo || removeAll) && project && project.workspaces.length > 0) {
         const removalPromises = project.workspaces.map((workspace) =>
           workspaces
             .remove(workspace.path, { keepBranch: false })
@@ -83,7 +84,7 @@
       // Pass removeLocalRepo option if checked (and project is remote)
       await projectsApi.close(
         project!.path,
-        deleteLocalRepo ? { removeLocalRepo: true } : undefined
+        shouldDeleteRepo ? { removeLocalRepo: true } : undefined
       );
       closeDialog();
     } catch (error) {
@@ -105,13 +106,13 @@
     removeAll = (event.target as unknown as { checked: boolean }).checked;
   }
 
-  // Handle delete local repo checkbox change
-  function handleDeleteLocalRepoChange(event: Event): void {
+  // Handle keep local repo checkbox change
+  function handleKeepLocalRepoChange(event: Event): void {
     const checked = (event.target as unknown as { checked: boolean }).checked;
-    deleteLocalRepo = checked;
-    // When delete local repo is checked, also check remove all workspaces
+    keepLocalRepo = checked;
+    // When "Keep" is checked, unlock the workspace checkbox (uncheck removeAll)
     if (checked) {
-      removeAll = true;
+      removeAll = false;
     }
   }
 
@@ -140,9 +141,9 @@
 
       <div class="ch-checkbox-row">
         <vscode-checkbox
-          checked={removeAll}
+          checked={shouldDeleteRepo || removeAll}
           onchange={handleRemoveAllChange}
-          disabled={isSubmitting || deleteLocalRepo}
+          disabled={isSubmitting || shouldDeleteRepo}
           label="Remove all workspaces and their branches"
         ></vscode-checkbox>
       </div>
@@ -151,14 +152,14 @@
     {#if isRemoteProject}
       <div class="ch-checkbox-row">
         <vscode-checkbox
-          checked={deleteLocalRepo}
-          onchange={handleDeleteLocalRepoChange}
+          checked={keepLocalRepo}
+          onchange={handleKeepLocalRepoChange}
           disabled={isSubmitting}
-          label="Delete cloned repository and all local files"
+          label="Keep cloned repository"
         ></vscode-checkbox>
       </div>
 
-      {#if deleteLocalRepo}
+      {#if shouldDeleteRepo}
         <div class="ch-alert-box warning" role="alert">
           <span class="ch-alert-box-icon" aria-hidden="true">
             <Icon name="warning" />

--- a/src/renderer/lib/components/CloseProjectDialog.test.ts
+++ b/src/renderer/lib/components/CloseProjectDialog.test.ts
@@ -94,12 +94,12 @@ function getRemoveAllCheckbox(): HTMLElement & { checked?: boolean } {
   return checkbox;
 }
 
-function getDeleteRepoCheckbox(): HTMLElement & { checked?: boolean } {
+function getKeepRepoCheckbox(): HTMLElement & { checked?: boolean } {
   const checkboxes = getAllCheckboxes();
   const checkbox = Array.from(checkboxes).find(
-    (cb) => getCheckboxLabel(cb)?.includes("Delete cloned") ?? false
+    (cb) => getCheckboxLabel(cb)?.includes("Keep cloned") ?? false
   );
-  if (!checkbox) throw new Error("Delete repo checkbox not found");
+  if (!checkbox) throw new Error("Keep repo checkbox not found");
   return checkbox;
 }
 
@@ -535,15 +535,15 @@ describe("CloseProjectDialog component", () => {
       mockProjects.mockReturnValue([remoteProject]);
     });
 
-    it("shows delete repo checkbox for remote projects", async () => {
+    it("shows keep repo checkbox for remote projects", async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
-      const deleteCheckbox = getDeleteRepoCheckbox();
-      expect(deleteCheckbox).toBeInTheDocument();
+      const keepCheckbox = getKeepRepoCheckbox();
+      expect(keepCheckbox).toBeInTheDocument();
     });
 
-    it("hides delete repo checkbox for local projects", async () => {
+    it("hides keep repo checkbox for local projects", async () => {
       const localProject = createProject(testProjectId, "test-project", [
         createWorkspace("ws1", testProjectId),
       ]);
@@ -553,74 +553,87 @@ describe("CloseProjectDialog component", () => {
       await vi.runAllTimersAsync();
 
       const checkboxes = getAllCheckboxes();
-      const deleteCheckbox = Array.from(checkboxes).find(
-        (cb) => cb.getAttribute("label")?.includes("Delete cloned") ?? false
+      const keepCheckbox = Array.from(checkboxes).find(
+        (cb) => cb.getAttribute("label")?.includes("Keep cloned") ?? false
       );
-      expect(deleteCheckbox).toBeUndefined();
+      expect(keepCheckbox).toBeUndefined();
     });
 
-    it("shows warning message when delete checkbox is checked", async () => {
+    it("shows warning by default, hides when keep is checked", async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
-      const deleteCheckbox = getDeleteRepoCheckbox();
-      deleteCheckbox.checked = true;
-      await fireEvent(deleteCheckbox, new Event("change", { bubbles: true }));
-
+      // Warning visible by default for remote projects
       expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
       expect(screen.getByText(/https:\/\/github.com\/org\/test-repo.git/)).toBeInTheDocument();
-    });
 
-    it("auto-checks removeAll when delete checkbox is checked", async () => {
-      render(CloseProjectDialog, { props: defaultProps });
-      await vi.runAllTimersAsync();
+      // Check "Keep" to hide warning
+      const keepCheckbox = getKeepRepoCheckbox();
+      keepCheckbox.checked = true;
+      await fireEvent(keepCheckbox, new Event("change", { bubbles: true }));
 
-      const removeAllCheckbox = getRemoveAllCheckbox();
-      const deleteCheckbox = getDeleteRepoCheckbox();
-
-      // Initially unchecked
-      expect(removeAllCheckbox.checked).toBe(false);
-
-      // Check delete checkbox
-      deleteCheckbox.checked = true;
-      await fireEvent(deleteCheckbox, new Event("change", { bubbles: true }));
-
-      // removeAll should now be checked
       await waitFor(() => {
-        expect(removeAllCheckbox.checked).toBe(true);
+        expect(screen.queryByText(/permanently delete/i)).not.toBeInTheDocument();
       });
     });
 
-    it("disables removeAll checkbox when delete is checked", async () => {
+    it("removeAll is auto-checked by default, unchecked when keep is checked", async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
-
-      const deleteCheckbox = getDeleteRepoCheckbox();
-      deleteCheckbox.checked = true;
-      await fireEvent(deleteCheckbox, new Event("change", { bubbles: true }));
 
       const removeAllCheckbox = getRemoveAllCheckbox();
+
+      // Auto-checked by default for remote projects (shouldDeleteRepo = true)
+      expect(removeAllCheckbox.checked).toBe(true);
+
+      // Check "Keep" to uncheck removeAll
+      const keepCheckbox = getKeepRepoCheckbox();
+      keepCheckbox.checked = true;
+      await fireEvent(keepCheckbox, new Event("change", { bubbles: true }));
+
+      await waitFor(() => {
+        expect(removeAllCheckbox.checked).toBe(false);
+      });
+    });
+
+    it("disables removeAll checkbox by default, enables when keep is checked", async () => {
+      render(CloseProjectDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const removeAllCheckbox = getRemoveAllCheckbox();
+      // Disabled by default (shouldDeleteRepo = true)
       expect(removeAllCheckbox).toBeDisabled();
+
+      // Check "Keep" to enable removeAll
+      const keepCheckbox = getKeepRepoCheckbox();
+      keepCheckbox.checked = true;
+      await fireEvent(keepCheckbox, new Event("change", { bubbles: true }));
+
+      await waitFor(() => {
+        expect(removeAllCheckbox).not.toBeDisabled();
+      });
     });
 
-    it('shows "Delete & Close" button when delete checkbox is checked', async () => {
+    it('shows "Delete & Close" button by default, "Close Project" when keep is checked', async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
-      const deleteCheckbox = getDeleteRepoCheckbox();
-      deleteCheckbox.checked = true;
-      await fireEvent(deleteCheckbox, new Event("change", { bubbles: true }));
-
+      // Default: Delete & Close
       expect(screen.getByRole("button", { name: /delete & close/i })).toBeInTheDocument();
+
+      // Check "Keep"
+      const keepCheckbox = getKeepRepoCheckbox();
+      keepCheckbox.checked = true;
+      await fireEvent(keepCheckbox, new Event("change", { bubbles: true }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /close project/i })).toBeInTheDocument();
+      });
     });
 
-    it("calls close with removeLocalRepo option when delete is checked", async () => {
+    it("calls close with removeLocalRepo by default", async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
-
-      const deleteCheckbox = getDeleteRepoCheckbox();
-      deleteCheckbox.checked = true;
-      await fireEvent(deleteCheckbox, new Event("change", { bubbles: true }));
 
       const submitButton = screen.getByRole("button", { name: /delete & close/i });
       await fireEvent.click(submitButton);
@@ -632,9 +645,14 @@ describe("CloseProjectDialog component", () => {
       });
     });
 
-    it("does not pass removeLocalRepo when delete is unchecked", async () => {
+    it("does not pass removeLocalRepo when keep is checked", async () => {
       render(CloseProjectDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
+
+      // Check "Keep"
+      const keepCheckbox = getKeepRepoCheckbox();
+      keepCheckbox.checked = true;
+      await fireEvent(keepCheckbox, new Event("change", { bubbles: true }));
 
       const submitButton = screen.getByRole("button", { name: /close project/i });
       await fireEvent.click(submitButton);


### PR DESCRIPTION
- Default to full cleanup (delete repo + workspaces) when closing a remote project
- Replace "Delete cloned repository" opt-in checkbox with "Keep cloned repository" opt-out checkbox
- Warning and "Delete & Close" button shown by default for remote projects, hidden when "Keep" is checked