### PR TITLE
feat(ship): auto-retry failed CI jobs on infrastructure failures

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -224,7 +224,6 @@ If ship-wait exited with code 1 and the output contains "CI failed":
    Code issues (do NOT retry): test failures, lint errors, build errors, type errors.
 
 4. If infrastructure issue:
-
    - Rerun the failed job(s):
      ```bash
      gh run rerun --repo stefanhoelzl/codehydra <run-id> --failed


### PR DESCRIPTION
- Add step 5.5 to ship.md: when CI fails, agent analyzes failed job logs to distinguish infrastructure issues from code issues
- Infrastructure failures (runner flakiness, network timeouts, GitHub outages) trigger a single retry via `gh run rerun --failed`
- Code failures (test/lint/build/type errors) proceed to FAILED report as usual
- Retry re-runs ship-wait.ts which handles the rebase/push no-op and watches the retried CI