### PR TITLE
feat(dispatcher): centralize logging in intent dispatcher

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -246,7 +246,7 @@ const setupExtensionManager = new ExtensionManager(
 );
 
 const hookRegistry = new HookRegistry();
-const dispatcher = new Dispatcher(hookRegistry);
+const dispatcher = new Dispatcher(hookRegistry, loggingService.createLogger("dispatcher"));
 
 // Runtime services (non-agent, used by lifecycle modules)
 const pluginServer = new PluginServer(networkLayer, loggingService.createLogger("plugin"), {
@@ -447,12 +447,10 @@ const telemetryLifecycleModule = createTelemetryModule({
   platformInfo,
   buildInfo,
   dispatcher,
-  logger: lifecycleLogger,
 });
 const autoUpdaterLifecycleModule = createAutoUpdaterModule({
   autoUpdater,
   dispatcher,
-  logger: lifecycleLogger,
 });
 const migrationModule = createMigrationModule({
   projectsDir: pathProvider.projectsDir.toString(),
@@ -475,11 +473,10 @@ const gitWorktreeWorkspaceModule = createGitWorktreeWorkspaceModule(
   pathProvider,
   apiLogger
 );
-const badgeModule = createBadgeModule(badgeManager, lifecycleLogger);
+const badgeModule = createBadgeModule(badgeManager);
 const workspaceSelectionModule = createWorkspaceSelectionModule(agentStatusManager);
 const mcpModule = createMcpModule({
   mcpServerManager,
-  logger: lifecycleLogger,
 });
 
 // 8. New modules
@@ -607,7 +604,6 @@ codeHydraApi = registry.getInterface();
 // 11. Dispatch app:start
 
 // Dispatch app:start — orchestrates the entire startup flow via hook points
-appLogger.info("Dispatching app:start");
 void dispatcher
   .dispatch({
     type: INTENT_APP_START,

--- a/src/main/intents/infrastructure/dispatcher.integration.test.ts
+++ b/src/main/intents/infrastructure/dispatcher.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for Dispatcher.
  *
  * Verifies dispatch → execute flow, interceptor modify/cancel/ordering,
- * event emission, causation chain tracking, and no-operation error.
+ * event emission, causation chain tracking, no-operation error, and logging.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -12,6 +12,7 @@ import { HookRegistry } from "./hook-registry";
 import type { IntentModule } from "./module";
 import type { Intent, DomainEvent } from "./types";
 import type { Operation, OperationContext, HookContext } from "./operation";
+import type { Logger } from "../../../services/logging/types";
 
 // =============================================================================
 // Test Helpers
@@ -35,6 +36,30 @@ function createTestOperation<R>(
     execute: async (ctx) => {
       sideEffect?.(ctx);
       return returnValue;
+    },
+  };
+}
+
+function createMockLogger(): Logger & {
+  calls: { level: string; message: string; context?: unknown }[];
+} {
+  const calls: { level: string; message: string; context?: unknown }[] = [];
+  return {
+    calls,
+    silly(message: string, context?: unknown) {
+      calls.push({ level: "silly", message, context });
+    },
+    debug(message: string, context?: unknown) {
+      calls.push({ level: "debug", message, context });
+    },
+    info(message: string, context?: unknown) {
+      calls.push({ level: "info", message, context });
+    },
+    warn(message: string, context?: unknown) {
+      calls.push({ level: "warn", message, context });
+    },
+    error(message: string, context?: unknown) {
+      calls.push({ level: "error", message, context });
     },
   };
 }
@@ -390,6 +415,7 @@ describe("Dispatcher", () => {
       const hookRan = vi.fn();
 
       const testModule: IntentModule = {
+        name: "test-hook",
         hooks: {
           "action-op": {
             execute: {
@@ -416,6 +442,7 @@ describe("Dispatcher", () => {
       const eventHandler = vi.fn();
 
       const testModule: IntentModule = {
+        name: "test-event",
         events: {
           "test:completed": eventHandler,
         },
@@ -455,6 +482,7 @@ describe("Dispatcher", () => {
       };
 
       const testModule: IntentModule = {
+        name: "test-interceptor",
         interceptors: [cancelInterceptor],
       };
 
@@ -478,7 +506,7 @@ describe("Dispatcher", () => {
       const hookRegistry = new HookRegistry();
       const dispatcher = new Dispatcher(hookRegistry);
 
-      const emptyModule: IntentModule = {};
+      const emptyModule: IntentModule = { name: "test-empty" };
 
       expect(() => dispatcher.registerModule(emptyModule)).not.toThrow();
     });
@@ -489,6 +517,7 @@ describe("Dispatcher", () => {
       const order: string[] = [];
 
       const moduleA: IntentModule = {
+        name: "test-a",
         hooks: {
           "action-op": {
             execute: {
@@ -501,6 +530,7 @@ describe("Dispatcher", () => {
       };
 
       const moduleB: IntentModule = {
+        name: "test-b",
         hooks: {
           "action-op": {
             execute: {
@@ -520,6 +550,206 @@ describe("Dispatcher", () => {
       await hooks.collect("execute", ctx);
 
       expect(order).toEqual(["module-a", "module-b"]);
+    });
+  });
+
+  describe("logging", () => {
+    it("logs dispatch start with intent type and causation", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      await dispatcher.dispatch(createActionIntent());
+
+      const dispatchLog = logger.calls.find((c) => c.level === "info" && c.message === "dispatch");
+      expect(dispatchLog).toBeDefined();
+      expect(dispatchLog!.context).toEqual(
+        expect.objectContaining({ intent: "test:action", causation: "" })
+      );
+    });
+
+    it("logs completion with intent type and duration", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      await dispatcher.dispatch(createActionIntent());
+
+      const completedLog = logger.calls.find(
+        (c) => c.level === "info" && c.message === "completed"
+      );
+      expect(completedLog).toBeDefined();
+      expect(completedLog!.context).toEqual(
+        expect.objectContaining({ intent: "test:action", ms: expect.any(Number) })
+      );
+    });
+
+    it("logs failure when operation throws", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      dispatcher.registerOperation("test:action", {
+        id: "op",
+        execute: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      await expect(dispatcher.dispatch(createActionIntent())).rejects.toThrow("boom");
+
+      const failedLog = logger.calls.find((c) => c.level === "error" && c.message === "failed");
+      expect(failedLog).toBeDefined();
+      expect(failedLog!.context).toEqual(
+        expect.objectContaining({ intent: "test:action", error: "boom" })
+      );
+    });
+
+    it("logs interceptor block", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      dispatcher.addInterceptor({
+        id: "block-it",
+        async before() {
+          return null;
+        },
+      });
+
+      await dispatcher.dispatch(createActionIntent());
+
+      const blockLog = logger.calls.find(
+        (c) => c.level === "warn" && c.message === "interceptor blocked"
+      );
+      expect(blockLog).toBeDefined();
+      expect(blockLog!.context).toEqual(
+        expect.objectContaining({ intent: "test:action", interceptor: "block-it" })
+      );
+    });
+
+    it("logs hook execution with module names", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      const testModule: IntentModule = {
+        name: "test-mod",
+        hooks: {
+          "action-op": {
+            run: { handler: async () => ({ value: 1 }) },
+          },
+        },
+      };
+
+      dispatcher.registerModule(testModule);
+      dispatcher.registerOperation("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          await ctx.hooks.collect("run", { intent: ctx.intent });
+        },
+      });
+
+      await dispatcher.dispatch(createActionIntent());
+
+      const hookLog = logger.calls.find((c) => c.level === "debug" && c.message === "hook");
+      expect(hookLog).toBeDefined();
+      expect(hookLog!.context).toEqual(
+        expect.objectContaining({
+          op: "action-op",
+          hook: "run",
+          modules: "test-mod",
+          results: 1,
+          errors: 0,
+          ms: expect.any(Number),
+        })
+      );
+    });
+
+    it("logs hook errors", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      const testModule: IntentModule = {
+        name: "failing-mod",
+        hooks: {
+          "action-op": {
+            run: {
+              handler: async () => {
+                throw new Error("hook failed");
+              },
+            },
+          },
+        },
+      };
+
+      dispatcher.registerModule(testModule);
+      dispatcher.registerOperation("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          await ctx.hooks.collect("run", { intent: ctx.intent });
+        },
+      });
+
+      await dispatcher.dispatch(createActionIntent());
+
+      const hookErrorLog = logger.calls.find(
+        (c) => c.level === "warn" && c.message === "hook error"
+      );
+      expect(hookErrorLog).toBeDefined();
+      expect(hookErrorLog!.context).toEqual(
+        expect.objectContaining({
+          op: "action-op",
+          hook: "run",
+          error: "hook failed",
+        })
+      );
+    });
+
+    it("logs event emission with subscriber names", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      const testModule: IntentModule = {
+        name: "subscriber-mod",
+        events: {
+          "test:completed": () => {},
+        },
+      };
+
+      dispatcher.registerModule(testModule);
+      dispatcher.registerOperation("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          ctx.emit({ type: "test:completed", payload: {} });
+        },
+      });
+
+      await dispatcher.dispatch(createActionIntent());
+
+      const emitLog = logger.calls.find((c) => c.level === "info" && c.message === "emit");
+      expect(emitLog).toBeDefined();
+      expect(emitLog!.context).toEqual(
+        expect.objectContaining({
+          event: "test:completed",
+          subscribers: "subscriber-mod",
+        })
+      );
+    });
+
+    it("works without logger (backward compatible)", async () => {
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+
+      dispatcher.registerOperation("test:action", createTestOperation("op", { ok: true }));
+
+      const result = await dispatcher.dispatch(createActionIntent());
+      expect(result).toEqual({ ok: true });
     });
   });
 });

--- a/src/main/intents/infrastructure/dispatcher.ts
+++ b/src/main/intents/infrastructure/dispatcher.ts
@@ -3,12 +3,29 @@
  *
  * Orchestrates: interceptor pipeline → operation resolution → hook injection → execute → emit events.
  * Events are emitted inline when `ctx.emit()` is called during operation execution.
+ *
+ * When a Logger is provided, the dispatcher logs:
+ * - Intent dispatch start (info)
+ * - Interceptor blocks (warn)
+ * - Hook point execution with timing, module names, results, errors (debug)
+ * - Hook errors (warn)
+ * - Event emissions with subscriber names (info)
+ * - Intent completion with timing (info)
+ * - Intent failure (error)
  */
 
 import type { Intent, IntentResult, DomainEvent } from "./types";
-import type { Operation, OperationContext, DispatchFn } from "./operation";
+import type {
+  Operation,
+  OperationContext,
+  DispatchFn,
+  ResolvedHooks,
+  HookContext,
+} from "./operation";
+import type { HookResult } from "./operation";
 import type { IHookRegistry } from "./hook-registry";
 import type { IntentModule } from "./module";
+import type { Logger } from "../../../services/logging/types";
 
 // =============================================================================
 // IntentHandle
@@ -117,7 +134,16 @@ export class Dispatcher implements IDispatcher {
   private readonly interceptors: IntentInterceptor[] = [];
   private readonly subscribers = new Map<string, Set<EventHandler>>();
 
-  constructor(private readonly hookRegistry: IHookRegistry) {}
+  /** operationId → hookPointId → module names[] */
+  private readonly hookModuleNames = new Map<string, Map<string, string[]>>();
+
+  /** eventType → module names[] */
+  private readonly eventSubscriberNames = new Map<string, string[]>();
+
+  constructor(
+    private readonly hookRegistry: IHookRegistry,
+    private readonly logger?: Logger
+  ) {}
 
   /**
    * Register an operation for a specific intent type.
@@ -143,12 +169,14 @@ export class Dispatcher implements IDispatcher {
       for (const [operationId, hookPoints] of Object.entries(module.hooks)) {
         for (const [hookPointId, handler] of Object.entries(hookPoints)) {
           this.hookRegistry.register(operationId, hookPointId, handler);
+          this.trackHookModule(operationId, hookPointId, module.name);
         }
       }
     }
     if (module.events) {
       for (const [eventType, handler] of Object.entries(module.events)) {
         this.subscribe(eventType, handler);
+        this.trackEventSubscriber(eventType, module.name);
       }
     }
     if (module.interceptors) {
@@ -179,17 +207,83 @@ export class Dispatcher implements IDispatcher {
     return handle;
   }
 
+  private trackHookModule(operationId: string, hookPointId: string, moduleName: string): void {
+    let opMap = this.hookModuleNames.get(operationId);
+    if (!opMap) {
+      opMap = new Map<string, string[]>();
+      this.hookModuleNames.set(operationId, opMap);
+    }
+    let names = opMap.get(hookPointId);
+    if (!names) {
+      names = [];
+      opMap.set(hookPointId, names);
+    }
+    names.push(moduleName);
+  }
+
+  private trackEventSubscriber(eventType: string, moduleName: string): void {
+    let names = this.eventSubscriberNames.get(eventType);
+    if (!names) {
+      names = [];
+      this.eventSubscriberNames.set(eventType, names);
+    }
+    names.push(moduleName);
+  }
+
+  private createLoggedHooks(hooks: ResolvedHooks, operationId: string): ResolvedHooks {
+    return {
+      collect: async <T>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>> => {
+        const modules = this.hookModuleNames.get(operationId)?.get(hookPointId) ?? [];
+        const start = performance.now();
+        const result = await hooks.collect<T>(hookPointId, ctx);
+        const duration = Math.round(performance.now() - start);
+
+        this.logger!.debug("hook", {
+          op: operationId,
+          hook: hookPointId,
+          modules: modules.join(","),
+          results: result.results.length,
+          errors: result.errors.length,
+          ms: duration,
+        });
+
+        if (result.errors.length > 0) {
+          for (const error of result.errors) {
+            this.logger!.warn("hook error", {
+              op: operationId,
+              hook: hookPointId,
+              error: error.message,
+            });
+          }
+        }
+
+        return result;
+      },
+    };
+  }
+
   private async runPipeline<I extends Intent>(
     intent: I,
     causation: readonly string[] | undefined,
     handle: IntentHandle<IntentResult<I>>
   ): Promise<void> {
+    const pipelineStart = performance.now();
+
     try {
+      this.logger?.info("dispatch", {
+        intent: intent.type,
+        causation: causation?.join(" > ") ?? "",
+      });
+
       // Run interceptor pipeline
       let current: Intent | null = intent;
       for (const interceptor of this.interceptors) {
         current = await interceptor.before(current);
         if (current === null) {
+          this.logger?.warn("interceptor blocked", {
+            intent: intent.type,
+            interceptor: interceptor.id,
+          });
           handle.signalAccepted(false);
           handle.resolve(undefined as IntentResult<I>);
           return;
@@ -217,6 +311,9 @@ export class Dispatcher implements IDispatcher {
 
       // Resolve hooks for this operation
       const hooks = this.hookRegistry.resolve(operation.id);
+      const loggedHooks: ResolvedHooks = this.logger
+        ? this.createLoggedHooks(hooks, operation.id)
+        : hooks;
 
       // Build operation context
       const ctx: OperationContext<Intent> = {
@@ -225,19 +322,34 @@ export class Dispatcher implements IDispatcher {
         emit: (event: DomainEvent) => {
           const handlers = this.subscribers.get(event.type);
           if (handlers) {
+            if (this.logger) {
+              const names = this.eventSubscriberNames.get(event.type) ?? [];
+              this.logger.info("emit", {
+                event: event.type,
+                subscribers: names.join(","),
+              });
+            }
             for (const handler of handlers) {
               handler(event);
             }
           }
         },
-        hooks,
+        hooks: loggedHooks,
         causation: causationChain,
       };
 
       // Execute operation
       const result = await operation.execute(ctx);
+
+      const duration = Math.round(performance.now() - pipelineStart);
+      this.logger?.info("completed", { intent: current.type, ms: duration });
+
       handle.resolve(result as IntentResult<I>);
     } catch (e) {
+      this.logger?.error("failed", {
+        intent: intent.type,
+        error: e instanceof Error ? e.message : String(e),
+      });
       // Ensure accepted is signaled even if interceptor itself throws.
       // Calling signalAccepted twice is safe — Promise resolves only once.
       handle.signalAccepted(true);

--- a/src/main/intents/infrastructure/idempotency-module.ts
+++ b/src/main/intents/infrastructure/idempotency-module.ts
@@ -90,6 +90,7 @@ export function createIdempotencyModule(rules: readonly IdempotencyRule[]): Inte
   }
 
   return {
+    name: "idempotency",
     interceptors: [
       {
         id: "idempotency",

--- a/src/main/intents/infrastructure/module.ts
+++ b/src/main/intents/infrastructure/module.ts
@@ -35,6 +35,8 @@ export type EventDeclarations = Readonly<Record<string, (event: DomainEvent) => 
  * Modules are registered at bootstrap via `dispatcher.registerModule()`.
  */
 export interface IntentModule {
+  /** Human-readable module name for logging and diagnostics. */
+  readonly name: string;
   /** Hook contributions: operationId → hookPointId → HookHandler */
   readonly hooks?: HookDeclarations;
   /** Event subscriptions: eventType → handler */

--- a/src/main/modules/auto-updater-module.integration.test.ts
+++ b/src/main/modules/auto-updater-module.integration.test.ts
@@ -31,9 +31,7 @@ import {
   type UpdateAvailableIntent,
 } from "../operations/update-available";
 import { createAutoUpdaterModule } from "./auto-updater-module";
-import { SILENT_LOGGER } from "../../services/logging";
 import type { AutoUpdater, UpdateAvailableCallback } from "../../services/auto-updater";
-import type { Logger } from "../../services/logging/types";
 
 // =============================================================================
 // Minimal Start Operation
@@ -120,27 +118,13 @@ function createMockAutoUpdater(overrides?: { disposeThrows?: Error }): MockAutoU
   };
 }
 
-function createTrackingLogger(): { logger: Logger; errors: unknown[] } {
-  const errors: unknown[] = [];
-  const logger: Logger = {
-    silly() {},
-    debug() {},
-    info() {},
-    warn() {},
-    error(message: string, _context?: unknown, error?: Error) {
-      errors.push({ message, error });
-    },
-  };
-  return { logger, errors };
-}
-
 interface TestSetup {
   dispatcher: Dispatcher;
   autoUpdater: MockAutoUpdater;
   updateOperation: TrackingUpdateOperation;
 }
 
-function createTestSetup(overrides?: { disposeThrows?: Error; logger?: Logger }): TestSetup {
+function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
   const autoUpdater = createMockAutoUpdater(
     overrides?.disposeThrows ? { disposeThrows: overrides.disposeThrows } : undefined
   );
@@ -152,7 +136,6 @@ function createTestSetup(overrides?: { disposeThrows?: Error; logger?: Logger })
   const autoUpdaterModule = createAutoUpdaterModule({
     autoUpdater: autoUpdater.mock,
     dispatcher,
-    logger: overrides?.logger ?? SILENT_LOGGER,
   });
 
   dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
@@ -208,20 +191,12 @@ describe("AutoUpdaterModule Integration", () => {
     expect(autoUpdater.disposeCalled).toBe(true);
   });
 
-  it("dispose() throws — error logged, no re-throw", async () => {
-    const disposeError = new Error("dispose failed");
-    const { logger, errors } = createTrackingLogger();
+  it("dispose() throws — collect catches error, dispatch still resolves", async () => {
     const { dispatcher } = createTestSetup({
-      disposeThrows: disposeError,
-      logger,
+      disposeThrows: new Error("dispose failed"),
     });
 
+    // Handler throws, but collect() catches it and shutdown is best-effort
     await expect(dispatcher.dispatch(shutdownIntent())).resolves.toBeUndefined();
-
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toEqual({
-      message: "AutoUpdater lifecycle shutdown failed (non-fatal)",
-      error: disposeError,
-    });
   });
 });

--- a/src/main/modules/auto-updater-module.ts
+++ b/src/main/modules/auto-updater-module.ts
@@ -15,16 +15,15 @@ import {
 } from "../operations/update-available";
 import type { AutoUpdater } from "../../services/auto-updater";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
-import type { Logger } from "../../services/logging/types";
 
 interface AutoUpdaterModuleDeps {
   readonly autoUpdater: AutoUpdater;
   readonly dispatcher: Dispatcher;
-  readonly logger: Logger;
 }
 
 export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModule {
   return {
+    name: "auto-updater",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -45,15 +44,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              deps.autoUpdater.dispose();
-            } catch (error) {
-              deps.logger.error(
-                "AutoUpdater lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
-            }
+            deps.autoUpdater.dispose();
           },
         },
       },

--- a/src/main/modules/badge-module.integration.test.ts
+++ b/src/main/modules/badge-module.integration.test.ts
@@ -96,8 +96,8 @@ class MinimalStopOperation implements Operation<AppShutdownIntent, void> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
 
   async execute(ctx: OperationContext<AppShutdownIntent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
-    if (errors.length > 0) throw errors[0]!;
+    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
+    await ctx.hooks.collect("stop", { intent: ctx.intent });
   }
 }
 
@@ -118,6 +118,7 @@ interface TestSetup {
  */
 function createMockResolveModule(): IntentModule {
   return {
+    name: "test-resolve",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -163,7 +164,7 @@ function createTestSetup(): TestSetup {
   dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  const badgeModule = createBadgeModule(badgeManager, SILENT_LOGGER);
+  const badgeModule = createBadgeModule(badgeManager);
   const resolveModule = createMockResolveModule();
 
   dispatcher.registerModule(badgeModule);
@@ -343,17 +344,18 @@ describe("BadgeModule Integration", () => {
       expect(appLayer).toHaveDockBadge("");
     });
 
-    it("does not propagate errors from dispose (non-fatal)", async () => {
+    it("collect catches dispose error, dispatch still resolves", async () => {
       const { dispatcher, badgeManager } = createTestSetup();
 
-      // Make dispose() throw
+      // Make dispose() throw - handler throws directly (no internal try/catch),
+      // but AppShutdownOperation uses collect() which catches errors
       vi.spyOn(badgeManager, "dispose").mockImplementation(() => {
         throw new Error("dispose failed");
       });
 
       dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new MinimalStopOperation());
 
-      // Should not throw - shutdown errors are non-fatal
+      // Should not throw - collect() catches the error
       await expect(
         dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent)
       ).resolves.not.toThrow();

--- a/src/main/modules/badge-module.ts
+++ b/src/main/modules/badge-module.ts
@@ -20,7 +20,6 @@ import { EVENT_AGENT_STATUS_UPDATED } from "../operations/update-agent-status";
 import type { WorkspaceDeletedEvent } from "../operations/delete-workspace";
 import { EVENT_WORKSPACE_DELETED } from "../operations/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
-import type { Logger } from "../../services/logging/types";
 import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
 
 /**
@@ -73,10 +72,9 @@ export function aggregateWorkspaceStates(
  * and disposes the BadgeManager on app shutdown.
  *
  * @param badgeManager - The BadgeManager to call updateBadge() on
- * @param logger - Logger for shutdown error reporting
  * @returns IntentModule with event subscriptions and shutdown hook
  */
-export function createBadgeModule(badgeManager: BadgeManager, logger: Logger): IntentModule {
+export function createBadgeModule(badgeManager: BadgeManager): IntentModule {
   const workspaceStatuses = new Map<WorkspacePath, AggregatedAgentStatus>();
 
   function updateBadge(): void {
@@ -85,6 +83,7 @@ export function createBadgeModule(badgeManager: BadgeManager, logger: Logger): I
   }
 
   return {
+    name: "badge",
     events: {
       [EVENT_AGENT_STATUS_UPDATED]: (event: DomainEvent) => {
         const { workspacePath, status } = (event as AgentStatusUpdatedEvent).payload;
@@ -101,15 +100,7 @@ export function createBadgeModule(badgeManager: BadgeManager, logger: Logger): I
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              badgeManager.dispose();
-            } catch (error) {
-              logger.error(
-                "Badge lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
-            }
+            badgeManager.dispose();
           },
         },
       },

--- a/src/main/modules/claude-agent-module.integration.test.ts
+++ b/src/main/modules/claude-agent-module.integration.test.ts
@@ -148,8 +148,8 @@ class MinimalStopOperation implements Operation<Intent, void> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
 
   async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
-    if (errors.length > 0) throw errors[0]!;
+    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
+    await ctx.hooks.collect("stop", { intent: ctx.intent });
   }
 }
 
@@ -1180,7 +1180,7 @@ describe("ClaudeAgentModule", () => {
       expect(mockASM.dispose).not.toHaveBeenCalled();
     });
 
-    it("handles non-fatal stop errors", async () => {
+    it("collect catches stop error, dispatch still resolves", async () => {
       const mockDepsResult = createMockDeps();
       mockDepsResult.mockSM.dispose.mockRejectedValue(new Error("dispose failed"));
       const { dispatcher, module } = createTestSetup(mockDepsResult);
@@ -1188,7 +1188,7 @@ describe("ClaudeAgentModule", () => {
 
       dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
 
-      // Should not throw - errors are caught internally
+      // Handler throws directly, but collect() catches the error
       await expect(
         dispatcher.dispatch({ type: "app:shutdown", payload: {} })
       ).resolves.not.toThrow();

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -187,6 +187,7 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
   // =========================================================================
 
   return {
+    name: "claude-agent",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
@@ -250,32 +251,24 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              if (serverStartedCleanupFn) {
-                serverStartedCleanupFn();
-                serverStartedCleanupFn = null;
-              }
-              if (serverStoppedCleanupFn) {
-                serverStoppedCleanupFn();
-                serverStoppedCleanupFn = null;
-              }
+            if (serverStartedCleanupFn) {
+              serverStartedCleanupFn();
+              serverStartedCleanupFn = null;
+            }
+            if (serverStoppedCleanupFn) {
+              serverStoppedCleanupFn();
+              serverStoppedCleanupFn = null;
+            }
 
-              await serverManager.dispose();
+            await serverManager.dispose();
 
-              if (statusUnsubscribeFn) {
-                statusUnsubscribeFn();
-                statusUnsubscribeFn = null;
-              }
+            if (statusUnsubscribeFn) {
+              statusUnsubscribeFn();
+              statusUnsubscribeFn = null;
+            }
 
-              if (active) {
-                deps.agentStatusManager.dispose();
-              }
-            } catch (error) {
-              logger.error(
-                "Claude agent lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            if (active) {
+              deps.agentStatusManager.dispose();
             }
           },
         },

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -102,8 +102,8 @@ class MinimalStopOperation implements Operation<Intent, void> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
 
   async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
-    if (errors.length > 0) throw errors[0]!;
+    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
+    await ctx.hooks.collect("stop", { intent: ctx.intent });
   }
 }
 
@@ -467,7 +467,7 @@ describe("CodeServerModule", () => {
       expect(callOrder).toEqual(["cs-stop", "plugin-close"]);
     });
 
-    it("handles non-fatal stop errors", async () => {
+    it("collect catches stop error, dispatch still resolves", async () => {
       const deps = createMockDeps({
         codeServerManager: {
           ...createMockDeps().codeServerManager,
@@ -477,7 +477,7 @@ describe("CodeServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
       dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
 
-      // Should not throw
+      // Handler throws directly, but collect() catches the error
       await expect(
         dispatcher.dispatch({ type: "app:shutdown", payload: {} })
       ).resolves.not.toThrow();

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -79,6 +79,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
   let codeServerPort = 0;
 
   return {
+    name: "code-server",
     hooks: {
       [APP_START_OPERATION_ID]: {
         // -------------------------------------------------------------------
@@ -128,7 +129,6 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             if (pluginServer) {
               try {
                 pluginPort = await pluginServer.start();
-                logger.info("PluginServer started", { port: pluginPort });
 
                 // Pass pluginPort to CodeServerManager so extensions can connect
                 codeServerManager.setPluginPort(pluginPort);
@@ -165,20 +165,12 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              // Stop code-server
-              await codeServerManager.stop();
+            // Stop code-server
+            await codeServerManager.stop();
 
-              // Close PluginServer AFTER code-server (extensions disconnect first)
-              if (pluginServer) {
-                await pluginServer.close();
-              }
-            } catch (error) {
-              logger.error(
-                "CodeServer lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            // Close PluginServer AFTER code-server (extensions disconnect first)
+            if (pluginServer) {
+              await pluginServer.close();
             }
           },
         },

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -223,6 +223,7 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
   }
 
   return {
+    name: "config",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {

--- a/src/main/modules/electron-lifecycle-module.ts
+++ b/src/main/modules/electron-lifecycle-module.ts
@@ -85,6 +85,7 @@ export interface ElectronLifecycleModuleDeps {
 
 export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps): IntentModule {
   return {
+    name: "electron-lifecycle",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -144,6 +144,7 @@ export function createGitWorktreeWorkspaceModule(
   // ---------------------------------------------------------------------------
 
   return {
+    name: "git-worktree",
     hooks: {
       // resolve-workspace -> resolve (single registration replaces 8 per-operation hooks)
       [RESOLVE_WORKSPACE_OPERATION_ID]: {

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -184,6 +184,7 @@ const TEST_WORKSPACE_PATH = "/projects/test/workspaces/feature-branch";
 
 function createMockResolveModule(): IntentModule {
   return {
+    name: "test-resolve",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -311,6 +312,7 @@ function createLifecycleTestSetup(
 
   // Wire quit module to prevent app.quit() error on shutdown
   const quitModule: IntentModule = {
+    name: "test-quit",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         quit: { handler: async () => {} },
@@ -643,6 +645,7 @@ describe("IpcEventBridge - lifecycle", () => {
       });
 
       const quitModule: IntentModule = {
+        name: "test-quit",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -671,12 +674,7 @@ describe("IpcEventBridge - lifecycle", () => {
       expect(mockApiRegistry.dispose).toHaveBeenCalled();
     });
 
-    it("logs error but does not throw when cleanup fails", async () => {
-      const mockLogger = {
-        ...SILENT_LOGGER,
-        error: vi.fn(),
-      };
-
+    it("collect catches error, dispatch still resolves", async () => {
       // Create an API where on() returns a cleanup function that throws
       const throwingCleanup = () => {
         throw new Error("cleanup boom");
@@ -701,7 +699,7 @@ describe("IpcEventBridge - lifecycle", () => {
         getApi: () => mockApi,
         sendToUI: vi.fn<(channel: string, ...args: unknown[]) => void>(),
         pluginServer: null,
-        logger: mockLogger,
+        logger: SILENT_LOGGER,
         dispatcher: dispatcher as unknown as IpcEventBridgeDeps["dispatcher"],
         agentStatusManager: {
           getStatus: vi.fn(),
@@ -717,6 +715,7 @@ describe("IpcEventBridge - lifecycle", () => {
       });
 
       const quitModule: IntentModule = {
+        name: "test-quit",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -733,17 +732,14 @@ describe("IpcEventBridge - lifecycle", () => {
         payload: {},
       } as AppStartIntent);
 
-      // Shutdown should not throw, but should log the error
-      await dispatcher.dispatch({
-        type: INTENT_APP_SHUTDOWN,
-        payload: {},
-      } as AppShutdownIntent);
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "IpcBridge lifecycle shutdown failed (non-fatal)",
-        {},
-        expect.any(Error)
-      );
+      // Handler throws directly, but AppShutdownOperation uses collect()
+      // which catches errors -- dispatch still resolves
+      await expect(
+        dispatcher.dispatch({
+          type: INTENT_APP_SHUTDOWN,
+          payload: {},
+        } as AppShutdownIntent)
+      ).resolves.not.toThrow();
     });
   });
 });
@@ -794,6 +790,7 @@ describe("IpcEventBridge - setup:error", () => {
 
     // Hook module that throws to trigger the setup:error domain event
     const failingSetupHook: IntentModule = {
+      name: "test-failing-setup",
       hooks: {
         setup: {
           "show-ui": {
@@ -859,6 +856,7 @@ describe("IpcEventBridge - setup:error", () => {
 
     const errorWithCode = Object.assign(new Error("Network timeout"), { code: "ETIMEDOUT" });
     const failingHook: IntentModule = {
+      name: "test-failing-hook",
       hooks: {
         setup: {
           "show-ui": {

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -583,6 +583,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
   );
 
   return {
+    name: "ipc-event-bridge",
     events,
     hooks: {
       [APP_START_OPERATION_ID]: {
@@ -600,19 +601,11 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              if (apiEventCleanupFn) {
-                apiEventCleanupFn();
-                apiEventCleanupFn = null;
-              }
-              await deps.apiRegistry.dispose();
-            } catch (error) {
-              deps.logger.error(
-                "IpcBridge lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            if (apiEventCleanupFn) {
+              apiEventCleanupFn();
+              apiEventCleanupFn = null;
             }
+            await deps.apiRegistry.dispose();
           },
         },
       },

--- a/src/main/modules/keepfiles-module.ts
+++ b/src/main/modules/keepfiles-module.ts
@@ -25,6 +25,7 @@ interface KeepFilesModuleDeps {
 
 export function createKeepFilesModule(deps: KeepFilesModuleDeps): IntentModule {
   return {
+    name: "keepfiles",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {

--- a/src/main/modules/local-project-module.ts
+++ b/src/main/modules/local-project-module.ts
@@ -291,6 +291,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
   const projects = new Map<string, LocalProject>();
 
   return {
+    name: "local-project",
     hooks: {
       // resolve-project -> resolve (single registration replaces 5 per-operation hooks)
       [RESOLVE_PROJECT_OPERATION_ID]: {

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -36,6 +36,7 @@ export interface LoggingModuleDeps {
  */
 export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
   return {
+    name: "logging",
     hooks: {
       [APP_START_OPERATION_ID]: {
         init: {

--- a/src/main/modules/mcp-module.integration.test.ts
+++ b/src/main/modules/mcp-module.integration.test.ts
@@ -22,7 +22,6 @@ import type { AppShutdownIntent } from "../operations/app-shutdown";
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { IntentModule } from "../intents/infrastructure/module";
 import { createMcpModule, type McpModuleDeps } from "./mcp-module";
-import { SILENT_LOGGER } from "../../services/logging";
 
 // =============================================================================
 // Mock McpServerManager
@@ -81,7 +80,6 @@ function createTestSetup(): TestSetup {
 
   const mcpModule = createMcpModule({
     mcpServerManager: mcpServerManager as unknown as McpModuleDeps["mcpServerManager"],
-    logger: SILENT_LOGGER,
   });
 
   dispatcher.registerModule(mcpModule);
@@ -115,6 +113,7 @@ describe("McpModule Integration", () => {
     it("disposes MCP server", async () => {
       // Wire a quit module to prevent app.quit() error
       const quitModule: IntentModule = {
+        name: "test-quit",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -129,7 +128,6 @@ describe("McpModule Integration", () => {
       const msm = createMockMcpServerManager();
       const mcpModule = createMcpModule({
         mcpServerManager: msm as unknown as McpModuleDeps["mcpServerManager"],
-        logger: SILENT_LOGGER,
       });
 
       shutdownDispatcher.registerModule(mcpModule);

--- a/src/main/modules/mcp-module.ts
+++ b/src/main/modules/mcp-module.ts
@@ -15,7 +15,6 @@ import type { StartHookResult } from "../operations/app-start";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import type { McpServerManager } from "../../services/mcp-server/mcp-server-manager";
-import type { Logger } from "../../services/logging";
 
 // =============================================================================
 // Dependencies
@@ -23,7 +22,6 @@ import type { Logger } from "../../services/logging";
 
 export interface McpModuleDeps {
   readonly mcpServerManager: McpServerManager;
-  readonly logger: Logger;
 }
 
 // =============================================================================
@@ -32,15 +30,12 @@ export interface McpModuleDeps {
 
 export function createMcpModule(deps: McpModuleDeps): IntentModule {
   return {
+    name: "mcp",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
           handler: async (): Promise<StartHookResult> => {
             const mcpPort = await deps.mcpServerManager.start();
-            deps.logger.info("MCP server started", {
-              port: mcpPort,
-            });
-
             return { mcpPort };
           },
         },
@@ -48,15 +43,7 @@ export function createMcpModule(deps: McpModuleDeps): IntentModule {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              await deps.mcpServerManager.dispose();
-            } catch (error) {
-              deps.logger.error(
-                "MCP lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
-            }
+            await deps.mcpServerManager.dispose();
           },
         },
       },

--- a/src/main/modules/metadata-module.integration.test.ts
+++ b/src/main/modules/metadata-module.integration.test.ts
@@ -104,6 +104,7 @@ function createTestSetup(): TestSetup {
 
   // resolve stub: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -121,6 +122,7 @@ function createTestSetup(): TestSetup {
 
   // resolve-project stub: resolves projectPath → projectId (for set-metadata commands)
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {

--- a/src/main/modules/metadata-module.ts
+++ b/src/main/modules/metadata-module.ts
@@ -21,6 +21,7 @@ interface MetadataModuleDeps {
 
 export function createMetadataModule(deps: MetadataModuleDeps): IntentModule {
   return {
+    name: "metadata",
     hooks: {
       [SET_METADATA_OPERATION_ID]: {
         set: {

--- a/src/main/modules/migration-module.ts
+++ b/src/main/modules/migration-module.ts
@@ -182,6 +182,7 @@ export function createMigrationModule(deps: MigrationModuleDeps): IntentModule {
   const { projectsDir, remotesDir, fs } = deps;
 
   return {
+    name: "migration",
     hooks: {
       [APP_START_OPERATION_ID]: {
         activate: {

--- a/src/main/modules/opencode-agent-module.integration.test.ts
+++ b/src/main/modules/opencode-agent-module.integration.test.ts
@@ -1030,6 +1030,7 @@ describe("OpenCodeAgentModule Integration", () => {
 
       // Need a quit hook module to avoid errors in AppShutdownOperation
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -1053,6 +1054,7 @@ describe("OpenCodeAgentModule Integration", () => {
       await activateModule(setup, "claude");
 
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },

--- a/src/main/modules/opencode-agent-module.ts
+++ b/src/main/modules/opencode-agent-module.ts
@@ -225,6 +225,7 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
   // =========================================================================
 
   return {
+    name: "opencode-agent",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
@@ -283,32 +284,24 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              if (serverStartedCleanupFn) {
-                serverStartedCleanupFn();
-                serverStartedCleanupFn = null;
-              }
-              if (serverStoppedCleanupFn) {
-                serverStoppedCleanupFn();
-                serverStoppedCleanupFn = null;
-              }
+            if (serverStartedCleanupFn) {
+              serverStartedCleanupFn();
+              serverStartedCleanupFn = null;
+            }
+            if (serverStoppedCleanupFn) {
+              serverStoppedCleanupFn();
+              serverStoppedCleanupFn = null;
+            }
 
-              await serverManager.dispose();
+            await serverManager.dispose();
 
-              if (statusUnsubscribeFn) {
-                statusUnsubscribeFn();
-                statusUnsubscribeFn = null;
-              }
+            if (statusUnsubscribeFn) {
+              statusUnsubscribeFn();
+              statusUnsubscribeFn = null;
+            }
 
-              if (active) {
-                deps.agentStatusManager.dispose();
-              }
-            } catch (error) {
-              logger.error(
-                "OpenCode agent lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            if (active) {
+              deps.agentStatusManager.dispose();
             }
           },
         },

--- a/src/main/modules/remote-project-module.ts
+++ b/src/main/modules/remote-project-module.ts
@@ -58,6 +58,7 @@ export function createRemoteProjectModule(deps: {
   const { fs, gitClient, pathProvider, logger } = deps;
 
   return {
+    name: "remote-project",
     hooks: {
       // -----------------------------------------------------------------------
       // open-project

--- a/src/main/modules/script-module.ts
+++ b/src/main/modules/script-module.ts
@@ -32,6 +32,7 @@ export interface ScriptModuleDeps {
  */
 export function createScriptModule(deps: ScriptModuleDeps): IntentModule {
   return {
+    name: "script",
     hooks: {
       [APP_START_OPERATION_ID]: {
         init: {

--- a/src/main/modules/shortcut-module.ts
+++ b/src/main/modules/shortcut-module.ts
@@ -39,6 +39,7 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
   let controller: ShortcutController | null = null;
 
   return {
+    name: "shortcut",
     hooks: {
       [APP_START_OPERATION_ID]: {
         init: {

--- a/src/main/modules/telemetry-module.integration.test.ts
+++ b/src/main/modules/telemetry-module.integration.test.ts
@@ -36,9 +36,7 @@ import {
 } from "../operations/config-set-values";
 import { createTelemetryModule } from "./telemetry-module";
 import { createMockPlatformInfo } from "../../services/platform/platform-info.test-utils";
-import { SILENT_LOGGER } from "../../services/logging";
 import type { TelemetryService, TelemetryConfigureOptions } from "../../services/telemetry/types";
-import type { Logger } from "../../services/logging/types";
 
 // =============================================================================
 // Minimal Start Operation
@@ -141,20 +139,6 @@ function createTrackingTelemetryService(): {
   };
 }
 
-function createTrackingLogger(): { logger: Logger; errors: unknown[] } {
-  const errors: unknown[] = [];
-  const logger: Logger = {
-    silly() {},
-    debug() {},
-    info() {},
-    warn() {},
-    error(message: string, _context?: unknown, error?: Error) {
-      errors.push({ message, error });
-    },
-  };
-  return { logger, errors };
-}
-
 interface TestSetup {
   dispatcher: Dispatcher;
   captures: CaptureCall[];
@@ -163,10 +147,7 @@ interface TestSetup {
   shutdownCalled: boolean;
 }
 
-function createTestSetup(overrides?: {
-  telemetryService?: TelemetryService | null;
-  logger?: Logger;
-}): TestSetup {
+function createTestSetup(overrides?: { telemetryService?: TelemetryService | null }): TestSetup {
   const tracking = createTrackingTelemetryService();
   const platformInfo = createMockPlatformInfo({ platform: "darwin", arch: "arm64" });
   const buildInfo = { version: "1.0.0", isDevelopment: true, isPackaged: false, appPath: "/app" };
@@ -180,7 +161,6 @@ function createTestSetup(overrides?: {
     platformInfo,
     buildInfo,
     dispatcher,
-    logger: overrides?.logger ?? SILENT_LOGGER,
   });
 
   dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
@@ -476,8 +456,7 @@ describe("TelemetryModule Integration", () => {
       await expect(dispatcher.dispatch(shutdownIntent())).resolves.toBeUndefined();
     });
 
-    it("shutdown() throws -- error logged, no re-throw", async () => {
-      const shutdownError = new Error("PostHog flush failed");
+    it("shutdown() throws -- collect catches error, dispatch still resolves", async () => {
       const failingService: TelemetryService = {
         configure() {},
         generateDistinctId() {
@@ -486,22 +465,15 @@ describe("TelemetryModule Integration", () => {
         capture() {},
         captureError() {},
         async shutdown() {
-          throw shutdownError;
+          throw new Error("PostHog flush failed");
         },
       };
-      const { logger, errors } = createTrackingLogger();
       const { dispatcher } = createTestSetup({
         telemetryService: failingService,
-        logger,
       });
 
+      // Handler throws, but collect() catches it and shutdown is best-effort
       await expect(dispatcher.dispatch(shutdownIntent())).resolves.toBeUndefined();
-
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toEqual({
-        message: "Telemetry lifecycle shutdown failed (non-fatal)",
-        error: shutdownError,
-      });
     });
   });
 });

--- a/src/main/modules/telemetry-module.ts
+++ b/src/main/modules/telemetry-module.ts
@@ -22,7 +22,6 @@ import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/co
 import type { TelemetryService } from "../../services/telemetry/types";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { BuildInfo } from "../../services/platform/build-info";
-import type { Logger } from "../../services/logging/types";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { ConfigAgentType } from "../../services/config/config-values";
 
@@ -31,7 +30,6 @@ interface TelemetryModuleDeps {
   readonly platformInfo: PlatformInfo;
   readonly buildInfo: BuildInfo;
   readonly dispatcher: Dispatcher;
-  readonly logger: Logger;
 }
 
 export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
@@ -57,6 +55,7 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
   }
 
   return {
+    name: "telemetry",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -76,16 +75,8 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              if (deps.telemetryService) {
-                await deps.telemetryService.shutdown();
-              }
-            } catch (error) {
-              deps.logger.error(
-                "Telemetry lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            if (deps.telemetryService) {
+              await deps.telemetryService.shutdown();
             }
           },
         },

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -971,6 +971,7 @@ describe("ViewModule Integration", () => {
     it("calls viewManager.destroy() and disposes shell layers", async () => {
       // Need a quit module to prevent missing handler error
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -1015,6 +1016,7 @@ describe("ViewModule Integration", () => {
     it("calls loading change unsubscribe during shutdown", async () => {
       const cleanupFn = vi.fn();
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },
@@ -1069,6 +1071,7 @@ describe("ViewModule Integration", () => {
   describe("app-shutdown with null layers", () => {
     it("does not throw when layers are null", async () => {
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: { handler: async () => {} },

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -157,6 +157,7 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
   });
 
   const module: IntentModule = {
+    name: "view",
     hooks: {
       // -------------------------------------------------------------------
       // ui:set-mode → set: capture previous mode, apply new mode
@@ -408,32 +409,24 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
-            try {
-              // Cleanup loading state callback
-              if (loadingChangeCleanupFn) {
-                loadingChangeCleanupFn();
-                loadingChangeCleanupFn = null;
-              }
+            // Cleanup loading state callback
+            if (loadingChangeCleanupFn) {
+              loadingChangeCleanupFn();
+              loadingChangeCleanupFn = null;
+            }
 
-              // Destroy all views before disposing layers (uses viewLayer internally)
-              viewManager.destroy();
+            // Destroy all views before disposing layers (uses viewLayer internally)
+            viewManager.destroy();
 
-              // Dispose layers in reverse initialization order
-              if (deps.viewLayer) {
-                await deps.viewLayer.dispose();
-              }
-              if (deps.windowLayer) {
-                await deps.windowLayer.dispose();
-              }
-              if (deps.sessionLayer) {
-                await deps.sessionLayer.dispose();
-              }
-            } catch (error) {
-              logger.error(
-                "View lifecycle shutdown failed (non-fatal)",
-                {},
-                error instanceof Error ? error : undefined
-              );
+            // Dispose layers in reverse initialization order
+            if (deps.viewLayer) {
+              await deps.viewLayer.dispose();
+            }
+            if (deps.windowLayer) {
+              await deps.windowLayer.dispose();
+            }
+            if (deps.sessionLayer) {
+              await deps.sessionLayer.dispose();
             }
           },
         },

--- a/src/main/modules/window-title-module.ts
+++ b/src/main/modules/window-title-module.ts
@@ -46,6 +46,7 @@ export function createWindowTitleModule(
   }
 
   return {
+    name: "window-title",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {

--- a/src/main/modules/windows-file-lock-module.ts
+++ b/src/main/modules/windows-file-lock-module.ts
@@ -32,6 +32,7 @@ interface WindowsFileLockModuleDeps {
 
 export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): IntentModule {
   return {
+    name: "windows-file-lock",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         release: {

--- a/src/main/modules/workspace-selection-module.integration.test.ts
+++ b/src/main/modules/workspace-selection-module.integration.test.ts
@@ -104,6 +104,7 @@ function createTestSetup(opts: {
 
   // Resolve module: workspace path → project path + workspace name
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -123,6 +124,7 @@ function createTestSetup(opts: {
 
   // Resolve project module
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -143,6 +145,7 @@ function createTestSetup(opts: {
 
   // Activate module
   const activateModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
@@ -158,6 +161,7 @@ function createTestSetup(opts: {
 
   // Find-candidates module (returns fixed candidates)
   const findCandidatesModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "find-candidates": {

--- a/src/main/modules/workspace-selection-module.ts
+++ b/src/main/modules/workspace-selection-module.ts
@@ -32,6 +32,7 @@ export function createWorkspaceSelectionModule(agentStatusManager: {
   };
 
   return {
+    name: "workspace-selection",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "select-next": {

--- a/src/main/operations/app-shutdown.integration.test.ts
+++ b/src/main/operations/app-shutdown.integration.test.ts
@@ -55,6 +55,7 @@ function createServerManagerModule(
   options?: { fail?: boolean }
 ): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -77,6 +78,7 @@ function createServerManagerModule(
 
 function createMcpShutdownModule(state: DisposalState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -98,6 +100,7 @@ function createPluginServerModule(
   options?: { fail?: boolean }
 ): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -120,6 +123,7 @@ function createPluginServerModule(
 
 function createTelemetryModule(state: DisposalState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -138,6 +142,7 @@ function createTelemetryModule(state: DisposalState): IntentModule {
 
 function createViewShutdownModule(state: DisposalState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -156,6 +161,7 @@ function createViewShutdownModule(state: DisposalState): IntentModule {
 
 function createBadgeShutdownModule(state: DisposalState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -174,6 +180,7 @@ function createBadgeShutdownModule(state: DisposalState): IntentModule {
 
 function createAutoUpdaterShutdownModule(state: DisposalState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
@@ -297,6 +304,7 @@ describe("AppShutdown Operation", () => {
     it("quit hook fires after all stop hooks complete", async () => {
       const order: string[] = [];
       const stopModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             stop: {
@@ -308,6 +316,7 @@ describe("AppShutdown Operation", () => {
         },
       };
       const quitModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             quit: {
@@ -331,6 +340,7 @@ describe("AppShutdown Operation", () => {
     it("second dispatch is no-op, services disposed only once", async () => {
       let disposeCount = 0;
       const countingModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_SHUTDOWN_OPERATION_ID]: {
             stop: {

--- a/src/main/operations/app-shutdown.ts
+++ b/src/main/operations/app-shutdown.ts
@@ -3,13 +3,14 @@
  *
  * Runs two hook points in sequence:
  * 1. "stop" - All modules dispose their resources (independent, best-effort).
- *    Each module's stop handler wraps its own logic in try/catch,
+ *    collect() catches errors from each handler and continues to the next,
  *    ensuring all modules get a chance to dispose even if earlier ones fail.
+ *    The dispatcher logs hook errors centrally.
  * 2. "quit" - Terminates the process (runs after all cleanup).
  *
  * The operation ignores both results and errors because shutdown is
- * best-effort -- individual module errors are logged but do not
- * prevent other modules from disposing.
+ * best-effort -- individual module errors are logged by the dispatcher
+ * and do not prevent other modules from disposing.
  *
  * No provider dependencies - hook handlers do the actual work.
  */
@@ -52,14 +53,14 @@ export class AppShutdownOperation implements Operation<AppShutdownIntent, void> 
     };
 
     // Hook: "stop" -- All modules dispose (independent, best-effort)
-    // Each module wraps its logic in try/catch internally.
-    // With collect(), all handlers always run regardless of errors.
+    // collect() catches errors from each handler and continues to the next.
+    // The dispatcher logs hook errors centrally.
     await ctx.hooks.collect<void>("stop", hookCtx);
 
     // Hook: "quit" -- Terminate the process (runs after all cleanup)
     await ctx.hooks.collect<void>("quit", hookCtx);
 
     // Intentionally ignore both results and errors -- shutdown is best-effort.
-    // Individual module errors are logged by each module's handler.
+    // Individual module errors are logged by the dispatcher.
   }
 }

--- a/src/main/operations/app-start.integration.test.ts
+++ b/src/main/operations/app-start.integration.test.ts
@@ -88,6 +88,7 @@ function createTestState(): TestState {
 
 function createCodeServerModule(state: TestState, options?: { fail?: boolean }): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -107,6 +108,7 @@ function createCodeServerModule(state: TestState, options?: { fail?: boolean }):
 
 function createMcpModule(state: TestState, options?: { fail?: boolean }): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -129,6 +131,7 @@ function createDataModule(
   options?: { fail?: boolean; projectPaths?: readonly string[] }
 ): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         activate: {
@@ -152,6 +155,7 @@ function createDataModule(
 
 function createViewModule(state: TestState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         activate: {
@@ -173,6 +177,7 @@ function createViewModule(state: TestState): IntentModule {
  */
 function createMountModule(state: TestState): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         activate: {
@@ -197,6 +202,7 @@ function createCodeServerModuleWithGracefulPluginDegradation(
   pluginFails: boolean
 ): IntentModule {
   return {
+    name: "test",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
@@ -259,6 +265,7 @@ function createProjectOpenStub(
 function defaultCheckModules(): IntentModule[] {
   return [
     {
+      name: "test",
       hooks: {
         [APP_START_OPERATION_ID]: {
           init: {
@@ -524,6 +531,7 @@ describe("AppStart Operation", () => {
 
     function createConfigCheckModule(agent: ConfigAgentType | null): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
@@ -538,6 +546,7 @@ describe("AppStart Operation", () => {
 
     function createBinaryCheckModule(missingBinaries: BinaryType[]): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
@@ -555,6 +564,7 @@ describe("AppStart Operation", () => {
       outdated?: string[];
     }): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
@@ -690,6 +700,7 @@ describe("AppStart Operation", () => {
     it("init error from config module aborts startup (#12)", async () => {
       const state = createTestState();
       const failingInitConfigModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
@@ -714,6 +725,7 @@ describe("AppStart Operation", () => {
     it("check-deps error aborts startup (#13)", async () => {
       const state = createTestState();
       const failingDepsModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
@@ -742,6 +754,7 @@ describe("AppStart Operation", () => {
       let receivedAgent: ConfigAgentType | null | undefined;
 
       const agentReadingDepsModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
@@ -783,6 +796,7 @@ describe("AppStart Operation", () => {
       let receivedMcpPort: number | null | undefined;
 
       const mcpPortReaderModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             activate: {
@@ -811,6 +825,7 @@ describe("AppStart Operation", () => {
       let receivedMcpPort: number | null | undefined;
 
       const mcpPortReaderModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             activate: {
@@ -835,6 +850,7 @@ describe("AppStart Operation", () => {
       let receivedCodeServerPort: number | null | undefined;
 
       const portReaderModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             activate: {
@@ -863,6 +879,7 @@ describe("AppStart Operation", () => {
       let receivedCodeServerPort: number | null | undefined;
 
       const portReaderModule: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             activate: {
@@ -948,6 +965,7 @@ describe("AppStart Operation", () => {
   describe("pre-ready hooks (before-ready, await-ready, init)", () => {
     function createConfigureModule(scripts: string[]): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
@@ -962,6 +980,7 @@ describe("AppStart Operation", () => {
 
     function createFailingConfigureModule(message: string): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
@@ -976,6 +995,7 @@ describe("AppStart Operation", () => {
 
     function createAwaitReadyModule(options?: { fail?: boolean }): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "await-ready": {
@@ -995,6 +1015,7 @@ describe("AppStart Operation", () => {
       options?: { fail?: boolean; captureScripts?: (scripts: readonly string[]) => void }
     ): IntentModule {
       return {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
@@ -1109,6 +1130,7 @@ describe("AppStart Operation", () => {
       const state = createTestState();
 
       const configureTracker: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
@@ -1122,6 +1144,7 @@ describe("AppStart Operation", () => {
       };
 
       const awaitReadyTracker: IntentModule = {
+        name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             "await-ready": {

--- a/src/main/operations/close-project.integration.test.ts
+++ b/src/main/operations/close-project.integration.test.ts
@@ -237,6 +237,7 @@ function createTestHarness(options?: {
 
   // Resolve modules (shared workspace:resolve and project:resolve operations)
   const deleteResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -259,6 +260,7 @@ function createTestHarness(options?: {
   };
 
   const deleteResolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -274,6 +276,7 @@ function createTestHarness(options?: {
 
   // Delete-workspace hook modules (simplified for close-project testing)
   const deleteViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
@@ -294,6 +297,7 @@ function createTestHarness(options?: {
   };
 
   const deleteAgentModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
@@ -311,6 +315,7 @@ function createTestHarness(options?: {
   };
 
   const deleteStateModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceDeletedEvent).payload;
@@ -321,6 +326,7 @@ function createTestHarness(options?: {
 
   // ProjectResolveModule: "resolve" hook -- resolves projectPath to config/workspaces
   const projectResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -351,6 +357,7 @@ function createTestHarness(options?: {
   // ProjectCloseViewModule: "close" hook -- returns otherProjectsExist, clears active workspace if no other projects
   // Note: workspace:switched(null) is emitted by CloseProjectOperation, not here
   const projectCloseViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
@@ -370,6 +377,7 @@ function createTestHarness(options?: {
 
   // ProjectLocalCloseModule: "close" hook -- deregister + remove store for local projects
   const projectLocalCloseModule: IntentModule = {
+    name: "test",
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
@@ -399,6 +407,7 @@ function createTestHarness(options?: {
 
   // ProjectRemoteCloseModule: "close" hook -- deregister + remove store for remote projects, optionally delete dir
   const projectRemoteCloseModule: IntentModule = {
+    name: "test",
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
@@ -434,6 +443,7 @@ function createTestHarness(options?: {
 
   // ProjectWorktreeCloseModule: "close" hook -- unregister project from global git provider
   const projectWorktreeCloseModule: IntentModule = {
+    name: "test",
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {

--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -376,6 +376,7 @@ function createTestHarness(options?: {
   // Add interceptor via module (inline, matching bootstrap pattern)
   const inProgressDeletions = new Set<string>();
   const idempotencyModule: IntentModule = {
+    name: "test",
     interceptors: [
       {
         id: "idempotency",
@@ -414,6 +415,7 @@ function createTestHarness(options?: {
   const workspaceLockHandler = options?.workspaceLockHandler ?? undefined;
 
   const resolveWorkspaceModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -431,6 +433,7 @@ function createTestHarness(options?: {
   };
 
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -448,6 +451,7 @@ function createTestHarness(options?: {
   };
 
   const deleteViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
@@ -479,6 +483,7 @@ function createTestHarness(options?: {
   };
 
   const deleteAgentModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
@@ -532,6 +537,7 @@ function createTestHarness(options?: {
   };
 
   const deleteWindowsLockModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         release: {
@@ -587,6 +593,7 @@ function createTestHarness(options?: {
   };
 
   const deleteWorktreeModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
@@ -618,6 +625,7 @@ function createTestHarness(options?: {
   };
 
   const deleteCodeServerModule: IntentModule = {
+    name: "test",
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
@@ -647,6 +655,7 @@ function createTestHarness(options?: {
   };
 
   const deleteStateModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceDeletedEvent).payload;
@@ -656,6 +665,7 @@ function createTestHarness(options?: {
   };
 
   const deleteIpcBridge: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceDeletedEvent).payload;
@@ -670,6 +680,7 @@ function createTestHarness(options?: {
 
   // Switch modules: activate (resolve is handled by shared resolve operations)
   const switchViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
@@ -699,6 +710,7 @@ function createTestHarness(options?: {
 
   // find-candidates module: returns all workspaces from appState for auto-select
   const switchFindCandidatesModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "find-candidates": {
@@ -726,6 +738,7 @@ function createTestHarness(options?: {
   };
 
   const progressCaptureModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_DELETION_PROGRESS]: (event: DomainEvent) => {
         progressCaptures.push((event as WorkspaceDeletionProgressEvent).payload);
@@ -735,6 +748,7 @@ function createTestHarness(options?: {
 
   // select-next module: uses selectNextWorkspace with agent status scoring
   const switchSelectNextModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "select-next": {

--- a/src/main/operations/get-active-workspace.integration.test.ts
+++ b/src/main/operations/get-active-workspace.integration.test.ts
@@ -55,6 +55,7 @@ function createTestSetup(cachedRef: WorkspaceRef | null): TestSetup {
 
   // Active workspace hook handler module (event-cache pattern)
   const activeWorkspaceModule: IntentModule = {
+    name: "test",
     hooks: {
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {

--- a/src/main/operations/get-agent-session.integration.test.ts
+++ b/src/main/operations/get-agent-session.integration.test.ts
@@ -89,6 +89,7 @@ function createTestSetup(opts: { agentStatusManager?: MockAgentStatusManager | n
 
   // Resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -106,6 +107,7 @@ function createTestSetup(opts: { agentStatusManager?: MockAgentStatusManager | n
 
   // Agent session hook handler module (reads from enriched context)
   const agentSessionModule: IntentModule = {
+    name: "test",
     hooks: {
       [GET_AGENT_SESSION_OPERATION_ID]: {
         get: {

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -138,6 +138,7 @@ function createTestSetup(): TestSetup {
 
   // resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -155,6 +156,7 @@ function createTestSetup(): TestSetup {
 
   // resolve-project module: resolves projectPath → projectId
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -172,6 +174,7 @@ function createTestSetup(): TestSetup {
 
   // set/get module: performs actual provider operations (reads workspacePath from enriched context)
   const metadataModule: IntentModule = {
+    name: "test",
     hooks: {
       [SET_METADATA_OPERATION_ID]: {
         set: {

--- a/src/main/operations/get-workspace-status.integration.test.ts
+++ b/src/main/operations/get-workspace-status.integration.test.ts
@@ -102,6 +102,7 @@ function createTestSetup(opts: {
 
   // resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -119,6 +120,7 @@ function createTestSetup(opts: {
 
   // get module: returns isDirty from mock provider (reads workspacePath from enriched context)
   const getStatusModule: IntentModule = {
+    name: "test",
     hooks: {
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
@@ -135,6 +137,7 @@ function createTestSetup(opts: {
 
   // agent status module: returns agentStatus from mock manager (reads workspacePath from enriched context)
   const agentStatusModule: IntentModule = {
+    name: "test",
     hooks: {
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {

--- a/src/main/operations/open-project.integration.test.ts
+++ b/src/main/operations/open-project.integration.test.ts
@@ -351,6 +351,7 @@ function createTestHarness(options?: {
 
   // LocalResolveModule: validates path for local projects (no git URL)
   const localResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -373,6 +374,7 @@ function createTestHarness(options?: {
 
   // RemoteResolveModule: handles git URL cloning
   const remoteResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -413,6 +415,7 @@ function createTestHarness(options?: {
   const registeredPaths = new Set<string>();
 
   const localRegisterModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         register: {
@@ -443,6 +446,7 @@ function createTestHarness(options?: {
 
   // AppStateRegisterModule: registers project in state, caches defaultBaseBranch
   const appStateRegisterModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         register: {
@@ -479,6 +483,7 @@ function createTestHarness(options?: {
   // ---------------------------------------------------------------------------
 
   const discoverModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         discover: {
@@ -496,6 +501,7 @@ function createTestHarness(options?: {
 
   // WorktreeModule for workspace:open (handles existingWorkspace)
   const worktreeModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         create: {
@@ -526,6 +532,7 @@ function createTestHarness(options?: {
 
   // CodeServerModule for workspace:open
   const codeServerModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
@@ -540,6 +547,7 @@ function createTestHarness(options?: {
 
   // StateModule for workspace:created
   const stateModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_CREATED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceCreatedEvent).payload;
@@ -555,6 +563,7 @@ function createTestHarness(options?: {
 
   // ViewModule for workspace:created
   const viewModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_WORKSPACE_CREATED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceCreatedEvent).payload;
@@ -571,6 +580,7 @@ function createTestHarness(options?: {
   // ProjectViewModule for project:opened (preloads non-first workspaces)
   // Note: first workspace activation is now done by OpenProjectOperation dispatching workspace:switch
   const projectViewModule: IntentModule = {
+    name: "test",
     events: {
       [EVENT_PROJECT_OPENED]: (event: DomainEvent) => {
         const payload = (event as ProjectOpenedEvent).payload;
@@ -584,6 +594,7 @@ function createTestHarness(options?: {
 
   // Resolve modules: workspace:resolve and project:resolve (shared across all operations)
   const switchResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -607,6 +618,7 @@ function createTestHarness(options?: {
     },
   };
   const switchResolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -622,6 +634,7 @@ function createTestHarness(options?: {
     },
   };
   const switchViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
@@ -786,6 +799,7 @@ describe("OpenProjectOperation", () => {
 
     // Resolve module that always returns alreadyOpen: true
     const alreadyOpenResolveModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           resolve: {
@@ -802,6 +816,7 @@ describe("OpenProjectOperation", () => {
 
     // Minimal register module
     const registerModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           register: {
@@ -817,6 +832,7 @@ describe("OpenProjectOperation", () => {
 
     // Discover module returning workspaces
     const discoverModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           discover: {
@@ -949,6 +965,7 @@ describe("OpenProjectOperation", () => {
 
     // Add a select-folder module that returns the project path
     const selectFolderModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {
@@ -982,6 +999,7 @@ describe("OpenProjectOperation", () => {
 
     // Select-folder module that returns null (user canceled)
     const selectFolderModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {
@@ -1009,6 +1027,7 @@ describe("OpenProjectOperation", () => {
 
     // Add a select-folder module with spy
     const selectFolderModule: IntentModule = {
+      name: "test",
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {

--- a/src/main/operations/open-workspace.integration.test.ts
+++ b/src/main/operations/open-workspace.integration.test.ts
@@ -226,6 +226,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // Shared resolve modules for workspace:resolve and project:resolve
   const resolveWorkspaceModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -245,6 +246,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
   // Only PROJECT_ROOT is known by default; tests can add more.
   const knownProjectPaths = new Set<string>([PROJECT_ROOT]);
   const resolveProjectResolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -260,6 +262,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     },
   };
   const switchViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
@@ -274,6 +277,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // Default FetchBasesModule: "fetch-bases" hook — returns bases for dialog
   const defaultFetchBasesModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         "fetch-bases": {
@@ -298,6 +302,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // WorktreeModule: "create" hook — returns CreateHookResult
   const worktreeModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         create: {
@@ -340,6 +345,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // KeepFilesModule: "setup" hook (best-effort, try/catch internal)
   const keepFilesModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
@@ -362,6 +368,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // AgentModule: "setup" hook (fatal — no try/catch)
   const agentModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
@@ -392,6 +399,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
   // Only registered when setupThrows is true.
   const failingSetupModule: IntentModule | null = opts?.setupThrows
     ? {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             setup: {
@@ -406,6 +414,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   // CodeServerModule: "finalize" hook — returns FinalizeHookResult
   const codeServerModule: IntentModule = {
+    name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
@@ -893,6 +902,7 @@ describe("OpenWorkspace Operation", () => {
     it("merges envVars from multiple setup hooks", async () => {
       // Add a second setup module that contributes additional env vars
       const extraEnvModule: IntentModule = {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             setup: {
@@ -916,6 +926,7 @@ describe("OpenWorkspace Operation", () => {
 
       // Shared resolve modules
       const resolveWorkspaceModule: IntentModule = {
+        name: "test",
         hooks: {
           [RESOLVE_WORKSPACE_OPERATION_ID]: {
             resolve: {
@@ -932,6 +943,7 @@ describe("OpenWorkspace Operation", () => {
         },
       };
       const resolveProjectResolveModule: IntentModule = {
+        name: "test",
         hooks: {
           [RESOLVE_PROJECT_OPERATION_ID]: {
             resolve: {
@@ -943,6 +955,7 @@ describe("OpenWorkspace Operation", () => {
         },
       };
       const switchViewModule: IntentModule = {
+        name: "test",
         hooks: {
           [SWITCH_WORKSPACE_OPERATION_ID]: {
             activate: {
@@ -955,6 +968,7 @@ describe("OpenWorkspace Operation", () => {
         },
       };
       const fetchBasesModule: IntentModule = {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             "fetch-bases": {
@@ -966,6 +980,7 @@ describe("OpenWorkspace Operation", () => {
         },
       };
       const worktreeModule: IntentModule = {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             create: {
@@ -980,6 +995,7 @@ describe("OpenWorkspace Operation", () => {
       };
       // Agent module contributes AGENT_PORT
       const agentModule: IntentModule = {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             setup: {
@@ -993,6 +1009,7 @@ describe("OpenWorkspace Operation", () => {
       // Finalize module captures envVars for verification
       let capturedEnvVars: Record<string, string> = {};
       const codeServerModule: IntentModule = {
+        name: "test",
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             finalize: {

--- a/src/main/operations/resolve-project.integration.test.ts
+++ b/src/main/operations/resolve-project.integration.test.ts
@@ -47,6 +47,7 @@ function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveH
 
   if (resolveHandler) {
     const module: IntentModule = {
+      name: "test",
       hooks: {
         [RESOLVE_PROJECT_OPERATION_ID]: {
           resolve: { handler: resolveHandler },

--- a/src/main/operations/resolve-workspace.integration.test.ts
+++ b/src/main/operations/resolve-workspace.integration.test.ts
@@ -47,6 +47,7 @@ function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveH
 
   if (resolveHandler) {
     const module: IntentModule = {
+      name: "test",
       hooks: {
         [RESOLVE_WORKSPACE_OPERATION_ID]: {
           resolve: { handler: resolveHandler },

--- a/src/main/operations/restart-agent.integration.test.ts
+++ b/src/main/operations/restart-agent.integration.test.ts
@@ -99,6 +99,7 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
 
   // Resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -116,6 +117,7 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
 
   // Resolve-project module: resolves projectPath → projectId (for domain events)
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -133,6 +135,7 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
 
   // Restart hook handler module (reads from enriched context)
   const restartModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESTART_AGENT_OPERATION_ID]: {
         restart: {

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -145,6 +145,7 @@ function createTestSetup(): TestSetup {
 
   // resolve module: validates workspacePath → returns projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -162,6 +163,7 @@ function createTestSetup(): TestSetup {
 
   // resolve-project module: resolves projectPath → projectId
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -179,6 +181,7 @@ function createTestSetup(): TestSetup {
 
   // set/get module: performs actual provider operations (reads workspacePath from enriched context)
   const metadataModule: IntentModule = {
+    name: "test",
     hooks: {
       [SET_METADATA_OPERATION_ID]: {
         set: {

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -94,6 +94,7 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
 
   // Set mode hook handler module
   const setModeModule: IntentModule = {
+    name: "test",
     hooks: {
       [SET_MODE_OPERATION_ID]: {
         set: {

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -224,6 +224,7 @@ function createTestSetup(opts?: {
 
   // ResolveModule: "resolve" hook -- resolves workspacePath → projectPath + workspaceName
   const resolveModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -245,6 +246,7 @@ function createTestSetup(opts?: {
 
   // ResolveProjectModule: "resolve" hook -- resolves projectPath → projectId + projectName
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -262,6 +264,7 @@ function createTestSetup(opts?: {
   // SwitchViewModule: "activate" hook -- calls setActiveWorkspace
   // Also subscribes to workspace:switched(null) to clear viewManager.
   const switchViewModule: IntentModule = {
+    name: "test",
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
@@ -295,6 +298,7 @@ function createTestSetup(opts?: {
 
   if (opts?.withAutoSelect) {
     const findCandidatesModule: IntentModule = {
+      name: "test",
       hooks: {
         [SWITCH_WORKSPACE_OPERATION_ID]: {
           "find-candidates": {
@@ -322,6 +326,7 @@ function createTestSetup(opts?: {
     modules.push(findCandidatesModule);
 
     const selectNextModule: IntentModule = {
+      name: "test",
       hooks: {
         [SWITCH_WORKSPACE_OPERATION_ID]: {
           "select-next": {

--- a/src/main/operations/update-agent-status.integration.test.ts
+++ b/src/main/operations/update-agent-status.integration.test.ts
@@ -49,6 +49,7 @@ const TEST_WORKSPACE_NAME = "test-workspace" as WorkspaceName;
  */
 function createMockResolveModules(): IntentModule[] {
   const resolveWorkspaceModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
@@ -64,6 +65,7 @@ function createMockResolveModules(): IntentModule[] {
   };
 
   const resolveProjectModule: IntentModule = {
+    name: "test",
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
@@ -187,6 +189,7 @@ describe("UpdateAgentStatus Operation", () => {
       // Register resolve modules that return empty — resolve operations will throw,
       // and update-agent-status catches the error and silently returns.
       const emptyResolveModule: IntentModule = {
+        name: "test",
         hooks: {
           [RESOLVE_WORKSPACE_OPERATION_ID]: {
             resolve: {

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -55,7 +55,8 @@ export type LoggerName =
   | "telemetry" // TelemetryService - PostHog analytics
   | "updater" // AutoUpdater - auto-update service
   | "agent" // AgentServerManager / AgentStatusManager - agent lifecycle
-  | "shortcut"; // ShortcutController - keyboard shortcut detection
+  | "shortcut" // ShortcutController - keyboard shortcut detection
+  | "dispatcher"; // Dispatcher - intent dispatch pipeline
 
 /**
  * Context data for log entries.


### PR DESCRIPTION
- Add structured logging to the Dispatcher for intent dispatches, hook executions, event emissions, and interceptor decisions
- Add required `name` field to `IntentModule` interface for log attribution
- Remove 12 redundant per-module shutdown try/catch wrappers (collect() already catches errors, dispatcher now logs them centrally)
- Remove `logger` dependency from 4 modules (telemetry, auto-updater, mcp, badge) where it was only used for shutdown logging
- Keep 31 domain-specific log calls in modules (fallback logic, agent reconnection, force-delete, etc.)