### PR TITLE
feat(logging): restore startup info and log config changes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -503,6 +503,9 @@ const electronLifecycleModule = createElectronLifecycleModule({
 const loggingModule = createLoggingModule({
   loggingService,
   registerLogHandlers: () => registerLogHandlers(loggingService),
+  buildInfo,
+  platformInfo,
+  logger: appLogger,
 });
 
 const scriptModule = createScriptModule({

--- a/src/main/modules/logging-module.integration.test.ts
+++ b/src/main/modules/logging-module.integration.test.ts
@@ -9,27 +9,62 @@ import { describe, it, expect, vi } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
-import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../operations/app-start";
-import type { AppStartIntent, InitHookContext } from "../operations/app-start";
+import type { AppStartIntent, InitHookContext, ConfigureResult } from "../operations/app-start";
+import type { ConfigUpdatedEvent } from "../operations/config-set-values";
+import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
+import { createMockLogger } from "../../services/logging";
 import { createLoggingModule } from "./logging-module";
 
 // =============================================================================
 // Minimal Test Operation
 // =============================================================================
 
-/** Runs "init" hook point with InitHookContext. */
-class MinimalInitOperation implements Operation<Intent, void> {
+/** Runs "before-ready" and "init" hook points in sequence. */
+class MinimalAppStartOperation implements Operation<Intent, void> {
   readonly id = APP_START_OPERATION_ID;
   async execute(ctx: OperationContext<Intent>): Promise<void> {
+    const hookCtx: HookContext = { intent: ctx.intent };
+
+    const { errors: beforeReadyErrors } = await ctx.hooks.collect<ConfigureResult>(
+      "before-ready",
+      hookCtx
+    );
+    if (beforeReadyErrors.length > 0) throw beforeReadyErrors[0]!;
+
     const initCtx: InitHookContext = {
       intent: ctx.intent,
       requiredScripts: [],
     };
-    const { errors } = await ctx.hooks.collect<void>("init", initCtx);
-    if (errors.length > 0) throw errors[0]!;
+    const { errors: initErrors } = await ctx.hooks.collect<void>("init", initCtx);
+    if (initErrors.length > 0) throw initErrors[0]!;
   }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createDeps() {
+  const loggingService = {
+    initialize: vi.fn(),
+    configure: vi.fn(),
+  };
+  const registerLogHandlers = vi.fn();
+  const buildInfo = {
+    version: "2026.2.0-test",
+    isDevelopment: true,
+    isPackaged: false,
+  };
+  const platformInfo = {
+    platform: "linux" as NodeJS.Platform,
+    arch: "x64" as const,
+  };
+  const logger = createMockLogger();
+
+  return { loggingService, registerLogHandlers, buildInfo, platformInfo, logger };
 }
 
 // =============================================================================
@@ -37,27 +72,91 @@ class MinimalInitOperation implements Operation<Intent, void> {
 // =============================================================================
 
 describe("LoggingModule Integration", () => {
-  it("initializes logging service and registers log handlers during init hook", async () => {
-    const loggingService = {
-      initialize: vi.fn(),
-      configure: vi.fn(),
-    };
-    const registerLogHandlers = vi.fn();
-
+  it("logs build and platform info during before-ready hook", async () => {
+    const deps = createDeps();
     const hookRegistry = new HookRegistry();
     const dispatcher = new Dispatcher(hookRegistry);
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
-
-    const module = createLoggingModule({ loggingService, registerLogHandlers });
-    dispatcher.registerModule(module);
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
       type: INTENT_APP_START,
       payload: {},
     } as AppStartIntent);
 
-    expect(loggingService.initialize).toHaveBeenCalledOnce();
-    expect(registerLogHandlers).toHaveBeenCalledOnce();
+    expect(deps.logger.info).toHaveBeenCalledWith("App starting", {
+      version: "2026.2.0-test",
+      isDev: true,
+      isPackaged: false,
+      platform: "linux",
+      arch: "x64",
+    });
+  });
+
+  it("initializes logging service and registers log handlers during init hook", async () => {
+    const deps = createDeps();
+    const hookRegistry = new HookRegistry();
+    const dispatcher = new Dispatcher(hookRegistry);
+
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+
+    await dispatcher.dispatch({
+      type: INTENT_APP_START,
+      payload: {},
+    } as AppStartIntent);
+
+    expect(deps.loggingService.initialize).toHaveBeenCalledOnce();
+    expect(deps.registerLogHandlers).toHaveBeenCalledOnce();
+  });
+
+  it("logs startup info before initializing logging service", async () => {
+    const deps = createDeps();
+    const hookRegistry = new HookRegistry();
+    const dispatcher = new Dispatcher(hookRegistry);
+
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+
+    await dispatcher.dispatch({
+      type: INTENT_APP_START,
+      payload: {},
+    } as AppStartIntent);
+
+    const logOrder = deps.logger.info.mock.invocationCallOrder[0]!;
+    const initOrder = deps.loggingService.initialize.mock.invocationCallOrder[0]!;
+    expect(logOrder).toBeLessThan(initOrder);
+  });
+
+  it("logs all changed config values on config:updated event", () => {
+    const deps = createDeps();
+    const module = createLoggingModule(deps);
+
+    const handler = module.events![EVENT_CONFIG_UPDATED]!;
+    handler({
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: { agent: "claude", "log.level": "debug" } },
+    } as ConfigUpdatedEvent);
+
+    expect(deps.logger.info).toHaveBeenCalledWith("Config updated", {
+      agent: "claude",
+      "log.level": "debug",
+    });
+  });
+
+  it("converts undefined config values to null when logging", () => {
+    const deps = createDeps();
+    const module = createLoggingModule(deps);
+
+    const handler = module.events![EVENT_CONFIG_UPDATED]!;
+    handler({
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: { "telemetry.distinct-id": undefined } },
+    } as unknown as ConfigUpdatedEvent);
+
+    expect(deps.logger.info).toHaveBeenCalledWith("Config updated", {
+      "telemetry.distinct-id": null,
+    });
   });
 });

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -1,16 +1,21 @@
 /**
- * LoggingModule - Initializes the logging service.
+ * LoggingModule - Initializes the logging service and logs startup/config info.
  *
- * Provides the "init" hook on app-start to initialize the logging service
- * (enabling renderer logging via IPC) and register log handlers.
+ * Hooks:
+ * - app:start → "before-ready": logs build and platform info
+ * - app:start → "init": initializes logging service, registers IPC log handlers
  *
- * Subscribes to config:updated events to reconfigure logging when
- * log.level, log.console, or log.filter values change.
+ * Events:
+ * - config:updated: logs all changed values, reconfigures logging when
+ *   log.level, log.console, or log.filter values change
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
 import type { LoggingService } from "../../services/logging";
+import type { Logger } from "../../services/logging/types";
+import type { BuildInfo } from "../../services/platform/build-info";
+import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import { parseLoggerFilter } from "../../services/logging/electron-log-service";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
@@ -24,6 +29,9 @@ export interface LoggingModuleDeps {
   readonly loggingService: Pick<LoggingService, "initialize" | "configure">;
   /** Called after initialize() to register IPC log handlers. */
   readonly registerLogHandlers: () => void;
+  readonly buildInfo: Pick<BuildInfo, "version" | "isDevelopment" | "isPackaged">;
+  readonly platformInfo: Pick<PlatformInfo, "platform" | "arch">;
+  readonly logger: Logger;
 }
 
 // =============================================================================
@@ -39,6 +47,17 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     name: "logging",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "before-ready": {
+          handler: async (): Promise<void> => {
+            deps.logger.info("App starting", {
+              version: deps.buildInfo.version,
+              isDev: deps.buildInfo.isDevelopment,
+              isPackaged: deps.buildInfo.isPackaged,
+              platform: deps.platformInfo.platform,
+              arch: deps.platformInfo.arch,
+            });
+          },
+        },
         init: {
           handler: async (): Promise<void> => {
             deps.loggingService.initialize();
@@ -50,6 +69,14 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     events: {
       [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
         const { values } = (event as ConfigUpdatedEvent).payload;
+
+        // Log all config changes
+        const context: Record<string, string | number | boolean | null> = {};
+        for (const [key, value] of Object.entries(values)) {
+          context[key] = value ?? null;
+        }
+        deps.logger.info("Config updated", context);
+
         // Reconfigure logging when any log-related value changes
         if (
           values["log.level"] !== undefined ||


### PR DESCRIPTION
- Restore startup log (version, isDev, isPackaged, platform, arch) in logging module's before-ready hook, lost during bootstrap refactor (6cc670ad)
- Log all changed config values on every config:updated event