### PR TITLE
feat(process): stream stdout/stderr to logger in real-time

### DIFF
--- a/src/services/platform/process.boundary.test.ts
+++ b/src/services/platform/process.boundary.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ExecaProcessRunner, type SpawnedProcess, type ProcessRunner } from "./process";
 import { SILENT_LOGGER } from "../logging";
+import { createBehavioralLogger } from "../logging/logging.test-utils";
 import {
   isWindows,
   spawnIgnoringSignals,
@@ -713,6 +714,141 @@ describe("ExecaProcessRunner", () => {
         expect(result.exitCode).toBe(0);
         // 100KB of zeros produces ~137KB of base64 (4/3 ratio)
         expect(result.stdout.length).toBeGreaterThan(130000);
+      },
+      TEST_TIMEOUT
+    );
+  });
+
+  describe("real-time streaming", () => {
+    it(
+      "streams stdout lines to logger",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, [
+          "-e",
+          'console.log("line1"); console.log("line2"); console.log("line3")',
+        ]);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const debugMessages = logger.getMessagesByLevel("debug");
+        const stdoutMessages = debugMessages.filter((m) => m.message.includes("stdout:"));
+        expect(stdoutMessages.some((m) => m.message.includes("line1"))).toBe(true);
+        expect(stdoutMessages.some((m) => m.message.includes("line2"))).toBe(true);
+        expect(stdoutMessages.some((m) => m.message.includes("line3"))).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "streams stderr lines to logger",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, [
+          "-e",
+          'console.error("err1"); console.error("err2"); console.error("err3")',
+        ]);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const debugMessages = logger.getMessagesByLevel("debug");
+        const stderrMessages = debugMessages.filter((m) => m.message.includes("stderr:"));
+        expect(stderrMessages.some((m) => m.message.includes("err1"))).toBe(true);
+        expect(stderrMessages.some((m) => m.message.includes("err2"))).toBe(true);
+        expect(stderrMessages.some((m) => m.message.includes("err3"))).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "does not double-log output when streaming is active",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, ["-e", 'console.log("unique-output")']);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const debugMessages = logger.getMessagesByLevel("debug");
+        const matches = debugMessages.filter((m) => m.message.includes("unique-output"));
+        expect(matches).toHaveLength(1);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "flushes partial line without trailing newline",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, [
+          "-e",
+          'process.stdout.write("no-newline")',
+        ]);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const debugMessages = logger.getMessagesByLevel("debug");
+        expect(debugMessages.some((m) => m.message.includes("no-newline"))).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "preserves ProcessResult stdout and stderr",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, [
+          "-e",
+          'console.log("out-data"); console.error("err-data")',
+        ]);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        const result = await proc.wait();
+
+        expect(result.stdout).toContain("out-data");
+        expect(result.stderr).toContain("err-data");
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "streams output before wait() is called",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, [
+          "-e",
+          'console.log("early-output"); setTimeout(() => {}, 30000)',
+        ]);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        // Wait for output to be streamed (without calling wait())
+        await delay(500);
+
+        const debugMessages = logger.getMessagesByLevel("debug");
+        expect(debugMessages.some((m) => m.message.includes("early-output"))).toBe(true);
+
+        await proc.kill(100, 100);
       },
       TEST_TIMEOUT
     );

--- a/src/services/platform/process.ts
+++ b/src/services/platform/process.ts
@@ -2,6 +2,7 @@
  * Process spawning utilities.
  */
 
+import type { Readable } from "node:stream";
 import { execa } from "execa";
 import type { Logger } from "../logging";
 
@@ -143,11 +144,13 @@ export class ExecaSpawnedProcess implements SpawnedProcess {
   private readonly logger: Logger;
   private readonly command: string;
   private cachedResult: ProcessResult | null = null;
+  private readonly streamingActive: boolean;
 
   constructor(subprocess: ExecaSubprocess, logger: Logger, command: string) {
     this.subprocess = subprocess;
     this.logger = logger;
     this.command = command;
+    this.streamingActive = this.setupStreamLogging();
   }
 
   get pid(): number | undefined {
@@ -299,12 +302,61 @@ export class ExecaSpawnedProcess implements SpawnedProcess {
   }
 
   /**
+   * Set up real-time streaming of stdout/stderr to the logger.
+   * Returns true if streaming was activated (streams were available).
+   */
+  private setupStreamLogging(): boolean {
+    const { stdout, stderr } = this.subprocess;
+
+    if (!stdout && !stderr) {
+      return false;
+    }
+
+    if (stdout) {
+      this.attachStreamLogger(stdout as Readable, "stdout");
+    }
+    if (stderr) {
+      this.attachStreamLogger(stderr as Readable, "stderr");
+    }
+
+    return true;
+  }
+
+  /**
+   * Attach a line-buffered logger to a readable stream.
+   * Logs complete lines as they arrive, flushes partial line on stream end.
+   */
+  private attachStreamLogger(stream: Readable, name: "stdout" | "stderr"): void {
+    let buffer = "";
+    const prefix = `[${this.command} ${this.pid ?? 0}]`;
+
+    stream.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop()!;
+
+      for (const line of lines) {
+        if (line.trim() === "") continue;
+        this.logger.debug(`${prefix} ${name}: ${line}`);
+      }
+    });
+
+    stream.on("end", () => {
+      if (buffer.trim() !== "") {
+        this.logger.debug(`${prefix} ${name}: ${buffer}`);
+      }
+    });
+  }
+
+  /**
    * Log the result of a completed process.
    */
   private logResult(result: ProcessResult): void {
-    // Log stdout/stderr lines
-    this.logOutputLines(result.stdout, "stdout");
-    this.logOutputLines(result.stderr, "stderr");
+    // Skip batch logging when streaming was active (already logged in real-time)
+    if (!this.streamingActive) {
+      this.logOutputLines(result.stdout, "stdout");
+      this.logOutputLines(result.stderr, "stderr");
+    }
 
     // Log exit status
     if (result.signal) {


### PR DESCRIPTION
- Stream process stdout/stderr to logger in real-time via line-buffered stream listeners
- Skip batch logging in logResult() when streaming is active to prevent double-logging
- Flush partial lines (no trailing newline) on stream end
- Add 6 boundary tests covering stdout/stderr streaming, no-double-log, partial flush, ProcessResult preservation, and pre-wait streaming