### PR TITLE
chore(test): add createMinimalOperation factory to reduce test boilerplate

### DIFF
--- a/src/main/intents/infrastructure/operation.test-utils.integration.test.ts
+++ b/src/main/intents/infrastructure/operation.test-utils.integration.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+/**
+ * Integration tests for createMinimalOperation factory.
+ *
+ * Verifies the factory produces operations that correctly collect a single
+ * hook point, handle errors, and support custom hook contexts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { HookRegistry } from "./hook-registry";
+import { Dispatcher } from "./dispatcher";
+import type { HookContext } from "./operation";
+import type { Intent } from "./types";
+import { createMinimalOperation } from "./operation.test-utils";
+
+// =============================================================================
+// Test Constants
+// =============================================================================
+
+const TEST_OPERATION_ID = "test-op";
+const TEST_INTENT_TYPE = "test:action";
+const TEST_HOOK_POINT = "do-work";
+
+function testIntent(): Intent {
+  return { type: TEST_INTENT_TYPE, payload: {} };
+}
+
+function createTestSetup() {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  return { hookRegistry, dispatcher };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("createMinimalOperation", () => {
+  it("returns first result by default", async () => {
+    const { hookRegistry, dispatcher } = createTestSetup();
+    hookRegistry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async () => ({ value: 42 }),
+    });
+
+    const op = createMinimalOperation<Intent, { value: number }>(
+      TEST_OPERATION_ID,
+      TEST_HOOK_POINT
+    );
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    const result = await dispatcher.dispatch(testIntent());
+
+    expect(result).toEqual({ value: 42 });
+  });
+
+  it("returns undefined when no results (void operation)", async () => {
+    const { dispatcher } = createTestSetup();
+
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    const result = await dispatcher.dispatch(testIntent());
+
+    expect(result).toBeUndefined();
+  });
+
+  it("throws first error when throwOnError is true (default)", async () => {
+    const { hookRegistry, dispatcher } = createTestSetup();
+    hookRegistry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async () => {
+        throw new Error("hook failed");
+      },
+    });
+
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    await expect(dispatcher.dispatch(testIntent())).rejects.toThrow("hook failed");
+  });
+
+  it("does not throw when throwOnError is false", async () => {
+    const { hookRegistry, dispatcher } = createTestSetup();
+    hookRegistry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async () => {
+        throw new Error("hook failed");
+      },
+    });
+
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      throwOnError: false,
+    });
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    await expect(dispatcher.dispatch(testIntent())).resolves.toBeUndefined();
+  });
+
+  it("uses custom hookContext when provided", async () => {
+    const { hookRegistry, dispatcher } = createTestSetup();
+
+    let receivedContext: HookContext | undefined;
+    hookRegistry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async (ctx: HookContext) => {
+        receivedContext = ctx;
+        return "ok";
+      },
+    });
+
+    interface CustomContext extends HookContext {
+      readonly workspacePath: string;
+    }
+
+    const op = createMinimalOperation<Intent, string>(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      hookContext: (ctx) => ({
+        intent: ctx.intent,
+        workspacePath: "/test/workspace",
+      }),
+    });
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    await dispatcher.dispatch(testIntent());
+
+    expect((receivedContext as CustomContext).workspacePath).toBe("/test/workspace");
+  });
+
+  it("uses default { intent } context when no hookContext provided", async () => {
+    const { hookRegistry, dispatcher } = createTestSetup();
+
+    let receivedContext: HookContext | undefined;
+    hookRegistry.register(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+      handler: async (ctx: HookContext) => {
+        receivedContext = ctx;
+      },
+    });
+
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
+    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+
+    const intent = testIntent();
+    await dispatcher.dispatch(intent);
+
+    expect(receivedContext?.intent).toEqual(intent);
+    expect(Object.keys(receivedContext!)).toEqual(["intent"]);
+  });
+});

--- a/src/main/intents/infrastructure/operation.test-utils.ts
+++ b/src/main/intents/infrastructure/operation.test-utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Factory for creating minimal test operations.
+ *
+ * Replaces boilerplate Minimal*Operation classes in module integration tests.
+ * Each created operation calls a single hook point via `ctx.hooks.collect()`,
+ * optionally throws the first error, and returns the first result.
+ */
+
+import type { Intent } from "./types";
+import type { Operation, OperationContext, HookContext } from "./operation";
+
+/**
+ * Options for `createMinimalOperation`.
+ *
+ * @template TIntent - The intent type the operation handles.
+ */
+export interface MinimalOperationOptions<TIntent extends Intent> {
+  /** Whether to throw `errors[0]` when the hook returns errors. Default: `true`. */
+  throwOnError?: boolean;
+  /** Custom hook context builder. Default: `{ intent: ctx.intent }`. */
+  hookContext?: (ctx: OperationContext<TIntent>) => HookContext;
+}
+
+/**
+ * Create a minimal test operation that collects a single hook point.
+ *
+ * Behavior:
+ * 1. Calls `ctx.hooks.collect<TResult>(hookPoint, hookContext)`
+ * 2. If `throwOnError !== false` and `errors.length > 0`: throws `errors[0]`
+ * 3. Returns `results[0] as TResult`
+ *
+ * @example
+ * // Simple void operation
+ * const op = createMinimalOperation(APP_START_OPERATION_ID, "start");
+ *
+ * // No-throw (shutdown/stop)
+ * const op = createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false });
+ *
+ * // Custom hook context
+ * const op = createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+ *   GET_WORKSPACE_STATUS_OPERATION_ID, "get",
+ *   { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) },
+ * );
+ */
+export function createMinimalOperation<TIntent extends Intent = Intent, TResult = void>(
+  operationId: string,
+  hookPoint: string,
+  options?: MinimalOperationOptions<TIntent>
+): Operation<TIntent, TResult> {
+  const throwOnError = options?.throwOnError !== false;
+  const buildHookContext = options?.hookContext;
+
+  return {
+    id: operationId,
+    async execute(ctx: OperationContext<TIntent>): Promise<TResult> {
+      const hookCtx = buildHookContext ? buildHookContext(ctx) : { intent: ctx.intent };
+      const { results, errors } = await ctx.hooks.collect<TResult>(hookPoint, hookCtx);
+      if (throwOnError && errors.length > 0) throw errors[0]!;
+      return results[0] as TResult;
+    },
+  };
+}

--- a/src/main/modules/auto-updater-module.integration.test.ts
+++ b/src/main/modules/auto-updater-module.integration.test.ts
@@ -14,12 +14,12 @@ import { describe, it, expect } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
-import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import {
   APP_START_OPERATION_ID,
   INTENT_APP_START,
   type AppStartIntent,
-  type StartHookResult,
 } from "../operations/app-start";
 import {
   AppShutdownOperation,
@@ -36,27 +36,6 @@ import type { DomainEvent } from "../intents/infrastructure/types";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { ConfigValues } from "../../services/config/config-values";
 import type { AutoUpdater, UpdateAvailableCallback } from "../../services/auto-updater";
-
-// =============================================================================
-// Minimal Start Operation
-// =============================================================================
-
-/**
- * Minimal start operation that only runs the "start" hook point.
- * Avoids the full AppStartOperation pipeline (check-config, check-deps, etc.)
- * while still exercising the auto-updater module's start hook through the dispatcher.
- */
-class MinimalStartOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
-    const hookCtx: HookContext = { intent: ctx.intent };
-    const { errors } = await ctx.hooks.collect<StartHookResult>("start", hookCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-  }
-}
 
 // =============================================================================
 // Tracking Update Operation
@@ -143,7 +122,10 @@ function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
     dispatcher,
   });
 
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "start")
+  );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
   dispatcher.registerOperation(INTENT_UPDATE_AVAILABLE, updateOperation);
 

--- a/src/main/modules/badge-module.integration.test.ts
+++ b/src/main/modules/badge-module.integration.test.ts
@@ -41,6 +41,7 @@ import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../operations
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
 import type { AppShutdownIntent } from "../operations/app-shutdown";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import type { IntentModule } from "../intents/infrastructure/module";
 import { createBadgeModule } from "./badge-module";
 import { BadgeManager } from "../managers/badge-manager";
@@ -85,19 +86,6 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
     };
     ctx.emit(event);
     return { started: true };
-  }
-}
-
-/**
- * Minimal shutdown operation that runs the "stop" hook point.
- * Used to trigger app:shutdown/stop through the public dispatcher API.
- */
-class MinimalStopOperation implements Operation<AppShutdownIntent, void> {
-  readonly id = APP_SHUTDOWN_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppShutdownIntent>): Promise<void> {
-    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
-    await ctx.hooks.collect("stop", { intent: ctx.intent });
   }
 }
 
@@ -337,7 +325,10 @@ describe("BadgeModule Integration", () => {
       expect(appLayer).toHaveDockBadge("\u25CF");
 
       // Register shutdown operation and dispatch
-      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new MinimalStopOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_SHUTDOWN,
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
       await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
 
       // Badge should be cleared by dispose()
@@ -353,7 +344,10 @@ describe("BadgeModule Integration", () => {
         throw new Error("dispose failed");
       });
 
-      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new MinimalStopOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_SHUTDOWN,
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       // Should not throw - collect() catches the error
       await expect(

--- a/src/main/modules/claude-agent-module.integration.test.ts
+++ b/src/main/modules/claude-agent-module.integration.test.ts
@@ -13,6 +13,7 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent, DomainEvent } from "../intents/infrastructure/types";
 import type { IntentModule } from "../intents/infrastructure/module";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import type {
   ConfigureResult,
@@ -38,14 +39,11 @@ import type {
   DeleteWorkspaceIntent,
 } from "../operations/delete-workspace";
 import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../operations/get-workspace-status";
-import type { GetStatusHookInput, GetStatusHookResult } from "../operations/get-workspace-status";
+import type { GetStatusHookResult } from "../operations/get-workspace-status";
 import { GET_AGENT_SESSION_OPERATION_ID } from "../operations/get-agent-session";
-import type {
-  GetAgentSessionHookInput,
-  GetAgentSessionHookResult,
-} from "../operations/get-agent-session";
+import type { GetAgentSessionHookResult } from "../operations/get-agent-session";
 import { RESTART_AGENT_OPERATION_ID } from "../operations/restart-agent";
-import type { RestartAgentHookInput, RestartAgentHookResult } from "../operations/restart-agent";
+import type { RestartAgentHookResult } from "../operations/restart-agent";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import { EVENT_CONFIG_UPDATED, INTENT_CONFIG_SET_VALUES } from "../operations/config-set-values";
 import type { ConfigValues } from "../../services/config/config-values";
@@ -144,15 +142,6 @@ class MinimalStartAndActivateOperation implements Operation<Intent, readonly Act
   }
 }
 
-class MinimalStopOperation implements Operation<Intent, void> {
-  readonly id = APP_SHUTDOWN_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
-    await ctx.hooks.collect("stop", { intent: ctx.intent });
-  }
-}
-
 class MinimalRegisterAgentsOperation implements Operation<Intent, readonly RegisterAgentResult[]> {
   readonly id = SETUP_OPERATION_ID;
 
@@ -240,60 +229,6 @@ class MinimalShutdownOperation implements Operation<
     };
     const { results, errors } = await ctx.hooks.collect<ShutdownHookResult | undefined>(
       "shutdown",
-      hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalGetStatusOperation implements Operation<Intent, GetStatusHookResult | undefined> {
-  readonly id = GET_WORKSPACE_STATUS_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<GetStatusHookResult | undefined> {
-    const hookCtx: GetStatusHookInput = {
-      intent: ctx.intent,
-      workspacePath: "/test/workspace",
-    };
-    const { results, errors } = await ctx.hooks.collect<GetStatusHookResult | undefined>(
-      "get",
-      hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalGetSessionOperation implements Operation<
-  Intent,
-  GetAgentSessionHookResult | undefined
-> {
-  readonly id = GET_AGENT_SESSION_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<GetAgentSessionHookResult | undefined> {
-    const hookCtx: GetAgentSessionHookInput = {
-      intent: ctx.intent,
-      workspacePath: "/test/workspace",
-    };
-    const { results, errors } = await ctx.hooks.collect<GetAgentSessionHookResult | undefined>(
-      "get",
-      hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalRestartOperation implements Operation<Intent, RestartAgentHookResult | undefined> {
-  readonly id = RESTART_AGENT_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<RestartAgentHookResult | undefined> {
-    const hookCtx: RestartAgentHookInput = {
-      intent: ctx.intent,
-      workspacePath: "/test/workspace",
-    };
-    const { results, errors } = await ctx.hooks.collect<RestartAgentHookResult | undefined>(
-      "restart",
       hookCtx
     );
     if (errors.length > 0) throw errors[0]!;
@@ -1003,7 +938,14 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, mockASM, module } = createTestSetup();
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
+      dispatcher.registerOperation(
+        "workspace:get-status",
+        createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+          GET_WORKSPACE_STATUS_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "workspace:get-status",
@@ -1022,7 +964,14 @@ describe("ClaudeAgentModule", () => {
       dispatcher.registerOperation("app:start", new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
+      dispatcher.registerOperation(
+        "workspace:get-status",
+        createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+          GET_WORKSPACE_STATUS_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "workspace:get-status",
@@ -1042,7 +991,14 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, mockASM, module } = createTestSetup();
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("agent:get-session", new MinimalGetSessionOperation());
+      dispatcher.registerOperation(
+        "agent:get-session",
+        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+          GET_AGENT_SESSION_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "agent:get-session",
@@ -1060,7 +1016,14 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, module } = createTestSetup(mockDepsResult);
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("agent:get-session", new MinimalGetSessionOperation());
+      dispatcher.registerOperation(
+        "agent:get-session",
+        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+          GET_AGENT_SESSION_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "agent:get-session",
@@ -1078,7 +1041,14 @@ describe("ClaudeAgentModule", () => {
       dispatcher.registerOperation("app:start", new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("agent:get-session", new MinimalGetSessionOperation());
+      dispatcher.registerOperation(
+        "agent:get-session",
+        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+          GET_AGENT_SESSION_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "agent:get-session",
@@ -1098,7 +1068,14 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, mockSM, module } = createTestSetup();
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("agent:restart", new MinimalRestartOperation());
+      dispatcher.registerOperation(
+        "agent:restart",
+        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+          RESTART_AGENT_OPERATION_ID,
+          "restart",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "agent:restart",
@@ -1119,7 +1096,14 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, module } = createTestSetup(mockDepsResult);
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("agent:restart", new MinimalRestartOperation());
+      dispatcher.registerOperation(
+        "agent:restart",
+        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+          RESTART_AGENT_OPERATION_ID,
+          "restart",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       await expect(
         dispatcher.dispatch({
@@ -1136,7 +1120,14 @@ describe("ClaudeAgentModule", () => {
       dispatcher.registerOperation("app:start", new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("agent:restart", new MinimalRestartOperation());
+      dispatcher.registerOperation(
+        "agent:restart",
+        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+          RESTART_AGENT_OPERATION_ID,
+          "restart",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       const result = (await dispatcher.dispatch({
         type: "agent:restart",
@@ -1157,7 +1148,10 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, mockSM, mockASM, module } = createTestSetup();
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+      dispatcher.registerOperation(
+        "app:shutdown",
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
 
@@ -1172,7 +1166,10 @@ describe("ClaudeAgentModule", () => {
       dispatcher.registerOperation("app:start", new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+      dispatcher.registerOperation(
+        "app:shutdown",
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
 
@@ -1186,7 +1183,10 @@ describe("ClaudeAgentModule", () => {
       const { dispatcher, module } = createTestSetup(mockDepsResult);
       await activateModule(dispatcher, module);
 
-      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+      dispatcher.registerOperation(
+        "app:shutdown",
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       // Handler throws directly, but collect() catches the error
       await expect(

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -13,6 +13,7 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import type { CheckDepsResult, ConfigureResult, StartHookResult } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
@@ -106,15 +107,6 @@ class MinimalStartOperation implements Operation<Intent, StartHookResult> {
       }
     }
     return merged;
-  }
-}
-
-class MinimalStopOperation implements Operation<Intent, void> {
-  readonly id = APP_SHUTDOWN_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    // Matches real AppShutdownOperation: collect() catches errors, does not rethrow
-    await ctx.hooks.collect("stop", { intent: ctx.intent });
   }
 }
 
@@ -500,7 +492,10 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+      dispatcher.registerOperation(
+        "app:shutdown",
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
 
@@ -515,7 +510,10 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:shutdown", new MinimalStopOperation());
+      dispatcher.registerOperation(
+        "app:shutdown",
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
 
       // Handler throws directly, but collect() catches the error
       await expect(

--- a/src/main/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/main/modules/electron-lifecycle-module.integration.test.ts
@@ -13,6 +13,7 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../operations/app-start";
 import type { AppStartIntent, ConfigureResult } from "../operations/app-start";
 import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
@@ -27,17 +28,6 @@ import {
 // =============================================================================
 // Minimal Test Operations
 // =============================================================================
-
-/** Runs "await-ready" hook point only. */
-class MinimalAwaitReadyOperation implements Operation<Intent, void> {
-  readonly id = APP_START_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect<void>("await-ready", {
-      intent: ctx.intent,
-    });
-    if (errors.length > 0) throw errors[0]!;
-  }
-}
 
 /** Runs "before-ready" hook point only. */
 class MinimalBeforeReadyOperation implements Operation<Intent, ConfigureResult> {
@@ -84,7 +74,10 @@ describe("ElectronLifecycleModule Integration", () => {
     const hookRegistry = new HookRegistry();
     const dispatcher = new Dispatcher(hookRegistry);
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAwaitReadyOperation());
+    dispatcher.registerOperation(
+      INTENT_APP_START,
+      createMinimalOperation(APP_START_OPERATION_ID, "await-ready")
+    );
 
     const module = createElectronLifecycleModule({ app: mockApp, logger: SILENT_LOGGER });
     dispatcher.registerModule(module);
@@ -104,7 +97,10 @@ describe("ElectronLifecycleModule Integration", () => {
     const hookRegistry = new HookRegistry();
     const dispatcher = new Dispatcher(hookRegistry);
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAwaitReadyOperation());
+    dispatcher.registerOperation(
+      INTENT_APP_START,
+      createMinimalOperation(APP_START_OPERATION_ID, "await-ready")
+    );
 
     const module = createElectronLifecycleModule({ app: mockApp, logger: SILENT_LOGGER });
     dispatcher.registerModule(module);

--- a/src/main/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/main/modules/git-worktree-workspace-module.integration.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
@@ -19,12 +20,11 @@ import type { GitWorktreeProvider } from "../../services/git/git-worktree-provid
 import type { PathProvider } from "../../services/platform/path-provider";
 import type { Workspace } from "../../services/git/types";
 import { OPEN_PROJECT_OPERATION_ID } from "../operations/open-project";
-import type { DiscoverHookResult, DiscoverHookInput } from "../operations/open-project";
+import type { DiscoverHookResult } from "../operations/open-project";
 import { CLOSE_PROJECT_OPERATION_ID } from "../operations/close-project";
-import type { CloseHookInput } from "../operations/close-project";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
 import type { OpenWorkspaceIntent } from "../operations/open-workspace";
-import type { CreateHookInput, CreateHookResult } from "../operations/open-workspace";
+import type { CreateHookResult } from "../operations/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
 import type {
   DeleteWorkspaceIntent,
@@ -69,59 +69,39 @@ function createMockPathProvider(): PathProvider {
 // Minimal Test Operations
 // =============================================================================
 
-/**
- * Open-project operation: runs "discover" hook point.
- */
-class MinimalOpenProjectOperation implements Operation<Intent, DiscoverHookResult> {
-  readonly id = OPEN_PROJECT_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<DiscoverHookResult> {
-    const input: DiscoverHookInput = {
+const openProjectOperation = createMinimalOperation<Intent, DiscoverHookResult>(
+  OPEN_PROJECT_OPERATION_ID,
+  "discover",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
       projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
-    };
-    const { results, errors } = await ctx.hooks.collect<DiscoverHookResult>("discover", input);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? { workspaces: [] };
+    }),
   }
-}
+);
 
-/**
- * Close-project operation: runs "close" hook point.
- */
-class MinimalCloseProjectOperation implements Operation<Intent, Record<string, never>> {
-  readonly id = CLOSE_PROJECT_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<Record<string, never>> {
-    const payload = ctx.intent.payload as { projectPath: string };
-    const input: CloseHookInput = {
+const closeProjectOperation = createMinimalOperation<Intent, Record<string, never>>(
+  CLOSE_PROJECT_OPERATION_ID,
+  "close",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: payload.projectPath,
+      projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
       removeLocalRepo: false,
-    };
-    const { results, errors } = await ctx.hooks.collect<Record<string, never>>("close", input);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
+    }),
   }
-}
+);
 
-/**
- * Open-workspace operation: runs "create" hook point.
- */
-class MinimalOpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, CreateHookResult> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<CreateHookResult> {
-    const payload = ctx.intent.payload as { projectPath?: string };
-    const input: CreateHookInput = {
+const openWorkspaceOperation = createMinimalOperation<OpenWorkspaceIntent, CreateHookResult>(
+  OPEN_WORKSPACE_OPERATION_ID,
+  "create",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: payload.projectPath ?? "",
-    };
-    const { results, errors } = await ctx.hooks.collect<CreateHookResult>("create", input);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0]!;
+      projectPath: (ctx.intent.payload as { projectPath?: string }).projectPath ?? "",
+    }),
   }
-}
+);
 
 /** Extended delete result that includes the resolved path and possible error. */
 interface DeleteResult extends DeleteHookResult {
@@ -198,23 +178,16 @@ class MinimalResolveWorkspaceOperation implements Operation<Intent, ResolveResul
   }
 }
 
-/**
- * Fetch-bases operation: runs "fetch-bases" hook point on the open-workspace operation.
- */
-class MinimalFetchBasesOperation implements Operation<Intent, FetchBasesHookResult> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<FetchBasesHookResult> {
-    const payload = ctx.intent.payload as { projectPath: string };
-    const input = {
+const fetchBasesOperation = createMinimalOperation<Intent, FetchBasesHookResult>(
+  OPEN_WORKSPACE_OPERATION_ID,
+  "fetch-bases",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: payload.projectPath,
-    };
-    const { results, errors } = await ctx.hooks.collect<FetchBasesHookResult>("fetch-bases", input);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? { bases: [] };
+      projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
+    }),
   }
-}
+);
 
 /** Result from get-workspace-status: resolve-workspace + get. */
 interface GetStatusResult {
@@ -274,12 +247,12 @@ function createTestSetup(): TestSetup {
   const dispatcher = new Dispatcher(hookRegistry);
 
   // Register operations
-  dispatcher.registerOperation("project:open", new MinimalOpenProjectOperation());
-  dispatcher.registerOperation("project:close", new MinimalCloseProjectOperation());
-  dispatcher.registerOperation("workspace:open", new MinimalOpenWorkspaceOperation());
+  dispatcher.registerOperation("project:open", openProjectOperation);
+  dispatcher.registerOperation("project:close", closeProjectOperation);
+  dispatcher.registerOperation("workspace:open", openWorkspaceOperation);
   dispatcher.registerOperation("workspace:delete", new MinimalDeleteWorkspaceOperation());
   dispatcher.registerOperation("workspace:resolve", new MinimalResolveWorkspaceOperation());
-  dispatcher.registerOperation("open-workspace", new MinimalFetchBasesOperation());
+  dispatcher.registerOperation("open-workspace", fetchBasesOperation);
   dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
 
   // Wire the module under test

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -61,6 +61,7 @@ import {
 } from "../operations/app-shutdown";
 import type { AppShutdownIntent } from "../operations/app-shutdown";
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import { SetupOperation, INTENT_SETUP } from "../operations/setup";
 import type { SetupIntent } from "../operations/setup";
 import { createIpcEventBridge, type IpcEventBridgeDeps } from "./ipc-event-bridge";
@@ -134,14 +135,6 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
     };
     ctx.emit(event);
     return { started: true };
-  }
-}
-
-class MinimalAppStartOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
-    await ctx.hooks.collect("start", { intent: ctx.intent });
   }
 }
 
@@ -280,7 +273,10 @@ function createLifecycleTestSetup(
     INTENT_DELETE_WORKSPACE,
     new MinimalDeleteOperation(TEST_PROJECT_ID, TEST_WORKSPACE_NAME, TEST_PROJECT_PATH)
   );
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+  );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
   const mockApiRegistry = createMockApiRegistry();
@@ -620,7 +616,10 @@ describe("IpcEventBridge - lifecycle", () => {
 
       const hookRegistry = new HookRegistry();
       const dispatcher = new Dispatcher(hookRegistry);
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_START,
+        createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+      );
       dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
       const mockApiRegistry = createMockApiRegistry();
@@ -690,7 +689,10 @@ describe("IpcEventBridge - lifecycle", () => {
 
       const hookRegistry = new HookRegistry();
       const dispatcher = new Dispatcher(hookRegistry);
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_START,
+        createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+      );
       dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
       const mockApiRegistry = createMockApiRegistry();

--- a/src/main/modules/keepfiles-module.integration.test.ts
+++ b/src/main/modules/keepfiles-module.integration.test.ts
@@ -10,13 +10,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
-import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
-import {
-  OPEN_WORKSPACE_OPERATION_ID,
-  type SetupHookInput,
-  type SetupHookResult,
-} from "../operations/open-workspace";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
+import { OPEN_WORKSPACE_OPERATION_ID, type SetupHookResult } from "../operations/open-workspace";
 import { createKeepFilesModule } from "./keepfiles-module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { createBehavioralLogger } from "../../services/logging/logging.test-utils";
@@ -39,30 +35,6 @@ function createMockKeepFilesService() {
 }
 
 // =============================================================================
-// Minimal Test Operation
-// =============================================================================
-
-/**
- * Minimal operation that runs only the "setup" hook point.
- * Avoids needing stubs for resolve-project, create, finalize.
- */
-class MinimalSetupOperation implements Operation<Intent, SetupHookResult> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<SetupHookResult> {
-    const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
-    const input: SetupHookInput = {
-      intent: ctx.intent,
-      projectPath: payload.projectPath,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<SetupHookResult>("setup", input);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
-  }
-}
-
-// =============================================================================
 // Test Setup
 // =============================================================================
 
@@ -77,7 +49,19 @@ function createTestSetup(logger = SILENT_LOGGER): TestSetup {
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
 
-  dispatcher.registerOperation("workspace:open", new MinimalSetupOperation());
+  dispatcher.registerOperation(
+    "workspace:open",
+    createMinimalOperation<Intent, SetupHookResult>(OPEN_WORKSPACE_OPERATION_ID, "setup", {
+      hookContext: (ctx) => {
+        const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
+        return {
+          intent: ctx.intent,
+          projectPath: payload.projectPath,
+          workspacePath: payload.workspacePath,
+        };
+      },
+    })
+  );
 
   const module = createKeepFilesModule({
     keepFilesService: keepFilesService as unknown as IKeepFilesService,

--- a/src/main/modules/mcp-module.integration.test.ts
+++ b/src/main/modules/mcp-module.integration.test.ts
@@ -19,7 +19,7 @@ import {
   APP_SHUTDOWN_OPERATION_ID,
 } from "../operations/app-shutdown";
 import type { AppShutdownIntent } from "../operations/app-shutdown";
-import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import type { IntentModule } from "../intents/infrastructure/module";
 import { createMcpModule, type McpModuleDeps } from "./mcp-module";
 
@@ -42,23 +42,6 @@ function createMockMcpServerManager(port = 9999): MockMcpServerManager {
 }
 
 // =============================================================================
-// Minimal operations for testing
-// =============================================================================
-
-/**
- * Minimal app:start that only runs the "start" hook point.
- * The real AppStartOperation has many hook points (show-ui, check-config, etc.)
- * but we only need "start" for MCP module testing.
- */
-class MinimalAppStartOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
-    await ctx.hooks.collect("start", { intent: ctx.intent });
-  }
-}
-
-// =============================================================================
 // Test Setup
 // =============================================================================
 
@@ -75,7 +58,10 @@ function createTestSetup(): TestSetup {
   const mcpServerManager = createMockMcpServerManager();
 
   // Register operations
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+  );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 
   const mcpModule = createMcpModule({
@@ -123,7 +109,10 @@ describe("McpModule Integration", () => {
       const hookRegistry = new HookRegistry();
       const shutdownDispatcher = new Dispatcher(hookRegistry);
       shutdownDispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
-      shutdownDispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+      shutdownDispatcher.registerOperation(
+        INTENT_APP_START,
+        createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+      );
 
       const msm = createMockMcpServerManager();
       const mcpModule = createMcpModule({

--- a/src/main/modules/opencode-agent-module.integration.test.ts
+++ b/src/main/modules/opencode-agent-module.integration.test.ts
@@ -12,6 +12,7 @@ import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import type { IntentModule } from "../intents/infrastructure/module";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import type {
@@ -41,14 +42,11 @@ import type {
   DeletePipelineHookInput,
 } from "../operations/delete-workspace";
 import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../operations/get-workspace-status";
-import type { GetStatusHookResult, GetStatusHookInput } from "../operations/get-workspace-status";
+import type { GetStatusHookResult } from "../operations/get-workspace-status";
 import { GET_AGENT_SESSION_OPERATION_ID } from "../operations/get-agent-session";
-import type {
-  GetAgentSessionHookResult,
-  GetAgentSessionHookInput,
-} from "../operations/get-agent-session";
+import type { GetAgentSessionHookResult } from "../operations/get-agent-session";
 import { RESTART_AGENT_OPERATION_ID } from "../operations/restart-agent";
-import type { RestartAgentHookResult, RestartAgentHookInput } from "../operations/restart-agent";
+import type { RestartAgentHookResult } from "../operations/restart-agent";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
 import { createOpenCodeAgentModule, type OpenCodeAgentModuleDeps } from "./opencode-agent-module";
@@ -303,69 +301,6 @@ class MinimalShutdownOperation implements Operation<
     const { results, errors } = await ctx.hooks.collect<ShutdownHookResult | undefined>(
       "shutdown",
       hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalGetStatusOperation implements Operation<Intent, GetStatusHookResult | undefined> {
-  readonly id = GET_WORKSPACE_STATUS_OPERATION_ID;
-  private readonly workspacePath: string;
-
-  constructor(workspacePath = "/test/project/.worktrees/feature-1") {
-    this.workspacePath = workspacePath;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<GetStatusHookResult | undefined> {
-    const { results, errors } = await ctx.hooks.collect<GetStatusHookResult | undefined>("get", {
-      intent: ctx.intent,
-      workspacePath: this.workspacePath,
-    } as GetStatusHookInput);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalGetSessionOperation implements Operation<
-  Intent,
-  GetAgentSessionHookResult | undefined
-> {
-  readonly id = GET_AGENT_SESSION_OPERATION_ID;
-  private readonly workspacePath: string;
-
-  constructor(workspacePath = "/test/project/.worktrees/feature-1") {
-    this.workspacePath = workspacePath;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<GetAgentSessionHookResult | undefined> {
-    const { results, errors } = await ctx.hooks.collect<GetAgentSessionHookResult | undefined>(
-      "get",
-      {
-        intent: ctx.intent,
-        workspacePath: this.workspacePath,
-      } as GetAgentSessionHookInput
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
-}
-
-class MinimalRestartOperation implements Operation<Intent, RestartAgentHookResult | undefined> {
-  readonly id = RESTART_AGENT_OPERATION_ID;
-  private readonly workspacePath: string;
-
-  constructor(workspacePath = "/test/project/.worktrees/feature-1") {
-    this.workspacePath = workspacePath;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<RestartAgentHookResult | undefined> {
-    const { results, errors } = await ctx.hooks.collect<RestartAgentHookResult | undefined>(
-      "restart",
-      {
-        intent: ctx.intent,
-        workspacePath: this.workspacePath,
-      } as RestartAgentHookInput
     );
     if (errors.length > 0) throw errors[0]!;
     return results[0];
@@ -858,7 +793,11 @@ describe("OpenCodeAgentModule Integration", () => {
       const wsPath = "/test/project/.worktrees/feature-1";
       setup.dispatcher.registerOperation(
         "workspace:get-status",
-        new MinimalGetStatusOperation(wsPath)
+        createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+          GET_WORKSPACE_STATUS_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: wsPath }) }
+        )
       );
 
       const result = (await setup.dispatcher.dispatch({
@@ -883,7 +822,11 @@ describe("OpenCodeAgentModule Integration", () => {
       const wsPath = "/test/project/.worktrees/feature-1";
       setup.dispatcher.registerOperation(
         "agent:get-session",
-        new MinimalGetSessionOperation(wsPath)
+        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+          GET_AGENT_SESSION_OPERATION_ID,
+          "get",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: wsPath }) }
+        )
       );
 
       const result = (await setup.dispatcher.dispatch({
@@ -906,7 +849,14 @@ describe("OpenCodeAgentModule Integration", () => {
       await activateModule(setup, null);
 
       const wsPath = "/test/project/.worktrees/feature-1";
-      setup.dispatcher.registerOperation("agent:restart", new MinimalRestartOperation(wsPath));
+      setup.dispatcher.registerOperation(
+        "agent:restart",
+        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+          RESTART_AGENT_OPERATION_ID,
+          "restart",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: wsPath }) }
+        )
+      );
 
       const result = (await setup.dispatcher.dispatch({
         type: "agent:restart",
@@ -927,7 +877,14 @@ describe("OpenCodeAgentModule Integration", () => {
         error: "server not running",
       });
 
-      setup.dispatcher.registerOperation("agent:restart", new MinimalRestartOperation());
+      setup.dispatcher.registerOperation(
+        "agent:restart",
+        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+          RESTART_AGENT_OPERATION_ID,
+          "restart",
+          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+        )
+      );
 
       await expect(
         setup.dispatcher.dispatch({
@@ -968,17 +925,32 @@ describe("OpenCodeAgentModule Integration", () => {
       },
       {
         intentType: "workspace:get-status",
-        operation: () => new MinimalGetStatusOperation(),
+        operation: () =>
+          createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+            GET_WORKSPACE_STATUS_OPERATION_ID,
+            "get",
+            { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          ),
         payload: { workspacePath: "/test/path" },
       },
       {
         intentType: "agent:get-session",
-        operation: () => new MinimalGetSessionOperation(),
+        operation: () =>
+          createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+            GET_AGENT_SESSION_OPERATION_ID,
+            "get",
+            { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          ),
         payload: { workspacePath: "/test/path" },
       },
       {
         intentType: "agent:restart",
-        operation: () => new MinimalRestartOperation(),
+        operation: () =>
+          createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+            RESTART_AGENT_OPERATION_ID,
+            "restart",
+            { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          ),
         payload: { workspacePath: "/test/path" },
       },
     ])(

--- a/src/main/modules/telemetry-module.integration.test.ts
+++ b/src/main/modules/telemetry-module.integration.test.ts
@@ -18,12 +18,12 @@ import { describe, it, expect } from "vitest";
 import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
-import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import {
   APP_START_OPERATION_ID,
   INTENT_APP_START,
   type AppStartIntent,
-  type StartHookResult,
 } from "../operations/app-start";
 import {
   AppShutdownOperation,
@@ -37,27 +37,6 @@ import {
 import { createTelemetryModule } from "./telemetry-module";
 import { createMockPlatformInfo } from "../../services/platform/platform-info.test-utils";
 import type { TelemetryService, TelemetryConfigureOptions } from "../../services/telemetry/types";
-
-// =============================================================================
-// Minimal Start Operation
-// =============================================================================
-
-/**
- * Minimal start operation that only runs the "start" hook point.
- * Avoids the full AppStartOperation pipeline (check-config, check-deps, etc.)
- * while still exercising the telemetry module's start hook through the dispatcher.
- */
-class MinimalStartOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
-    const hookCtx: HookContext = { intent: ctx.intent };
-    const { errors } = await ctx.hooks.collect<StartHookResult>("start", hookCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-  }
-}
 
 /**
  * Minimal config set-values operation that runs the "set" hook and emits
@@ -163,7 +142,10 @@ function createTestSetup(overrides?: { telemetryService?: TelemetryService | nul
     dispatcher,
   });
 
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "start")
+  );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
   dispatcher.registerOperation(INTENT_CONFIG_SET_VALUES, new MinimalConfigSetValuesOperation());
 
@@ -437,7 +419,7 @@ describe("TelemetryModule Integration", () => {
       const { dispatcher } = createTestSetup({ telemetryService: null });
 
       await dispatcher.dispatch(configSetValuesIntent({ agent: "opencode" }));
-      await expect(dispatcher.dispatch(startIntent())).resolves.toBeUndefined();
+      await dispatcher.dispatch(startIntent());
     });
   });
 

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -22,6 +22,7 @@ import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import type { IntentModule } from "../intents/infrastructure/module";
 import { INTENT_SET_MODE, SET_MODE_OPERATION_ID } from "../operations/set-mode";
 import type { SetModeIntent, SetModeHookResult } from "../operations/set-mode";
@@ -180,17 +181,6 @@ class MinimalShowUIOperation implements Operation<Intent, ShowUIHookResult> {
       }
     }
     return merged;
-  }
-}
-
-/** Runs "init" hook point only. */
-class MinimalInitOperation implements Operation<Intent, void> {
-  readonly id = APP_START_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect<void>("init", {
-      intent: ctx.intent,
-    });
-    if (errors.length > 0) throw errors[0]!;
   }
 }
 
@@ -1115,7 +1105,10 @@ describe("ViewModule Integration", () => {
       const viewManager = createMockViewManager();
       const layers = createMockShellLayers();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_START,
+        createMinimalOperation(APP_START_OPERATION_ID, "init")
+      );
 
       const menuLayer = { setApplicationMenu: vi.fn() };
       const windowManager = {
@@ -1161,7 +1154,10 @@ describe("ViewModule Integration", () => {
       const dispatcher = new Dispatcher(hookRegistry);
       const viewManager = createMockViewManager();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+      dispatcher.registerOperation(
+        INTENT_APP_START,
+        createMinimalOperation(APP_START_OPERATION_ID, "init")
+      );
 
       const { module } = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],

--- a/src/main/modules/window-title-module.integration.test.ts
+++ b/src/main/modules/window-title-module.integration.test.ts
@@ -17,13 +17,13 @@ import { UpdateAvailableOperation, INTENT_UPDATE_AVAILABLE } from "../operations
 import type { UpdateAvailableIntent } from "../operations/update-available";
 import { EVENT_WORKSPACE_SWITCHED } from "../operations/switch-workspace";
 import type { WorkspaceSwitchedEvent } from "../operations/switch-workspace";
-import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Operation, OperationContext } from "../intents/infrastructure/operation";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import type { Intent } from "../intents/infrastructure/types";
 import {
   APP_START_OPERATION_ID,
   INTENT_APP_START,
   type AppStartIntent,
-  type StartHookResult,
 } from "../operations/app-start";
 import { createWindowTitleModule } from "./window-title-module";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
@@ -69,27 +69,6 @@ class MinimalSwitchOperation implements Operation<MinimalSwitchIntent, void> {
 }
 
 // =============================================================================
-// Minimal start operation that runs the "start" hook point
-// =============================================================================
-
-/**
- * Minimal start operation that only runs the "start" hook point.
- * Avoids the full AppStartOperation pipeline while exercising the
- * window title module's start hook through the dispatcher.
- */
-class MinimalStartOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
-    const hookCtx: HookContext = { intent: ctx.intent };
-    const { errors } = await ctx.hooks.collect<StartHookResult>("start", hookCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-  }
-}
-
-// =============================================================================
 // Test Setup
 // =============================================================================
 
@@ -106,7 +85,10 @@ function createTestSetup(titleVersion?: string): TestSetup {
 
   dispatcher.registerOperation(INTENT_MINIMAL_SWITCH, new MinimalSwitchOperation());
   dispatcher.registerOperation(INTENT_UPDATE_AVAILABLE, new UpdateAvailableOperation());
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "start")
+  );
 
   const windowTitleModule = createWindowTitleModule(setTitle, titleVersion ?? "main");
 
@@ -250,7 +232,10 @@ describe("WindowTitleModule Integration", () => {
     const hookRegistry = new HookRegistry();
     const dispatcher = new Dispatcher(hookRegistry);
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
+    dispatcher.registerOperation(
+      INTENT_APP_START,
+      createMinimalOperation(APP_START_OPERATION_ID, "start")
+    );
 
     const windowTitleModule = createWindowTitleModule(setTitle, undefined);
     dispatcher.registerModule(windowTitleModule);

--- a/src/main/modules/windows-file-lock-module.integration.test.ts
+++ b/src/main/modules/windows-file-lock-module.integration.test.ts
@@ -12,10 +12,10 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
   type DeleteWorkspaceIntent,
-  type DeletePipelineHookInput,
   type ReleaseHookResult,
   type DetectHookResult,
   type FlushHookResult,
@@ -60,43 +60,33 @@ function makeDeleteIntent(overrides?: Partial<DeleteWorkspaceIntent["payload"]>)
 // Minimal Test Operations
 // =============================================================================
 
-/**
- * Runs only the "release" hook point.
- */
-class ReleaseOperation implements Operation<Intent, ReleaseHookResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<ReleaseHookResult> {
-    const { payload } = ctx.intent as DeleteWorkspaceIntent;
-    const hookCtx: DeletePipelineHookInput = {
+const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
+  DELETE_WORKSPACE_OPERATION_ID,
+  "release",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
       projectPath: "/projects/my-app",
-      workspacePath: payload.workspacePath ?? "",
-    };
-    const { results, errors } = await ctx.hooks.collect<ReleaseHookResult>("release", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
+      workspacePath:
+        ((ctx.intent as DeleteWorkspaceIntent).payload as { workspacePath?: string })
+          .workspacePath ?? "",
+    }),
   }
-}
+);
 
-/**
- * Runs only the "detect" hook point.
- */
-class DetectOperation implements Operation<Intent, DetectHookResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<DetectHookResult> {
-    const { payload } = ctx.intent as DeleteWorkspaceIntent;
-    const hookCtx: DeletePipelineHookInput = {
+const detectOperation = createMinimalOperation<Intent, DetectHookResult>(
+  DELETE_WORKSPACE_OPERATION_ID,
+  "detect",
+  {
+    hookContext: (ctx) => ({
       intent: ctx.intent,
       projectPath: "/projects/my-app",
-      workspacePath: payload.workspacePath ?? "",
-    };
-    const { results, errors } = await ctx.hooks.collect<DetectHookResult>("detect", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
+      workspacePath:
+        ((ctx.intent as DeleteWorkspaceIntent).payload as { workspacePath?: string })
+          .workspacePath ?? "",
+    }),
   }
-}
+);
 
 /**
  * Runs only the "flush" hook point with provided blockingPids.
@@ -126,7 +116,7 @@ class FlushOperation implements Operation<Intent, FlushHookResult> {
 function createReleaseSetup(lockHandler: WorkspaceLockHandler | undefined, logger = SILENT_LOGGER) {
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
-  dispatcher.registerOperation("workspace:delete", new ReleaseOperation());
+  dispatcher.registerOperation("workspace:delete", releaseOperation);
 
   const module = createWindowsFileLockModule({
     workspaceLockHandler: lockHandler,
@@ -140,7 +130,7 @@ function createReleaseSetup(lockHandler: WorkspaceLockHandler | undefined, logge
 function createDetectSetup(lockHandler: WorkspaceLockHandler | undefined, logger = SILENT_LOGGER) {
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
-  dispatcher.registerOperation("workspace:delete", new DetectOperation());
+  dispatcher.registerOperation("workspace:delete", detectOperation);
 
   const module = createWindowsFileLockModule({
     workspaceLockHandler: lockHandler,


### PR DESCRIPTION
- Add shared `createMinimalOperation()` factory in `operation.test-utils.ts` for single-hook-point test operations
- Replace ~21 boilerplate `Minimal*Operation` classes across 14 module integration test files with factory calls
- Add 6 integration tests for the factory itself
- Net reduction of ~150 lines of test boilerplate while preserving identical test behavior