### PR TITLE
refactor(test): parameterize repetitive tests with it.each

### DIFF
--- a/src/agents/claude/server-manager.integration.test.ts
+++ b/src/agents/claude/server-manager.integration.test.ts
@@ -225,100 +225,87 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChangesB).toEqual(["busy"]);
     });
 
-    it("WrapperStart -> idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
+    it.each([
+      {
+        hookName: "WrapperStart",
+        setupHooks: [] as string[],
+        extraPayload: {},
+        expectedChanges: ["idle"],
+        finalStatus: "idle",
+      },
+      {
+        hookName: "WrapperEnd",
+        setupHooks: ["SessionStart"],
+        extraPayload: {},
+        expectedChanges: ["idle", "none"],
+        finalStatus: "none",
+      },
+      {
+        hookName: "SessionStart",
+        setupHooks: [] as string[],
+        extraPayload: { session_id: "test-session" },
+        expectedChanges: ["idle"],
+        finalStatus: "idle",
+      },
+      {
+        hookName: "UserPromptSubmit",
+        setupHooks: ["SessionStart"],
+        extraPayload: {},
+        expectedChanges: ["idle", "busy"],
+        finalStatus: "busy",
+      },
+      {
+        hookName: "PermissionRequest",
+        setupHooks: ["SessionStart", "UserPromptSubmit"],
+        extraPayload: {},
+        expectedChanges: ["idle", "busy", "idle"],
+        finalStatus: "idle",
+      },
+      {
+        hookName: "PreCompact",
+        setupHooks: ["SessionStart"],
+        extraPayload: {},
+        expectedChanges: ["idle", "busy"],
+        finalStatus: "busy",
+      },
+      {
+        hookName: "Stop",
+        setupHooks: ["SessionStart", "UserPromptSubmit"],
+        extraPayload: {},
+        expectedChanges: ["idle", "busy", "idle"],
+        finalStatus: "idle",
+      },
+      {
+        hookName: "SessionEnd",
+        setupHooks: ["SessionStart"],
+        extraPayload: {},
+        expectedChanges: ["idle", "none"],
+        finalStatus: "none",
+      },
+    ])(
+      "$hookName -> $finalStatus",
+      async ({ hookName, setupHooks, extraPayload, expectedChanges, finalStatus }) => {
+        const port = await serverManager.startServer("/workspace/feature-a");
+        const statusChanges: AgentStatus[] = [];
+        serverManager.onStatusChange("/workspace/feature-a", (status) => {
+          statusChanges.push(status);
+        });
 
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+        for (const hook of setupHooks) {
+          await sendHook(port, hook, { workspacePath: "/workspace/feature-a" });
+        }
+        await sendHook(port, hookName, {
+          workspacePath: "/workspace/feature-a",
+          ...extraPayload,
+        });
 
-      expect(statusChanges).toEqual(["idle"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
-    });
-
-    it("WrapperEnd -> none", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Start session first
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      // Then wrapper ends (Claude closed)
-      await sendHook(port, "WrapperEnd", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "none"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("none");
-    });
-
-    it("SessionStart -> idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", {
-        workspacePath: "/workspace/feature-a",
-        session_id: "test-session",
-      });
-
-      expect(statusChanges).toEqual(["idle"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
-      expect(serverManager.getSessionId("/workspace/feature-a")).toBe("test-session");
-    });
-
-    it("UserPromptSubmit -> busy", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // First make idle
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      // Then submit prompt
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "busy"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
-    });
-
-    it("PermissionRequest -> idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Start session and make busy
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      // Permission request while busy
-      await sendHook(port, "PermissionRequest", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
-    });
-
-    it("PreCompact -> busy", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Start session (idle)
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      // Compaction starts
-      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "busy"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
-    });
+        expect(statusChanges).toEqual(expectedChanges);
+        expect(serverManager.getStatus("/workspace/feature-a")).toBe(finalStatus);
+        if (hookName === "SessionStart") {
+          expect(serverManager.getSessionId("/workspace/feature-a")).toBe("test-session");
+        }
+      }
+    );
 
     it("SessionStart during automatic compaction stays busy", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
@@ -402,37 +389,6 @@ describe("ClaudeCodeServerManager integration", () => {
 
       expect(statusChanges).toEqual(["idle", "busy", "none", "idle"]);
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
-    });
-
-    it("Stop -> idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Start session and make busy
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      // Stop
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
-    });
-
-    it("SessionEnd -> none", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Start and end session
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SessionEnd", { workspacePath: "/workspace/feature-a" });
-
-      expect(statusChanges).toEqual(["idle", "none"]);
-      expect(serverManager.getStatus("/workspace/feature-a")).toBe("none");
     });
 
     it("PreToolUse does not change status without prior PermissionRequest", async () => {

--- a/src/main/modules/opencode-agent-module.integration.test.ts
+++ b/src/main/modules/opencode-agent-module.integration.test.ts
@@ -790,25 +790,6 @@ describe("OpenCodeAgentModule Integration", () => {
         })
       );
     });
-
-    it("returns undefined when inactive", async () => {
-      const setup = createTestSetup();
-      await activateModule(setup, "claude");
-
-      setup.dispatcher.registerOperation("workspace:open", new MinimalSetupOperation());
-
-      const result = (await setup.dispatcher.dispatch({
-        type: "workspace:open",
-        payload: {
-          projectId: "test-12345678",
-          workspaceName: "feature-1",
-          base: "main",
-        },
-      } as OpenWorkspaceIntent)) as SetupHookResult | undefined;
-
-      expect(result).toBeUndefined();
-      expect(setup.serverManager.startServer).not.toHaveBeenCalled();
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -837,26 +818,6 @@ describe("OpenCodeAgentModule Integration", () => {
       expect(setup.agentStatusManager.clearTuiTracking).toHaveBeenCalled();
       expect(result).toBeDefined();
       expect(result!.serverName).toBe("OpenCode");
-    });
-
-    it("returns undefined when inactive", async () => {
-      const setup = createTestSetup();
-      await activateModule(setup, "claude");
-
-      setup.dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
-
-      const result = (await setup.dispatcher.dispatch({
-        type: "workspace:delete",
-        payload: {
-          workspacePath: "/test/path",
-          keepBranch: false,
-          force: false,
-          removeWorktree: true,
-        },
-      } as DeleteWorkspaceIntent)) as ShutdownHookResult | undefined;
-
-      expect(result).toBeUndefined();
-      expect(setup.serverManager.stopServer).not.toHaveBeenCalled();
     });
 
     it("includes error when stopServer fails", async () => {
@@ -908,20 +869,6 @@ describe("OpenCodeAgentModule Integration", () => {
       expect(result).toBeDefined();
       expect(result!.agentStatus).toEqual({ status: "idle", counts: { idle: 1, busy: 0 } });
     });
-
-    it("returns undefined when inactive", async () => {
-      const setup = createTestSetup();
-      await activateModule(setup, "claude");
-
-      setup.dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
-
-      const result = (await setup.dispatcher.dispatch({
-        type: "workspace:get-status",
-        payload: { workspacePath: "/test/path" },
-      })) as GetStatusHookResult | undefined;
-
-      expect(result).toBeUndefined();
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -947,20 +894,6 @@ describe("OpenCodeAgentModule Integration", () => {
       expect(result).toBeDefined();
       expect(result!.session).toEqual({ port: 8080, sessionId: "sess-1" });
     });
-
-    it("returns undefined when inactive", async () => {
-      const setup = createTestSetup();
-      await activateModule(setup, "claude");
-
-      setup.dispatcher.registerOperation("agent:get-session", new MinimalGetSessionOperation());
-
-      const result = (await setup.dispatcher.dispatch({
-        type: "agent:get-session",
-        payload: { workspacePath: "/test/path" },
-      })) as GetAgentSessionHookResult | undefined;
-
-      expect(result).toBeUndefined();
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -985,20 +918,6 @@ describe("OpenCodeAgentModule Integration", () => {
       expect(result!.port).toBe(8081);
     });
 
-    it("returns undefined when inactive", async () => {
-      const setup = createTestSetup();
-      await activateModule(setup, "claude");
-
-      setup.dispatcher.registerOperation("agent:restart", new MinimalRestartOperation());
-
-      const result = (await setup.dispatcher.dispatch({
-        type: "agent:restart",
-        payload: { workspacePath: "/test/path" },
-      })) as RestartAgentHookResult | undefined;
-
-      expect(result).toBeUndefined();
-    });
-
     it("throws when restart fails", async () => {
       const setup = createTestSetup();
       await activateModule(setup, null);
@@ -1017,6 +936,68 @@ describe("OpenCodeAgentModule Integration", () => {
         })
       ).rejects.toThrow("server not running");
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // returns undefined when inactive (parameterized)
+  // ---------------------------------------------------------------------------
+
+  describe("returns undefined when inactive", () => {
+    it.each<{
+      intentType: string;
+      operation: () => Operation<Intent, unknown>;
+      payload: Record<string, unknown>;
+      notCalled?: "startServer" | "stopServer";
+    }>([
+      {
+        intentType: "workspace:open",
+        operation: () => new MinimalSetupOperation(),
+        payload: { projectId: "test-12345678", workspaceName: "feature-1", base: "main" },
+        notCalled: "startServer",
+      },
+      {
+        intentType: "workspace:delete",
+        operation: () => new MinimalShutdownOperation(),
+        payload: {
+          workspacePath: "/test/path",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+        notCalled: "stopServer",
+      },
+      {
+        intentType: "workspace:get-status",
+        operation: () => new MinimalGetStatusOperation(),
+        payload: { workspacePath: "/test/path" },
+      },
+      {
+        intentType: "agent:get-session",
+        operation: () => new MinimalGetSessionOperation(),
+        payload: { workspacePath: "/test/path" },
+      },
+      {
+        intentType: "agent:restart",
+        operation: () => new MinimalRestartOperation(),
+        payload: { workspacePath: "/test/path" },
+      },
+    ])(
+      "$intentType returns undefined when inactive",
+      async ({ intentType, operation, payload, notCalled }) => {
+        const setup = createTestSetup();
+        await activateModule(setup, "claude");
+        setup.dispatcher.registerOperation(intentType, operation());
+
+        const result = await setup.dispatcher.dispatch({ type: intentType, payload });
+
+        expect(result).toBeUndefined();
+        if (notCalled) {
+          expect(
+            setup.serverManager[notCalled as keyof typeof setup.serverManager]
+          ).not.toHaveBeenCalled();
+        }
+      }
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/src/main/modules/windows-file-lock-module.integration.test.ts
+++ b/src/main/modules/windows-file-lock-module.integration.test.ts
@@ -212,14 +212,6 @@ describe("WindowsFileLockModule Integration", () => {
       expect(handler.killProcesses).not.toHaveBeenCalled();
     });
 
-    it("is a no-op when handler is undefined", async () => {
-      const dispatcher = createReleaseSetup(undefined);
-
-      const result = await dispatcher.dispatch(makeDeleteIntent());
-
-      expect(result).toEqual({});
-    });
-
     it("swallows errors from detectCwd", async () => {
       handler.detectCwd.mockRejectedValue(new Error("powershell failed"));
       const dispatcher = createReleaseSetup(handler);
@@ -257,14 +249,6 @@ describe("WindowsFileLockModule Integration", () => {
       expect(warnings).toHaveLength(1);
       expect(warnings[0]!.message).toBe("Detection failed");
     });
-
-    it("is a no-op when handler is undefined", async () => {
-      const dispatcher = createDetectSetup(undefined);
-
-      const result = await dispatcher.dispatch(makeDeleteIntent());
-
-      expect(result).toEqual({});
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -289,14 +273,6 @@ describe("WindowsFileLockModule Integration", () => {
       expect(result.error).toBe("access denied");
     });
 
-    it("is a no-op when handler is undefined", async () => {
-      const dispatcher = createFlushSetup(undefined, [1234]);
-
-      const result = await dispatcher.dispatch(makeDeleteIntent());
-
-      expect(result).toEqual({});
-    });
-
     it("skips kill when blockingPids is empty", async () => {
       const dispatcher = createFlushSetup(handler, []);
 
@@ -304,5 +280,19 @@ describe("WindowsFileLockModule Integration", () => {
 
       expect(handler.killProcesses).not.toHaveBeenCalled();
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // no-op when handler is undefined (parameterized)
+  // ---------------------------------------------------------------------------
+
+  it.each([
+    { hook: "release", createSetup: () => createReleaseSetup(undefined) },
+    { hook: "detect", createSetup: () => createDetectSetup(undefined) },
+    { hook: "flush", createSetup: () => createFlushSetup(undefined, [1234]) },
+  ])("$hook is a no-op when handler is undefined", async ({ createSetup }) => {
+    const dispatcher = createSetup();
+    const result = await dispatcher.dispatch(makeDeleteIntent());
+    expect(result).toEqual({});
   });
 });

--- a/src/main/operations/app-start.integration.test.ts
+++ b/src/main/operations/app-start.integration.test.ts
@@ -791,17 +791,42 @@ describe("AppStart Operation", () => {
   // ===========================================================================
 
   describe("activate hook receives mcpPort from start results (#15)", () => {
-    it("passes mcpPort from MCP start handler to activate handlers", async () => {
+    it.each([
+      {
+        portName: "mcpPort" as const,
+        modules: (s: TestState) => [createCodeServerModule(s), createMcpModule(s)],
+        expected: 9090,
+        label: "passes mcpPort from MCP start handler to activate handlers",
+      },
+      {
+        portName: "mcpPort" as const,
+        modules: (s: TestState) => [createCodeServerModule(s)],
+        expected: null,
+        label: "passes null mcpPort when no start handler returns mcpPort",
+      },
+      {
+        portName: "codeServerPort" as const,
+        modules: (s: TestState) => [createCodeServerModule(s), createMcpModule(s)],
+        expected: 8080,
+        label: "passes codeServerPort from CodeServer start handler to activate handlers",
+      },
+      {
+        portName: "codeServerPort" as const,
+        modules: (s: TestState) => [createMcpModule(s)],
+        expected: null,
+        label: "passes null codeServerPort when no start handler returns codeServerPort",
+      },
+    ])("$label", async ({ portName, modules, expected }) => {
       const state = createTestState();
-      let receivedMcpPort: number | null | undefined;
+      let receivedPort: number | null | undefined;
 
-      const mcpPortReaderModule: IntentModule = {
+      const readerModule: IntentModule = {
         name: "test",
         hooks: {
           [APP_START_OPERATION_ID]: {
             activate: {
               handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
-                receivedMcpPort = (ctx as ActivateHookContext).mcpPort;
+                receivedPort = (ctx as ActivateHookContext)[portName];
                 return {};
               },
             },
@@ -809,94 +834,14 @@ describe("AppStart Operation", () => {
         },
       };
 
-      const { dispatcher } = createTestSetup([
-        createCodeServerModule(state),
-        createMcpModule(state),
-        mcpPortReaderModule,
-      ]);
-
+      const { dispatcher } = createTestSetup([...modules(state), readerModule]);
       await dispatcher.dispatch(appStartIntent());
 
-      expect(receivedMcpPort).toBe(9090);
-    });
-
-    it("passes null mcpPort when no start handler returns mcpPort", async () => {
-      const state = createTestState();
-      let receivedMcpPort: number | null | undefined;
-
-      const mcpPortReaderModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [APP_START_OPERATION_ID]: {
-            activate: {
-              handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
-                receivedMcpPort = (ctx as ActivateHookContext).mcpPort;
-                return {};
-              },
-            },
-          },
-        },
-      };
-
-      const { dispatcher } = createTestSetup([createCodeServerModule(state), mcpPortReaderModule]);
-
-      await dispatcher.dispatch(appStartIntent());
-
-      expect(receivedMcpPort).toBeNull();
-    });
-
-    it("passes codeServerPort from CodeServer start handler to activate handlers", async () => {
-      const state = createTestState();
-      let receivedCodeServerPort: number | null | undefined;
-
-      const portReaderModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [APP_START_OPERATION_ID]: {
-            activate: {
-              handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
-                receivedCodeServerPort = (ctx as ActivateHookContext).codeServerPort;
-                return {};
-              },
-            },
-          },
-        },
-      };
-
-      const { dispatcher } = createTestSetup([
-        createCodeServerModule(state),
-        createMcpModule(state),
-        portReaderModule,
-      ]);
-
-      await dispatcher.dispatch(appStartIntent());
-
-      expect(receivedCodeServerPort).toBe(8080);
-    });
-
-    it("passes null codeServerPort when no start handler returns codeServerPort", async () => {
-      const state = createTestState();
-      let receivedCodeServerPort: number | null | undefined;
-
-      const portReaderModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [APP_START_OPERATION_ID]: {
-            activate: {
-              handler: async (ctx: HookContext): Promise<ActivateHookResult> => {
-                receivedCodeServerPort = (ctx as ActivateHookContext).codeServerPort;
-                return {};
-              },
-            },
-          },
-        },
-      };
-
-      const { dispatcher } = createTestSetup([createMcpModule(state), portReaderModule]);
-
-      await dispatcher.dispatch(appStartIntent());
-
-      expect(receivedCodeServerPort).toBeNull();
+      if (expected === null) {
+        expect(receivedPort).toBeNull();
+      } else {
+        expect(receivedPort).toBe(expected);
+      }
     });
   });
 


### PR DESCRIPTION
- Replace 3 identical no-op tests in windows-file-lock-module with `it.each`
- Replace 5 identical "returns undefined when inactive" tests in opencode-agent-module with `it.each`
- Replace 8 hook-to-status mapping tests in server-manager with `it.each`
- Replace 4 port-passing tests in app-start with `it.each`

Net reduction: 133 lines removed while preserving identical test coverage and descriptive test names.