### PR TITLE
fix(ui): synchronize pulse animations across agent status indicators

### DIFF
--- a/src/renderer/lib/components/AgentStatusIndicator.svelte
+++ b/src/renderer/lib/components/AgentStatusIndicator.svelte
@@ -8,17 +8,6 @@
 
   let { idleCount, busyCount }: AgentStatusIndicatorProps = $props();
 
-  // Pulse animation timing - single source of truth
-  const PULSE_DURATION_MS = 1500;
-  // Recalculate sync offset when pulsing starts to synchronize all pulsing indicators
-  let pulseDelay = $state(0);
-
-  $effect(() => {
-    if (isPulsing) {
-      pulseDelay = -(performance.now() % PULSE_DURATION_MS);
-    }
-  });
-
   // Derive status type from counts
   const status = $derived.by(() => {
     if (idleCount === 0 && busyCount === 0) return "none";
@@ -29,6 +18,11 @@
 
   // Derive if pulsing animation should be applied
   const isPulsing = $derived(status === "busy" || status === "mixed");
+
+  // Pulse animation timing - single source of truth
+  const PULSE_DURATION_MS = 1500;
+  // Negative delay synchronizes all pulsing indicators to the same phase
+  const pulseDelay = $derived(isPulsing ? -(performance.now() % PULSE_DURATION_MS) : 0);
 
   // Generate status text for aria-label and tooltip using shared utility
   const statusText = $derived(getStatusText(idleCount, busyCount));

--- a/src/renderer/lib/components/AgentStatusIndicator.test.ts
+++ b/src/renderer/lib/components/AgentStatusIndicator.test.ts
@@ -137,6 +137,21 @@ describe("AgentStatusIndicator component", () => {
       expect(indicator).not.toHaveClass("indicator--pulsing");
     });
 
+    it("sets negative pulse-delay for animation synchronization when pulsing", () => {
+      vi.spyOn(performance, "now").mockReturnValue(750);
+      render(AgentStatusIndicator, { props: { idleCount: 0, busyCount: 1 } });
+
+      const indicator = screen.getByRole("status");
+      expect(indicator.style.getPropertyValue("--pulse-delay")).toBe("-750ms");
+    });
+
+    it("sets pulse-delay to 0ms when not pulsing", () => {
+      render(AgentStatusIndicator, { props: { idleCount: 2, busyCount: 0 } });
+
+      const indicator = screen.getByRole("status");
+      expect(indicator.style.getPropertyValue("--pulse-delay")).toBe("0ms");
+    });
+
     it("respects prefers-reduced-motion media query", () => {
       // The component uses CSS @media (prefers-reduced-motion: reduce)
       // We verify the class is applied (CSS handles the actual animation disable)


### PR DESCRIPTION
## Summary
- Replace `$effect` + `$state` with `$derived` for pulse delay so the correct `animation-delay` is in the DOM from the first paint
- Prevents indicators that become busy at different times from pulsing out of phase
- Add tests verifying synchronized negative pulse-delay when pulsing and zero delay when idle

## Test plan
- [x] `pnpm validate:fix` passes (lint, format, types, all 3609 tests, build)
- [ ] Manual: run `pnpm dev`, create 2+ workspaces with busy agents, observe sidebar indicators pulse in unison

🤖 Generated with [Claude Code](https://claude.com/claude-code)