### PR TITLE
ci: cache apt packages for Wine installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,6 +137,14 @@ jobs:
           name: build-output
           path: out
 
+      - name: Cache Wine packages
+        if: matrix.wine
+        id: wine-cache
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-wine-ubuntu-24.04
+
       - name: Install Wine
         if: matrix.wine
         timeout-minutes: 5


### PR DESCRIPTION
- Cache `/var/cache/apt/archives` for Wine installation in build workflow
- Skips ~400MB package download on cache hit; `apt-get install` naturally uses cached debs