### PR TITLE
feat(site): embed screencast video in site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 Run multiple AI coding assistants simultaneously in isolated git worktrees
 with real-time status monitoring.
 
+https://github.com/user-attachments/assets/82b56a86-3dee-42a6-90d3-e2a002949f7a
+
 ## Installation
 
 ```bash
@@ -37,10 +39,6 @@ Or download directly from [GitHub Releases](https://github.com/stefanhoelzl/code
 - **VS Code Powered** - Full code-server integration with all your extensions
 - **Voice Dictation** - Built-in speech-to-text for hands-free coding
 - **Cross-platform** - Linux, macOS, and Windows
-
-## Screenshot
-
-> Screenshots coming soon
 
 ## How It Works
 

--- a/site/src/App.svelte
+++ b/site/src/App.svelte
@@ -12,8 +12,8 @@
 <main id="main-content">
   <Hero />
   <QuickStart />
+  <Screenshot />
   <Abstract />
   <Features />
-  <Screenshot />
 </main>
 <Footer />

--- a/site/src/components/Screenshot.svelte
+++ b/site/src/components/Screenshot.svelte
@@ -4,11 +4,17 @@
 
 <section class="screenshot">
   <div class="container">
-    <img
-      src="{base}screenshot.png"
-      alt="CodeHydra showing multiple workspaces with AI agents running in parallel"
-      class="screenshot-img"
-    />
+    <video autoplay loop muted playsinline class="screenshot-img" poster="{base}screenshot.png">
+      <source
+        src="https://github.com/user-attachments/assets/82b56a86-3dee-42a6-90d3-e2a002949f7a"
+        type="video/mp4"
+      />
+      <img
+        src="{base}screenshot.png"
+        alt="CodeHydra showing multiple workspaces with AI agents running in parallel"
+        class="screenshot-img"
+      />
+    </video>
   </div>
 </section>
 


### PR DESCRIPTION
- Replace static screenshot with autoplaying looping video from GitHub CDN in site
- Move video section directly below Get Started
- Add inline video to README (bare MP4 URL for GitHub auto-rendering)
- Remove placeholder "Screenshots coming soon" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)