### PR TITLE
chore(config): simplify logging config to 2 keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,18 +298,17 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                     | Default   | Description                                |
-| ----------------------- | --------- | ------------------------------------------ |
-| `agent`                 | `null`    | Agent selection: claude\|opencode          |
-| `version.claude`        | `null`    | Claude agent version override              |
-| `version.opencode`      | `null`    | OpenCode agent version override            |
-| `version.code-server`   | `4.107.0` | Code-server version                        |
-| `telemetry.enabled`     | `true`    | Enable telemetry (false in dev/unpackaged) |
-| `telemetry.distinct-id` | —         | Telemetry user ID (auto-generated)         |
-| `log.level`             | `warn`    | Log level: silly\|debug\|info\|warn\|error |
-| `log.console`           | `false`   | Print logs to stdout/stderr                |
-| `log.filter`            | —         | Filter logs by scope (e.g., `git,process`) |
-| `electron.flags`        | —         | Electron switches (e.g., `--disable-gpu`)  |
+| Key                     | Default   | Description                                                             |
+| ----------------------- | --------- | ----------------------------------------------------------------------- |
+| `agent`                 | `null`    | Agent selection: claude\|opencode                                       |
+| `version.claude`        | `null`    | Claude agent version override                                           |
+| `version.opencode`      | `null`    | OpenCode agent version override                                         |
+| `version.code-server`   | `4.107.0` | Code-server version                                                     |
+| `telemetry.enabled`     | `true`    | Enable telemetry (false in dev/unpackaged)                              |
+| `telemetry.distinct-id` | —         | Telemetry user ID (auto-generated)                                      |
+| `log.level`             | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`) |
+| `log.output`            | `file`    | Output destinations: `file`, `console`, or `file,console`               |
+| `electron.flags`        | —         | Electron switches (e.g., `--disable-gpu`)                               |
 
 File keys (persisted to config.json): `agent`, `version.*`, `telemetry.*`.
 Runtime-only keys (env/CLI only): `log.*`, `electron.*`.
@@ -324,6 +323,6 @@ Source of truth: `src/services/config/config-values.ts` (the `CONFIG` schema obj
 - **Windows**: `%APPDATA%\Codehydra\logs\`
 
 ```bash
-# Debug mode (env var form of log.level=debug, log.console=true)
-CH_LOG__LEVEL=debug CH_LOG__CONSOLE=1 pnpm dev
+# Debug mode (env var form of log.level=debug, log.output=console)
+CH_LOG__LEVEL=debug CH_LOG__OUTPUT=console pnpm dev
 ```

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -151,14 +151,14 @@ describe("ConfigModule Integration", () => {
       expect(result["log.level"]).toBe("debug");
     });
 
-    it("maps CH_LOG__CONSOLE to log.console", () => {
-      const result = parseEnvVars({ CH_LOG__CONSOLE: "1" });
-      expect(result["log.console"]).toBe(true);
+    it("maps CH_LOG__OUTPUT to log.output", () => {
+      const result = parseEnvVars({ CH_LOG__OUTPUT: "console" });
+      expect(result["log.output"]).toBe("console");
     });
 
-    it("maps CH_LOG__FILTER to log.filter", () => {
-      const result = parseEnvVars({ CH_LOG__FILTER: "git,process" });
-      expect(result["log.filter"]).toBe("git,process");
+    it("parses combined CH_LOG__LEVEL with filter", () => {
+      const result = parseEnvVars({ CH_LOG__LEVEL: "debug:git,process" });
+      expect(result["log.level"]).toBe("debug:git,process");
     });
 
     it("maps CH_ELECTRON__FLAGS to electron.flags", () => {
@@ -210,9 +210,9 @@ describe("ConfigModule Integration", () => {
       expect(result["log.level"]).toBe("debug");
     });
 
-    it("parses boolean flags without value as true", () => {
-      const result = parseCliArgs(["--log.console"]);
-      expect(result["log.console"]).toBe(true);
+    it("parses --log.output flag", () => {
+      const result = parseCliArgs(["--log.output=console"]);
+      expect(result["log.output"]).toBe("console");
     });
 
     it("ignores unknown flags silently", () => {
@@ -221,9 +221,9 @@ describe("ConfigModule Integration", () => {
     });
 
     it("parses multiple flags", () => {
-      const result = parseCliArgs(["--log.level=debug", "--log.console=true", "--agent=claude"]);
+      const result = parseCliArgs(["--log.level=debug", "--log.output=console", "--agent=claude"]);
       expect(result["log.level"]).toBe("debug");
-      expect(result["log.console"]).toBe(true);
+      expect(result["log.output"]).toBe("console");
       expect(result.agent).toBe("claude");
     });
   });
@@ -292,8 +292,8 @@ describe("ConfigModule Integration", () => {
       expect(events[0]!.payload.values["log.level"]).toBe("error");
     });
 
-    it("sets log.console from CH_LOG__CONSOLE env var", async () => {
-      const { dispatcher } = createTestSetup({ env: { CH_LOG__CONSOLE: "1" } });
+    it("sets log.output from CH_LOG__OUTPUT env var", async () => {
+      const { dispatcher } = createTestSetup({ env: { CH_LOG__OUTPUT: "console" } });
 
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
@@ -306,11 +306,11 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.console"]).toBe(true);
+      expect(events[0]!.payload.values["log.output"]).toBe("console");
     });
 
-    it("sets log.filter from CH_LOG__FILTER env var", async () => {
-      const { dispatcher } = createTestSetup({ env: { CH_LOG__FILTER: "git,process" } });
+    it("sets combined log.level with filter from CH_LOG__LEVEL env var", async () => {
+      const { dispatcher } = createTestSetup({ env: { CH_LOG__LEVEL: "debug:git,process" } });
 
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
@@ -323,7 +323,7 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.filter"]).toBe("git,process");
+      expect(events[0]!.payload.values["log.level"]).toBe("debug:git,process");
     });
 
     it("sets electron.flags from CH_ELECTRON__FLAGS env var", async () => {
@@ -608,7 +608,7 @@ describe("ConfigModule Integration", () => {
       await dispatcher.dispatch({
         type: INTENT_CONFIG_SET_VALUES,
         payload: {
-          values: { "log.level": "debug" as const, "log.console": true },
+          values: { "log.level": "debug", "log.output": "console" },
           persist: false,
         },
       } as ConfigSetValuesIntent);
@@ -704,7 +704,7 @@ describe("ConfigModule Integration", () => {
 
       // Should not contain non-FILE_KEYS
       expect(parsed["log.level"]).toBeUndefined();
-      expect(parsed["log.console"]).toBeUndefined();
+      expect(parsed["log.output"]).toBeUndefined();
       expect(parsed["electron.flags"]).toBeUndefined();
     });
 

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -7,7 +7,7 @@
  *
  * Events:
  * - config:updated: logs all changed values, reconfigures logging when
- *   log.level, log.console, or log.filter values change
+ *   log.level or log.output values change
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
@@ -17,7 +17,7 @@ import type { Logger } from "../../services/logging/types";
 import type { BuildInfo } from "../../services/platform/build-info";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
-import { parseLoggerFilter } from "../../services/logging/electron-log-service";
+import { splitLogLevelSpec } from "../../services/logging/electron-log-service";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
 
@@ -78,18 +78,15 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
         deps.logger.info("Config updated", context);
 
         // Reconfigure logging when any log-related value changes
-        if (
-          values["log.level"] !== undefined ||
-          values["log.console"] !== undefined ||
-          values["log.filter"] !== undefined
-        ) {
+        if (values["log.level"] !== undefined || values["log.output"] !== undefined) {
+          const levelSpec = (values["log.level"] as string | undefined) ?? "warn";
+          const { level, filter } = splitLogLevelSpec(levelSpec);
+          const output = (values["log.output"] as string | undefined) ?? "file";
           deps.loggingService.configure({
-            logLevel: values["log.level"] ?? "warn",
-            enableConsole: values["log.console"] ?? false,
-            allowedLoggers:
-              values["log.filter"] !== undefined
-                ? parseLoggerFilter(values["log.filter"])
-                : undefined,
+            logLevel: level,
+            logFile: output.includes("file"),
+            logConsole: output.includes("console"),
+            allowedLoggers: filter,
           });
         }
       },

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -10,8 +10,7 @@
  *   Env var:                CH_ prefix, . → __, - → _, UPPER  (e.g. CH_VERSION__CODE_SERVER)
  */
 
-import type { LogLevel } from "../logging/types";
-import { parseLogLevel } from "../logging/electron-log-service";
+import { parseLogLevelSpec, parseLogOutput } from "../logging/electron-log-service";
 
 // =============================================================================
 // Schema Helpers
@@ -71,18 +70,13 @@ export const CONFIG = {
     default: undefined,
     parse: (s) => (s === "" ? undefined : s),
   }),
-  "log.level": key<LogLevel>({
+  "log.level": key<string>({
     default: "warn",
-    parse: parseLogLevel,
+    parse: parseLogLevelSpec,
   }),
-  "log.console": key<boolean>({
-    default: false,
-    parse: (s) =>
-      s === "true" || s === "1" ? true : s === "false" || s === "0" ? false : undefined,
-  }),
-  "log.filter": key<string | undefined>({
-    default: undefined,
-    parse: (s) => (s === "" ? undefined : s),
+  "log.output": key<string>({
+    default: "file",
+    parse: parseLogOutput,
   }),
   "electron.flags": key<string | undefined>({
     default: undefined,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -148,7 +148,9 @@ export type {
 export {
   ElectronLogService,
   parseLogLevel,
-  parseLoggerFilter,
+  parseLogLevelSpec,
+  splitLogLevelSpec,
+  parseLogOutput,
   createMockLogger,
   createMockLoggingService,
   SILENT_LOGGER,
@@ -160,6 +162,7 @@ export type {
   LogContext,
   LoggerName,
   LogLevel,
+  LogOutput,
   MockLogger,
   MockLoggingService,
 } from "./logging";

--- a/src/services/logging/electron-log-service.boundary.test.ts
+++ b/src/services/logging/electron-log-service.boundary.test.ts
@@ -18,7 +18,8 @@ const WRITE_DELAY_MS = 100;
 
 const DEFAULT_OPTIONS: LoggingConfigureOptions = {
   logLevel: "debug",
-  enableConsole: false,
+  logFile: true,
+  logConsole: false,
   allowedLoggers: undefined,
 };
 

--- a/src/services/logging/electron-log-service.test.ts
+++ b/src/services/logging/electron-log-service.test.ts
@@ -56,7 +56,8 @@ describe("ElectronLogService", () => {
 
   const DEFAULT_OPTIONS: LoggingConfigureOptions = {
     logLevel: "debug",
-    enableConsole: false,
+    logFile: true,
+    logConsole: false,
     allowedLoggers: undefined,
   };
 
@@ -104,25 +105,33 @@ describe("ElectronLogService", () => {
   });
 
   describe("console transport configuration", () => {
-    it("disables console when enableConsole is false", async () => {
+    it("disables console when logConsole is false", async () => {
       await createService({
-        configureOptions: { ...DEFAULT_OPTIONS, enableConsole: false },
+        configureOptions: { ...DEFAULT_OPTIONS, logConsole: false },
       });
       expect(mockTransports.console.level).toBe(false);
     });
 
-    it("enables console at log level when enableConsole is true", async () => {
+    it("enables console at log level when logConsole is true", async () => {
       await createService({
-        configureOptions: { ...DEFAULT_OPTIONS, logLevel: "debug", enableConsole: true },
+        configureOptions: { ...DEFAULT_OPTIONS, logLevel: "debug", logConsole: true },
       });
       expect(mockTransports.console.level).toBe("debug");
     });
 
     it("console level matches file level when enabled", async () => {
       await createService({
-        configureOptions: { ...DEFAULT_OPTIONS, logLevel: "warn", enableConsole: true },
+        configureOptions: { ...DEFAULT_OPTIONS, logLevel: "warn", logConsole: true },
       });
       expect(mockTransports.console.level).toBe("warn");
+    });
+
+    it("disables file transport when logFile is false", async () => {
+      await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFile: false, logConsole: true },
+      });
+      expect(mockTransports.file.level).toBe(false);
+      expect(mockTransports.console.level).toBe("debug");
     });
   });
 
@@ -585,10 +594,20 @@ describe("ElectronLogService", () => {
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLogService(pathProvider);
 
-      service.configure({ logLevel: "debug", enableConsole: false, allowedLoggers: undefined });
+      service.configure({
+        logLevel: "debug",
+        logFile: true,
+        logConsole: false,
+        allowedLoggers: undefined,
+      });
       expect(mockTransports.file.level).toBe("debug");
 
-      service.configure({ logLevel: "warn", enableConsole: true, allowedLoggers: undefined });
+      service.configure({
+        logLevel: "warn",
+        logFile: true,
+        logConsole: true,
+        allowedLoggers: undefined,
+      });
       expect(mockTransports.file.level).toBe("warn");
       expect(mockTransports.console.level).toBe("warn");
     });
@@ -668,6 +687,112 @@ describe("ElectronLogService", () => {
     it("returns undefined for whitespace-only input", async () => {
       const { parseLoggerFilter } = await import("./electron-log-service");
       expect(parseLoggerFilter("  ,  ,  ")).toBeUndefined();
+    });
+  });
+
+  describe("parseLogLevelSpec", () => {
+    it("validates plain log levels", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("debug")).toBe("debug");
+      expect(parseLogLevelSpec("warn")).toBe("warn");
+      expect(parseLogLevelSpec("error")).toBe("error");
+      expect(parseLogLevelSpec("silly")).toBe("silly");
+      expect(parseLogLevelSpec("info")).toBe("info");
+    });
+
+    it("validates combined level:filter format", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("debug:git,process")).toBe("debug:git,process");
+      expect(parseLogLevelSpec("warn:network")).toBe("warn:network");
+    });
+
+    it("validates wildcard filter", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("debug:*")).toBe("debug:*");
+    });
+
+    it("trims whitespace", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("  debug  ")).toBe("debug");
+    });
+
+    it("returns undefined for invalid level", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("invalid")).toBeUndefined();
+      expect(parseLogLevelSpec("invalid:git")).toBeUndefined();
+    });
+
+    it("returns undefined for empty or undefined input", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec(undefined)).toBeUndefined();
+      expect(parseLogLevelSpec("")).toBeUndefined();
+      expect(parseLogLevelSpec("  ")).toBeUndefined();
+    });
+
+    it("returns undefined for level with empty filter", async () => {
+      const { parseLogLevelSpec } = await import("./electron-log-service");
+      expect(parseLogLevelSpec("debug:")).toBeUndefined();
+    });
+  });
+
+  describe("splitLogLevelSpec", () => {
+    it("extracts level from plain spec", async () => {
+      const { splitLogLevelSpec } = await import("./electron-log-service");
+      expect(splitLogLevelSpec("debug")).toEqual({ level: "debug", filter: undefined });
+      expect(splitLogLevelSpec("warn")).toEqual({ level: "warn", filter: undefined });
+    });
+
+    it("extracts level and filter from combined spec", async () => {
+      const { splitLogLevelSpec } = await import("./electron-log-service");
+      const result = splitLogLevelSpec("debug:git,process");
+      expect(result.level).toBe("debug");
+      expect(result.filter).toEqual(new Set(["git", "process"]));
+    });
+
+    it("treats * filter as undefined (all loggers)", async () => {
+      const { splitLogLevelSpec } = await import("./electron-log-service");
+      expect(splitLogLevelSpec("debug:*")).toEqual({ level: "debug", filter: undefined });
+    });
+  });
+
+  describe("parseLogOutput", () => {
+    it("validates file output", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("file")).toBe("file");
+    });
+
+    it("validates console output", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("console")).toBe("console");
+    });
+
+    it("validates combined output and sorts canonically", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("file,console")).toBe("console,file");
+      expect(parseLogOutput("console,file")).toBe("console,file");
+    });
+
+    it("deduplicates tokens", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("file,file")).toBe("file");
+    });
+
+    it("handles whitespace and case", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("  FILE  ")).toBe("file");
+      expect(parseLogOutput(" Console , File ")).toBe("console,file");
+    });
+
+    it("returns undefined for invalid tokens", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput("stdout")).toBeUndefined();
+      expect(parseLogOutput("file,stdout")).toBeUndefined();
+    });
+
+    it("returns undefined for empty or undefined input", async () => {
+      const { parseLogOutput } = await import("./electron-log-service");
+      expect(parseLogOutput(undefined)).toBeUndefined();
+      expect(parseLogOutput("")).toBeUndefined();
     });
   });
 });

--- a/src/services/logging/electron-log-service.ts
+++ b/src/services/logging/electron-log-service.ts
@@ -20,6 +20,7 @@ import type {
   LoggingService,
   LogContext,
   LogLevel,
+  LogOutput,
 } from "./types";
 import { LogLevel as LogLevelValues } from "./types";
 
@@ -59,6 +60,79 @@ export function parseLogLevel(envValue: string | undefined): LogLevel | undefine
     return normalized as LogLevel;
   }
   return undefined;
+}
+
+/**
+ * Validate a combined log level spec string: `<level>` or `<level>:<filter>`.
+ *
+ * The level part must be a valid log level. The filter part (after `:`) is
+ * freeform comma-separated logger names or `*` for all loggers.
+ *
+ * @param raw - Raw string value (e.g., "debug", "debug:git,process", "debug:*")
+ * @returns The validated spec string (trimmed), or undefined if invalid
+ */
+export function parseLogLevelSpec(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+
+  const colonIndex = trimmed.indexOf(":");
+  const levelPart = colonIndex === -1 ? trimmed : trimmed.slice(0, colonIndex);
+
+  if (parseLogLevel(levelPart) === undefined) return undefined;
+
+  if (colonIndex !== -1) {
+    const filterPart = trimmed.slice(colonIndex + 1);
+    if (filterPart.length === 0) return undefined;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Split a validated log level spec into its level and filter components.
+ *
+ * @param spec - A validated spec string from `parseLogLevelSpec`
+ * @returns Parsed level and optional filter set (undefined means all loggers)
+ */
+export function splitLogLevelSpec(spec: string): {
+  level: LogLevel;
+  filter: Set<LoggerName> | undefined;
+} {
+  const colonIndex = spec.indexOf(":");
+  const levelPart = colonIndex === -1 ? spec : spec.slice(0, colonIndex);
+  const level = parseLogLevel(levelPart)!;
+
+  if (colonIndex === -1) return { level, filter: undefined };
+
+  const filterPart = spec.slice(colonIndex + 1);
+  if (filterPart === "*") return { level, filter: undefined };
+
+  return { level, filter: parseLoggerFilter(filterPart) };
+}
+
+/**
+ * Validate and normalize a log output destination string.
+ *
+ * @param raw - Raw string value (e.g., "file", "console", "file,console")
+ * @returns Normalized output string, or undefined if invalid
+ */
+export function parseLogOutput(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const tokens = raw
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return undefined;
+
+  const valid: LogOutput[] = ["file", "console"];
+  for (const token of tokens) {
+    if (!valid.includes(token as LogOutput)) return undefined;
+  }
+
+  // Deduplicate and sort for canonical form
+  const unique = [...new Set(tokens)].sort() as LogOutput[];
+  return unique.join(",");
 }
 
 /**
@@ -261,7 +335,7 @@ class QueuedLogger implements Logger {
  * @example
  * ```typescript
  * const loggingService = new ElectronLogService(pathProvider);
- * loggingService.configure({ logLevel: 'debug', enableConsole: false, allowedLoggers: undefined });
+ * loggingService.configure({ logLevel: 'debug', logFile: true, logConsole: false, allowedLoggers: undefined });
  * loggingService.initialize();
  *
  * const logger = loggingService.createLogger('git');
@@ -296,8 +370,8 @@ export class ElectronLogService implements LoggingService {
     this.allowedLoggers = options.allowedLoggers;
 
     // Enable transports with the configured level
-    log.transports.file.level = this.logLevel;
-    log.transports.console.level = options.enableConsole ? this.logLevel : false;
+    log.transports.file.level = options.logFile ? this.logLevel : false;
+    log.transports.console.level = options.logConsole ? this.logLevel : false;
 
     // Activate all existing queued loggers
     for (const [name, queued] of this.loggers) {

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -9,8 +9,15 @@ export type {
   LogContext,
   LoggerName,
   LogLevel,
+  LogOutput,
 } from "./types";
 export { LogLevel as LogLevelValues, logAtLevel } from "./types";
-export { ElectronLogService, parseLogLevel, parseLoggerFilter } from "./electron-log-service";
+export {
+  ElectronLogService,
+  parseLogLevel,
+  parseLogLevelSpec,
+  splitLogLevelSpec,
+  parseLogOutput,
+} from "./electron-log-service";
 export { createMockLogger, createMockLoggingService, SILENT_LOGGER } from "./logging.test-utils";
 export type { MockLogger, MockLoggingService } from "./logging.test-utils";

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -68,12 +68,18 @@ export type LoggerName =
 export type LogContext = Record<string, string | number | boolean | null>;
 
 /**
+ * Log output destinations.
+ */
+export type LogOutput = "file" | "console";
+
+/**
  * Configuration options for the logging service.
  * Passed to `configure()` to set transport levels and filters.
  */
 export interface LoggingConfigureOptions {
   readonly logLevel: LogLevel;
-  readonly enableConsole: boolean;
+  readonly logFile: boolean;
+  readonly logConsole: boolean;
   readonly allowedLoggers: Set<LoggerName> | undefined;
 }
 
@@ -142,7 +148,7 @@ export interface Logger {
  * ```typescript
  * // In main process startup
  * const loggingService = new ElectronLogService(pathProvider);
- * loggingService.configure({ logLevel: 'debug', enableConsole: false, allowedLoggers: undefined });
+ * loggingService.configure({ logLevel: 'debug', logFile: true, logConsole: false, allowedLoggers: undefined });
  * loggingService.initialize(); // Enable renderer logging
  *
  * // Create loggers for services


### PR DESCRIPTION
- Combine `log.level` and `log.filter` into single spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)
- Rename `log.console` to `log.output` with values: `file`, `console`, `file,console`
- Remove `log.filter` config key entirely
- Add `parseLogLevelSpec`, `splitLogLevelSpec`, `parseLogOutput` parse functions
- Update `LoggingConfigureOptions` to use `logFile`/`logConsole` booleans