### PR TITLE
feat(config): add --help flag to print config usage guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,7 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | `log.level`             | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`) |
 | `log.output`            | `file`    | Output destinations: `file`, `console`, or `file,console`               |
 | `electron.flags`        | —         | Electron switches (e.g., `--disable-gpu`)                               |
+| `help`                  | `false`   | Print config help and exit                                              |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -490,6 +490,7 @@ const configModule = createConfigModule({
   isPackaged: buildInfo.isPackaged,
   env: process.env as Record<string, string | undefined>,
   argv: process.argv,
+  stdout: process.stdout,
 });
 
 const electronLifecycleModule = createElectronLifecycleModule({

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -14,7 +14,7 @@
  * - Config file migration (old keys → new keys)
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Path } from "../../services/platform/path";
 import { SILENT_LOGGER } from "../../services/logging";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
@@ -30,12 +30,18 @@ import {
   EVENT_CONFIG_UPDATED,
 } from "../operations/config-set-values";
 import type { ConfigSetValuesIntent, ConfigUpdatedEvent } from "../operations/config-set-values";
+import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
 import {
   createFileSystemMock,
   file,
   directory,
 } from "../../services/platform/filesystem.state-mock";
 import { createConfigModule, parseEnvVars, parseCliArgs } from "./config-module";
+import {
+  CONFIG_KEYS,
+  DEFAULT_CONFIG_VALUES,
+  generateHelpText,
+} from "../../services/config/config-values";
 
 // =============================================================================
 // Minimal Test Operations
@@ -115,6 +121,8 @@ function createTestSetup(options?: {
     },
   });
 
+  const stdout = { write: vi.fn().mockReturnValue(true) };
+
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
 
@@ -130,11 +138,12 @@ function createTestSetup(options?: {
     isPackaged: options?.isPackaged ?? false,
     env: options?.env ?? {},
     argv: options?.argv ?? [],
+    stdout,
   });
 
   dispatcher.registerModule(module);
 
-  return { fileSystem, hookRegistry, dispatcher, module };
+  return { fileSystem, hookRegistry, dispatcher, module, stdout };
 }
 
 // =============================================================================
@@ -1002,6 +1011,113 @@ describe("ConfigModule Integration", () => {
       const logLevelEvent = events.find((e) => e.payload.values["log.level"] !== undefined);
       expect(logLevelEvent).toBeDefined();
       expect(logLevelEvent!.payload.values["log.level"]).toBe("error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // --help flag
+  // ---------------------------------------------------------------------------
+  describe("--help flag", () => {
+    it("prints help text to stdout and dispatches app:shutdown", async () => {
+      const { dispatcher, stdout } = createTestSetup({ argv: ["--help"] });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(stdout.write).toHaveBeenCalledOnce();
+      const output = stdout.write.mock.calls[0]![0] as string;
+      expect(output).toContain("CodeHydra Configuration");
+      expect(output).toContain(CONFIG_PATH.toString());
+    });
+
+    it("shows computed defaults in help output (isDevelopment)", async () => {
+      const { dispatcher, stdout } = createTestSetup({
+        isDevelopment: true,
+        argv: ["--help"],
+      });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      const output = stdout.write.mock.calls[0]![0] as string;
+      // isDevelopment=true computes log.level=debug (not static default "warn")
+      expect(output).toContain("log.level");
+      expect(output).toMatch(/log\.level\s+default: debug/);
+    });
+
+    it("CH_HELP=1 env var prints help and dispatches shutdown", async () => {
+      const { dispatcher, stdout } = createTestSetup({ env: { CH_HELP: "1" } });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(stdout.write).toHaveBeenCalledOnce();
+      const output = stdout.write.mock.calls[0]![0] as string;
+      expect(output).toContain("CodeHydra Configuration");
+    });
+
+    it("does not print help or dispatch shutdown when --help is not set", async () => {
+      const { dispatcher, stdout } = createTestSetup();
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(stdout.write).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // generateHelpText
+  // ---------------------------------------------------------------------------
+  describe("generateHelpText", () => {
+    it("contains every config key", () => {
+      const text = generateHelpText("/some/config.json", DEFAULT_CONFIG_VALUES);
+      for (const key of CONFIG_KEYS) {
+        expect(text).toContain(key);
+      }
+    });
+
+    it("contains the config file path", () => {
+      const text = generateHelpText("/custom/path/config.json", DEFAULT_CONFIG_VALUES);
+      expect(text).toContain("/custom/path/config.json");
+    });
+
+    it("shows static defaults", () => {
+      const text = generateHelpText("/some/config.json", DEFAULT_CONFIG_VALUES);
+      expect(text).toContain("default: warn");
+      expect(text).toContain("default: false");
+      expect(text).toContain("default: true");
+    });
+
+    it("shows computed effective values when provided", () => {
+      const defaults = {
+        ...DEFAULT_CONFIG_VALUES,
+        "log.level": "debug" as const,
+        "telemetry.enabled": false,
+      };
+      const text = generateHelpText("/some/config.json", defaults);
+      expect(text).toMatch(/log\.level\s+default: debug/);
+      expect(text).toMatch(/telemetry\.enabled\s+default: false/);
     });
   });
 });

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -31,12 +31,15 @@ import {
   envVarToConfigKey,
   parseConfigValue,
   validateConfigValue,
+  generateHelpText,
 } from "../../services/config/config-values";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import {
   CONFIG_SET_VALUES_OPERATION_ID,
   INTENT_CONFIG_SET_VALUES,
 } from "../operations/config-set-values";
+import { INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
+import type { AppShutdownIntent } from "../operations/app-shutdown";
 
 // =============================================================================
 // Dependency Interface
@@ -51,6 +54,7 @@ export interface ConfigModuleDeps {
   readonly isPackaged: boolean;
   readonly env: Record<string, string | undefined>;
   readonly argv: readonly string[];
+  readonly stdout: { write(text: string): boolean };
 }
 
 // =============================================================================
@@ -299,6 +303,14 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
               type: INTENT_CONFIG_SET_VALUES,
               payload: { values: merged, persist: false },
             } as ConfigSetValuesIntent);
+
+            if (effective.help === true) {
+              deps.stdout.write(generateHelpText(deps.configPath.toString(), effective));
+              await dispatcher.dispatch({
+                type: INTENT_APP_SHUTDOWN,
+                payload: {},
+              } as AppShutdownIntent);
+            }
 
             return {};
           },

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -26,6 +26,10 @@ function key<T>(def: ConfigKeyDef<T>): ConfigKeyDef<T> {
   return def;
 }
 
+function parseBool(s: string): boolean | undefined {
+  return s === "true" || s === "1" ? true : s === "false" || s === "0" ? false : undefined;
+}
+
 // =============================================================================
 // Config Schema
 // =============================================================================
@@ -65,8 +69,7 @@ export const CONFIG = {
   }),
   "telemetry.enabled": key<boolean>({
     default: true,
-    parse: (s) =>
-      s === "true" || s === "1" ? true : s === "false" || s === "0" ? false : undefined,
+    parse: parseBool,
     validate: (v) => (typeof v === "boolean" ? v : undefined),
   }),
   "telemetry.distinct-id": key<string | undefined>({
@@ -88,6 +91,11 @@ export const CONFIG = {
     default: undefined,
     parse: (s) => (s === "" ? undefined : s),
     validate: (v) => (typeof v === "string" ? v : undefined),
+  }),
+  help: key<boolean>({
+    default: false,
+    parse: parseBool,
+    validate: (v) => (typeof v === "boolean" ? v : undefined),
   }),
 } as const satisfies Record<string, ConfigKeyDef<unknown>>;
 
@@ -116,14 +124,6 @@ export const DEFAULT_CONFIG_VALUES: Readonly<ConfigValues> = Object.fromEntries(
 // =============================================================================
 // Name Derivation
 // =============================================================================
-
-/**
- * Convert a config key to its env var name.
- * Rules: CH_ prefix, . → __, - → _, UPPERCASE.
- */
-export function configKeyToEnvVar(key: ConfigKey): string {
-  return "CH_" + key.replace(/\./g, "__").replace(/-/g, "_").toUpperCase();
-}
 
 /**
  * Convert an env var name to a config key (or undefined if not a CH_ var).
@@ -155,4 +155,39 @@ export function validateConfigValue(
   const def = CONFIG[key];
   if (!def) return undefined;
   return def.validate(value) as ConfigValues[ConfigKey] | undefined;
+}
+
+// =============================================================================
+// Help Text
+// =============================================================================
+
+/**
+ * Generate a human-readable config usage guide.
+ *
+ * `defaults` should be the effective config values (accounting for
+ * isDevelopment, isPackaged, etc.) so users see the actual defaults
+ * that apply to their environment.
+ */
+export function generateHelpText(configFilePath: string, defaults: Readonly<ConfigValues>): string {
+  const lines: string[] = [
+    "CodeHydra Configuration",
+    "=======================",
+    "",
+    "Every key can be set three ways (highest precedence first):",
+    "  CLI flag:   --<key>=<value>        e.g. --log.level=debug",
+    "  Env var:    CH_ prefix, . → __, - → _, UPPER  e.g. CH_LOG__LEVEL=debug",
+    "  Config file: " + configFilePath,
+    "",
+    "Keys:",
+    "",
+  ];
+
+  for (const key of Object.keys(CONFIG) as ConfigKey[]) {
+    const value = defaults[key];
+    const valueStr = value === undefined ? "—" : String(value);
+    lines.push(`  ${key.padEnd(24)} default: ${valueStr}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
 }

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -9,10 +9,10 @@ export {
   type ConfigAgentType,
   CONFIG_KEYS,
   DEFAULT_CONFIG_VALUES,
-  configKeyToEnvVar,
   envVarToConfigKey,
   parseConfigValue,
   validateConfigValue,
+  generateHelpText,
 } from "./config-values";
 
 // Legacy exports — kept for backwards compatibility with tests


### PR DESCRIPTION
- Add `help` boolean config key (`--help` / `CH_HELP=1`) that prints all available config keys with their effective defaults, then exits via shutdown intent
- Extract shared `parseBool` helper, reuse for `telemetry.enabled` and `help`
- Add `generateHelpText(configFilePath, defaults)` pure function
- Remove unused `configKeyToEnvVar` export
- Add `stdout` dependency to `ConfigModuleDeps` for testable output