### PR TITLE
fix(ci): cache only .deb files to avoid permission denied on apt archives

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -142,7 +142,7 @@ jobs:
         id: wine-cache
         uses: actions/cache@v4
         with:
-          path: /var/cache/apt/archives
+          path: /var/cache/apt/archives/*.deb
           key: apt-wine-ubuntu-24.04
 
       - name: Install Wine


### PR DESCRIPTION
- Cache path changed from `/var/cache/apt/archives` to `/var/cache/apt/archives/*.deb` to skip root-owned `lock` file and `partial/` directory that cause `tar` to fail with exit code 2 during cache save