### PR TITLE
fix(ci): bump Wine apt cache key to invalidate corrupted entry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /var/cache/apt/archives/*.deb
-          key: apt-wine-ubuntu-24.04
+          key: apt-wine-ubuntu-24.04-v2
 
       - name: Install Wine
         if: matrix.wine


### PR DESCRIPTION
- Bump Wine apt cache key from `apt-wine-ubuntu-24.04` to `apt-wine-ubuntu-24.04-v2` to invalidate the corrupted cache entry that fails to restore with tar exit code 2