### PR TITLE
fix(dispatcher): propagate causation chain via AsyncLocalStorage

### DIFF
--- a/src/main/intents/infrastructure/dispatcher.integration.test.ts
+++ b/src/main/intents/infrastructure/dispatcher.integration.test.ts
@@ -553,6 +553,104 @@ describe("Dispatcher", () => {
     });
   });
 
+  describe("AsyncLocalStorage causation", () => {
+    it("hook handler inherits causation via ALS when calling dispatcher.dispatch() directly", async () => {
+      const hookRegistry = new HookRegistry();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher(hookRegistry, logger);
+
+      // Child operation captures its causation
+      const capturedCausation: (readonly string[])[] = [];
+      dispatcher.registerOperation("test:child", {
+        id: "child-op",
+        execute: async (ctx) => {
+          capturedCausation.push(ctx.causation);
+        },
+      });
+
+      // Parent operation with a hook point
+      dispatcher.registerOperation("test:parent", {
+        id: "parent-op",
+        execute: async (ctx) => {
+          await ctx.hooks.collect("run", { intent: ctx.intent });
+        },
+      });
+
+      // Hook handler dispatches directly on the dispatcher (not via ctx.dispatch)
+      // — simulating what hook modules do in practice
+      const hookModule: IntentModule = {
+        name: "dispatching-hook",
+        hooks: {
+          "parent-op": {
+            run: {
+              handler: async () => {
+                await dispatcher.dispatch({ type: "test:child", payload: {} });
+              },
+            },
+          },
+        },
+      };
+      dispatcher.registerModule(hookModule);
+
+      await dispatcher.dispatch({ type: "test:parent", payload: {} });
+
+      // Child should see parent in its causation chain via ALS
+      expect(capturedCausation).toHaveLength(1);
+      expect(capturedCausation[0]).toEqual(["test:parent", "test:child"]);
+
+      // Verify the log shows the ALS-resolved causation
+      const childDispatchLog = logger.calls.find(
+        (c) =>
+          c.level === "info" &&
+          c.message === "dispatch" &&
+          (c.context as Record<string, unknown>).intent === "test:child"
+      );
+      expect(childDispatchLog).toBeDefined();
+      expect((childDispatchLog!.context as Record<string, unknown>).causation).toBe("test:parent");
+    });
+
+    it("explicit causation takes precedence over ALS context", async () => {
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+
+      const capturedCausation: (readonly string[])[] = [];
+      dispatcher.registerOperation("test:child", {
+        id: "child-op",
+        execute: async (ctx) => {
+          capturedCausation.push(ctx.causation);
+        },
+      });
+
+      dispatcher.registerOperation("test:parent", {
+        id: "parent-op",
+        execute: async (ctx) => {
+          await ctx.hooks.collect("run", { intent: ctx.intent });
+        },
+      });
+
+      // Hook handler passes explicit causation — should override ALS
+      const hookModule: IntentModule = {
+        name: "explicit-causation-hook",
+        hooks: {
+          "parent-op": {
+            run: {
+              handler: async () => {
+                await dispatcher.dispatch({ type: "test:child", payload: {} }, ["custom:origin"]);
+              },
+            },
+          },
+        },
+      };
+      dispatcher.registerModule(hookModule);
+
+      await dispatcher.dispatch({ type: "test:parent", payload: {} });
+
+      // Explicit causation should be used, not ALS
+      expect(capturedCausation).toHaveLength(1);
+      expect(capturedCausation[0]).toEqual(["custom:origin", "test:child"]);
+    });
+  });
+
   describe("logging", () => {
     it("logs dispatch start with intent type and causation", async () => {
       const hookRegistry = new HookRegistry();

--- a/src/main/intents/infrastructure/dispatcher.ts
+++ b/src/main/intents/infrastructure/dispatcher.ts
@@ -14,6 +14,7 @@
  * - Intent failure (error)
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Intent, IntentResult, DomainEvent } from "./types";
 import type {
   Operation,
@@ -133,6 +134,7 @@ export class Dispatcher implements IDispatcher {
   private readonly operations = new Map<string, Operation<Intent, unknown>>();
   private readonly interceptors: IntentInterceptor[] = [];
   private readonly subscribers = new Map<string, Set<EventHandler>>();
+  private readonly causationContext = new AsyncLocalStorage<readonly string[]>();
 
   /** operationId → hookPointId → module names[] */
   private readonly hookModuleNames = new Map<string, Map<string, string[]>>();
@@ -208,7 +210,8 @@ export class Dispatcher implements IDispatcher {
     causation?: readonly string[]
   ): IntentHandle<IntentResult<I>> {
     const handle = new IntentHandle<IntentResult<I>>();
-    void this.runPipeline(intent, causation, handle);
+    const resolvedCausation = causation ?? this.causationContext.getStore();
+    void this.runPipeline(intent, resolvedCausation, handle);
     return handle;
   }
 
@@ -343,8 +346,9 @@ export class Dispatcher implements IDispatcher {
         causation: causationChain,
       };
 
-      // Execute operation
-      const result = await operation.execute(ctx);
+      // Execute operation within causation context so that any
+      // dispatcher.dispatch() calls from hooks inherit the chain.
+      const result = await this.causationContext.run(causationChain, () => operation.execute(ctx));
 
       const duration = Math.round(performance.now() - pipelineStart);
       this.logger?.info("completed", { intent: current.type, ms: duration });

--- a/src/main/operations/app-start.ts
+++ b/src/main/operations/app-start.ts
@@ -216,21 +216,18 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       let setupComplete = false;
       while (!setupComplete) {
         try {
-          await ctx.dispatch(
-            {
-              type: INTENT_SETUP,
-              payload: {
-                needsAgentSelection: checkResult.needsAgentSelection,
-                needsBinaryDownload: checkResult.needsBinaryDownload,
-                missingBinaries: checkResult.missingBinaries,
-                needsExtensions: checkResult.needsExtensions,
-                missingExtensions: checkResult.missingExtensions,
-                outdatedExtensions: checkResult.outdatedExtensions,
-                configuredAgent: checkResult.configuredAgent,
-              },
+          await ctx.dispatch({
+            type: INTENT_SETUP,
+            payload: {
+              needsAgentSelection: checkResult.needsAgentSelection,
+              needsBinaryDownload: checkResult.needsBinaryDownload,
+              missingBinaries: checkResult.missingBinaries,
+              needsExtensions: checkResult.needsExtensions,
+              missingExtensions: checkResult.missingExtensions,
+              outdatedExtensions: checkResult.outdatedExtensions,
+              configuredAgent: checkResult.configuredAgent,
             },
-            ctx.causation
-          );
+          });
           setupComplete = true;
         } catch (error) {
           // Setup failed -- error event already emitted by SetupOperation
@@ -282,13 +279,10 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // The mount handler in activate ensures the renderer is subscribed before these fire.
     for (const projectPath of projectPaths) {
       try {
-        await ctx.dispatch(
-          {
-            type: INTENT_OPEN_PROJECT,
-            payload: { path: new Path(projectPath) },
-          } as OpenProjectIntent,
-          ctx.causation
-        );
+        await ctx.dispatch({
+          type: INTENT_OPEN_PROJECT,
+          payload: { path: new Path(projectPath) },
+        } as OpenProjectIntent);
       } catch {
         // Skip invalid projects (no longer exist, not git repos, etc.)
       }


### PR DESCRIPTION
- Use `AsyncLocalStorage` in `Dispatcher` to propagate the causation chain through the async call stack, so hook handlers calling `dispatcher.dispatch()` directly inherit the parent chain
- Remove redundant `ctx.causation` args from two `ctx.dispatch()` calls in `AppStartOperation` that duplicated causation entries
- Add integration tests verifying ALS causation inheritance and explicit causation precedence