### PR TITLE
feat(config): make version.code-server control runtime code-server version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,19 +298,19 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                     | Default   | Description                                                             |
-| ----------------------- | --------- | ----------------------------------------------------------------------- |
-| `agent`                 | `null`    | Agent selection: claude\|opencode                                       |
-| `auto-update`           | `always`  | Auto-update preference: always\|never                                   |
-| `version.claude`        | `null`    | Claude agent version override                                           |
-| `version.opencode`      | `null`    | OpenCode agent version override                                         |
-| `version.code-server`   | `4.107.0` | Code-server version                                                     |
-| `telemetry.enabled`     | `true`    | Enable telemetry (false in dev/unpackaged)                              |
-| `telemetry.distinct-id` | —         | Telemetry user ID (auto-generated)                                      |
-| `log.level`             | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`) |
-| `log.output`            | `file`    | Output destinations: `file`, `console`, or `file,console`               |
-| `electron.flags`        | —         | Electron switches (e.g., `--disable-gpu`)                               |
-| `help`                  | `false`   | Print config help and exit                                              |
+| Key                     | Default  | Description                                                             |
+| ----------------------- | -------- | ----------------------------------------------------------------------- |
+| `agent`                 | `null`   | Agent selection: claude\|opencode                                       |
+| `auto-update`           | `always` | Auto-update preference: always\|never                                   |
+| `version.claude`        | `null`   | Claude agent version override                                           |
+| `version.opencode`      | `null`   | OpenCode agent version override                                         |
+| `version.code-server`   | `null`   | Code-server version override (null = built-in)                          |
+| `telemetry.enabled`     | `true`   | Enable telemetry (false in dev/unpackaged)                              |
+| `telemetry.distinct-id` | —        | Telemetry user ID (auto-generated)                                      |
+| `log.level`             | `warn`   | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`) |
+| `log.output`            | `file`   | Output destinations: `file`, `console`, or `file,console`               |
+| `electron.flags`        | —        | Electron switches (e.g., `--disable-gpu`)                               |
+| `help`                  | `false`  | Print config help and exit                                              |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -445,6 +445,9 @@ const codeServerModule = createCodeServerModule({
   pluginServer,
   fileSystemLayer,
   workspaceFileService,
+  pathProvider,
+  platform,
+  arch,
   wrapperPath: pathProvider.claudeCodeWrapperPath.toString(),
   logger: apiLogger,
 });

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
-import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import type { CheckDepsResult, ConfigureResult, StartHookResult } from "../operations/app-start";
@@ -31,6 +31,17 @@ import type {
   DeleteHookResult,
 } from "../operations/delete-workspace";
 import { createCodeServerModule, type CodeServerModuleDeps } from "./code-server-module";
+import {
+  CONFIG_SET_VALUES_OPERATION_ID,
+  ConfigSetValuesOperation,
+  INTENT_CONFIG_SET_VALUES,
+} from "../operations/config-set-values";
+import type {
+  ConfigSetValuesIntent,
+  ConfigSetHookInput,
+  ConfigSetHookResult,
+} from "../operations/config-set-values";
+import type { IntentModule } from "../intents/infrastructure/module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { Path } from "../../services/platform/path";
 import { SetupError } from "../../services/errors";
@@ -184,6 +195,26 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteH
   }
 }
 
+/**
+ * Minimal config module stub: handles the "set" hook and returns all input values
+ * as changed, so ConfigSetValuesOperation emits config:updated events.
+ */
+function createMockConfigModule(): IntentModule {
+  return {
+    name: "mock-config",
+    hooks: {
+      [CONFIG_SET_VALUES_OPERATION_ID]: {
+        set: {
+          handler: async (ctx: HookContext): Promise<ConfigSetHookResult> => {
+            const { values } = ctx as ConfigSetHookInput;
+            return { changedValues: values };
+          },
+        },
+      },
+    },
+  };
+}
+
 // =============================================================================
 // Mock Factories
 // =============================================================================
@@ -201,6 +232,7 @@ function createMockDeps(overrides?: Partial<CodeServerModuleDeps>): CodeServerMo
         userDataDir: new Path("/user-data"),
       }),
       setPluginPort: vi.fn(),
+      setCodeServerVersion: vi.fn(),
       stop: vi.fn().mockResolvedValue(undefined),
     },
     extensionManager: {
@@ -212,6 +244,7 @@ function createMockDeps(overrides?: Partial<CodeServerModuleDeps>): CodeServerMo
       }),
       install: vi.fn().mockResolvedValue(undefined),
       cleanOutdated: vi.fn().mockResolvedValue(undefined),
+      setCodeServerBinaryPath: vi.fn(),
     },
     pluginServer: {
       start: vi.fn().mockResolvedValue(3456),
@@ -230,6 +263,13 @@ function createMockDeps(overrides?: Partial<CodeServerModuleDeps>): CodeServerMo
       createWorkspaceFile: vi.fn(),
       getWorkspaceFilePath: vi.fn(),
     } as unknown as CodeServerModuleDeps["workspaceFileService"],
+    pathProvider: {
+      getBinaryDir: vi.fn().mockImplementation((_type: string, version: string) => {
+        return new Path(`/bundles/code-server/${version}`);
+      }),
+    },
+    platform: "linux",
+    arch: "x64",
     wrapperPath: "/path/to/wrapper",
     logger: SILENT_LOGGER,
     ...overrides,
@@ -847,6 +887,77 @@ describe("CodeServerModule", () => {
       expect(deps.pluginServer!.removeWorkspaceConfig).toHaveBeenCalledWith(
         "/test/project/.worktrees/feature-1"
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // config:updated event
+  // ---------------------------------------------------------------------------
+
+  describe("config:updated event", () => {
+    it("propagates version override to managers", async () => {
+      const deps = createMockDeps();
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      dispatcher.registerModule(createMockConfigModule());
+      dispatcher.registerModule(createCodeServerModule(deps));
+      dispatcher.registerOperation("config:set-values", new ConfigSetValuesOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_CONFIG_SET_VALUES,
+        payload: { values: { "version.code-server": "4.200.0" }, persist: false },
+      } as ConfigSetValuesIntent);
+
+      expect(deps.codeServerManager.setCodeServerVersion).toHaveBeenCalledWith(
+        expect.stringContaining("4.200.0"),
+        expect.stringContaining("4.200.0"),
+        expect.objectContaining({
+          name: "code-server",
+          url: expect.stringContaining("4.200.0"),
+          destDir: expect.stringContaining("4.200.0"),
+        })
+      );
+      expect(deps.extensionManager.setCodeServerBinaryPath).toHaveBeenCalledWith(
+        expect.stringContaining("4.200.0")
+      );
+    });
+
+    it("falls back to built-in version when config value is null", async () => {
+      const deps = createMockDeps();
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      dispatcher.registerModule(createMockConfigModule());
+      dispatcher.registerModule(createCodeServerModule(deps));
+      dispatcher.registerOperation("config:set-values", new ConfigSetValuesOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_CONFIG_SET_VALUES,
+        payload: { values: { "version.code-server": null }, persist: false },
+      } as ConfigSetValuesIntent);
+
+      // Should use built-in CODE_SERVER_VERSION, not "null"
+      const call = (deps.codeServerManager.setCodeServerVersion as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(call).toBeDefined();
+      expect(call![0]).not.toContain("null");
+      expect(call![1]).not.toContain("null");
+    });
+
+    it("does not propagate when version.code-server is not in changed values", async () => {
+      const deps = createMockDeps();
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      dispatcher.registerModule(createMockConfigModule());
+      dispatcher.registerModule(createCodeServerModule(deps));
+      dispatcher.registerOperation("config:set-values", new ConfigSetValuesOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_CONFIG_SET_VALUES,
+        payload: { values: { agent: "claude" }, persist: false },
+      } as ConfigSetValuesIntent);
+
+      expect(deps.codeServerManager.setCodeServerVersion).not.toHaveBeenCalled();
+      expect(deps.extensionManager.setCodeServerBinaryPath).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -18,9 +18,14 @@ import type { HookContext } from "../intents/infrastructure/operation";
 import type { CodeServerManager } from "../../services/code-server/code-server-manager";
 import type { ExtensionManager } from "../../services/vscode-setup/extension-manager";
 import type { FileSystemLayer } from "../../services/platform/filesystem";
+import type { PathProvider } from "../../services/platform/path-provider";
 import type { IWorkspaceFileService } from "../../services/vscode-workspace/types";
 import type { PluginServer } from "../../services/plugin-server/plugin-server";
 import type { Logger } from "../../services/logging/types";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import type { SupportedPlatform, SupportedArch } from "../../agents/types";
+import type { DownloadRequest } from "../../services/binary-download";
+import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { CheckDepsResult, ConfigureResult, StartHookResult } from "../operations/app-start";
 import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
 import type { FinalizeHookInput, FinalizeHookResult } from "../operations/open-workspace";
@@ -28,10 +33,16 @@ import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
 import type { DeleteHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
 import { SETUP_OPERATION_ID } from "../operations/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
 import { urlForWorkspace, urlForFolder } from "../../services/code-server/code-server-manager";
+import {
+  CODE_SERVER_VERSION,
+  getCodeServerUrlForVersion,
+  getCodeServerExecutablePath,
+} from "../../services/code-server/setup-info";
 import { Path } from "../../services/platform/path";
 import { SetupError, getErrorMessage } from "../../services/errors";
 
@@ -51,15 +62,22 @@ export interface CodeServerModuleDeps {
     | "port"
     | "getConfig"
     | "setPluginPort"
+    | "setCodeServerVersion"
     | "stop"
   >;
-  readonly extensionManager: Pick<ExtensionManager, "preflight" | "install" | "cleanOutdated">;
+  readonly extensionManager: Pick<
+    ExtensionManager,
+    "preflight" | "install" | "cleanOutdated" | "setCodeServerBinaryPath"
+  >;
   readonly pluginServer: Pick<
     PluginServer,
     "start" | "close" | "setWorkspaceConfig" | "removeWorkspaceConfig"
   > | null;
   readonly fileSystemLayer: Pick<FileSystemLayer, "mkdir">;
   readonly workspaceFileService: IWorkspaceFileService;
+  readonly pathProvider: Pick<PathProvider, "getBinaryDir">;
+  readonly platform: SupportedPlatform;
+  readonly arch: SupportedArch;
   readonly wrapperPath: string;
   readonly logger: Logger;
 }
@@ -343,6 +361,29 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             }
           },
         },
+      },
+    },
+    events: {
+      [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
+        const { values } = (event as ConfigUpdatedEvent).payload;
+        if (values["version.code-server"] !== undefined) {
+          const version = (values["version.code-server"] as string | null) ?? CODE_SERVER_VERSION;
+          const codeServerDir = deps.pathProvider.getBinaryDir("code-server", version);
+          const execPath = getCodeServerExecutablePath(deps.platform);
+          const binaryPath = new Path(codeServerDir, execPath).toNative();
+          const downloadRequest: DownloadRequest = {
+            name: "code-server",
+            url: getCodeServerUrlForVersion(version, deps.platform, deps.arch),
+            destDir: codeServerDir.toNative(),
+            executablePath: execPath,
+          };
+          codeServerManager.setCodeServerVersion(
+            binaryPath,
+            codeServerDir.toNative(),
+            downloadRequest
+          );
+          extensionManager.setCodeServerBinaryPath(binaryPath);
+        }
       },
     },
   };

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -601,6 +601,105 @@ describe("ConfigModule Integration", () => {
       expect(parsed["versions.codeServer"]).toBeUndefined();
       expect(parsed["telemetry.distinctId"]).toBeUndefined();
     });
+
+    it("converts legacy nested codeServer old default to null", async () => {
+      const legacyConfig = JSON.stringify({
+        agent: "claude",
+        versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+      });
+
+      const { dispatcher } = createTestSetup({ configFileContent: legacyConfig });
+
+      const events: ConfigUpdatedEvent[] = [];
+      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      // "4.107.0" becomes null (= default), so version.code-server should NOT be in changed values
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values["version.code-server"]).toBeUndefined();
+    });
+
+    it("preserves legacy nested codeServer explicit override", async () => {
+      const legacyConfig = JSON.stringify({
+        agent: "claude",
+        versions: { claude: null, opencode: null, codeServer: "4.150.0" },
+      });
+
+      const { dispatcher } = createTestSetup({ configFileContent: legacyConfig });
+
+      const events: ConfigUpdatedEvent[] = [];
+      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values["version.code-server"]).toBe("4.150.0");
+    });
+
+    it("converts old flat versions.codeServer old default to null", async () => {
+      const oldFlatConfig = JSON.stringify({
+        agent: "claude",
+        "versions.codeServer": "4.107.0",
+      });
+
+      const { dispatcher, fileSystem } = createTestSetup({ configFileContent: oldFlatConfig });
+
+      const events: ConfigUpdatedEvent[] = [];
+      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      // "4.107.0" becomes null (= default), so not in changed values
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values["version.code-server"]).toBeUndefined();
+
+      // Migrated file should have null
+      const content = await fileSystem.readFile(CONFIG_PATH);
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      expect(parsed["version.code-server"]).toBeNull();
+    });
+
+    it("preserves old flat versions.codeServer explicit override", async () => {
+      const oldFlatConfig = JSON.stringify({
+        agent: "claude",
+        "versions.codeServer": "4.200.0",
+      });
+
+      const { dispatcher, fileSystem } = createTestSetup({ configFileContent: oldFlatConfig });
+
+      const events: ConfigUpdatedEvent[] = [];
+      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values["version.code-server"]).toBe("4.200.0");
+
+      const content = await fileSystem.readFile(CONFIG_PATH);
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      expect(parsed["version.code-server"]).toBe("4.200.0");
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -152,6 +152,12 @@ const KEY_RENAMES: ReadonlyMap<string, ConfigKey> = new Map([
 ]);
 
 /**
+ * Old stale default for version.code-server. During migration, this value
+ * is converted to null (= use built-in CODE_SERVER_VERSION).
+ */
+const OLD_CODE_SERVER_DEFAULT = "4.107.0";
+
+/**
  * Legacy nested config format (pre-migration).
  */
 interface LegacyConfig {
@@ -200,7 +206,10 @@ function parseConfigFile(data: unknown): {
       if (legacy.versions.opencode !== undefined)
         result["version.opencode"] = legacy.versions.opencode;
       if (legacy.versions.codeServer !== undefined)
-        result["version.code-server"] = legacy.versions.codeServer;
+        result["version.code-server"] =
+          legacy.versions.codeServer === OLD_CODE_SERVER_DEFAULT
+            ? null
+            : legacy.versions.codeServer;
     }
     if (legacy.telemetry) {
       if (legacy.telemetry.enabled !== undefined)
@@ -216,7 +225,8 @@ function parseConfigFile(data: unknown): {
   for (const [key, value] of Object.entries(obj)) {
     const renamedKey = KEY_RENAMES.get(key);
     if (renamedKey !== undefined) {
-      result[renamedKey] = value;
+      result[renamedKey] =
+        renamedKey === "version.code-server" && value === OLD_CODE_SERVER_DEFAULT ? null : value;
       migrated = true;
     } else if (CONFIG_KEYS.has(key as ConfigKey)) {
       result[key] = value;

--- a/src/services/binary-resolution/binary-resolution-service.integration.test.ts
+++ b/src/services/binary-resolution/binary-resolution-service.integration.test.ts
@@ -274,8 +274,8 @@ describe("BinaryResolutionService", () => {
       // Set up downloaded code-server
       const bundlesRoot = pathProvider.getBinaryBaseDir("code-server").dirname;
       const baseDir = `${bundlesRoot.toString()}/code-server`;
-      fileSystem.$.setEntry(`${baseDir}/4.107.0`, directory());
-      fileSystem.$.setEntry(`${baseDir}/4.107.0/bin/code-server`, file("binary"));
+      fileSystem.$.setEntry(`${baseDir}/4.109.2`, directory());
+      fileSystem.$.setEntry(`${baseDir}/4.109.2/bin/code-server`, file("binary"));
 
       const service = createService();
       const result = await service.resolve("code-server");

--- a/src/services/code-server/code-server-manager.integration.test.ts
+++ b/src/services/code-server/code-server-manager.integration.test.ts
@@ -529,4 +529,57 @@ describe("CodeServerManager Integration", () => {
       await expect(manager.downloadBinary()).rejects.toThrow("Failed to download code-server");
     });
   });
+
+  describe("setCodeServerVersion", () => {
+    it("updates binaryPath, codeServerDir, and download request", async () => {
+      const processRunner = createMockProcessRunner({
+        onSpawn: () => ({ pid: 12345, running: true }),
+      });
+      const httpClient = createMockHttpClient({ defaultResponse: { status: 200 } });
+      const portManager = createPortManagerMock([8080]);
+      const binaryService: BinaryDownloadService = {
+        isInstalled: vi.fn().mockResolvedValue(true),
+        download: vi.fn(),
+      };
+      const originalRequest: DownloadRequest = {
+        name: "code-server",
+        url: "https://example.com/old.tar.gz",
+        destDir: "/old/dir",
+        executablePath: "bin/code-server",
+      };
+      const config = {
+        port: CODE_SERVER_PORT,
+        binaryPath: "/old/binary",
+        runtimeDir: "/tmp/runtime",
+        extensionsDir: "/tmp/extensions",
+        userDataDir: "/tmp/user-data",
+        binDir: "/app/bin",
+        codeServerDir: "/old/dir",
+        opencodeDir: "/app/opencode-dir",
+      };
+      const manager = new CodeServerManager(
+        config,
+        processRunner,
+        httpClient,
+        portManager,
+        testLogger,
+        { service: binaryService, request: originalRequest }
+      );
+
+      const newRequest: DownloadRequest = {
+        name: "code-server",
+        url: "https://example.com/new.tar.gz",
+        destDir: "/new/dir",
+        executablePath: "bin/code-server",
+      };
+      manager.setCodeServerVersion("/new/binary", "/new/dir", newRequest);
+
+      expect(manager.getConfig().binaryPath).toBe("/new/binary");
+      expect(manager.getConfig().codeServerDir).toBe("/new/dir");
+
+      // Verify download uses new request by triggering preflight
+      await manager.preflight();
+      expect(binaryService.isInstalled).toHaveBeenCalledWith("/new/dir");
+    });
+  });
 });

--- a/src/services/code-server/code-server-manager.ts
+++ b/src/services/code-server/code-server-manager.ts
@@ -148,7 +148,7 @@ export class CodeServerManager {
   private readonly httpClient: HttpClient;
   private readonly portManager: PortManager;
   private readonly logger: Logger;
-  private readonly binaryDownload: {
+  private binaryDownload: {
     service: BinaryDownloadService;
     request: DownloadRequest;
   } | null;
@@ -302,6 +302,26 @@ export class CodeServerManager {
    */
   setPluginPort(port: number): void {
     (this.config as { pluginPort?: number }).pluginPort = port;
+  }
+
+  /**
+   * Override the code-server version paths.
+   * Must be called before ensureRunning() to take effect.
+   *
+   * @param binaryPath - Absolute path to the code-server binary
+   * @param codeServerDir - Absolute path to the code-server directory
+   * @param downloadRequest - Updated download request for the new version
+   */
+  setCodeServerVersion(
+    binaryPath: string,
+    codeServerDir: string,
+    downloadRequest: DownloadRequest
+  ): void {
+    (this.config as { binaryPath: string }).binaryPath = binaryPath;
+    (this.config as { codeServerDir: string }).codeServerDir = codeServerDir;
+    if (this.binaryDownload) {
+      this.binaryDownload = { ...this.binaryDownload, request: downloadRequest };
+    }
   }
 
   /**

--- a/src/services/code-server/setup-info.test.ts
+++ b/src/services/code-server/setup-info.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { CODE_SERVER_VERSION, getCodeServerUrl, getCodeServerExecutablePath } from "./setup-info";
+import {
+  CODE_SERVER_VERSION,
+  getCodeServerUrl,
+  getCodeServerUrlForVersion,
+  getCodeServerExecutablePath,
+} from "./setup-info";
 
 describe("CODE_SERVER_VERSION", () => {
   it("is a valid semver string", () => {
@@ -49,6 +54,34 @@ describe("getCodeServerUrl", () => {
 
   it("throws on win32-arm64", () => {
     expect(() => getCodeServerUrl("win32", "arm64")).toThrow(
+      "Windows code-server builds only support x64"
+    );
+  });
+});
+
+describe("getCodeServerUrlForVersion", () => {
+  it("generates URL with explicit version for linux-x64", () => {
+    const url = getCodeServerUrlForVersion("4.200.0", "linux", "x64");
+    expect(url).toBe(
+      "https://github.com/coder/code-server/releases/download/v4.200.0/code-server-4.200.0-linux-amd64.tar.gz"
+    );
+  });
+
+  it("generates URL with explicit version for win32-x64", () => {
+    const url = getCodeServerUrlForVersion("4.200.0", "win32", "x64");
+    expect(url).toBe(
+      "https://github.com/stefanhoelzl/codehydra/releases/download/code-server-windows-v4.200.0/code-server-4.200.0-win32-x64.tar.gz"
+    );
+  });
+
+  it("delegates correctly when called with CODE_SERVER_VERSION", () => {
+    const direct = getCodeServerUrlForVersion(CODE_SERVER_VERSION, "linux", "arm64");
+    const wrapper = getCodeServerUrl("linux", "arm64");
+    expect(direct).toBe(wrapper);
+  });
+
+  it("throws on win32-arm64", () => {
+    expect(() => getCodeServerUrlForVersion("4.200.0", "win32", "arm64")).toThrow(
       "Windows code-server builds only support x64"
     );
   });

--- a/src/services/code-server/setup-info.ts
+++ b/src/services/code-server/setup-info.ts
@@ -25,7 +25,32 @@ const CODE_SERVER_ARCH = {
 } as const;
 
 /**
- * Get the download URL for code-server.
+ * Get the download URL for a specific code-server version.
+ *
+ * @param version - Code-server version string
+ * @param platform - Operating system platform
+ * @param arch - CPU architecture
+ * @returns Download URL for the code-server release
+ * @throws Error if platform/arch combination is not supported
+ */
+export function getCodeServerUrlForVersion(
+  version: string,
+  platform: SupportedPlatform,
+  arch: SupportedArch
+): string {
+  if (platform === "win32") {
+    if (arch !== "x64") {
+      throw new Error(`Windows code-server builds only support x64, got: ${arch}`);
+    }
+    return `https://github.com/${CODEHYDRA_REPO}/releases/download/code-server-windows-v${version}/code-server-${version}-win32-x64.tar.gz`;
+  }
+  const os = platform === "darwin" ? "macos" : "linux";
+  const archName = CODE_SERVER_ARCH[arch];
+  return `https://github.com/coder/code-server/releases/download/v${version}/code-server-${version}-${os}-${archName}.tar.gz`;
+}
+
+/**
+ * Get the download URL for code-server using the built-in version.
  *
  * @param platform - Operating system platform
  * @param arch - CPU architecture
@@ -33,15 +58,7 @@ const CODE_SERVER_ARCH = {
  * @throws Error if platform/arch combination is not supported
  */
 export function getCodeServerUrl(platform: SupportedPlatform, arch: SupportedArch): string {
-  if (platform === "win32") {
-    if (arch !== "x64") {
-      throw new Error(`Windows code-server builds only support x64, got: ${arch}`);
-    }
-    return `https://github.com/${CODEHYDRA_REPO}/releases/download/code-server-windows-v${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION}-win32-x64.tar.gz`;
-  }
-  const os = platform === "darwin" ? "macos" : "linux";
-  const archName = CODE_SERVER_ARCH[arch];
-  return `https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION}-${os}-${archName}.tar.gz`;
+  return getCodeServerUrlForVersion(CODE_SERVER_VERSION, platform, arch);
 }
 
 /**

--- a/src/services/config/config-service.integration.test.ts
+++ b/src/services/config/config-service.integration.test.ts
@@ -69,7 +69,7 @@ describe("ConfigService", () => {
         versions: {
           claude: "1.0.58",
           opencode: null,
-          codeServer: "4.107.0",
+          codeServer: null,
         },
       };
       fileSystem.$.setEntry(
@@ -130,7 +130,7 @@ describe("ConfigService", () => {
         versions: {
           claude: null,
           opencode: "1.0.223",
-          codeServer: "4.107.0",
+          codeServer: null,
         },
       };
 
@@ -203,7 +203,7 @@ describe("ConfigService", () => {
         versions: {
           claude: null,
           opencode: null,
-          codeServer: "4.107.0",
+          codeServer: null,
         },
       };
       fileSystem.$.setEntry(

--- a/src/services/config/config-service.ts
+++ b/src/services/config/config-service.ts
@@ -138,8 +138,8 @@ export class ConfigService {
       return null;
     }
 
-    // codeServer must be string
-    if (typeof versions.codeServer !== "string") {
+    // codeServer must be string or null
+    if (versions.codeServer !== null && typeof versions.codeServer !== "string") {
       return null;
     }
 
@@ -167,7 +167,7 @@ export class ConfigService {
       versions: {
         claude: versions.claude as string | null,
         opencode: versions.opencode as string | null,
-        codeServer: versions.codeServer as string,
+        codeServer: versions.codeServer as string | null,
       },
       ...(telemetry !== undefined && { telemetry }),
     };

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -74,10 +74,10 @@ export const CONFIG = {
     parse: (s) => (s === "" ? null : s),
     validate: (v) => (v === null || typeof v === "string" ? v : undefined),
   }),
-  "version.code-server": key<string>({
-    default: "4.107.0",
-    parse: (s) => (s.length > 0 ? s : undefined),
-    validate: (v) => (typeof v === "string" ? v : undefined),
+  "version.code-server": key<string | null>({
+    default: null,
+    parse: (s) => (s === "" ? null : s),
+    validate: (v) => (v === null || typeof v === "string" ? v : undefined),
   }),
   "telemetry.enabled": key<boolean>({
     default: true,

--- a/src/services/config/types.ts
+++ b/src/services/config/types.ts
@@ -21,8 +21,8 @@ export interface VersionConfig {
   readonly claude: string | null;
   /** OpenCode agent version (null = prefer system, download latest if needed) */
   readonly opencode: string | null;
-  /** code-server version (pinned, always download exact version) */
-  readonly codeServer: string;
+  /** code-server version override (null = use built-in version) */
+  readonly codeServer: string | null;
 }
 
 /**
@@ -56,7 +56,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   versions: {
     claude: null,
     opencode: null,
-    codeServer: "4.107.0",
+    codeServer: null,
   },
   telemetry: {
     enabled: true,

--- a/src/services/vscode-setup/extension-manager.integration.test.ts
+++ b/src/services/vscode-setup/extension-manager.integration.test.ts
@@ -312,4 +312,30 @@ describe("ExtensionManager", () => {
       );
     });
   });
+
+  describe("setCodeServerBinaryPath", () => {
+    it("uses updated binary path for subsequent installs", async () => {
+      const pathProvider = createMockPathProvider();
+      const fs = createMockFileSystem({ installedExtensions: new Map() });
+      const processRunner = createMockProcessRunner();
+
+      const manager = new ExtensionManager(
+        pathProvider,
+        fs,
+        processRunner,
+        TEST_CODE_SERVER_BINARY_PATH
+      );
+
+      // Override the binary path
+      manager.setCodeServerBinaryPath("/new/code-server/bin/code-server");
+
+      await manager.install(["codehydra.sidekick"]);
+
+      // Verify the new binary path was used for installation
+      expect(processRunner.run).toHaveBeenCalledWith(
+        "/new/code-server/bin/code-server",
+        expect.arrayContaining(["--install-extension"])
+      );
+    });
+  });
 });

--- a/src/services/vscode-setup/extension-manager.ts
+++ b/src/services/vscode-setup/extension-manager.ts
@@ -56,10 +56,18 @@ export class ExtensionManager {
     private readonly pathProvider: PathProvider,
     private readonly fileSystem: FileSystemLayer,
     private readonly processRunner: ProcessRunner,
-    private readonly codeServerBinaryPath: string,
+    private codeServerBinaryPath: string,
     private readonly logger?: Logger
   ) {
     this.assetsDir = pathProvider.vscodeAssetsDir;
+  }
+
+  /**
+   * Override the code-server binary path.
+   * Must be called before install() to take effect.
+   */
+  setCodeServerBinaryPath(path: string): void {
+    this.codeServerBinaryPath = path;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Changed `version.code-server` config default from `"4.107.0"` to `null` (null = use built-in `CODE_SERVER_VERSION`)
- Added `config:updated` event handler in code-server module that propagates version override to `CodeServerManager` and `ExtensionManager` via new setter methods
- Extracted `getCodeServerUrlForVersion()` from `setup-info.ts` to support generating download URLs for arbitrary versions
- Added config migration: legacy `"4.107.0"` default converts to `null` during migration (explicit overrides preserved)

## Test plan
- [x] `pnpm validate:fix` passes (all 3744 tests, lint, types, build)
- [ ] Manual: `pnpm preview -- --version.code-server=4.108.2` uses overridden version paths
- [ ] Manual: no `version.code-server` in config.json uses built-in version

🤖 Generated with [Claude Code](https://claude.com/claude-code)