### PR TITLE
chore(logging): remove redundant brackets from log scope

### DIFF
--- a/src/services/logging/electron-log-service.boundary.test.ts
+++ b/src/services/logging/electron-log-service.boundary.test.ts
@@ -111,10 +111,9 @@ describe("ElectronLogService boundary tests", () => {
     const logContent = await readFile(join(logsDir, files[0] as string), "utf-8");
 
     // Verify format: [timestamp] [level] (scope) message context
-    // electron-log uses parentheses around scope by default
-    // e.g., [2025-12-16 10:30:00.123] [info]   ([git]) Clone complete repo=test-repo branch=main
+    // e.g., [2025-12-16 10:30:00.123] [info]   (git) Clone complete repo=test-repo branch=main
     expect(logContent).toMatch(
-      /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] \[info\].*\[git\].*Clone complete repo=test-repo branch=main/
+      /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] \[info\].*\(git\).*Clone complete repo=test-repo branch=main/
     );
   });
 

--- a/src/services/logging/electron-log-service.test.ts
+++ b/src/services/logging/electron-log-service.test.ts
@@ -173,7 +173,7 @@ describe("ElectronLogService", () => {
       const service = await createService();
       service.createLogger("git");
 
-      expect(mockScope).toHaveBeenCalledWith("[git]");
+      expect(mockScope).toHaveBeenCalledWith("git");
     });
 
     it("caches loggers for same name", async () => {
@@ -191,8 +191,8 @@ describe("ElectronLogService", () => {
       service.createLogger("process");
 
       expect(mockScope).toHaveBeenCalledTimes(2);
-      expect(mockScope).toHaveBeenCalledWith("[git]");
-      expect(mockScope).toHaveBeenCalledWith("[process]");
+      expect(mockScope).toHaveBeenCalledWith("git");
+      expect(mockScope).toHaveBeenCalledWith("process");
     });
   });
 
@@ -216,7 +216,7 @@ describe("ElectronLogService", () => {
       // Creating logger again should call scope again
       mockScope.mockClear();
       service.createLogger("git");
-      expect(mockScope).toHaveBeenCalledWith("[git]");
+      expect(mockScope).toHaveBeenCalledWith("git");
     });
   });
 

--- a/src/services/logging/electron-log-service.ts
+++ b/src/services/logging/electron-log-service.ts
@@ -301,7 +301,7 @@ export class ElectronLogService implements LoggingService {
 
     // Activate all existing queued loggers
     for (const [name, queued] of this.loggers) {
-      const scope = log.scope(`[${name}]`);
+      const scope = log.scope(name);
       const inner = new ElectronLogLogger(scope);
       const filtered = new FilteredLogger(inner, this.allowedLoggers, name);
       queued.activate(filtered);
@@ -325,7 +325,7 @@ export class ElectronLogService implements LoggingService {
 
     // If already configured, activate immediately
     if (this.configured) {
-      const scope = log.scope(`[${name}]`);
+      const scope = log.scope(name);
       const inner = new ElectronLogLogger(scope);
       const filtered = new FilteredLogger(inner, this.allowedLoggers, name);
       queued.activate(filtered);


### PR DESCRIPTION
- Remove square bracket wrapping from `log.scope()` calls so log output changes from `([name])` to `(name)`
- Update boundary test to match new format