### PR TITLE
fix(agent): suppress false idle notification during context compaction

### DIFF
--- a/src/agents/claude/server-manager.integration.test.ts
+++ b/src/agents/claude/server-manager.integration.test.ts
@@ -332,6 +332,90 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
     });
 
+    it("SessionStart during automatic compaction stays busy", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Agent is working (busy)
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      // Automatic compaction mid-turn: PreCompact while busy sets flag
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+      // SessionStart after compaction should stay busy (flag consumed)
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      // No false idle transition — status stays busy throughout
+      expect(statusChanges).toEqual(["idle", "busy"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
+    });
+
+    it("manual compact: SessionStart goes idle normally", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Agent is idle (waiting for user), user runs /compact
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      // PreCompact while idle does NOT set flag
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+      // SessionStart after compaction should go idle normally
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
+    it("compacting flag cleared after use", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Automatic compaction mid-turn
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      // Agent finishes, stops
+      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+
+      // Next SessionStart should go idle normally (flag was consumed)
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
+    it("WrapperEnd clears ignoreNextSessionStart flag", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Automatic compaction sets flag
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+
+      // Claude exits before SessionStart (abnormal exit clears flag)
+      await sendHook(port, "WrapperEnd", { workspacePath: "/workspace/feature-a" });
+
+      // New session should go idle (flag was defensively cleared)
+      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy", "none", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
     it("Stop -> idle", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];

--- a/src/agents/claude/server-manager.ts
+++ b/src/agents/claude/server-manager.ts
@@ -45,6 +45,8 @@ export interface WorkspaceState {
   statusCallbacks: Set<(status: AgentStatus) => void>;
   /** Flag set after PermissionRequest, cleared on PreToolUse */
   awaitingPermissionResolution?: boolean;
+  /** Flag set when PreCompact arrives while busy, cleared on SessionStart */
+  ignoreNextSessionStart?: boolean;
   /** Path to the initial prompt file (for getInitialPromptPath) */
   initialPromptPath?: Path;
 }
@@ -631,6 +633,23 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     } else if (hookName === "PreToolUse" && state.awaitingPermissionResolution) {
       state.awaitingPermissionResolution = false;
       newStatus = "busy";
+    }
+
+    // Special handling for compaction flow:
+    // PreCompact while busy sets flag (automatic compaction mid-turn).
+    // SessionStart during compaction stays busy instead of going idle.
+    // Manual /compact starts from idle, so flag is NOT set and SessionStart goes idle normally.
+    // Terminal hooks (WrapperEnd, SessionEnd) clear the flag as defensive cleanup.
+    if (hookName === "PreCompact" && state.status === "busy") {
+      state.ignoreNextSessionStart = true;
+    } else if (hookName === "SessionStart" && state.ignoreNextSessionStart) {
+      state.ignoreNextSessionStart = false;
+      newStatus = "busy";
+    } else if (
+      (hookName === "WrapperEnd" || hookName === "SessionEnd") &&
+      state.ignoreNextSessionStart
+    ) {
+      state.ignoreNextSessionStart = false;
     }
 
     this.logger.debug("Hook received", {


### PR DESCRIPTION
- Add `ignoreNextSessionStart` flag to `WorkspaceState`, set when `PreCompact` arrives while busy (automatic compaction mid-turn)
- `SessionStart` after automatic compaction stays busy instead of falsely transitioning to idle
- Manual `/compact` (from idle) is unaffected — `SessionStart` correctly goes idle
- Terminal hooks (`WrapperEnd`, `SessionEnd`) defensively clear the flag
- Add 4 integration tests covering automatic compact, manual compact, flag cleanup, and abnormal exit