### PR TITLE
feat(config): add auto-update config key (always | never)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | Key                     | Default   | Description                                                             |
 | ----------------------- | --------- | ----------------------------------------------------------------------- |
 | `agent`                 | `null`    | Agent selection: claude\|opencode                                       |
+| `auto-update`           | `always`  | Auto-update preference: always\|never                                   |
 | `version.claude`        | `null`    | Claude agent version override                                           |
 | `version.opencode`      | `null`    | OpenCode agent version override                                         |
 | `version.code-server`   | `4.107.0` | Code-server version                                                     |

--- a/packages/npm/codehydra.js
+++ b/packages/npm/codehydra.js
@@ -136,7 +136,9 @@ async function main() {
     console.log("Done!\n");
   }
 
-  const child = spawn(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+  const child = spawn(binaryPath, ["--auto-update=never", ...process.argv.slice(2)], {
+    stdio: "inherit",
+  });
   child.on("exit", (code) => process.exit(code || 0));
 }
 

--- a/packages/pypi/src/codehydra/__init__.py
+++ b/packages/pypi/src/codehydra/__init__.py
@@ -102,10 +102,11 @@ def main() -> None:
 
         print("Done!\n")
 
+    args = ["--auto-update=never"] + sys.argv[1:]
     if platform.system() == "Windows":
-        sys.exit(subprocess.run([str(binary_path)] + sys.argv[1:]).returncode)
+        sys.exit(subprocess.run([str(binary_path)] + args).returncode)
     else:
-        os.execv(str(binary_path), [str(binary_path)] + sys.argv[1:])
+        os.execv(str(binary_path), [str(binary_path)] + args)
 
 
 if __name__ == "__main__":

--- a/src/main/modules/auto-updater-module.integration.test.ts
+++ b/src/main/modules/auto-updater-module.integration.test.ts
@@ -31,6 +31,10 @@ import {
   type UpdateAvailableIntent,
 } from "../operations/update-available";
 import { createAutoUpdaterModule } from "./auto-updater-module";
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
+import type { ConfigValues } from "../../services/config/config-values";
 import type { AutoUpdater, UpdateAvailableCallback } from "../../services/auto-updater";
 
 // =============================================================================
@@ -122,6 +126,7 @@ interface TestSetup {
   dispatcher: Dispatcher;
   autoUpdater: MockAutoUpdater;
   updateOperation: TrackingUpdateOperation;
+  module: IntentModule;
 }
 
 function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
@@ -144,7 +149,21 @@ function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
 
   dispatcher.registerModule(autoUpdaterModule);
 
-  return { dispatcher, autoUpdater, updateOperation };
+  return { dispatcher, autoUpdater, updateOperation, module: autoUpdaterModule };
+}
+
+/**
+ * Simulate a config:updated event by calling the module's event handler directly.
+ */
+function simulateConfigUpdated(
+  module: IntentModule,
+  values: Partial<Readonly<ConfigValues>>
+): void {
+  const event: ConfigUpdatedEvent = {
+    type: EVENT_CONFIG_UPDATED,
+    payload: { values },
+  };
+  module.events![EVENT_CONFIG_UPDATED]!(event as DomainEvent);
 }
 
 function startIntent(): AppStartIntent {
@@ -198,5 +217,37 @@ describe("AutoUpdaterModule Integration", () => {
 
     // Handler throws, but collect() catches it and shutdown is best-effort
     await expect(dispatcher.dispatch(shutdownIntent())).resolves.toBeUndefined();
+  });
+
+  it("auto-update=always (default) starts autoUpdater", async () => {
+    const { dispatcher, autoUpdater, module } = createTestSetup();
+
+    simulateConfigUpdated(module, { "auto-update": "always" });
+
+    await dispatcher.dispatch(startIntent());
+
+    expect(autoUpdater.startCalled).toBe(true);
+  });
+
+  it("auto-update=never skips autoUpdater.start()", async () => {
+    const { dispatcher, autoUpdater, module } = createTestSetup();
+
+    simulateConfigUpdated(module, { "auto-update": "never" });
+
+    await dispatcher.dispatch(startIntent());
+
+    expect(autoUpdater.startCalled).toBe(false);
+  });
+
+  it("auto-update=never still calls dispose() on shutdown", async () => {
+    const { dispatcher, autoUpdater, module } = createTestSetup();
+
+    simulateConfigUpdated(module, { "auto-update": "never" });
+
+    await dispatcher.dispatch(startIntent());
+    await dispatcher.dispatch(shutdownIntent());
+
+    expect(autoUpdater.startCalled).toBe(false);
+    expect(autoUpdater.disposeCalled).toBe(true);
   });
 });

--- a/src/main/modules/auto-updater-module.ts
+++ b/src/main/modules/auto-updater-module.ts
@@ -2,17 +2,24 @@
  * AutoUpdaterModule - Lifecycle module for auto-update checking and cleanup.
  *
  * Hooks:
- * - app:start -> "start": starts auto-updater, wires onUpdateAvailable to dispatch update:available
+ * - app:start -> "start": starts auto-updater (unless auto-update=never),
+ *   wires onUpdateAvailable to dispatch update:available
  * - app:shutdown -> "stop": disposes auto-updater (best-effort)
+ *
+ * Events:
+ * - config:updated: tracks auto-update preference
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
+import type { DomainEvent } from "../intents/infrastructure/types";
 import { APP_START_OPERATION_ID, type StartHookResult } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import {
   INTENT_UPDATE_AVAILABLE,
   type UpdateAvailableIntent,
 } from "../operations/update-available";
+import { EVENT_CONFIG_UPDATED, type ConfigUpdatedPayload } from "../operations/config-set-values";
+import type { AutoUpdatePreference } from "../../services/config/config-values";
 import type { AutoUpdater } from "../../services/auto-updater";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
 
@@ -22,12 +29,18 @@ interface AutoUpdaterModuleDeps {
 }
 
 export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModule {
+  let autoUpdate: AutoUpdatePreference = "always";
+
   return {
     name: "auto-updater",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
           handler: async (): Promise<StartHookResult> => {
+            if (autoUpdate === "never") {
+              return {};
+            }
+
             deps.autoUpdater.start();
 
             // Wire auto-updater to dispatch update:available intent
@@ -47,6 +60,14 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
             deps.autoUpdater.dispose();
           },
         },
+      },
+    },
+    events: {
+      [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
+        const { values } = event.payload as ConfigUpdatedPayload;
+        if (values["auto-update"] !== undefined) {
+          autoUpdate = values["auto-update"];
+        }
       },
     },
   };

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -203,6 +203,11 @@ describe("ConfigModule Integration", () => {
       const result = parseEnvVars({ CH_LOG__LEVEL: "not-a-level" });
       expect(result["log.level"]).toBeUndefined();
     });
+
+    it("maps CH_AUTO_UPDATE=never to auto-update", () => {
+      const result = parseEnvVars({ CH_AUTO_UPDATE: "never" });
+      expect(result["auto-update"]).toBe("never");
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -234,6 +239,11 @@ describe("ConfigModule Integration", () => {
       expect(result["log.level"]).toBe("debug");
       expect(result["log.output"]).toBe("console");
       expect(result.agent).toBe("claude");
+    });
+
+    it("parses --auto-update=never flag", () => {
+      const result = parseCliArgs(["--auto-update=never"]);
+      expect(result["auto-update"]).toBe("never");
     });
   });
 
@@ -436,6 +446,28 @@ describe("ConfigModule Integration", () => {
       expect(events).toHaveLength(1);
       expect(events[0]!.payload.values.agent).toBe("claude");
       expect(events[0]!.payload.values["version.code-server"]).toBe("4.200.0");
+    });
+
+    it("auto-update value from config.json round-trips through init", async () => {
+      const configContent = JSON.stringify({ "auto-update": "never" });
+
+      const { dispatcher } = createTestSetup({
+        configFileContent: configContent,
+        isPackaged: true,
+      });
+
+      const events: ConfigUpdatedEvent[] = [];
+      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values["auto-update"]).toBe("never");
     });
 
     it("returns configuredAgent from effective config", async () => {

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -41,6 +41,13 @@ function parseBool(s: string): boolean | undefined {
 export type ConfigAgentType = "claude" | "opencode" | null;
 
 /**
+ * Auto-update behavior preference.
+ * "always" = background check + download (default).
+ * "never" = skip auto-update entirely.
+ */
+export type AutoUpdatePreference = "always" | "never";
+
+/**
  * The single source of truth for all configuration keys.
  *
  * Any key can appear in config.json, env vars, or CLI flags.
@@ -51,6 +58,11 @@ export const CONFIG = {
     default: null,
     parse: (s) => (s === "claude" || s === "opencode" ? s : s === "" ? null : undefined),
     validate: (v) => (v === null || v === "claude" || v === "opencode" ? v : undefined),
+  }),
+  "auto-update": key<AutoUpdatePreference>({
+    default: "always",
+    parse: (s) => (s === "always" || s === "never" ? s : undefined),
+    validate: (v) => (v === "always" || v === "never" ? v : undefined),
   }),
   "version.claude": key<string | null>({
     default: null,


### PR DESCRIPTION
- Add `auto-update` config key to schema (`always` | `never`, default: `always`)
- Auto-updater module subscribes to `config:updated` and skips `start()` when `never`
- npm and pypi launchers prepend `--auto-update=never` to disable updates for pinned versions
- Add tests for env var, CLI flag, config.json round-trip, and auto-updater behavior