### PR TITLE
feat(workspace): allow dots and slashes in workspace names

### DIFF
--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -12,6 +12,7 @@
     type ProjectId,
     type Project,
   } from "$lib/api";
+  import { validateWorkspaceName } from "@shared/api/types";
   import { closeDialog, openGitCloneDialog } from "$lib/stores/dialogs.svelte.js";
   import { getProjectById, projects } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
@@ -69,14 +70,8 @@
 
   // Validate name
   function validateName(value: string): string | null {
-    if (!value.trim()) return "Name is required";
-    if (value.includes("/")) return "Name cannot contain /";
-    if (value.includes("\\")) return "Name cannot contain \\";
-    if (value.includes("..")) return "Name cannot contain ..";
-    if (value.length > 100) return "Name must be 100 characters or less";
-    if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
-      return "Name can only contain letters, numbers, dash, underscore";
-    }
+    const formatError = validateWorkspaceName(value);
+    if (formatError) return formatError;
     if (existingNames.includes(value.toLowerCase())) return "Workspace already exists";
     return null;
   }

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -372,37 +372,34 @@ describe("CreateWorkspaceDialog component", () => {
       expect(okButton).toBeDisabled();
     });
 
-    it('name with / shows error "Name cannot contain /"', async () => {
+    it("name with / is valid (branch name style)", async () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       await completeAllLoading();
 
       const nameInput = getNameInput();
-      // Note: Names with / are typically valid branch names, but the dialog validates against /
-      // The NameBranchDropdown filters options but allows free text
-      // Enter the invalid name and press Enter to confirm
       await enterName(nameInput, "feature/branch");
 
-      expect(screen.getByText(/name cannot contain \//i)).toBeInTheDocument();
+      expect(screen.queryByText(/name cannot contain/i)).not.toBeInTheDocument();
     });
 
-    it('name with \\ shows error "Name cannot contain \\"', async () => {
+    it("name with \\ shows error", async () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       await completeAllLoading();
 
       const nameInput = getNameInput();
       await enterName(nameInput, "feature\\branch");
 
-      expect(screen.getByText(/name cannot contain \\/i)).toBeInTheDocument();
+      expect(screen.getByText(/name cannot contain/i)).toBeInTheDocument();
     });
 
-    it('name with .. shows error "Name cannot contain .."', async () => {
+    it("name with .. shows error", async () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       await completeAllLoading();
 
       const nameInput = getNameInput();
       await enterName(nameInput, "feature..branch");
 
-      expect(screen.getByText(/name cannot contain \.\./i)).toBeInTheDocument();
+      expect(screen.getByText(/name cannot contain/i)).toBeInTheDocument();
     });
 
     it("name > 100 chars shows error", async () => {

--- a/src/services/git/git-worktree-provider.integration.test.ts
+++ b/src/services/git/git-worktree-provider.integration.test.ts
@@ -184,6 +184,73 @@ describe("GitWorktreeProvider integration", () => {
     });
   });
 
+  describe("discover name resolution", () => {
+    it("returns branch name (not sanitized basename) for workspaces with /", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature/login"],
+            currentBranch: "main",
+            worktrees: [
+              {
+                name: "feature%login",
+                path: "/workspaces/feature%login",
+                branch: "feature/login",
+              },
+            ],
+            branchConfigs: {
+              "feature/login": { "codehydra.base": "main" },
+            },
+          },
+        },
+      });
+
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const discovered = await provider.discover(PROJECT_ROOT);
+      expect(discovered).toHaveLength(1);
+      expect(discovered[0]?.name).toBe("feature/login");
+      expect(discovered[0]?.branch).toBe("feature/login");
+    });
+
+    it("falls back to filesystem name for detached HEAD workspaces", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main"],
+            currentBranch: "main",
+            worktrees: [
+              {
+                name: "detached-ws",
+                path: "/workspaces/detached-ws",
+                branch: null,
+              },
+            ],
+          },
+        },
+      });
+
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const discovered = await provider.discover(PROJECT_ROOT);
+      expect(discovered).toHaveLength(1);
+      expect(discovered[0]?.name).toBe("detached-ws");
+      expect(discovered[0]?.branch).toBeNull();
+    });
+  });
+
   describe("metadata setMetadata/getMetadata", () => {
     it("setMetadata persists and getMetadata retrieves", async () => {
       const mockClient = createMockGitClient({

--- a/src/services/git/git-worktree-provider.test.ts
+++ b/src/services/git/git-worktree-provider.test.ts
@@ -376,8 +376,9 @@ describe("GitWorktreeProvider", () => {
 
       expect(workspaces).toHaveLength(3);
 
-      const workspaceA = workspaces.find((w) => w.name === "workspace-a");
-      const workspaceB = workspaces.find((w) => w.name === "workspace-b");
+      // name is derived from branch (or filesystem name for detached HEAD)
+      const workspaceA = workspaces.find((w) => w.name === "branch-a");
+      const workspaceB = workspaces.find((w) => w.name === "branch-b");
       const workspaceC = workspaces.find((w) => w.name === "workspace-c");
 
       expect(workspaceA?.metadata.base).toBe("configured-base"); // Uses config

--- a/src/services/git/git-worktree-provider.ts
+++ b/src/services/git/git-worktree-provider.ts
@@ -11,7 +11,7 @@
 import type { IGitClient } from "./git-client";
 import type { BaseInfo, CleanupResult, RemovalResult, UpdateBasesResult, Workspace } from "./types";
 import { WorkspaceError, getErrorMessage } from "../errors";
-import { sanitizeWorkspaceName } from "../platform/paths";
+import { sanitizeWorkspaceName, unsanitizeWorkspaceName } from "../platform/paths";
 import { isValidMetadataKey } from "../../shared/api/types";
 import type { FileSystemLayer } from "../platform/filesystem";
 import type { Logger } from "../logging";
@@ -254,7 +254,7 @@ export class GitWorktreeProvider {
       }
 
       workspaces.push({
-        name: wt.name,
+        name: wt.branch ?? wt.name,
         path: wt.path,
         branch: wt.branch,
         metadata,
@@ -520,7 +520,7 @@ export class GitWorktreeProvider {
     // If worktree not found (retry after partial failure), extract branch from path
     // For git worktrees, the last path segment is the branch name
     // Note: Use ternary (not ??) to preserve null for detached HEAD workspaces
-    const branchName = worktree ? worktree.branch : workspacePath.basename;
+    const branchName = worktree ? worktree.branch : unsanitizeWorkspaceName(workspacePath.basename);
 
     // Step 1: Try to remove worktree, save error if it fails
     // We save the error to throw later, after attempting branch deletion

--- a/src/services/platform/paths.test.ts
+++ b/src/services/platform/paths.test.ts
@@ -14,7 +14,12 @@
 
 import { describe, it, expect } from "vitest";
 import { createHash } from "crypto";
-import { projectDirName, sanitizeWorkspaceName, encodePathForUrl } from "./paths";
+import {
+  projectDirName,
+  sanitizeWorkspaceName,
+  unsanitizeWorkspaceName,
+  encodePathForUrl,
+} from "./paths";
 
 describe("paths utility functions", () => {
   describe("projectDirName", () => {
@@ -77,6 +82,34 @@ describe("paths utility functions", () => {
       const result = sanitizeWorkspaceName("my-feature");
 
       expect(result).toBe("my-feature");
+    });
+  });
+
+  describe("unsanitizeWorkspaceName", () => {
+    it("replaces percent signs with forward slashes", () => {
+      const result = unsanitizeWorkspaceName("feature%my-feature");
+
+      expect(result).toBe("feature/my-feature");
+    });
+
+    it("handles multiple percent signs", () => {
+      const result = unsanitizeWorkspaceName("user%feature%sub-feature");
+
+      expect(result).toBe("user/feature/sub-feature");
+    });
+
+    it("returns unchanged if no percent signs", () => {
+      const result = unsanitizeWorkspaceName("my-feature");
+
+      expect(result).toBe("my-feature");
+    });
+
+    it("round-trips with sanitizeWorkspaceName", () => {
+      const original = "feature/login";
+      const sanitized = sanitizeWorkspaceName(original);
+      const recovered = unsanitizeWorkspaceName(sanitized);
+
+      expect(recovered).toBe(original);
     });
   });
 

--- a/src/services/platform/paths.ts
+++ b/src/services/platform/paths.ts
@@ -48,6 +48,19 @@ export function sanitizeWorkspaceName(name: string): string {
 }
 
 /**
+ * Reverse the sanitization of a workspace name.
+ * Replaces `%` with `/` to recover the original branch name.
+ *
+ * Safe because `%` is not in the workspace name character set — only sanitized names contain it.
+ *
+ * @param name Sanitized filesystem name
+ * @returns Original workspace/branch name
+ */
+export function unsanitizeWorkspaceName(name: string): string {
+  return name.replace(/%/g, "/");
+}
+
+/**
  * Encode a file path for use in URLs.
  * Percent-encodes special characters while preserving path structure.
  *

--- a/src/shared/api/id-utils.test.ts
+++ b/src/shared/api/id-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { extractWorkspaceName } from "./id-utils";
+
+describe("extractWorkspaceName", () => {
+  it("extracts basename from standard path", () => {
+    expect(extractWorkspaceName("/home/user/projects/.worktrees/feature-1")).toBe("feature-1");
+  });
+
+  it("unsanitizes % back to / in workspace name", () => {
+    expect(extractWorkspaceName("/workspaces/feature%login")).toBe("feature/login");
+  });
+
+  it("handles multiple % segments", () => {
+    expect(extractWorkspaceName("/workspaces/user%feature%sub-feature")).toBe(
+      "user/feature/sub-feature"
+    );
+  });
+
+  it("handles Windows-style paths", () => {
+    expect(extractWorkspaceName("C:\\Users\\projects\\.worktrees\\feature-1")).toBe("feature-1");
+  });
+
+  it("handles Windows-style paths with sanitized name", () => {
+    expect(extractWorkspaceName("C:\\Users\\projects\\.worktrees\\feature%login")).toBe(
+      "feature/login"
+    );
+  });
+
+  it("handles trailing slash", () => {
+    expect(extractWorkspaceName("/workspaces/feature-1/")).toBe("feature-1");
+  });
+
+  it("returns name unchanged when no % present", () => {
+    expect(extractWorkspaceName("/workspaces/simple-name")).toBe("simple-name");
+  });
+});

--- a/src/shared/api/id-utils.ts
+++ b/src/shared/api/id-utils.ts
@@ -26,5 +26,6 @@ export function extractWorkspaceName(workspacePath: string): WorkspaceName {
   // Get basename (last segment)
   const lastSlash = trimmed.lastIndexOf("/");
   const basename = lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed;
-  return basename as WorkspaceName;
+  // Reverse filesystem sanitization: sanitizeWorkspaceName replaces / with %
+  return basename.replace(/%/g, "/") as WorkspaceName;
 }

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -51,8 +51,8 @@ export type {
   AppState,
 } from "./types";
 
-// Type guards
-export { isProjectId, isWorkspaceName } from "./types";
+// Type guards and validation
+export { isProjectId, isWorkspaceName, validateWorkspaceName } from "./types";
 
 // API interfaces
 export type {

--- a/src/shared/api/types.test.ts
+++ b/src/shared/api/types.test.ts
@@ -8,6 +8,7 @@ import {
   type WorkspaceName,
   isProjectId,
   isWorkspaceName,
+  validateWorkspaceName,
   isValidMetadataKey,
   METADATA_KEY_REGEX,
 } from "./types";
@@ -189,6 +190,15 @@ describe("isWorkspaceName - Type Guard", () => {
       expect(isWorkspaceName("feature#1")).toBe(false);
       expect(isWorkspaceName("feature$1")).toBe(false);
     });
+
+    it("should reject names containing double dots", () => {
+      expect(isWorkspaceName("a..b")).toBe(false);
+      expect(isWorkspaceName("..foo")).toBe(false);
+    });
+
+    it("should reject names containing backslash", () => {
+      expect(isWorkspaceName("feature\\branch")).toBe(false);
+    });
   });
 
   describe("type narrowing", () => {
@@ -200,6 +210,51 @@ describe("isWorkspaceName - Type Guard", () => {
         expect(name).toBe(value);
       }
     });
+  });
+});
+
+describe("validateWorkspaceName - Validation with error messages", () => {
+  it("returns null for valid names", () => {
+    expect(validateWorkspaceName("feature-branch")).toBeNull();
+    expect(validateWorkspaceName("release.1.0")).toBeNull();
+    expect(validateWorkspaceName("feature/login")).toBeNull();
+    expect(validateWorkspaceName("a")).toBeNull();
+  });
+
+  it("returns error for empty string", () => {
+    expect(validateWorkspaceName("")).toBe("Name is required");
+  });
+
+  it("returns error for names exceeding max length", () => {
+    const tooLong = "a".repeat(101);
+    expect(validateWorkspaceName(tooLong)).toBe("Name must be 100 characters or less");
+  });
+
+  it("returns error for double dots", () => {
+    expect(validateWorkspaceName("a..b")).toBe('Name cannot contain ".."');
+    expect(validateWorkspaceName("..foo")).toBe('Name cannot contain ".."');
+  });
+
+  it("returns error for backslash", () => {
+    expect(validateWorkspaceName("feature\\branch")).toBe('Name cannot contain "\\"');
+  });
+
+  it("returns error for invalid characters", () => {
+    expect(validateWorkspaceName("feature@branch")).toBe(
+      "Name can only contain letters, numbers, dash, underscore, dot, forward slash"
+    );
+  });
+
+  it("returns error for names starting with non-alphanumeric", () => {
+    expect(validateWorkspaceName("-feature")).toBe(
+      "Name can only contain letters, numbers, dash, underscore, dot, forward slash"
+    );
+    expect(validateWorkspaceName(".feature")).toBe(
+      "Name can only contain letters, numbers, dash, underscore, dot, forward slash"
+    );
+    expect(validateWorkspaceName("/feature")).toBe(
+      "Name can only contain letters, numbers, dash, underscore, dot, forward slash"
+    );
   });
 });
 

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -61,16 +61,29 @@ export function isProjectId(value: string): value is ProjectId {
 }
 
 /**
+ * Validate a workspace name and return an error message or null.
+ * @param value String to validate
+ * @returns Error message if invalid, null if valid
+ */
+export function validateWorkspaceName(value: string): string | null {
+  if (!value) return "Name is required";
+  if (value.length > WORKSPACE_NAME_MAX_LENGTH)
+    return `Name must be ${WORKSPACE_NAME_MAX_LENGTH} characters or less`;
+  if (value.includes("..")) return 'Name cannot contain ".."';
+  if (value.includes("\\")) return 'Name cannot contain "\\"';
+  if (!WORKSPACE_NAME_REGEX.test(value)) {
+    return "Name can only contain letters, numbers, dash, underscore, dot, forward slash";
+  }
+  return null;
+}
+
+/**
  * Type guard for WorkspaceName validation.
  * @param value String to validate
  * @returns True if the value matches WorkspaceName format
  */
 export function isWorkspaceName(value: string): value is WorkspaceName {
-  return (
-    value.length > 0 &&
-    value.length <= WORKSPACE_NAME_MAX_LENGTH &&
-    WORKSPACE_NAME_REGEX.test(value)
-  );
+  return validateWorkspaceName(value) === null;
 }
 
 // =============================================================================


### PR DESCRIPTION
- Add shared `validateWorkspaceName()` function, refactor `isWorkspaceName()` to delegate
- Replace duplicated inline validation in `CreateWorkspaceDialog` with shared function
- Fix `discover()` to use branch name instead of sanitized filesystem basename
- Add `unsanitizeWorkspaceName()` for reversing `/` → `%` sanitization
- Fix `extractWorkspaceName()` to unsanitize `%` back to `/` so display layer never shows sanitized names
- Fix `removeWorkspace()` fallback to unsanitize basename for branch deletion