### PR TITLE
chore(test): extract shared mock factories for WindowManager and ApiRegistry

### DIFF
--- a/src/main/managers/badge-manager.integration.test.ts
+++ b/src/main/managers/badge-manager.integration.test.ts
@@ -11,25 +11,7 @@ import {
   type MockImageLayer,
 } from "../../services/platform/image.state-mock";
 import type { WindowManager } from "./window-manager";
-import type { ImageHandle } from "../../services/platform/types";
-
-/**
- * Mock WindowManager for BadgeManager testing.
- */
-interface MockWindowManager {
-  setOverlayIcon: (image: ImageHandle | null, description: string) => void;
-  setOverlayIconCalls: Array<{ image: ImageHandle | null; description: string }>;
-}
-
-function createMockWindowManager(): MockWindowManager {
-  const setOverlayIconCalls: Array<{ image: ImageHandle | null; description: string }> = [];
-  return {
-    setOverlayIcon: (image: ImageHandle | null, description: string) => {
-      setOverlayIconCalls.push({ image, description });
-    },
-    setOverlayIconCalls,
-  };
-}
+import { createMockWindowManager, type MockWindowManager } from "./window-manager.test-utils";
 
 describe("BadgeManager", () => {
   let appLayer: MockAppLayer;
@@ -110,8 +92,8 @@ describe("BadgeManager", () => {
       manager.updateBadge("all-working");
 
       expect(imageLayer).toHaveImages([{ id: "image-1" }]);
-      expect(windowManager.setOverlayIconCalls).toHaveLength(1);
-      expect(windowManager.setOverlayIconCalls[0]?.description).toBe("All workspaces working");
+      expect(windowManager.getOverlayIconCalls()).toHaveLength(1);
+      expect(windowManager.getOverlayIconCalls()[0]?.description).toBe("All workspaces working");
     });
 
     it("generates image for mixed state", () => {
@@ -128,8 +110,8 @@ describe("BadgeManager", () => {
       manager.updateBadge("mixed");
 
       expect(imageLayer).toHaveImages([{ id: "image-1" }]);
-      expect(windowManager.setOverlayIconCalls).toHaveLength(1);
-      expect(windowManager.setOverlayIconCalls[0]?.description).toBe("Some workspaces ready");
+      expect(windowManager.getOverlayIconCalls()).toHaveLength(1);
+      expect(windowManager.getOverlayIconCalls()[0]?.description).toBe("Some workspaces ready");
     });
 
     it("clears overlay for none state", () => {
@@ -146,33 +128,28 @@ describe("BadgeManager", () => {
       manager.updateBadge("none");
 
       expect(imageLayer).toHaveImages([]);
-      expect(windowManager.setOverlayIconCalls).toHaveLength(1);
-      expect(windowManager.setOverlayIconCalls[0]?.image).toBeNull();
-      expect(windowManager.setOverlayIconCalls[0]?.description).toBe("");
+      expect(windowManager.getOverlayIconCalls()).toHaveLength(1);
+      expect(windowManager.getOverlayIconCalls()[0]?.image).toBeNull();
+      expect(windowManager.getOverlayIconCalls()[0]?.description).toBe("");
     });
 
     it("creates image in shared ImageLayer that WindowLayer would use for lookup", () => {
       const platformInfo = createMockPlatformInfo({ platform: "win32" });
       appLayer = createAppLayerMock({ platform: "win32" });
       const sharedImageLayer = createImageLayerMock();
-
-      let capturedImageHandle: ImageHandle | null = null;
-      const mockWindowManager = {
-        setOverlayIcon: (image: ImageHandle | null) => {
-          capturedImageHandle = image;
-        },
-      };
+      const mockWm = createMockWindowManager();
 
       const manager = new BadgeManager(
         platformInfo,
         appLayer,
         sharedImageLayer,
-        mockWindowManager as unknown as WindowManager,
+        mockWm as unknown as WindowManager,
         SILENT_LOGGER
       );
 
       manager.updateBadge("all-working");
 
+      const capturedImageHandle = mockWm.getOverlayIconCalls()[0]?.image ?? null;
       expect(capturedImageHandle).not.toBeNull();
       expect(sharedImageLayer).toHaveImage(capturedImageHandle!.id, {
         isEmpty: false,
@@ -318,7 +295,7 @@ describe("BadgeManager", () => {
       manager.updateBadge("all-working");
 
       expect(imageLayer).toHaveImages([{ id: "image-1" }]);
-      expect(windowManager.setOverlayIconCalls).toHaveLength(3);
+      expect(windowManager.getOverlayIconCalls()).toHaveLength(3);
     });
 
     it("creates new images for different states", () => {
@@ -373,12 +350,12 @@ describe("BadgeManager", () => {
       );
 
       manager.updateBadge("all-working");
-      const callsAfterUpdate = windowManager.setOverlayIconCalls.length;
+      const callsAfterUpdate = windowManager.getOverlayIconCalls().length;
       expect(callsAfterUpdate).toBeGreaterThan(0);
 
       manager.dispose();
 
-      const lastCall = windowManager.setOverlayIconCalls.at(-1);
+      const lastCall = windowManager.getOverlayIconCalls().at(-1);
       expect(lastCall?.image).toBeNull();
     });
 

--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -21,6 +21,7 @@ import {
   type MockWindowLayerInternal,
 } from "../../services/shell/window.state-mock";
 import type { WindowHandle } from "../../services/shell/types";
+import { createMockWindowManager } from "./window-manager.test-utils";
 
 // Mock external-url
 const mockOpenExternal = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -28,17 +29,6 @@ const mockOpenExternal = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock("../utils/external-url", () => ({
   openExternal: mockOpenExternal,
 }));
-
-/**
- * Creates a mock WindowManager for testing.
- */
-function createMockWindowManager(windowHandle: WindowHandle) {
-  return {
-    getWindowHandle: vi.fn(() => windowHandle),
-    getBounds: vi.fn(() => ({ width: 1200, height: 800 })),
-    onResize: vi.fn(() => vi.fn()),
-  } as unknown as WindowManager;
-}
 
 /**
  * Creates a test window layer with a pre-created window for ViewManager tests.
@@ -72,7 +62,9 @@ function createViewManagerDeps(): ViewManagerDeps & {
   const windowLayer = createViewManagerWindowLayer();
   const viewLayer = createViewLayerMock();
   const sessionLayer = createSessionLayerMock();
-  const windowManager = createMockWindowManager(windowLayer._createdWindowHandle);
+  const windowManager = createMockWindowManager({
+    windowHandle: windowLayer._createdWindowHandle,
+  }) as unknown as WindowManager;
 
   return {
     windowManager,

--- a/src/main/managers/window-manager.test-utils.ts
+++ b/src/main/managers/window-manager.test-utils.ts
@@ -1,0 +1,83 @@
+/**
+ * Test utilities for WindowManager.
+ * Provides mock factory for consistent WindowManager mocking across test files.
+ */
+
+import { vi, type Mock } from "vitest";
+import type { WindowManager, ContentBounds, Unsubscribe } from "./window-manager";
+import type { WindowHandle } from "../../services/shell/types";
+import { createWindowHandle } from "../../services/shell/types";
+import type { ImageHandle } from "../../services/platform/types";
+
+/**
+ * Mock WindowManager with vitest spy methods.
+ * All method calls are recorded for assertion.
+ */
+export interface MockWindowManager {
+  create: Mock<WindowManager["create"]>;
+  getWindowHandle: Mock<WindowManager["getWindowHandle"]>;
+  getBounds: Mock<WindowManager["getBounds"]>;
+  onResize: Mock<WindowManager["onResize"]>;
+  maximizeAsync: Mock<WindowManager["maximizeAsync"]>;
+  setTitle: Mock<WindowManager["setTitle"]>;
+  setOverlayIcon: Mock<WindowManager["setOverlayIcon"]>;
+  close: Mock<WindowManager["close"]>;
+
+  /**
+   * Get all calls to setOverlayIcon with their arguments.
+   * Useful for badge-manager tests that need to inspect overlay icon state.
+   */
+  getOverlayIconCalls(): Array<{ image: ImageHandle | null; description: string }>;
+}
+
+/**
+ * Options for customizing the mock WindowManager.
+ */
+export interface MockWindowManagerOptions {
+  /** WindowHandle returned by getWindowHandle(). Defaults to createWindowHandle("test-window-1"). */
+  readonly windowHandle?: WindowHandle;
+  /** Bounds returned by getBounds(). Defaults to { width: 1200, height: 800 }. */
+  readonly bounds?: ContentBounds;
+}
+
+/**
+ * Create a mock WindowManager for testing.
+ *
+ * Omits the deprecated getWindow() method from the mock interface.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * const windowManager = createMockWindowManager();
+ * const badgeManager = new BadgeManager(..., windowManager as unknown as WindowManager, ...);
+ *
+ * // Custom window handle
+ * const windowManager = createMockWindowManager({ windowHandle: myHandle });
+ *
+ * // Assert overlay icon calls
+ * const calls = windowManager.getOverlayIconCalls();
+ * expect(calls[0]?.description).toBe("All workspaces working");
+ * ```
+ */
+export function createMockWindowManager(options?: MockWindowManagerOptions): MockWindowManager {
+  const windowHandle = options?.windowHandle ?? createWindowHandle("test-window-1");
+  const bounds = options?.bounds ?? { width: 1200, height: 800 };
+  const overlayIconCalls: Array<{ image: ImageHandle | null; description: string }> = [];
+
+  return {
+    create: vi.fn(),
+    getWindowHandle: vi.fn(() => windowHandle),
+    getBounds: vi.fn(() => bounds),
+    onResize: vi.fn((): Unsubscribe => vi.fn()),
+    maximizeAsync: vi.fn(async () => {}),
+    setTitle: vi.fn(),
+    setOverlayIcon: vi.fn((image: ImageHandle | null, description: string) => {
+      overlayIconCalls.push({ image, description });
+    }),
+    close: vi.fn(),
+
+    getOverlayIconCalls(): Array<{ image: ImageHandle | null; description: string }> {
+      return overlayIconCalls;
+    },
+  };
+}

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -65,7 +65,6 @@ import { createMinimalOperation } from "../intents/infrastructure/operation.test
 import { SetupOperation, INTENT_SETUP } from "../operations/setup";
 import type { SetupIntent } from "../operations/setup";
 import { createIpcEventBridge, type IpcEventBridgeDeps } from "./ipc-event-bridge";
-import type { IApiRegistry } from "../api/registry-types";
 import { ApiRegistry } from "../api/registry";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
@@ -75,39 +74,7 @@ import type { ICodeHydraApi } from "../../shared/api/interfaces";
 import { createMockLogger, SILENT_LOGGER } from "../../services/logging";
 import { createBehavioralIpcLayer } from "../../services/platform/ipc.test-utils";
 
-// =============================================================================
-// Mock ApiRegistry (behavioral mock with recorded events)
-// =============================================================================
-
-interface RecordedEvent {
-  readonly channel: string;
-  readonly data: unknown;
-}
-
-class MockApiRegistry {
-  readonly events: RecordedEvent[] = [];
-  readonly dispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-
-  emit(channel: string, data: unknown): void {
-    this.events.push({ channel, data });
-  }
-
-  register(): void {
-    // no-op
-  }
-
-  on(): () => void {
-    return () => {};
-  }
-
-  getInterface(): undefined {
-    return undefined;
-  }
-}
-
-function createMockApiRegistry(): MockApiRegistry {
-  return new MockApiRegistry();
-}
+import { createMockRegistry, type MockApiRegistry } from "../api/registry.test-utils";
 
 // =============================================================================
 // Minimal operations that emit events for testing
@@ -209,9 +176,9 @@ function createStatusTestSetup(): StatusTestSetup {
   dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  const mockApiRegistry = createMockApiRegistry();
+  const mockApiRegistry = createMockRegistry();
   const ipcEventBridge = createIpcEventBridge({
-    apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+    apiRegistry: mockApiRegistry,
     getApi: () => {
       throw new Error("not wired");
     },
@@ -279,12 +246,12 @@ function createLifecycleTestSetup(
   );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
-  const mockApiRegistry = createMockApiRegistry();
+  const mockApiRegistry = createMockRegistry();
   const mockApi = createMockApi();
   const mockPluginServer = createMockPluginServer();
 
   const ipcEventBridge = createIpcEventBridge({
-    apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+    apiRegistry: mockApiRegistry,
     getApi: () => mockApi,
     sendToUI: vi.fn<(channel: string, ...args: unknown[]) => void>(),
     pluginServer:
@@ -334,10 +301,10 @@ describe("IpcEventBridge - agent:status-updated", () => {
       const status: AggregatedAgentStatus = { status: "idle", counts: { idle: 2, busy: 0 } };
       await dispatcher.dispatch(updateStatusIntent(TEST_WORKSPACE_PATH, status));
 
-      expect(mockApiRegistry.events).toEqual([
+      expect(mockApiRegistry.getEmittedEvents()).toEqual([
         {
-          channel: "workspace:status-changed",
-          data: {
+          event: "workspace:status-changed",
+          payload: {
             projectId: TEST_PROJECT_ID,
             workspaceName: TEST_WORKSPACE_NAME,
             path: TEST_WORKSPACE_PATH,
@@ -358,10 +325,10 @@ describe("IpcEventBridge - agent:status-updated", () => {
       const status: AggregatedAgentStatus = { status: "busy", counts: { idle: 0, busy: 3 } };
       await dispatcher.dispatch(updateStatusIntent(TEST_WORKSPACE_PATH, status));
 
-      expect(mockApiRegistry.events).toEqual([
+      expect(mockApiRegistry.getEmittedEvents()).toEqual([
         {
-          channel: "workspace:status-changed",
-          data: {
+          event: "workspace:status-changed",
+          payload: {
             projectId: TEST_PROJECT_ID,
             workspaceName: TEST_WORKSPACE_NAME,
             path: TEST_WORKSPACE_PATH,
@@ -382,10 +349,10 @@ describe("IpcEventBridge - agent:status-updated", () => {
       const status: AggregatedAgentStatus = { status: "mixed", counts: { idle: 1, busy: 2 } };
       await dispatcher.dispatch(updateStatusIntent(TEST_WORKSPACE_PATH, status));
 
-      expect(mockApiRegistry.events).toEqual([
+      expect(mockApiRegistry.getEmittedEvents()).toEqual([
         {
-          channel: "workspace:status-changed",
-          data: {
+          event: "workspace:status-changed",
+          payload: {
             projectId: TEST_PROJECT_ID,
             workspaceName: TEST_WORKSPACE_NAME,
             path: TEST_WORKSPACE_PATH,
@@ -406,10 +373,10 @@ describe("IpcEventBridge - agent:status-updated", () => {
       const status: AggregatedAgentStatus = { status: "none", counts: { idle: 0, busy: 0 } };
       await dispatcher.dispatch(updateStatusIntent(TEST_WORKSPACE_PATH, status));
 
-      expect(mockApiRegistry.events).toEqual([
+      expect(mockApiRegistry.getEmittedEvents()).toEqual([
         {
-          channel: "workspace:status-changed",
-          data: {
+          event: "workspace:status-changed",
+          payload: {
             projectId: TEST_PROJECT_ID,
             workspaceName: TEST_WORKSPACE_NAME,
             path: TEST_WORKSPACE_PATH,
@@ -442,11 +409,13 @@ describe("IpcEventBridge - workspace:deleted", () => {
       },
     } as DeleteWorkspaceIntent);
 
-    const removedEvents = mockApiRegistry.events.filter((e) => e.channel === "workspace:removed");
+    const removedEvents = mockApiRegistry
+      .getEmittedEvents()
+      .filter((e) => e.event === "workspace:removed");
     expect(removedEvents).toEqual([
       {
-        channel: "workspace:removed",
-        data: {
+        event: "workspace:removed",
+        payload: {
           projectId: TEST_PROJECT_ID,
           workspaceName: TEST_WORKSPACE_NAME,
           path: TEST_WORKSPACE_PATH,
@@ -469,9 +438,9 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
 
   it("sends deletion progress to webContents via IPC", () => {
     const mockWebContents = createMockWebContents();
-    const mockApiRegistry = createMockApiRegistry();
+    const mockApiRegistry = createMockRegistry();
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("not wired");
       },
@@ -522,9 +491,9 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
   });
 
   it("ignores when sendToUI is a no-op", () => {
-    const mockApiRegistry = createMockApiRegistry();
+    const mockApiRegistry = createMockRegistry();
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("not wired");
       },
@@ -622,9 +591,9 @@ describe("IpcEventBridge - lifecycle", () => {
       );
       dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
-      const mockApiRegistry = createMockApiRegistry();
+      const mockApiRegistry = createMockRegistry();
       const ipcEventBridge = createIpcEventBridge({
-        apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+        apiRegistry: mockApiRegistry,
         getApi: () => mockApi,
         sendToUI: vi.fn<(channel: string, ...args: unknown[]) => void>(),
         pluginServer: null,
@@ -695,9 +664,9 @@ describe("IpcEventBridge - lifecycle", () => {
       );
       dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
-      const mockApiRegistry = createMockApiRegistry();
+      const mockApiRegistry = createMockRegistry();
       const ipcEventBridge = createIpcEventBridge({
-        apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+        apiRegistry: mockApiRegistry,
         getApi: () => mockApi,
         sendToUI: vi.fn<(channel: string, ...args: unknown[]) => void>(),
         pluginServer: null,
@@ -766,10 +735,10 @@ describe("IpcEventBridge - setup:error", () => {
 
     dispatcher.registerOperation(INTENT_SETUP, new SetupOperation());
 
-    const mockApiRegistry = createMockApiRegistry();
+    const mockApiRegistry = createMockRegistry();
     const mockWebContents = createMockWebContents();
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("getApi not available in setup-error test");
       },
@@ -832,10 +801,10 @@ describe("IpcEventBridge - setup:error", () => {
 
     dispatcher.registerOperation(INTENT_SETUP, new SetupOperation());
 
-    const mockApiRegistry = createMockApiRegistry();
+    const mockApiRegistry = createMockRegistry();
     const mockWebContents = createMockWebContents();
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("getApi not available in setup-error test");
       },

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -65,27 +65,7 @@ import type { HookContext } from "../intents/infrastructure/operation";
 const PROJECT_ROOT = new Path("/project");
 const WORKSPACES_DIR = new Path("/workspaces");
 
-// =============================================================================
-// Mock ApiRegistry for IpcEventBridge
-// =============================================================================
-
-interface MockApiRegistry {
-  emit: ReturnType<typeof vi.fn>;
-  register: ReturnType<typeof vi.fn>;
-  on: ReturnType<typeof vi.fn>;
-  getInterface: ReturnType<typeof vi.fn>;
-  dispose: ReturnType<typeof vi.fn>;
-}
-
-function createMockApiRegistry(): MockApiRegistry {
-  return {
-    emit: vi.fn(),
-    register: vi.fn(),
-    on: vi.fn().mockReturnValue(() => {}),
-    getInterface: vi.fn(),
-    dispose: vi.fn(),
-  };
-}
+import { createMockRegistry, type MockApiRegistry } from "../api/registry.test-utils";
 
 // =============================================================================
 // Test Setup Helper
@@ -209,9 +189,9 @@ function createTestSetup(): TestSetup {
   };
 
   // Wire IpcEventBridge
-  const mockApiRegistry = createMockApiRegistry();
+  const mockApiRegistry = createMockRegistry();
   const ipcEventBridge = createIpcEventBridge({
-    apiRegistry: mockApiRegistry as unknown as import("../api/registry-types").IApiRegistry,
+    apiRegistry: mockApiRegistry,
     getApi: () => {
       throw new Error("not wired");
     },

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -30,27 +30,7 @@ import { createIpcEventBridge } from "../modules/ipc-event-bridge";
 import type { UIMode } from "../../shared/ipc";
 import { SILENT_LOGGER } from "../../services/logging";
 
-// =============================================================================
-// Mock ApiRegistry for IpcEventBridge
-// =============================================================================
-
-interface MockApiRegistry {
-  emit: ReturnType<typeof vi.fn>;
-  register: ReturnType<typeof vi.fn>;
-  on: ReturnType<typeof vi.fn>;
-  getInterface: ReturnType<typeof vi.fn>;
-  dispose: ReturnType<typeof vi.fn>;
-}
-
-function createMockApiRegistry(): MockApiRegistry {
-  return {
-    emit: vi.fn(),
-    register: vi.fn(),
-    on: vi.fn().mockReturnValue(() => {}),
-    getInterface: vi.fn(),
-    dispose: vi.fn(),
-  };
-}
+import { createMockRegistry, type MockApiRegistry } from "../api/registry.test-utils";
 
 // =============================================================================
 // Behavioral Mocks
@@ -110,11 +90,11 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
   };
 
   // Optionally wire IpcEventBridge
-  const mockApiRegistry = createMockApiRegistry();
+  const mockApiRegistry = createMockRegistry();
   const modules: IntentModule[] = [setModeModule];
   if (opts?.withIpcEventBridge) {
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as import("../api/registry-types").IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("not wired");
       },

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -63,27 +63,7 @@ import type { UpdateAvailableIntent } from "./update-available";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 import { extractWorkspaceName } from "../../shared/api/id-utils";
 
-// =============================================================================
-// Mock ApiRegistry for IpcEventBridge
-// =============================================================================
-
-interface MockApiRegistry {
-  emit: ReturnType<typeof vi.fn>;
-  register: ReturnType<typeof vi.fn>;
-  on: ReturnType<typeof vi.fn>;
-  getInterface: ReturnType<typeof vi.fn>;
-  dispose: ReturnType<typeof vi.fn>;
-}
-
-function createMockApiRegistry(): MockApiRegistry {
-  return {
-    emit: vi.fn(),
-    register: vi.fn(),
-    on: vi.fn().mockReturnValue(() => {}),
-    getInterface: vi.fn(),
-    dispose: vi.fn(),
-  };
-}
+import { createMockRegistry, type MockApiRegistry } from "../api/registry.test-utils";
 
 // =============================================================================
 // Behavioral Mocks
@@ -293,7 +273,7 @@ function createTestSetup(opts?: {
     },
   };
 
-  const mockApiRegistry = createMockApiRegistry();
+  const mockApiRegistry = createMockRegistry();
   const modules: IntentModule[] = [resolveModule, resolveProjectModule, switchViewModule];
 
   if (opts?.withAutoSelect) {
@@ -344,7 +324,7 @@ function createTestSetup(opts?: {
 
   if (opts?.withIpcEventBridge) {
     const ipcEventBridge = createIpcEventBridge({
-      apiRegistry: mockApiRegistry as unknown as import("../api/registry-types").IApiRegistry,
+      apiRegistry: mockApiRegistry,
       getApi: () => {
         throw new Error("not wired");
       },


### PR DESCRIPTION
- Create shared `createMockWindowManager()` factory in `window-manager.test-utils.ts` with configurable options and `getOverlayIconCalls()` helper
- Migrate 3 test files (`badge-manager.test.ts`, `badge-manager.integration.test.ts`, `view-manager.integration.test.ts`) to use shared WindowManager mock
- Migrate 4 test files (`set-metadata`, `set-mode`, `switch-workspace`, `ipc-event-bridge`) to use existing `createMockRegistry()` from `registry.test-utils`
- Remove ~140 lines of duplicated inline mock definitions