### PR TITLE
chore(test): replace generic keyboard tests with navigation order tests

### DIFF
--- a/src/renderer/lib/components/BranchDropdown.test.ts
+++ b/src/renderer/lib/components/BranchDropdown.test.ts
@@ -297,22 +297,8 @@ describe("BranchDropdown component", () => {
     });
   });
 
-  describe("keyboard navigation", () => {
-    it("Arrow Down moves to next option", async () => {
-      render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-
-      // First option should be highlighted
-      const options = screen.getAllByRole("option");
-      expect(options[0]).toHaveAttribute("aria-selected", "true");
-    });
-
-    it("Arrow Up moves to previous option", async () => {
+  describe("navigation order", () => {
+    it("navigates local branches then remote branches", async () => {
       render(BranchDropdown, { props: defaultProps });
 
       await completeLoading();
@@ -320,40 +306,18 @@ describe("BranchDropdown component", () => {
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
-      // Go down twice, then up once
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-      await fireEvent.keyDown(input, { key: "ArrowUp" });
+      const expectedOrder = ["main", "develop", "origin/main", "origin/feature"];
 
-      const options = screen.getAllByRole("option");
-      expect(options[0]).toHaveAttribute("aria-selected", "true");
-    });
-
-    it("Arrow Down at last option wraps to first", async () => {
-      render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-
-      // Navigate to last option (4 branches total)
-      for (let i = 0; i < 4; i++) {
+      for (let i = 0; i < expectedOrder.length; i++) {
         await fireEvent.keyDown(input, { key: "ArrowDown" });
+
+        const options = screen.getAllByRole("option");
+        expect(options[i]).toHaveAttribute("aria-selected", "true");
+        expect(options[i]).toHaveTextContent(expectedOrder[i]!);
       }
-
-      // Should be at last option (index 3)
-      let options = screen.getAllByRole("option");
-      expect(options[3]).toHaveAttribute("aria-selected", "true");
-
-      // One more ArrowDown should wrap to first
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-
-      options = screen.getAllByRole("option");
-      expect(options[0]).toHaveAttribute("aria-selected", "true");
     });
 
-    it("Arrow Up at first option wraps to last", async () => {
+    it("ArrowDown from last local branch goes to first remote branch (skipping header)", async () => {
       render(BranchDropdown, { props: defaultProps });
 
       await completeLoading();
@@ -361,102 +325,16 @@ describe("BranchDropdown component", () => {
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
-      // Go down to first option
+      // Navigate to "develop" (2nd local branch)
+      await fireEvent.keyDown(input, { key: "ArrowDown" });
       await fireEvent.keyDown(input, { key: "ArrowDown" });
 
-      // First option should be selected
-      let options = screen.getAllByRole("option");
-      expect(options[0]).toHaveAttribute("aria-selected", "true");
-
-      // ArrowUp should wrap to last
-      await fireEvent.keyDown(input, { key: "ArrowUp" });
-
-      options = screen.getAllByRole("option");
-      expect(options[3]).toHaveAttribute("aria-selected", "true");
-    });
-
-    it("Enter selects current option", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
+      // One more ArrowDown should skip the "Remote Branches" header
       await fireEvent.keyDown(input, { key: "ArrowDown" });
-      await fireEvent.keyDown(input, { key: "Enter" });
 
-      expect(onSelect).toHaveBeenCalledWith("main");
-    });
-
-    it("Tab selects current option and moves focus", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-      await fireEvent.keyDown(input, { key: "Tab" });
-
-      expect(onSelect).toHaveBeenCalledWith("main");
-      expect(input).toHaveAttribute("aria-expanded", "false");
-    });
-
-    it("Escape closes dropdown without selecting", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-
-      expect(input).toHaveAttribute("aria-expanded", "true");
-
-      await fireEvent.keyDown(input, { key: "Escape" });
-
-      expect(input).toHaveAttribute("aria-expanded", "false");
-      expect(onSelect).not.toHaveBeenCalled();
-    });
-
-    it("Tab selects typed branch when it exactly matches an option", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-
-      // Type exact branch name without using arrow keys
-      await fireEvent.input(input, { target: { value: "main" } });
-
-      // Press Tab without navigating with arrows
-      await fireEvent.keyDown(input, { key: "Tab" });
-
-      // Should select the typed branch
-      expect(onSelect).toHaveBeenCalledWith("main");
-    });
-
-    it("Tab does not select when typed text does not match any branch", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-
-      // Type non-matching text
-      await fireEvent.input(input, { target: { value: "nonexistent" } });
-
-      // Press Tab
-      await fireEvent.keyDown(input, { key: "Tab" });
-
-      // Should NOT call onSelect
-      expect(onSelect).not.toHaveBeenCalled();
+      const options = screen.getAllByRole("option");
+      expect(options[2]).toHaveAttribute("aria-selected", "true");
+      expect(options[2]).toHaveTextContent("origin/main");
     });
   });
 

--- a/src/renderer/lib/components/NameBranchDropdown.test.ts
+++ b/src/renderer/lib/components/NameBranchDropdown.test.ts
@@ -418,4 +418,82 @@ describe("NameBranchDropdown component", () => {
       expect(input).toHaveAttribute("data-autofocus");
     });
   });
+
+  describe("keyboard navigation", () => {
+    it("navigates derivable local branches then derivable remote branches", async () => {
+      const branches: BaseInfo[] = [
+        { name: "main", isRemote: false }, // No derives — excluded
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+        { name: "feature-login", isRemote: false, derives: "feature-login" },
+        { name: "origin/main", isRemote: true }, // No derives — excluded
+        { name: "origin/feature-payments", isRemote: true, derives: "feature-payments" },
+      ];
+
+      await renderWithBranches(branches);
+
+      const input = screen.getByRole("combobox");
+      await fireEvent.focus(input);
+
+      // First ArrowDown opens dropdown (openOnFocus=false) and highlights first option
+      const expectedOrder = ["feature-auth", "feature-login", "feature-payments"];
+
+      for (let i = 0; i < expectedOrder.length; i++) {
+        await fireEvent.keyDown(input, { key: "ArrowDown" });
+
+        const options = screen.getAllByRole("option");
+        expect(options[i]).toHaveAttribute("aria-selected", "true");
+        expect(options[i]).toHaveTextContent(expectedOrder[i]!);
+      }
+
+      // Verify excluded branches are not in the options
+      const allOptions = screen.getAllByRole("option");
+      const optionTexts = allOptions.map((o) => o.textContent);
+      expect(optionTexts).not.toContain("main");
+      expect(optionTexts).not.toContain("origin/main");
+    });
+
+    it("selects highlighted branch via Enter with correct payload", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        {
+          name: "feature-auth",
+          isRemote: false,
+          derives: "feature-auth",
+          base: "origin/feature-auth",
+        },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+      await fireEvent.keyDown(input, { key: "ArrowDown" });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "feature-auth",
+        suggestedBase: "origin/feature-auth",
+        isExistingBranch: true,
+      });
+    });
+
+    it("Enter with no highlighted option submits typed text as custom name", async () => {
+      const onSelect = vi.fn();
+      const branches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      await renderWithBranches(branches, { onSelect });
+
+      const input = screen.getByRole("combobox");
+      await fireEvent.focus(input);
+      await fireEvent.input(input, { target: { value: "my-custom-branch" } });
+      await fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onSelect).toHaveBeenCalledWith({
+        name: "my-custom-branch",
+        isExistingBranch: false,
+      });
+    });
+  });
 });

--- a/src/renderer/lib/components/ProjectDropdown.test.ts
+++ b/src/renderer/lib/components/ProjectDropdown.test.ts
@@ -157,43 +157,21 @@ describe("ProjectDropdown component", () => {
     });
   });
 
-  describe("keyboard navigation", () => {
-    it("Arrow Down moves to next option", async () => {
+  describe("navigation order", () => {
+    it("navigates projects in store order", async () => {
       render(ProjectDropdown, { props: defaultProps });
 
       const input = screen.getByRole("combobox");
-      // ArrowDown opens the dropdown immediately
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
 
-      const options = screen.getAllByRole("option");
-      expect(options[0]).toHaveAttribute("aria-selected", "true");
-    });
+      const expectedOrder = ["project-alpha", "project-beta", "another-project"];
 
-    it("Enter selects highlighted option", async () => {
-      const onSelect = vi.fn();
-      render(ProjectDropdown, { props: { ...defaultProps, onSelect } });
+      for (let i = 0; i < expectedOrder.length; i++) {
+        await fireEvent.keyDown(input, { key: "ArrowDown" });
 
-      const input = screen.getByRole("combobox");
-      // ArrowDown opens the dropdown immediately
-      await fireEvent.keyDown(input, { key: "ArrowDown" });
-      await fireEvent.keyDown(input, { key: "Enter" });
-
-      // Should return project ID, not path
-      expect(onSelect).toHaveBeenCalledWith(alphaProjectId);
-    });
-
-    it("Escape closes dropdown without selecting", async () => {
-      const onSelect = vi.fn();
-      render(ProjectDropdown, { props: { ...defaultProps, onSelect } });
-
-      const input = screen.getByRole("combobox");
-      await focusAndOpenDropdown(input);
-      expect(input).toHaveAttribute("aria-expanded", "true");
-
-      await fireEvent.keyDown(input, { key: "Escape" });
-
-      expect(input).toHaveAttribute("aria-expanded", "false");
-      expect(onSelect).not.toHaveBeenCalled();
+        const options = screen.getAllByRole("option");
+        expect(options[i]).toHaveAttribute("aria-selected", "true");
+        expect(options[i]).toHaveTextContent(expectedOrder[i]!);
+      }
     });
   });
 


### PR DESCRIPTION
- Remove 9 duplicated generic keyboard navigation tests from BranchDropdown (ArrowDown/Up, Enter, Escape, Tab, wrap-around) already covered by FilterableDropdown
- Remove 3 duplicated generic keyboard tests from ProjectDropdown
- Add 2 navigation order tests to BranchDropdown verifying local-before-remote grouping and header skipping
- Add 1 navigation order test to ProjectDropdown verifying store order preservation
- Add 3 keyboard navigation tests to NameBranchDropdown: derivable branch ordering, Enter selection payload, and custom name entry