### PR TITLE
refactor(config): module-owned config definitions via register-config hook

### DIFF
--- a/src/main/modules/auto-pr-module.ts
+++ b/src/main/modules/auto-pr-module.ts
@@ -16,7 +16,11 @@
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { DomainEvent } from "../intents/infrastructure/types";
-import { APP_START_OPERATION_ID, type ActivateHookResult } from "../operations/app-start";
+import {
+  APP_START_OPERATION_ID,
+  type ActivateHookResult,
+  type RegisterConfigResult,
+} from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "../operations/open-workspace";
 import {
@@ -35,6 +39,7 @@ import type { InitialPrompt } from "../../shared/api/types";
 import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../shared/error-utils";
 import { renderTemplate } from "../../services/template/liquid-renderer";
+import { parseBool, type ConfigKeyDefinition } from "../../services/config/config-definition";
 
 // =============================================================================
 // Persistence Types
@@ -500,6 +505,24 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     name: "auto-pr",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "experimental.auto-pr-workspaces",
+                default: false,
+                parse: parseBool,
+                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+              },
+              {
+                name: "experimental.pr-auto-workspace.template-path",
+                default: null,
+                parse: (s: string) => (s === "" ? null : s),
+                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+              },
+            ] satisfies ConfigKeyDefinition<unknown>[],
+          }),
+        },
         activate: {
           handler: async (): Promise<ActivateHookResult> => {
             await activate();

--- a/src/main/modules/auto-updater-module.integration.test.ts
+++ b/src/main/modules/auto-updater-module.integration.test.ts
@@ -34,7 +34,6 @@ import { createAutoUpdaterModule } from "./auto-updater-module";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
-import type { ConfigValues } from "../../services/config/config-values";
 import type { AutoUpdater, UpdateAvailableCallback } from "../../services/auto-updater";
 
 // =============================================================================
@@ -139,7 +138,7 @@ function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
  */
 function simulateConfigUpdated(
   module: IntentModule,
-  values: Partial<Readonly<ConfigValues>>
+  values: Readonly<Record<string, unknown>>
 ): void {
   const event: ConfigUpdatedEvent = {
     type: EVENT_CONFIG_UPDATED,

--- a/src/main/modules/auto-updater-module.ts
+++ b/src/main/modules/auto-updater-module.ts
@@ -12,7 +12,11 @@
 
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
-import { APP_START_OPERATION_ID, type StartHookResult } from "../operations/app-start";
+import {
+  APP_START_OPERATION_ID,
+  type StartHookResult,
+  type RegisterConfigResult,
+} from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import {
   INTENT_UPDATE_AVAILABLE,
@@ -35,6 +39,20 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
     name: "auto-updater",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "auto-update",
+                default: "always" as AutoUpdatePreference,
+                parse: (s: string) =>
+                  s === "always" || s === "never" ? (s as AutoUpdatePreference) : undefined,
+                validate: (v: unknown) =>
+                  v === "always" || v === "never" ? (v as AutoUpdatePreference) : undefined,
+              },
+            ],
+          }),
+        },
         start: {
           handler: async (): Promise<StartHookResult> => {
             if (autoUpdate === "never") {
@@ -66,7 +84,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
       [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
         const { values } = event.payload as ConfigUpdatedPayload;
         if (values["auto-update"] !== undefined) {
-          autoUpdate = values["auto-update"];
+          autoUpdate = values["auto-update"] as AutoUpdatePreference;
         }
       },
     },

--- a/src/main/modules/claude-agent-module.integration.test.ts
+++ b/src/main/modules/claude-agent-module.integration.test.ts
@@ -46,7 +46,6 @@ import { RESTART_AGENT_OPERATION_ID } from "../operations/restart-agent";
 import type { RestartAgentHookResult } from "../operations/restart-agent";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import { EVENT_CONFIG_UPDATED, INTENT_CONFIG_SET_VALUES } from "../operations/config-set-values";
-import type { ConfigValues } from "../../services/config/config-values";
 import { createClaudeAgentModule, type ClaudeAgentModuleDeps } from "./claude-agent-module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { SetupError } from "../../services/errors";
@@ -338,7 +337,7 @@ function createTestSetup(mockDepsResult?: ReturnType<typeof createMockDeps>) {
 function simulateConfigUpdated(module: IntentModule, agent: string | null): void {
   const event: ConfigUpdatedEvent = {
     type: EVENT_CONFIG_UPDATED,
-    payload: { values: { agent } as Partial<Readonly<ConfigValues>> },
+    payload: { values: { agent } as Readonly<Record<string, unknown>> },
   };
   module.events![EVENT_CONFIG_UPDATED]!(event as DomainEvent);
 }

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -28,6 +28,7 @@ import type {
   StartHookResult,
   ActivateHookContext,
   ActivateHookResult,
+  RegisterConfigResult,
 } from "../operations/app-start";
 import type { RegisterAgentResult, SaveAgentHookInput, BinaryHookInput } from "../operations/setup";
 import type {
@@ -190,6 +191,19 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
     name: "claude-agent",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "version.claude",
+                default: null,
+                parse: (s: string) => (s === "" ? null : s),
+                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+              },
+            ],
+          }),
+        },
+
         "before-ready": {
           handler: async (): Promise<ConfigureResult> => {
             return {
@@ -446,7 +460,7 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
         const { values } = (event as ConfigUpdatedEvent).payload;
         if (values.agent !== undefined) {
           // Agent value received — check if this module should be active
-          const agentType = values.agent ?? "opencode";
+          const agentType = (values.agent as string | null) ?? "opencode";
           active = agentType === "claude";
         }
       },

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -26,7 +26,12 @@ import type { DomainEvent } from "../intents/infrastructure/types";
 import type { SupportedPlatform, SupportedArch } from "../../agents/types";
 import type { DownloadRequest } from "../../services/binary-download";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
-import type { CheckDepsResult, ConfigureResult, StartHookResult } from "../operations/app-start";
+import type {
+  CheckDepsResult,
+  ConfigureResult,
+  StartHookResult,
+  RegisterConfigResult,
+} from "../operations/app-start";
 import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
 import type { FinalizeHookInput, FinalizeHookResult } from "../operations/open-workspace";
 import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
@@ -100,6 +105,22 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
     name: "code-server",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        // -------------------------------------------------------------------
+        // app-start → register-config: declare version.code-server key
+        // -------------------------------------------------------------------
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "version.code-server",
+                default: null,
+                parse: (s: string) => (s === "" ? null : s),
+                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+              },
+            ],
+          }),
+        },
+
         // -------------------------------------------------------------------
         // app-start → before-ready: declare required scripts
         // -------------------------------------------------------------------

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -3,8 +3,9 @@
  * Integration tests for ConfigModule through the Dispatcher.
  *
  * Tests verify the full pipeline: dispatcher -> operation -> hook handlers.
- * Covers all three hook points:
- * - app:start / "before-ready" -- dispatches full merged config (defaults + computed + env + CLI)
+ * Covers all hook points:
+ * - app:start / "register-config" -- modules return config key definitions
+ * - app:start / "before-ready" -- collects definitions, dispatches full merged config
  * - app:start / "init" -- reads config.json, dispatches only delta
  * - config-set-values / "set" -- merges values into effective, optionally persists to disk
  *
@@ -12,6 +13,11 @@
  * - parseEnvVars / parseCliArgs standalone
  * - Precedence (CLI > env > file > computed > defaults)
  * - Config file migration (old keys → new keys)
+ *
+ * Most tests use test-specific config definitions (test.string, test.level, etc.)
+ * to verify config-module mechanics independently of real module definitions.
+ * Migration tests use additional real-key definitions because parseConfigFile
+ * is tied to production key names.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -22,8 +28,15 @@ import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import type { Operation, OperationContext } from "../intents/infrastructure/operation";
 import type { Intent } from "../intents/infrastructure/types";
+import type { IntentModule } from "../intents/infrastructure/module";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../operations/app-start";
-import type { AppStartIntent, ConfigureResult, InitHookContext } from "../operations/app-start";
+import type {
+  AppStartIntent,
+  ConfigureResult,
+  InitHookContext,
+  RegisterConfigResult,
+  BeforeReadyHookContext,
+} from "../operations/app-start";
 import {
   ConfigSetValuesOperation,
   INTENT_CONFIG_SET_VALUES,
@@ -37,27 +50,198 @@ import {
   directory,
 } from "../../services/platform/filesystem.state-mock";
 import { createConfigModule, parseEnvVars, parseCliArgs } from "./config-module";
-import {
-  CONFIG_KEYS,
-  DEFAULT_CONFIG_VALUES,
-  generateHelpText,
-} from "../../services/config/config-values";
+import { generateHelpText } from "../../services/config/config-values";
+import { parseBool } from "../../services/config/config-definition";
+import type { ConfigKeyDefinition } from "../../services/config/config-definition";
+
+// =============================================================================
+// Test Config Definitions
+// =============================================================================
+
+/**
+ * Test-specific config key definitions for config mechanics testing.
+ * These verify config-module behavior without duplicating real module definitions.
+ *
+ * Env var mapping (via envVarToConfigKey):
+ *   test.string       → CH_TEST__STRING
+ *   test.dev-flag     → CH_TEST__DEV_FLAG
+ *   test.nullable     → CH_TEST__NULLABLE
+ *   test.enum         → CH_TEST__ENUM
+ *   test.level        → CH_TEST__LEVEL
+ *   test.optional     → CH_TEST__OPTIONAL
+ */
+function testDefinitions(): ConfigKeyDefinition<unknown>[] {
+  return [
+    {
+      name: "test.string",
+      default: "default-val",
+      parse: (s: string) => (s === "" ? undefined : s),
+      validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+    },
+    {
+      name: "test.dev-flag",
+      default: true,
+      parse: parseBool,
+      validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+      computedDefault: (ctx) => (ctx.isDevelopment || !ctx.isPackaged ? false : undefined),
+    },
+    {
+      name: "test.nullable",
+      default: null,
+      parse: (s: string) => (s === "" ? null : s),
+      validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+    },
+    {
+      name: "test.enum",
+      default: "always",
+      parse: (s: string) => (s === "always" || s === "never" ? s : undefined),
+      validate: (v: unknown) => (v === "always" || v === "never" ? v : undefined),
+    },
+    {
+      name: "test.level",
+      default: "warn",
+      parse: (s: string) => {
+        const valid = ["silly", "debug", "info", "warn", "error"];
+        return valid.includes(s) ? s : undefined;
+      },
+      validate: (v: unknown) => {
+        if (typeof v !== "string") return undefined;
+        const valid = ["silly", "debug", "info", "warn", "error"];
+        return valid.includes(v) ? v : undefined;
+      },
+      computedDefault: (ctx) => (ctx.isDevelopment ? "debug" : undefined),
+    },
+    {
+      name: "test.optional",
+      default: undefined,
+      parse: (s: string) => (s === "" ? undefined : s),
+      validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+    },
+  ];
+}
+
+/**
+ * Definitions matching real keys used by config file migration logic.
+ * parseConfigFile references these key names in KEY_RENAMES and LegacyConfig.
+ * Only used by migration-specific tests.
+ */
+function migrationDefinitions(): ConfigKeyDefinition<unknown>[] {
+  return [
+    {
+      name: "version.claude",
+      default: null,
+      parse: (s: string) => (s === "" ? null : s),
+      validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+    },
+    {
+      name: "version.opencode",
+      default: null,
+      parse: (s: string) => (s === "" ? null : s),
+      validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+    },
+    {
+      name: "version.code-server",
+      default: null,
+      parse: (s: string) => (s === "" ? null : s),
+      validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+    },
+    {
+      name: "telemetry.enabled",
+      default: true,
+      parse: parseBool,
+      validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+    },
+    {
+      name: "telemetry.distinct-id",
+      default: undefined,
+      parse: (s: string) => (s === "" ? undefined : s),
+      validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+    },
+  ];
+}
+
+/**
+ * Module that registers test config definitions via the register-config hook.
+ */
+function createTestDefinitionsModule(defs: ConfigKeyDefinition<unknown>[]): IntentModule {
+  return {
+    name: "test-definitions",
+    hooks: {
+      [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: defs,
+          }),
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Build a definitions map from config-module's own definitions + test definitions.
+ * Used for standalone parseEnvVars/parseCliArgs tests.
+ */
+function buildTestDefinitionsMap(): Map<string, ConfigKeyDefinition<unknown>> {
+  const configModuleDefs: ConfigKeyDefinition<unknown>[] = [
+    {
+      name: "agent",
+      default: null,
+      parse: (s: string) => (s === "claude" || s === "opencode" ? s : s === "" ? null : undefined),
+      validate: (v: unknown) => (v === null || v === "claude" || v === "opencode" ? v : undefined),
+    },
+    {
+      name: "help",
+      default: false,
+      parse: parseBool,
+      validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+    },
+  ];
+  const allDefs = [...configModuleDefs, ...testDefinitions()];
+  return new Map(allDefs.map((d) => [d.name, d]));
+}
+
+/**
+ * All test config key names (config-module's own + test definitions).
+ */
+const ALL_TEST_KEYS = [
+  "agent",
+  "help",
+  "test.string",
+  "test.dev-flag",
+  "test.nullable",
+  "test.enum",
+  "test.level",
+  "test.optional",
+];
 
 // =============================================================================
 // Minimal Test Operations
 // =============================================================================
 
 /**
- * Runs "before-ready" hook point only.
+ * Runs "register-config" then "before-ready" hook points.
  * The before-ready hook dispatches config:set-values internally,
  * so the dispatcher must have ConfigSetValuesOperation registered.
  */
 class MinimalBeforeReadyOperation implements Operation<Intent, ConfigureResult> {
   readonly id = APP_START_OPERATION_ID;
   async execute(ctx: OperationContext<Intent>): Promise<ConfigureResult> {
-    const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
+    // Run register-config first
+    const { results: regResults, errors: regErrors } =
+      await ctx.hooks.collect<RegisterConfigResult>("register-config", { intent: ctx.intent });
+    if (regErrors.length > 0) throw regErrors[0]!;
+    const configDefinitions = regResults.flatMap((r) => r.definitions ?? []);
+
+    // Run before-ready with definitions
+    const beforeReadyCtx: BeforeReadyHookContext = {
       intent: ctx.intent,
-    });
+      configDefinitions,
+    };
+    const { results, errors } = await ctx.hooks.collect<ConfigureResult>(
+      "before-ready",
+      beforeReadyCtx
+    );
     if (errors.length > 0) throw errors[0]!;
     const merged: ConfigureResult = {};
     for (const r of results) {
@@ -73,12 +257,27 @@ class MinimalBeforeReadyOperation implements Operation<Intent, ConfigureResult> 
 }
 
 /**
- * Runs "init" hook point only.
- * The init hook dispatches config:set-values internally.
+ * Runs "register-config", "before-ready", then "init" hook points.
+ * init depends on before-ready having run to populate definitions.
  */
 class MinimalInitOperation implements Operation<Intent, { configuredAgent?: string | null }> {
   readonly id = APP_START_OPERATION_ID;
   async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
+    const { results: regResults, errors: regErrors } =
+      await ctx.hooks.collect<RegisterConfigResult>("register-config", { intent: ctx.intent });
+    if (regErrors.length > 0) throw regErrors[0]!;
+    const configDefinitions = regResults.flatMap((r) => r.definitions ?? []);
+
+    const beforeReadyCtx: BeforeReadyHookContext = {
+      intent: ctx.intent,
+      configDefinitions,
+    };
+    const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>(
+      "before-ready",
+      beforeReadyCtx
+    );
+    if (brErrors.length > 0) throw brErrors[0]!;
+
     const initCtx: InitHookContext = {
       intent: ctx.intent,
       requiredScripts: [],
@@ -88,6 +287,42 @@ class MinimalInitOperation implements Operation<Intent, { configuredAgent?: stri
       initCtx
     );
     if (errors.length > 0) throw errors[0]!;
+    let configuredAgent: string | null = null;
+    for (const result of results) {
+      if (result.configuredAgent !== undefined) configuredAgent = result.configuredAgent;
+    }
+    return { configuredAgent };
+  }
+}
+
+/**
+ * Runs all three hook points: register-config → before-ready → init.
+ * Used by tests that need the full pipeline (precedence, computed defaults).
+ */
+class CombinedStartOperation implements Operation<Intent, { configuredAgent?: string | null }> {
+  readonly id = APP_START_OPERATION_ID;
+  async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
+    const { results: regResults, errors: regErrors } =
+      await ctx.hooks.collect<RegisterConfigResult>("register-config", { intent: ctx.intent });
+    if (regErrors.length > 0) throw regErrors[0]!;
+    const configDefinitions = regResults.flatMap((r) => r.definitions ?? []);
+
+    const beforeReadyCtx: BeforeReadyHookContext = {
+      intent: ctx.intent,
+      configDefinitions,
+    };
+    const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>(
+      "before-ready",
+      beforeReadyCtx
+    );
+    if (brErrors.length > 0) throw brErrors[0]!;
+
+    const initCtx: InitHookContext = { intent: ctx.intent, requiredScripts: [] };
+    const { results, errors } = await ctx.hooks.collect<{
+      configuredAgent?: string | null;
+    }>("init", initCtx);
+    if (errors.length > 0) throw errors[0]!;
+
     let configuredAgent: string | null = null;
     for (const result of results) {
       if (result.configuredAgent !== undefined) configuredAgent = result.configuredAgent;
@@ -109,6 +344,7 @@ function createTestSetup(options?: {
   noConfigFile?: boolean;
   env?: Record<string, string | undefined>;
   argv?: string[];
+  extraDefinitions?: ConfigKeyDefinition<unknown>[];
 }) {
   const fileSystem = createFileSystemMock({
     entries: {
@@ -143,6 +379,10 @@ function createTestSetup(options?: {
 
   dispatcher.registerModule(module);
 
+  // Register test definitions module
+  const defs = [...testDefinitions(), ...(options?.extraDefinitions ?? [])];
+  dispatcher.registerModule(createTestDefinitionsModule(defs));
+
   return { fileSystem, hookRegistry, dispatcher, module, stdout };
 }
 
@@ -155,58 +395,57 @@ describe("ConfigModule Integration", () => {
   // parseEnvVars standalone
   // ---------------------------------------------------------------------------
   describe("parseEnvVars", () => {
-    it("maps CH_LOG__LEVEL to log.level", () => {
-      const result = parseEnvVars({ CH_LOG__LEVEL: "debug" });
-      expect(result["log.level"]).toBe("debug");
+    const definitions = buildTestDefinitionsMap();
+
+    it("maps CH_TEST__STRING to test.string", () => {
+      const result = parseEnvVars({ CH_TEST__STRING: "custom" }, definitions);
+      expect(result["test.string"]).toBe("custom");
     });
 
-    it("maps CH_LOG__OUTPUT to log.output", () => {
-      const result = parseEnvVars({ CH_LOG__OUTPUT: "console" });
-      expect(result["log.output"]).toBe("console");
+    it("maps CH_TEST__LEVEL to test.level", () => {
+      const result = parseEnvVars({ CH_TEST__LEVEL: "debug" }, definitions);
+      expect(result["test.level"]).toBe("debug");
     });
 
-    it("parses combined CH_LOG__LEVEL with filter", () => {
-      const result = parseEnvVars({ CH_LOG__LEVEL: "debug:git,process" });
-      expect(result["log.level"]).toBe("debug:git,process");
+    it("maps CH_TEST__ENUM to test.enum", () => {
+      const result = parseEnvVars({ CH_TEST__ENUM: "never" }, definitions);
+      expect(result["test.enum"]).toBe("never");
     });
 
-    it("maps CH_ELECTRON__FLAGS to electron.flags", () => {
-      const result = parseEnvVars({ CH_ELECTRON__FLAGS: "--disable-gpu" });
-      expect(result["electron.flags"]).toBe("--disable-gpu");
+    it("maps CH_TEST__OPTIONAL to test.optional", () => {
+      const result = parseEnvVars({ CH_TEST__OPTIONAL: "some-value" }, definitions);
+      expect(result["test.optional"]).toBe("some-value");
     });
 
-    it("maps CH_VERSION__CODE_SERVER to version.code-server", () => {
-      const result = parseEnvVars({ CH_VERSION__CODE_SERVER: "5.0.0" });
-      expect(result["version.code-server"]).toBe("5.0.0");
+    it("maps CH_TEST__NULLABLE to test.nullable", () => {
+      const result = parseEnvVars({ CH_TEST__NULLABLE: "override-val" }, definitions);
+      expect(result["test.nullable"]).toBe("override-val");
     });
 
-    it("maps CH_TELEMETRY__DISTINCT_ID to telemetry.distinct-id", () => {
-      const result = parseEnvVars({ CH_TELEMETRY__DISTINCT_ID: "user-abc" });
-      expect(result["telemetry.distinct-id"]).toBe("user-abc");
+    it("maps CH_TEST__DEV_FLAG to test.dev-flag", () => {
+      const result = parseEnvVars({ CH_TEST__DEV_FLAG: "false" }, definitions);
+      expect(result["test.dev-flag"]).toBe(false);
     });
 
     it("ignores _CH_ prefixed vars (internal)", () => {
-      const result = parseEnvVars({ _CH_INTERNAL: "value" });
+      const result = parseEnvVars({ _CH_INTERNAL: "value" }, definitions);
       expect(Object.keys(result)).toHaveLength(0);
     });
 
     it("ignores non-CH_ vars", () => {
-      const result = parseEnvVars({ HOME: "/home/user", PATH: "/usr/bin" });
+      const result = parseEnvVars({ HOME: "/home/user", PATH: "/usr/bin" }, definitions);
       expect(Object.keys(result)).toHaveLength(0);
     });
 
     it("throws on unknown CH_ env var", () => {
-      expect(() => parseEnvVars({ CH_UNKNOWN_VAR: "value" })).toThrow(/Unknown config env var/);
+      expect(() => parseEnvVars({ CH_UNKNOWN_VAR: "value" }, definitions)).toThrow(
+        /Unknown config env var/
+      );
     });
 
     it("skips invalid values without throwing", () => {
-      const result = parseEnvVars({ CH_LOG__LEVEL: "not-a-level" });
-      expect(result["log.level"]).toBeUndefined();
-    });
-
-    it("maps CH_AUTO_UPDATE=never to auto-update", () => {
-      const result = parseEnvVars({ CH_AUTO_UPDATE: "never" });
-      expect(result["auto-update"]).toBe("never");
+      const result = parseEnvVars({ CH_TEST__LEVEL: "not-a-level" }, definitions);
+      expect(result["test.level"]).toBeUndefined();
     });
   });
 
@@ -214,36 +453,41 @@ describe("ConfigModule Integration", () => {
   // parseCliArgs standalone
   // ---------------------------------------------------------------------------
   describe("parseCliArgs", () => {
+    const definitions = buildTestDefinitionsMap();
+
     it("parses --key=value format", () => {
-      const result = parseCliArgs(["--log.level=debug"]);
-      expect(result["log.level"]).toBe("debug");
+      const result = parseCliArgs(["--test.level=debug"], definitions);
+      expect(result["test.level"]).toBe("debug");
     });
 
     it("parses --key value format", () => {
-      const result = parseCliArgs(["--log.level", "debug"]);
-      expect(result["log.level"]).toBe("debug");
+      const result = parseCliArgs(["--test.level", "debug"], definitions);
+      expect(result["test.level"]).toBe("debug");
     });
 
-    it("parses --log.output flag", () => {
-      const result = parseCliArgs(["--log.output=console"]);
-      expect(result["log.output"]).toBe("console");
+    it("parses --test.enum flag", () => {
+      const result = parseCliArgs(["--test.enum=never"], definitions);
+      expect(result["test.enum"]).toBe("never");
     });
 
     it("ignores unknown flags silently", () => {
-      const result = parseCliArgs(["--unknown-flag=value"]);
+      const result = parseCliArgs(["--unknown-flag=value"], definitions);
       expect(Object.keys(result)).toHaveLength(0);
     });
 
     it("parses multiple flags", () => {
-      const result = parseCliArgs(["--log.level=debug", "--log.output=console", "--agent=claude"]);
-      expect(result["log.level"]).toBe("debug");
-      expect(result["log.output"]).toBe("console");
+      const result = parseCliArgs(
+        ["--test.level=debug", "--test.enum=never", "--agent=claude"],
+        definitions
+      );
+      expect(result["test.level"]).toBe("debug");
+      expect(result["test.enum"]).toBe("never");
       expect(result.agent).toBe("claude");
     });
 
-    it("parses --auto-update=never flag", () => {
-      const result = parseCliArgs(["--auto-update=never"]);
-      expect(result["auto-update"]).toBe("never");
+    it("parses boolean flag without value as true", () => {
+      const result = parseCliArgs(["--help"], definitions);
+      expect(result.help).toBe(true);
     });
   });
 
@@ -251,7 +495,7 @@ describe("ConfigModule Integration", () => {
   // app-start / "before-ready"
   // ---------------------------------------------------------------------------
   describe('app-start / "before-ready"', () => {
-    it("dispatches full merged config including computed defaults (isDevelopment)", async () => {
+    it("dispatches computed defaults when isDevelopment=true", async () => {
       const { dispatcher } = createTestSetup({ isDevelopment: true });
 
       const events: ConfigUpdatedEvent[] = [];
@@ -259,22 +503,21 @@ describe("ConfigModule Integration", () => {
 
       dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
 
-      const result = await dispatcher.dispatch({
+      await dispatcher.dispatch({
         type: INTENT_APP_START,
         payload: {},
       } as AppStartIntent);
 
-      expect(result).toEqual({});
-      // Computed defaults differ from static defaults → config:updated emitted
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.level"]).toBe("debug");
-      expect(events[0]!.payload.values["telemetry.enabled"]).toBe(false);
+      expect(events[0]!.payload.values["test.level"]).toBe("debug");
+      expect(events[0]!.payload.values["test.dev-flag"]).toBe(false);
     });
 
-    it("parses CH_LOG__LEVEL env var", async () => {
+    it("parses env var and applies to config", async () => {
       const { dispatcher } = createTestSetup({
         isDevelopment: false,
-        env: { CH_LOG__LEVEL: "silly" },
+        isPackaged: true,
+        env: { CH_TEST__LEVEL: "silly" },
       });
 
       const events: ConfigUpdatedEvent[] = [];
@@ -288,13 +531,13 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.level"]).toBe("silly");
+      expect(events[0]!.payload.values["test.level"]).toBe("silly");
     });
 
-    it("CH_LOG__LEVEL overrides isDevelopment default", async () => {
+    it("env var overrides computed default", async () => {
       const { dispatcher } = createTestSetup({
         isDevelopment: true,
-        env: { CH_LOG__LEVEL: "error" },
+        env: { CH_TEST__LEVEL: "error" },
       });
 
       const events: ConfigUpdatedEvent[] = [];
@@ -308,11 +551,14 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.level"]).toBe("error");
+      expect(events[0]!.payload.values["test.level"]).toBe("error");
     });
 
-    it("sets log.output from CH_LOG__OUTPUT env var", async () => {
-      const { dispatcher } = createTestSetup({ env: { CH_LOG__OUTPUT: "console" } });
+    it("sets enum value from env var", async () => {
+      const { dispatcher } = createTestSetup({
+        isPackaged: true,
+        env: { CH_TEST__ENUM: "never" },
+      });
 
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
@@ -325,11 +571,14 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.output"]).toBe("console");
+      expect(events[0]!.payload.values["test.enum"]).toBe("never");
     });
 
-    it("sets combined log.level with filter from CH_LOG__LEVEL env var", async () => {
-      const { dispatcher } = createTestSetup({ env: { CH_LOG__LEVEL: "debug:git,process" } });
+    it("sets optional value from env var", async () => {
+      const { dispatcher } = createTestSetup({
+        isPackaged: true,
+        env: { CH_TEST__OPTIONAL: "some-flags" },
+      });
 
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
@@ -342,30 +591,14 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.level"]).toBe("debug:git,process");
-    });
-
-    it("sets electron.flags from CH_ELECTRON__FLAGS env var", async () => {
-      const { dispatcher } = createTestSetup({ env: { CH_ELECTRON__FLAGS: "--disable-gpu" } });
-
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
-
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
-
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["electron.flags"]).toBe("--disable-gpu");
+      expect(events[0]!.payload.values["test.optional"]).toBe("some-flags");
     });
 
     it("CLI flags override env vars", async () => {
       const { dispatcher } = createTestSetup({
-        env: { CH_LOG__LEVEL: "silly" },
-        argv: ["--log.level=error"],
+        isPackaged: true,
+        env: { CH_TEST__LEVEL: "silly" },
+        argv: ["--test.level=error"],
       });
 
       const events: ConfigUpdatedEvent[] = [];
@@ -379,7 +612,7 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["log.level"]).toBe("error");
+      expect(events[0]!.payload.values["test.level"]).toBe("error");
     });
 
     it("returns empty ConfigureResult (no scripts)", async () => {
@@ -419,23 +652,24 @@ describe("ConfigModule Integration", () => {
   // app-start / "init"
   // ---------------------------------------------------------------------------
   describe('app-start / "init"', () => {
-    it("reads config.json from disk and dispatches config:set-values with file values", async () => {
+    it("reads config.json from disk and dispatches delta", async () => {
       const configContent = JSON.stringify({
         agent: "claude",
-        "version.code-server": "4.200.0",
-        "telemetry.enabled": true,
+        "test.nullable": "custom-val",
+        "test.enum": "never",
       });
 
-      // Use isPackaged=true so telemetry.enabled defaults to true (static default)
+      // Use isPackaged=true so computed defaults don't interfere
       const { dispatcher } = createTestSetup({
         configFileContent: configContent,
         isPackaged: true,
       });
 
+      // Subscribe after setup — before-ready events are internal to MinimalInitOperation
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       const result = (await dispatcher.dispatch({
         type: INTENT_APP_START,
@@ -443,31 +677,35 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
 
       expect(result.configuredAgent).toBe("claude");
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values.agent).toBe("claude");
-      expect(events[0]!.payload.values["version.code-server"]).toBe("4.200.0");
+      // Only init should produce changes (agent, test.nullable, test.enum from file)
+      const initEvents = events.filter((e) => e.payload.values.agent !== undefined);
+      expect(initEvents).toHaveLength(1);
+      expect(initEvents[0]!.payload.values.agent).toBe("claude");
+      expect(initEvents[0]!.payload.values["test.nullable"]).toBe("custom-val");
+      expect(initEvents[0]!.payload.values["test.enum"]).toBe("never");
     });
 
-    it("auto-update value from config.json round-trips through init", async () => {
-      const configContent = JSON.stringify({ "auto-update": "never" });
+    it("enum value from config.json round-trips through init", async () => {
+      const configContent = JSON.stringify({ "test.enum": "never" });
 
       const { dispatcher } = createTestSetup({
         configFileContent: configContent,
         isPackaged: true,
       });
 
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       await dispatcher.dispatch({
         type: INTENT_APP_START,
         payload: {},
       } as AppStartIntent);
 
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["auto-update"]).toBe("never");
+      const enumEvents = events.filter((e) => e.payload.values["test.enum"] !== undefined);
+      expect(enumEvents).toHaveLength(1);
+      expect(enumEvents[0]!.payload.values["test.enum"]).toBe("never");
     });
 
     it("returns configuredAgent from effective config", async () => {
@@ -489,10 +727,10 @@ describe("ConfigModule Integration", () => {
       // Use isPackaged=true so computed defaults don't interfere
       const { dispatcher } = createTestSetup({ noConfigFile: true, isPackaged: true });
 
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       const result = (await dispatcher.dispatch({
         type: INTENT_APP_START,
@@ -510,10 +748,10 @@ describe("ConfigModule Integration", () => {
         isPackaged: true,
       });
 
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       const result = (await dispatcher.dispatch({
         type: INTENT_APP_START,
@@ -524,181 +762,212 @@ describe("ConfigModule Integration", () => {
       expect(events).toHaveLength(0);
     });
 
-    it("handles legacy nested format (backwards compat)", async () => {
-      const legacyConfig = JSON.stringify({
-        agent: "claude",
-        versions: {
-          claude: "1.0.0",
-          opencode: null,
-          codeServer: "4.150.0",
-        },
-        telemetry: {
-          enabled: false,
-          distinctId: "user-123",
-        },
+    // -------------------------------------------------------------------------
+    // Config file migration (uses real key definitions)
+    // -------------------------------------------------------------------------
+    describe("config file migration", () => {
+      it("handles legacy nested format (backwards compat)", async () => {
+        const legacyConfig = JSON.stringify({
+          agent: "claude",
+          versions: {
+            claude: "1.0.0",
+            opencode: null,
+            codeServer: "4.150.0",
+          },
+          telemetry: {
+            enabled: false,
+            distinctId: "user-123",
+          },
+        });
+
+        const { dispatcher } = createTestSetup({
+          configFileContent: legacyConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
+
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+
+        const result = (await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
+
+        expect(result.configuredAgent).toBe("claude");
+
+        // Find the init event that has agent
+        const initEvent = events.find((e) => e.payload.values.agent !== undefined);
+        expect(initEvent).toBeDefined();
+        const values = initEvent!.payload.values;
+        expect(values.agent).toBe("claude");
+        expect(values["version.claude"]).toBe("1.0.0");
+        expect(values["version.code-server"]).toBe("4.150.0");
+        expect(values["telemetry.distinct-id"]).toBe("user-123");
+        // version.opencode is null (same as default), so not in changed values
+        expect(values["version.opencode"]).toBeUndefined();
       });
 
-      const { dispatcher } = createTestSetup({ configFileContent: legacyConfig });
+      it("migrates old flat key names to new names", async () => {
+        const oldFlatConfig = JSON.stringify({
+          agent: "claude",
+          "versions.codeServer": "4.200.0",
+          "versions.claude": "1.5.0",
+          "versions.opencode": null,
+          "telemetry.enabled": true,
+          "telemetry.distinctId": "user-456",
+        });
 
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+        const { dispatcher, fileSystem } = createTestSetup({
+          configFileContent: oldFlatConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
-      const result = (await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
 
-      expect(result.configuredAgent).toBe("claude");
-      expect(events).toHaveLength(1);
+        await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent);
 
-      const values = events[0]!.payload.values;
-      expect(values.agent).toBe("claude");
-      expect(values["version.claude"]).toBe("1.0.0");
-      expect(values["version.code-server"]).toBe("4.150.0");
-      expect(values["telemetry.distinct-id"]).toBe("user-123");
-      // version.opencode is null (same as default), so not in changed values
-      expect(values["version.opencode"]).toBeUndefined();
-    });
+        const initEvent = events.find((e) => e.payload.values["version.code-server"] !== undefined);
+        expect(initEvent).toBeDefined();
+        const values = initEvent!.payload.values;
+        expect(values["version.code-server"]).toBe("4.200.0");
+        expect(values["version.claude"]).toBe("1.5.0");
+        expect(values["telemetry.distinct-id"]).toBe("user-456");
 
-    it("migrates old flat key names to new names", async () => {
-      const oldFlatConfig = JSON.stringify({
-        agent: "claude",
-        "versions.codeServer": "4.200.0",
-        "versions.claude": "1.5.0",
-        "versions.opencode": null,
-        "telemetry.enabled": true,
-        "telemetry.distinctId": "user-456",
+        // Migration should have persisted new key names to disk
+        const content = await fileSystem.readFile(CONFIG_PATH);
+        const parsed = JSON.parse(content) as Record<string, unknown>;
+        // Use bracket notation — toHaveProperty("a.b") does nested lookup
+        expect(parsed["version.code-server"]).toBe("4.200.0");
+        expect(parsed["version.claude"]).toBe("1.5.0");
+        expect(parsed["telemetry.distinct-id"]).toBe("user-456");
+
+        // Old keys should NOT be present
+        expect(parsed["versions.codeServer"]).toBeUndefined();
+        expect(parsed["telemetry.distinctId"]).toBeUndefined();
       });
 
-      const { dispatcher, fileSystem } = createTestSetup({ configFileContent: oldFlatConfig });
+      it("converts legacy nested codeServer old default to null", async () => {
+        const legacyConfig = JSON.stringify({
+          agent: "claude",
+          versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+        });
 
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+        const { dispatcher } = createTestSetup({
+          configFileContent: legacyConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
 
-      expect(events).toHaveLength(1);
-      const values = events[0]!.payload.values;
-      expect(values["version.code-server"]).toBe("4.200.0");
-      expect(values["version.claude"]).toBe("1.5.0");
-      expect(values["telemetry.distinct-id"]).toBe("user-456");
+        await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent);
 
-      // Migration should have persisted new key names to disk
-      const content = await fileSystem.readFile(CONFIG_PATH);
-      const parsed = JSON.parse(content) as Record<string, unknown>;
-      // Use bracket notation — toHaveProperty("a.b") does nested lookup
-      expect(parsed["version.code-server"]).toBe("4.200.0");
-      expect(parsed["version.claude"]).toBe("1.5.0");
-      expect(parsed["telemetry.distinct-id"]).toBe("user-456");
-      // Old keys should NOT be present
-      expect(parsed["versions.codeServer"]).toBeUndefined();
-      expect(parsed["telemetry.distinctId"]).toBeUndefined();
-    });
-
-    it("converts legacy nested codeServer old default to null", async () => {
-      const legacyConfig = JSON.stringify({
-        agent: "claude",
-        versions: { claude: null, opencode: null, codeServer: "4.107.0" },
+        // "4.107.0" becomes null (= default), so version.code-server should NOT be in changed values
+        const initEvent = events.find((e) => e.payload.values.agent !== undefined);
+        expect(initEvent).toBeDefined();
+        expect(initEvent!.payload.values["version.code-server"]).toBeUndefined();
       });
 
-      const { dispatcher } = createTestSetup({ configFileContent: legacyConfig });
+      it("preserves legacy nested codeServer explicit override", async () => {
+        const legacyConfig = JSON.stringify({
+          agent: "claude",
+          versions: { claude: null, opencode: null, codeServer: "4.150.0" },
+        });
 
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+        const { dispatcher } = createTestSetup({
+          configFileContent: legacyConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
 
-      // "4.107.0" becomes null (= default), so version.code-server should NOT be in changed values
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["version.code-server"]).toBeUndefined();
-    });
+        await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent);
 
-    it("preserves legacy nested codeServer explicit override", async () => {
-      const legacyConfig = JSON.stringify({
-        agent: "claude",
-        versions: { claude: null, opencode: null, codeServer: "4.150.0" },
+        const initEvent = events.find((e) => e.payload.values.agent !== undefined);
+        expect(initEvent).toBeDefined();
+        expect(initEvent!.payload.values["version.code-server"]).toBe("4.150.0");
       });
 
-      const { dispatcher } = createTestSetup({ configFileContent: legacyConfig });
+      it("converts old flat versions.codeServer old default to null", async () => {
+        const oldFlatConfig = JSON.stringify({
+          agent: "claude",
+          "versions.codeServer": "4.107.0",
+        });
 
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+        const { dispatcher, fileSystem } = createTestSetup({
+          configFileContent: oldFlatConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
 
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["version.code-server"]).toBe("4.150.0");
-    });
+        await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent);
 
-    it("converts old flat versions.codeServer old default to null", async () => {
-      const oldFlatConfig = JSON.stringify({
-        agent: "claude",
-        "versions.codeServer": "4.107.0",
+        // "4.107.0" becomes null (= default), so not in changed values
+        const initEvent = events.find((e) => e.payload.values.agent !== undefined);
+        expect(initEvent).toBeDefined();
+        expect(initEvent!.payload.values["version.code-server"]).toBeUndefined();
+
+        // Migrated file should have null
+        const content = await fileSystem.readFile(CONFIG_PATH);
+        const parsed = JSON.parse(content) as Record<string, unknown>;
+        expect(parsed["version.code-server"]).toBeNull();
       });
 
-      const { dispatcher, fileSystem } = createTestSetup({ configFileContent: oldFlatConfig });
+      it("preserves old flat versions.codeServer explicit override", async () => {
+        const oldFlatConfig = JSON.stringify({
+          agent: "claude",
+          "versions.codeServer": "4.200.0",
+        });
 
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
+        const { dispatcher, fileSystem } = createTestSetup({
+          configFileContent: oldFlatConfig,
+          extraDefinitions: migrationDefinitions(),
+        });
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+        dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
+        const events: ConfigUpdatedEvent[] = [];
+        dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
 
-      // "4.107.0" becomes null (= default), so not in changed values
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["version.code-server"]).toBeUndefined();
+        await dispatcher.dispatch({
+          type: INTENT_APP_START,
+          payload: {},
+        } as AppStartIntent);
 
-      // Migrated file should have null
-      const content = await fileSystem.readFile(CONFIG_PATH);
-      const parsed = JSON.parse(content) as Record<string, unknown>;
-      expect(parsed["version.code-server"]).toBeNull();
-    });
+        const initEvent = events.find((e) => e.payload.values["version.code-server"] !== undefined);
+        expect(initEvent).toBeDefined();
+        expect(initEvent!.payload.values["version.code-server"]).toBe("4.200.0");
 
-    it("preserves old flat versions.codeServer explicit override", async () => {
-      const oldFlatConfig = JSON.stringify({
-        agent: "claude",
-        "versions.codeServer": "4.200.0",
+        const content = await fileSystem.readFile(CONFIG_PATH);
+        const parsed = JSON.parse(content) as Record<string, unknown>;
+        expect(parsed["version.code-server"]).toBe("4.200.0");
       });
-
-      const { dispatcher, fileSystem } = createTestSetup({ configFileContent: oldFlatConfig });
-
-      const events: ConfigUpdatedEvent[] = [];
-      dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
-
-      await dispatcher.dispatch({
-        type: INTENT_APP_START,
-        payload: {},
-      } as AppStartIntent);
-
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["version.code-server"]).toBe("4.200.0");
-
-      const content = await fileSystem.readFile(CONFIG_PATH);
-      const parsed = JSON.parse(content) as Record<string, unknown>;
-      expect(parsed["version.code-server"]).toBe("4.200.0");
     });
   });
 
@@ -748,7 +1017,7 @@ describe("ConfigModule Integration", () => {
       await dispatcher.dispatch({
         type: INTENT_CONFIG_SET_VALUES,
         payload: {
-          values: { "log.level": "debug", "log.output": "console" },
+          values: { "test.level": "debug", "test.enum": "never" },
           persist: false,
         },
       } as ConfigSetValuesIntent);
@@ -781,7 +1050,7 @@ describe("ConfigModule Integration", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0]!.payload.values.agent).toBe("claude");
-      expect(events[0]!.payload.values["version.code-server"]).toBeUndefined();
+      expect(events[0]!.payload.values["test.nullable"]).toBeUndefined();
     });
 
     it("persist=true always writes to disk (read-modify-write)", async () => {
@@ -807,7 +1076,7 @@ describe("ConfigModule Integration", () => {
       expect(parsed.agent).toBe("claude");
     });
 
-    it("writes flat format JSON to disk with new key names", async () => {
+    it("writes only dispatched keys to disk (flat format)", async () => {
       const { dispatcher, fileSystem } = createTestSetup();
 
       dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
@@ -824,8 +1093,8 @@ describe("ConfigModule Integration", () => {
         payload: {
           values: {
             agent: "claude",
-            "version.claude": "2.0.0",
-            "telemetry.enabled": false,
+            "test.string": "custom-val",
+            "test.dev-flag": false,
           },
         },
       } as ConfigSetValuesIntent);
@@ -835,17 +1104,13 @@ describe("ConfigModule Integration", () => {
 
       // Should be flat format with only the dispatched keys
       expect(parsed["agent"]).toBe("claude");
-      expect(parsed["version.claude"]).toBe("2.0.0");
-      expect(parsed["telemetry.enabled"]).toBe(false);
-
-      // Should NOT have nested structure or old key names
-      expect(parsed["versions"]).toBeUndefined();
-      expect(parsed["versions.codeServer"]).toBeUndefined();
+      expect(parsed["test.string"]).toBe("custom-val");
+      expect(parsed["test.dev-flag"]).toBe(false);
 
       // Should not contain keys that were not in the dispatch
-      expect(parsed["log.level"]).toBeUndefined();
-      expect(parsed["log.output"]).toBeUndefined();
-      expect(parsed["electron.flags"]).toBeUndefined();
+      expect(parsed["test.level"]).toBeUndefined();
+      expect(parsed["test.enum"]).toBeUndefined();
+      expect(parsed["test.optional"]).toBeUndefined();
     });
 
     it("does not emit config:updated when no values actually changed", async () => {
@@ -879,41 +1144,12 @@ describe("ConfigModule Integration", () => {
   describe("precedence", () => {
     it("CLI override takes precedence over file layer", async () => {
       // Config file sets agent to claude, CLI overrides to opencode.
-      // Use a combined operation that runs both before-ready and init.
       const configContent = JSON.stringify({ agent: "claude" });
 
       const { dispatcher } = createTestSetup({
         configFileContent: configContent,
         argv: ["--agent=opencode"],
       });
-
-      // Combined operation: before-ready then init
-      class CombinedStartOperation implements Operation<
-        Intent,
-        { configuredAgent?: string | null }
-      > {
-        readonly id = APP_START_OPERATION_ID;
-        async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
-          // before-ready
-          const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
-            intent: ctx.intent,
-          });
-          if (brErrors.length > 0) throw brErrors[0]!;
-
-          // init
-          const initCtx: InitHookContext = { intent: ctx.intent, requiredScripts: [] };
-          const { results, errors } = await ctx.hooks.collect<{
-            configuredAgent?: string | null;
-          }>("init", initCtx);
-          if (errors.length > 0) throw errors[0]!;
-
-          let configuredAgent: string | null = null;
-          for (const result of results) {
-            if (result.configuredAgent !== undefined) configuredAgent = result.configuredAgent;
-          }
-          return { configuredAgent };
-        }
-      }
 
       dispatcher.registerOperation(INTENT_APP_START, new CombinedStartOperation());
 
@@ -927,33 +1163,12 @@ describe("ConfigModule Integration", () => {
     });
 
     it("env var takes precedence over file defaults", async () => {
-      // No config file, env sets log.level to silly (overrides default "warn")
+      // No config file, env sets test.level to silly (overrides default "warn")
       const { dispatcher } = createTestSetup({
         noConfigFile: true,
-        env: { CH_LOG__LEVEL: "silly" },
+        isPackaged: true,
+        env: { CH_TEST__LEVEL: "silly" },
       });
-
-      // Combined operation
-      class CombinedStartOperation implements Operation<
-        Intent,
-        { configuredAgent?: string | null }
-      > {
-        readonly id = APP_START_OPERATION_ID;
-        async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
-          const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
-            intent: ctx.intent,
-          });
-          if (brErrors.length > 0) throw brErrors[0]!;
-
-          const initCtx: InitHookContext = { intent: ctx.intent, requiredScripts: [] };
-          const { errors } = await ctx.hooks.collect<{ configuredAgent?: string | null }>(
-            "init",
-            initCtx
-          );
-          if (errors.length > 0) throw errors[0]!;
-          return {};
-        }
-      }
 
       dispatcher.registerOperation(INTENT_APP_START, new CombinedStartOperation());
 
@@ -966,9 +1181,9 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       // Env var should override the default "warn"
-      const logLevelEvent = events.find((e) => e.payload.values["log.level"] !== undefined);
-      expect(logLevelEvent).toBeDefined();
-      expect(logLevelEvent!.payload.values["log.level"]).toBe("silly");
+      const levelEvent = events.find((e) => e.payload.values["test.level"] !== undefined);
+      expect(levelEvent).toBeDefined();
+      expect(levelEvent!.payload.values["test.level"]).toBe("silly");
     });
   });
 
@@ -976,49 +1191,51 @@ describe("ConfigModule Integration", () => {
   // Computed defaults
   // ---------------------------------------------------------------------------
   describe("computed defaults", () => {
-    it("isDevelopment=true: effective telemetry.enabled=false and log.level=debug", async () => {
-      // Computed defaults set telemetry.enabled=false and log.level=debug.
-      // Verify via config:updated event from init (which applies computed defaults).
+    it("isDevelopment=true sets computed defaults", async () => {
       const { dispatcher } = createTestSetup({ isDevelopment: true });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       await dispatcher.dispatch({
         type: INTENT_APP_START,
         payload: {},
       } as AppStartIntent);
 
-      // Init dispatches delta: computed defaults differ from static defaults
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["telemetry.enabled"]).toBe(false);
-      expect(events[0]!.payload.values["log.level"]).toBe("debug");
+      // before-ready dispatches computed defaults as delta
+      const devFlagEvent = events.find((e) => e.payload.values["test.dev-flag"] !== undefined);
+      expect(devFlagEvent).toBeDefined();
+      expect(devFlagEvent!.payload.values["test.dev-flag"]).toBe(false);
+
+      const levelEvent = events.find((e) => e.payload.values["test.level"] !== undefined);
+      expect(levelEvent).toBeDefined();
+      expect(levelEvent!.payload.values["test.level"]).toBe("debug");
     });
 
-    it("isPackaged=false sets telemetry.enabled=false even when not dev", async () => {
+    it("isPackaged=false sets test.dev-flag=false even when not dev", async () => {
       const { dispatcher } = createTestSetup({
         isDevelopment: false,
         isPackaged: false,
       });
 
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
+
       const events: ConfigUpdatedEvent[] = [];
       dispatcher.subscribe(EVENT_CONFIG_UPDATED, (e) => events.push(e as ConfigUpdatedEvent));
-
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
 
       await dispatcher.dispatch({
         type: INTENT_APP_START,
         payload: {},
       } as AppStartIntent);
 
-      // Init dispatches delta: computed telemetry.enabled=false differs from static default true
-      expect(events).toHaveLength(1);
-      expect(events[0]!.payload.values["telemetry.enabled"]).toBe(false);
+      const devFlagEvent = events.find((e) => e.payload.values["test.dev-flag"] !== undefined);
+      expect(devFlagEvent).toBeDefined();
+      expect(devFlagEvent!.payload.values["test.dev-flag"]).toBe(false);
     });
 
-    it("isPackaged=true and isDevelopment=false leaves telemetry.enabled=true (static default)", async () => {
+    it("isPackaged=true and isDevelopment=false leaves static defaults unchanged", async () => {
       const { dispatcher } = createTestSetup({ isDevelopment: false, isPackaged: true });
 
       dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
@@ -1031,48 +1248,20 @@ describe("ConfigModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      // No computed defaults override telemetry.enabled, and file defaults match static defaults.
+      // No computed defaults override static defaults, and file defaults match static defaults.
       // No changes should be emitted.
       expect(events).toHaveLength(0);
     });
 
     it("config file overrides computed defaults", async () => {
-      // isDevelopment=true sets computed telemetry.enabled=false + log.level=debug.
-      // Config file sets telemetry.enabled=true which overrides computed false.
       const configContent = JSON.stringify({
-        "telemetry.enabled": true,
+        "test.dev-flag": true,
       });
 
       const { dispatcher } = createTestSetup({
         isDevelopment: true,
         configFileContent: configContent,
       });
-
-      // Combined operation: before-ready sets computed defaults, init loads file
-      class CombinedStartOperation implements Operation<
-        Intent,
-        { configuredAgent?: string | null }
-      > {
-        readonly id = APP_START_OPERATION_ID;
-        async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
-          const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
-            intent: ctx.intent,
-          });
-          if (brErrors.length > 0) throw brErrors[0]!;
-
-          const initCtx: InitHookContext = { intent: ctx.intent, requiredScripts: [] };
-          const { results, errors } = await ctx.hooks.collect<{
-            configuredAgent?: string | null;
-          }>("init", initCtx);
-          if (errors.length > 0) throw errors[0]!;
-
-          let configuredAgent: string | null = null;
-          for (const result of results) {
-            if (result.configuredAgent !== undefined) configuredAgent = result.configuredAgent;
-          }
-          return { configuredAgent };
-        }
-      }
 
       dispatcher.registerOperation(INTENT_APP_START, new CombinedStartOperation());
 
@@ -1084,49 +1273,21 @@ describe("ConfigModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      // Event 1: before-ready sets computed defaults (log.level=debug, telemetry.enabled=false)
-      // Event 2: init delta — file's telemetry.enabled=true overrides computed false
+      // Event 1: before-ready sets computed defaults (test.level=debug, test.dev-flag=false)
+      // Event 2: init delta — file's test.dev-flag=true overrides computed false
       expect(events).toHaveLength(2);
       // before-ready event has computed defaults
-      expect(events[0]!.payload.values["log.level"]).toBe("debug");
-      expect(events[0]!.payload.values["telemetry.enabled"]).toBe(false);
+      expect(events[0]!.payload.values["test.level"]).toBe("debug");
+      expect(events[0]!.payload.values["test.dev-flag"]).toBe(false);
       // init event has file override
-      expect(events[1]!.payload.values["telemetry.enabled"]).toBe(true);
+      expect(events[1]!.payload.values["test.dev-flag"]).toBe(true);
     });
 
     it("CLI flag overrides computed defaults", async () => {
-      // isDevelopment=true sets computed log.level=debug,
-      // CLI --log.level=error should override it.
       const { dispatcher } = createTestSetup({
         isDevelopment: true,
-        argv: ["--log.level=error"],
+        argv: ["--test.level=error"],
       });
-
-      // Combined operation: before-ready then init
-      class CombinedStartOperation implements Operation<
-        Intent,
-        { configuredAgent?: string | null }
-      > {
-        readonly id = APP_START_OPERATION_ID;
-        async execute(ctx: OperationContext<Intent>): Promise<{ configuredAgent?: string | null }> {
-          const { errors: brErrors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
-            intent: ctx.intent,
-          });
-          if (brErrors.length > 0) throw brErrors[0]!;
-
-          const initCtx: InitHookContext = { intent: ctx.intent, requiredScripts: [] };
-          const { results, errors } = await ctx.hooks.collect<{
-            configuredAgent?: string | null;
-          }>("init", initCtx);
-          if (errors.length > 0) throw errors[0]!;
-
-          let configuredAgent: string | null = null;
-          for (const result of results) {
-            if (result.configuredAgent !== undefined) configuredAgent = result.configuredAgent;
-          }
-          return { configuredAgent };
-        }
-      }
 
       dispatcher.registerOperation(INTENT_APP_START, new CombinedStartOperation());
 
@@ -1139,9 +1300,9 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       // CLI override should win over computed default
-      const logLevelEvent = events.find((e) => e.payload.values["log.level"] !== undefined);
-      expect(logLevelEvent).toBeDefined();
-      expect(logLevelEvent!.payload.values["log.level"]).toBe("error");
+      const levelEvent = events.find((e) => e.payload.values["test.level"] !== undefined);
+      expect(levelEvent).toBeDefined();
+      expect(levelEvent!.payload.values["test.level"]).toBe("error");
     });
   });
 
@@ -1181,9 +1342,9 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent);
 
       const output = stdout.write.mock.calls[0]![0] as string;
-      // isDevelopment=true computes log.level=debug (not static default "warn")
-      expect(output).toContain("log.level");
-      expect(output).toMatch(/log\.level\s+default: debug/);
+      // isDevelopment=true computes test.level=debug (not static default "warn")
+      expect(output).toContain("test.level");
+      expect(output).toMatch(/test\.level\s+default: debug/);
     });
 
     it("CH_HELP=1 env var prints help and dispatches shutdown", async () => {
@@ -1221,34 +1382,40 @@ describe("ConfigModule Integration", () => {
   // generateHelpText
   // ---------------------------------------------------------------------------
   describe("generateHelpText", () => {
+    const definitions = buildTestDefinitionsMap();
+    const defaultValues: Record<string, unknown> = {};
+    for (const [key, def] of definitions) {
+      defaultValues[key] = def.default;
+    }
+
     it("contains every config key", () => {
-      const text = generateHelpText("/some/config.json", DEFAULT_CONFIG_VALUES);
-      for (const key of CONFIG_KEYS) {
+      const text = generateHelpText("/some/config.json", definitions, defaultValues);
+      for (const key of ALL_TEST_KEYS) {
         expect(text).toContain(key);
       }
     });
 
     it("contains the config file path", () => {
-      const text = generateHelpText("/custom/path/config.json", DEFAULT_CONFIG_VALUES);
+      const text = generateHelpText("/custom/path/config.json", definitions, defaultValues);
       expect(text).toContain("/custom/path/config.json");
     });
 
     it("shows static defaults", () => {
-      const text = generateHelpText("/some/config.json", DEFAULT_CONFIG_VALUES);
+      const text = generateHelpText("/some/config.json", definitions, defaultValues);
       expect(text).toContain("default: warn");
       expect(text).toContain("default: false");
       expect(text).toContain("default: true");
     });
 
     it("shows computed effective values when provided", () => {
-      const defaults = {
-        ...DEFAULT_CONFIG_VALUES,
-        "log.level": "debug" as const,
-        "telemetry.enabled": false,
+      const computedDefaults = {
+        ...defaultValues,
+        "test.level": "debug",
+        "test.dev-flag": false,
       };
-      const text = generateHelpText("/some/config.json", defaults);
-      expect(text).toMatch(/log\.level\s+default: debug/);
-      expect(text).toMatch(/telemetry\.enabled\s+default: false/);
+      const text = generateHelpText("/some/config.json", definitions, computedDefaults);
+      expect(text).toMatch(/test\.level\s+default: debug/);
+      expect(text).toMatch(/test\.dev-flag\s+default: false/);
     });
   });
 });

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -2,12 +2,15 @@
  * ConfigModule - Manages application configuration via the intent dispatcher.
  *
  * Single merged config. Precedence is handled by dispatch order:
- * - before-ready: defaults + computed defaults + env vars + CLI args
+ * - register-config: modules return their config key definitions
+ * - before-ready: build definition map, compute defaults + env vars + CLI args
  * - init: file values merged in (only changed values dispatched)
  * - set: external callers merge values; persist=true does read-modify-write on config.json
  *
  * Hooks:
- * - app:start / "before-ready" — parses env vars + CLI flags, dispatches full merged config
+ * - app:start / "register-config" — returns definitions for `agent` and `help`
+ * - app:start / "before-ready" — collects definitions, parses env vars + CLI flags,
+ *   dispatches full merged config
  * - app:start / "init" — reads config.json, dispatches only delta from file values
  * - config-set-values / "set" — merges values into effective, optionally persists to disk
  */
@@ -18,21 +21,24 @@ import type { Logger } from "../../services/logging/types";
 import type { FileSystemLayer } from "../../services/platform/filesystem";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { Path } from "../../services/platform/path";
-import type { ConfigValues, ConfigAgentType, ConfigKey } from "../../services/config/config-values";
+import type {
+  ConfigKeyDefinition,
+  ComputedDefaultContext,
+} from "../../services/config/config-definition";
+import { parseBool } from "../../services/config/config-definition";
+import type { ConfigAgentType } from "../../services/config/config-values";
+import { envVarToConfigKey, generateHelpText } from "../../services/config/config-values";
 import type {
   ConfigSetHookInput,
   ConfigSetHookResult,
   ConfigSetValuesIntent,
 } from "../operations/config-set-values";
-import type { ConfigureResult, InitHookContext } from "../operations/app-start";
-import {
-  CONFIG_KEYS,
-  DEFAULT_CONFIG_VALUES,
-  envVarToConfigKey,
-  parseConfigValue,
-  validateConfigValue,
-  generateHelpText,
-} from "../../services/config/config-values";
+import type {
+  ConfigureResult,
+  InitHookContext,
+  RegisterConfigResult,
+  BeforeReadyHookContext,
+} from "../operations/app-start";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import {
   CONFIG_SET_VALUES_OPERATION_ID,
@@ -63,9 +69,12 @@ export interface ConfigModuleDeps {
 
 /**
  * Scan an env object for CH_* keys (not _CH_*), convert to config keys,
- * validate against schema, parse values.
+ * validate against definition map, parse values.
  */
-export function parseEnvVars(env: Record<string, string | undefined>): Partial<ConfigValues> {
+export function parseEnvVars(
+  env: Record<string, string | undefined>,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
+): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (const [envKey, rawValue] of Object.entries(env)) {
@@ -75,11 +84,12 @@ export function parseEnvVars(env: Record<string, string | undefined>): Partial<C
     const configKey = envVarToConfigKey(envKey);
     if (configKey === undefined) continue;
 
-    if (!CONFIG_KEYS.has(configKey as ConfigKey)) {
+    const def = definitions.get(configKey);
+    if (!def) {
       throw new Error(`Unknown config env var: ${envKey} (maps to "${configKey}")`);
     }
 
-    const parsed = parseConfigValue(configKey as ConfigKey, rawValue);
+    const parsed = def.parse(rawValue);
     if (parsed === undefined && rawValue !== "") {
       // Invalid value — skip (don't throw, env vars may come from external sources)
       continue;
@@ -89,14 +99,17 @@ export function parseEnvVars(env: Record<string, string | undefined>): Partial<C
     }
   }
 
-  return result as Partial<ConfigValues>;
+  return result;
 }
 
 /**
  * Parse CLI args in the form --key=value or --key value.
  * Key is the config key directly (e.g. --log.level=debug).
  */
-export function parseCliArgs(argv: readonly string[]): Partial<ConfigValues> {
+export function parseCliArgs(
+  argv: readonly string[],
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
+): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (let i = 0; i < argv.length; i++) {
@@ -123,18 +136,19 @@ export function parseCliArgs(argv: readonly string[]): Partial<ConfigValues> {
       }
     }
 
-    if (!CONFIG_KEYS.has(key as ConfigKey)) {
+    const def = definitions.get(key);
+    if (!def) {
       // Unknown flag — skip silently (may be an Electron/Node flag)
       continue;
     }
 
-    const parsed = parseConfigValue(key as ConfigKey, value);
+    const parsed = def.parse(value);
     if (parsed !== undefined) {
       result[key] = parsed;
     }
   }
 
-  return result as Partial<ConfigValues>;
+  return result;
 }
 
 // =============================================================================
@@ -144,7 +158,7 @@ export function parseCliArgs(argv: readonly string[]): Partial<ConfigValues> {
 /**
  * Key rename map: old flat key → new flat key.
  */
-const KEY_RENAMES: ReadonlyMap<string, ConfigKey> = new Map([
+const KEY_RENAMES: ReadonlyMap<string, string> = new Map([
   ["versions.codeServer", "version.code-server"],
   ["versions.claude", "version.claude"],
   ["versions.opencode", "version.opencode"],
@@ -175,13 +189,16 @@ interface LegacyConfig {
 
 /**
  * Parse a config.json object (legacy nested, old flat, or new flat format)
- * into file-layer ConfigValues. Unknown keys are ignored.
+ * into file-layer config values. Unknown keys are ignored.
  *
  * Returns { values, migrated } where migrated is true if old key names
  * were found and renamed.
  */
-function parseConfigFile(data: unknown): {
-  values: Partial<ConfigValues>;
+function parseConfigFile(
+  data: unknown,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
+): {
+  values: Record<string, unknown>;
   migrated: boolean;
 } {
   if (typeof data !== "object" || data === null) return { values: {}, migrated: false };
@@ -218,7 +235,7 @@ function parseConfigFile(data: unknown): {
         result["telemetry.distinct-id"] = legacy.telemetry.distinctId;
     }
 
-    return { values: validateFileValues(result), migrated };
+    return { values: validateFileValues(result, definitions), migrated };
   }
 
   // Flat format — apply key renames if needed, then copy known file-layer keys
@@ -228,27 +245,31 @@ function parseConfigFile(data: unknown): {
       result[renamedKey] =
         renamedKey === "version.code-server" && value === OLD_CODE_SERVER_DEFAULT ? null : value;
       migrated = true;
-    } else if (CONFIG_KEYS.has(key as ConfigKey)) {
+    } else if (definitions.has(key)) {
       result[key] = value;
     }
   }
 
-  return { values: validateFileValues(result), migrated };
+  return { values: validateFileValues(result, definitions), migrated };
 }
 
 /**
- * Validate file-layer values using the schema's validators. Returns only valid entries.
+ * Validate file-layer values using the definition map's validators. Returns only valid entries.
  */
-function validateFileValues(values: Record<string, unknown>): Partial<ConfigValues> {
+function validateFileValues(
+  values: Record<string, unknown>,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
+): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(values)) {
-    if (!CONFIG_KEYS.has(key as ConfigKey) || value === undefined) continue;
-    const validated = validateConfigValue(key as ConfigKey, value);
+    const def = definitions.get(key);
+    if (!def || value === undefined) continue;
+    const validated = def.validate(value);
     if (validated !== undefined) {
       result[key] = validated;
     }
   }
-  return result as Partial<ConfigValues>;
+  return result;
 }
 
 // =============================================================================
@@ -258,56 +279,114 @@ function validateFileValues(values: Record<string, unknown>): Partial<ConfigValu
 export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
   const { fileSystem, configPath, dispatcher, logger } = deps;
 
-  // Computed defaults: build-dependent values
-  const _computedDefaults: Record<string, unknown> = {};
-  if (deps.isDevelopment) {
-    _computedDefaults["log.level"] = "debug";
-  }
-  if (deps.isDevelopment || !deps.isPackaged) {
-    _computedDefaults["telemetry.enabled"] = false;
-  }
-  const computedDefaults = _computedDefaults as Partial<ConfigValues>;
+  // Stored definition map — populated by before-ready from register-config results
+  let definitionMap: Map<string, ConfigKeyDefinition<unknown>> = new Map();
 
   // Internal state: single merged config
-  let envValues: Partial<ConfigValues> = {};
-  let cliValues: Partial<ConfigValues> = {};
-  const effective: ConfigValues = { ...DEFAULT_CONFIG_VALUES };
+  let envValues: Record<string, unknown> = {};
+  let cliValues: Record<string, unknown> = {};
+  const effective: Record<string, unknown> = {};
 
   /**
    * Compute which keys changed between old and new values.
    */
   function computeChanges(
-    oldValues: ConfigValues,
-    newValues: ConfigValues
-  ): Partial<ConfigValues> | null {
+    oldValues: Record<string, unknown>,
+    newValues: Record<string, unknown>
+  ): Record<string, unknown> | null {
     const changes: Record<string, unknown> = {};
     let hasChanges = false;
-    for (const key of Object.keys(newValues) as (keyof ConfigValues)[]) {
+    for (const key of Object.keys(newValues)) {
       if (oldValues[key] !== newValues[key]) {
         changes[key] = newValues[key];
         hasChanges = true;
       }
     }
-    return hasChanges ? (changes as Partial<ConfigValues>) : null;
+    return hasChanges ? changes : null;
+  }
+
+  /**
+   * Build default values from definitions, applying computedDefault where available.
+   */
+  function buildDefaults(
+    definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
+    ctx: ComputedDefaultContext
+  ): Record<string, unknown> {
+    const defaults: Record<string, unknown> = {};
+    for (const [key, def] of definitions) {
+      defaults[key] = def.default;
+      if (def.computedDefault) {
+        const computed = def.computedDefault(ctx);
+        if (computed !== undefined) {
+          defaults[key] = computed;
+        }
+      }
+    }
+    return defaults;
   }
 
   return {
     name: "config",
     hooks: {
       [APP_START_OPERATION_ID]: {
-        "before-ready": {
-          handler: async (): Promise<ConfigureResult> => {
-            // Parse env vars and CLI args (no I/O — pure computation)
-            envValues = parseEnvVars(deps.env);
-            cliValues = parseCliArgs(deps.argv);
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "agent",
+                default: null,
+                parse: (s: string) =>
+                  s === "claude" || s === "opencode" ? s : s === "" ? null : undefined,
+                validate: (v: unknown) =>
+                  v === null || v === "claude" || v === "opencode"
+                    ? (v as ConfigAgentType)
+                    : undefined,
+              },
+              {
+                name: "help",
+                default: false,
+                parse: parseBool,
+                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+              },
+            ],
+          }),
+        },
 
-            // Full merged config: defaults + computed + env + CLI
+        "before-ready": {
+          handler: async (ctx: HookContext): Promise<ConfigureResult> => {
+            const { configDefinitions } = ctx as BeforeReadyHookContext;
+
+            // Build definition map from collected definitions, check for duplicates
+            definitionMap = new Map();
+            for (const def of configDefinitions) {
+              if (definitionMap.has(def.name)) {
+                throw new Error(`Duplicate config key definition: "${def.name}"`);
+              }
+              definitionMap.set(def.name, def);
+            }
+
+            // Seed effective with static defaults so first dispatch only reports actual changes
+            for (const [key, def] of definitionMap) {
+              effective[key] = def.default;
+            }
+
+            // Build defaults (static + computed)
+            const computedDefaultCtx: ComputedDefaultContext = {
+              isDevelopment: deps.isDevelopment,
+              isPackaged: deps.isPackaged,
+            };
+            const defaults = buildDefaults(definitionMap, computedDefaultCtx);
+
+            // Parse env vars and CLI args (no I/O — pure computation)
+            envValues = parseEnvVars(deps.env, definitionMap);
+            cliValues = parseCliArgs(deps.argv, definitionMap);
+
+            // Full merged config: defaults + env + CLI
             const merged = {
-              ...DEFAULT_CONFIG_VALUES,
-              ...computedDefaults,
+              ...defaults,
               ...envValues,
               ...cliValues,
-            } as Partial<ConfigValues>;
+            };
 
             await dispatcher.dispatch({
               type: INTENT_CONFIG_SET_VALUES,
@@ -315,7 +394,9 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
             } as ConfigSetValuesIntent);
 
             if (effective.help === true) {
-              deps.stdout.write(generateHelpText(deps.configPath.toString(), effective));
+              deps.stdout.write(
+                generateHelpText(deps.configPath.toString(), definitionMap, effective)
+              );
               await dispatcher.dispatch({
                 type: INTENT_APP_SHUTDOWN,
                 payload: {},
@@ -331,13 +412,20 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
             const initCtx = _ctx as InitHookContext;
             void initCtx; // consume ctx
 
+            // Build defaults again for merging (same as before-ready)
+            const computedDefaultCtx: ComputedDefaultContext = {
+              isDevelopment: deps.isDevelopment,
+              isPackaged: deps.isPackaged,
+            };
+            const defaults = buildDefaults(definitionMap, computedDefaultCtx);
+
             // Read config.json from disk
-            let fileValues: Partial<ConfigValues> = {};
+            let fileValues: Record<string, unknown> = {};
             let migrated = false;
             try {
               const content = await fileSystem.readFile(configPath);
               const parsed = JSON.parse(content) as unknown;
-              ({ values: fileValues, migrated } = parseConfigFile(parsed));
+              ({ values: fileValues, migrated } = parseConfigFile(parsed, definitionMap));
               logger.debug("Config loaded from disk", { path: configPath.toString() });
             } catch (error) {
               if (error instanceof Error && "fsCode" in error && error.fsCode === "ENOENT") {
@@ -362,16 +450,15 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
 
             // Rebuild full effective with file values included
             const merged = {
-              ...DEFAULT_CONFIG_VALUES,
-              ...computedDefaults,
+              ...defaults,
               ...fileValues,
               ...envValues,
               ...cliValues,
-            } as ConfigValues;
+            };
 
             // Only dispatch values that actually changed since before-ready
             const delta: Record<string, unknown> = {};
-            for (const key of Object.keys(merged) as (keyof ConfigValues)[]) {
+            for (const key of Object.keys(merged)) {
               if (merged[key] !== effective[key]) {
                 delta[key] = merged[key];
               }
@@ -380,11 +467,11 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
             if (Object.keys(delta).length > 0) {
               await dispatcher.dispatch({
                 type: INTENT_CONFIG_SET_VALUES,
-                payload: { values: delta as Partial<ConfigValues>, persist: false },
+                payload: { values: delta, persist: false },
               } as ConfigSetValuesIntent);
             }
 
-            return { configuredAgent: effective.agent };
+            return { configuredAgent: effective.agent as ConfigAgentType };
           },
         },
       },
@@ -400,7 +487,7 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
             // Merge into effective
             for (const [key, value] of Object.entries(values)) {
               if (value !== undefined) {
-                (effective as Record<string, unknown>)[key] = value;
+                effective[key] = value;
               }
             }
 

--- a/src/main/modules/electron-lifecycle-module.ts
+++ b/src/main/modules/electron-lifecycle-module.ts
@@ -15,7 +15,7 @@ import type { AsyncWatcher } from "../../services/platform/async-watcher";
 import type { Logger } from "../../services/logging";
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
-import type { ConfigureResult } from "../operations/app-start";
+import type { ConfigureResult, RegisterConfigResult } from "../operations/app-start";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
@@ -88,6 +88,18 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
     name: "electron-lifecycle",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "electron.flags",
+                default: undefined,
+                parse: (s: string) => (s === "" ? undefined : s),
+                validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+              },
+            ],
+          }),
+        },
         "before-ready": {
           handler: async (): Promise<ConfigureResult> => {
             // Disable ASAR when not packaged
@@ -124,7 +136,7 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
       [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
         const { values } = (event as ConfigUpdatedEvent).payload;
         if (values["electron.flags"] !== undefined) {
-          const flags = parseElectronFlags(values["electron.flags"]);
+          const flags = parseElectronFlags(values["electron.flags"] as string | undefined);
           for (const flag of flags) {
             deps.app.commandLine.appendSwitch(
               flag.name,

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -17,7 +17,12 @@ import type { Logger } from "../../services/logging/types";
 import type { BuildInfo } from "../../services/platform/build-info";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
-import { splitLogLevelSpec } from "../../services/logging/electron-log-service";
+import type { RegisterConfigResult } from "../operations/app-start";
+import {
+  parseLogLevelSpec,
+  parseLogOutput,
+  splitLogLevelSpec,
+} from "../../services/logging/electron-log-service";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
 
@@ -47,6 +52,26 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     name: "logging",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "log.level",
+                default: "warn",
+                parse: parseLogLevelSpec,
+                validate: (v: unknown) =>
+                  typeof v === "string" ? parseLogLevelSpec(v) : undefined,
+                computedDefault: (ctx) => (ctx.isDevelopment ? "debug" : undefined),
+              },
+              {
+                name: "log.output",
+                default: "file",
+                parse: parseLogOutput,
+                validate: (v: unknown) => (typeof v === "string" ? parseLogOutput(v) : undefined),
+              },
+            ],
+          }),
+        },
         "before-ready": {
           handler: async (): Promise<void> => {
             deps.logger.info("App starting", {
@@ -73,7 +98,7 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
         // Log all config changes
         const context: Record<string, string | number | boolean | null> = {};
         for (const [key, value] of Object.entries(values)) {
-          context[key] = value ?? null;
+          context[key] = (value ?? null) as string | number | boolean | null;
         }
         deps.logger.info("Config updated", context);
 

--- a/src/main/modules/opencode-agent-module.ts
+++ b/src/main/modules/opencode-agent-module.ts
@@ -28,6 +28,7 @@ import type {
   StartHookResult,
   ActivateHookContext,
   ActivateHookResult,
+  RegisterConfigResult,
 } from "../operations/app-start";
 import type { RegisterAgentResult, SaveAgentHookInput, BinaryHookInput } from "../operations/setup";
 import type {
@@ -228,6 +229,19 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
     name: "opencode-agent",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "version.opencode",
+                default: null,
+                parse: (s: string) => (s === "" ? null : s),
+                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+              },
+            ],
+          }),
+        },
+
         "before-ready": {
           handler: async (): Promise<ConfigureResult> => {
             return {
@@ -483,7 +497,7 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
         const { values } = (event as ConfigUpdatedEvent).payload;
         if (values.agent !== undefined) {
           // Agent value received — check if this module should be active
-          const agentType = values.agent ?? "opencode";
+          const agentType = (values.agent as string | null) ?? "opencode";
           active = agentType === "opencode";
         }
       },

--- a/src/main/modules/telemetry-module.ts
+++ b/src/main/modules/telemetry-module.ts
@@ -13,12 +13,13 @@
 
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
-import type { StartHookResult } from "../operations/app-start";
+import type { StartHookResult, RegisterConfigResult } from "../operations/app-start";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { ConfigSetValuesIntent } from "../operations/config-set-values";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
+import { parseBool } from "../../services/config/config-definition";
 import type { TelemetryService } from "../../services/telemetry/types";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { BuildInfo } from "../../services/platform/build-info";
@@ -58,6 +59,26 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
     name: "telemetry",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: "telemetry.enabled",
+                default: true,
+                parse: parseBool,
+                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+                computedDefault: (ctx) =>
+                  ctx.isDevelopment || !ctx.isPackaged ? false : undefined,
+              },
+              {
+                name: "telemetry.distinct-id",
+                default: undefined,
+                parse: (s: string) => (s === "" ? undefined : s),
+                validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+              },
+            ],
+          }),
+        },
         start: {
           handler: async (): Promise<StartHookResult> => {
             if (configuredAgent !== undefined) {
@@ -87,15 +108,15 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
         const { values } = (event as ConfigUpdatedEvent).payload;
 
         if (values.agent !== undefined) {
-          configuredAgent = values.agent;
+          configuredAgent = values.agent as ConfigAgentType;
         }
 
         if (values["telemetry.enabled"] !== undefined) {
-          telemetryEnabled = values["telemetry.enabled"];
+          telemetryEnabled = values["telemetry.enabled"] as boolean;
         }
 
         if (values["telemetry.distinct-id"] !== undefined) {
-          distinctId = values["telemetry.distinct-id"];
+          distinctId = values["telemetry.distinct-id"] as string;
         }
 
         // Configure telemetry service when relevant values arrive

--- a/src/main/operations/app-start.ts
+++ b/src/main/operations/app-start.ts
@@ -40,6 +40,7 @@ import type { Intent, DomainEvent } from "../intents/infrastructure/types";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
 import type { ConfigAgentType } from "../../shared/api/types";
 import type { BinaryType } from "../../services/vscode-setup/types";
+import type { ConfigKeyDefinition } from "../../services/config/config-definition";
 import { INTENT_SETUP } from "./setup";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
 import { Path } from "../../services/platform/path";
@@ -88,6 +89,21 @@ export interface CheckDepsResult {
   readonly missingBinaries?: readonly BinaryType[];
   readonly missingExtensions?: readonly string[];
   readonly outdatedExtensions?: readonly string[];
+}
+
+/**
+ * Per-handler result for "register-config" hook point.
+ * Modules return their config key definitions.
+ */
+export interface RegisterConfigResult {
+  readonly definitions?: readonly ConfigKeyDefinition<unknown>[];
+}
+
+/**
+ * Input context for "before-ready" — carries config definitions collected from register-config.
+ */
+export interface BeforeReadyHookContext extends HookContext {
+  readonly configDefinitions: readonly ConfigKeyDefinition<unknown>[];
 }
 
 /**
@@ -167,10 +183,17 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       intent: ctx.intent,
     };
 
+    // --- Hook 0: "register-config" — collect config definitions from all modules ---
+    const { results: regResults, errors: regErrors } =
+      await ctx.hooks.collect<RegisterConfigResult>("register-config", hookCtx);
+    if (regErrors.length > 0) throw regErrors[0]!;
+    const configDefinitions = regResults.flatMap((r) => r.definitions ?? []);
+
     // --- Hook 1: "before-ready" (pre-ready, no I/O) ---
     // Env config + script declarations. All independent.
+    const beforeReadyCtx: BeforeReadyHookContext = { ...hookCtx, configDefinitions };
     const { results: configResults, errors: configErrors } =
-      await ctx.hooks.collect<ConfigureResult>("before-ready", hookCtx);
+      await ctx.hooks.collect<ConfigureResult>("before-ready", beforeReadyCtx);
     if (configErrors.length > 0) throw configErrors[0]!;
     const requiredScripts = configResults.flatMap((r) => r.scripts ?? []);
 

--- a/src/main/operations/config-set-values.ts
+++ b/src/main/operations/config-set-values.ts
@@ -12,7 +12,6 @@
 
 import type { Intent, DomainEvent } from "../intents/infrastructure/types";
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
-import type { ConfigValues } from "../../services/config/config-values";
 
 // =============================================================================
 // Intent + Event Types
@@ -20,7 +19,7 @@ import type { ConfigValues } from "../../services/config/config-values";
 
 export interface ConfigSetValuesPayload {
   /** Values to set. null value = delete key (revert to default). */
-  readonly values: Partial<ConfigValues>;
+  readonly values: Readonly<Record<string, unknown>>;
   /** When false, values are stored as runtime overrides (not written to disk). Default: true. */
   readonly persist?: boolean;
 }
@@ -32,7 +31,7 @@ export interface ConfigSetValuesIntent extends Intent<void> {
 
 export interface ConfigUpdatedPayload {
   /** Only the values that actually changed. */
-  readonly values: Partial<Readonly<ConfigValues>>;
+  readonly values: Readonly<Record<string, unknown>>;
 }
 
 export interface ConfigUpdatedEvent extends DomainEvent {
@@ -53,7 +52,7 @@ export const CONFIG_SET_VALUES_OPERATION_ID = "config-set-values";
  * Input context for the "set" hook — carries the values to be set.
  */
 export interface ConfigSetHookInput extends HookContext {
-  readonly values: Partial<ConfigValues>;
+  readonly values: Readonly<Record<string, unknown>>;
   readonly persist: boolean;
 }
 
@@ -61,7 +60,7 @@ export interface ConfigSetHookInput extends HookContext {
  * Result from the "set" hook — returns the changed values for the event.
  */
 export interface ConfigSetHookResult {
-  readonly changedValues: Partial<ConfigValues>;
+  readonly changedValues: Readonly<Record<string, unknown>>;
 }
 
 // =============================================================================
@@ -84,7 +83,7 @@ export class ConfigSetValuesOperation implements Operation<ConfigSetValuesIntent
     if (errors.length > 0) throw errors[0]!;
 
     // Merge changed values from all handlers (only config module responds)
-    let changedValues: Partial<ConfigValues> = {};
+    let changedValues: Readonly<Record<string, unknown>> = {};
     for (const result of results) {
       changedValues = { ...changedValues, ...result.changedValues };
     }

--- a/src/services/config/config-definition.ts
+++ b/src/services/config/config-definition.ts
@@ -1,0 +1,42 @@
+/**
+ * Config key definition types for module-owned config registration.
+ *
+ * Each module registers its own config keys via the "register-config" hook
+ * in app:start. The config module collects all definitions and uses them
+ * for parsing, validation, and help text generation.
+ */
+
+/**
+ * Context available to computedDefault callbacks for build-dependent defaults.
+ */
+export interface ComputedDefaultContext {
+  readonly isDevelopment: boolean;
+  readonly isPackaged: boolean;
+}
+
+/**
+ * Definition of a single configuration key.
+ *
+ * Modules return these from the "register-config" hook to declare
+ * their config keys, defaults, and parsing/validation logic.
+ */
+export interface ConfigKeyDefinition<T> {
+  /** Config key name (dot-separated, kebab-case). */
+  readonly name: string;
+  /** Static default value. */
+  readonly default: T;
+  /** Parse a raw CLI/env string into a typed value. undefined = invalid. */
+  readonly parse: (raw: string) => T | undefined;
+  /** Validate an unknown JSON value. undefined = invalid. */
+  readonly validate: (value: unknown) => T | undefined;
+  /** Optional computed default that overrides the static default based on build context. */
+  readonly computedDefault?: (ctx: ComputedDefaultContext) => T | undefined;
+}
+
+/**
+ * Parse a string as a boolean config value.
+ * Accepts "true"/"1" for true, "false"/"0" for false.
+ */
+export function parseBool(s: string): boolean | undefined {
+  return s === "true" || s === "1" ? true : s === "false" || s === "0" ? false : undefined;
+}

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -1,37 +1,19 @@
 /**
- * Schema-driven configuration values.
+ * Configuration value utilities and type aliases.
  *
- * Every config key is defined once in the CONFIG object with its default
- * value and string parser. The TypeScript type, defaults, and key set
- * are all derived mechanically — no hand-written interface to maintain.
+ * Config key definitions are owned by individual modules and registered
+ * via the "register-config" hook in app:start. This file provides shared
+ * utilities for config key name derivation and help text generation.
  *
  * Naming conventions:
  *   Config key / CLI flag:  dot-separated, kebab-case  (e.g. "version.code-server")
  *   Env var:                CH_ prefix, . → __, - → _, UPPER  (e.g. CH_VERSION__CODE_SERVER)
  */
 
-import { parseLogLevelSpec, parseLogOutput } from "../logging/electron-log-service";
+import type { ConfigKeyDefinition } from "./config-definition";
 
 // =============================================================================
-// Schema Helpers
-// =============================================================================
-
-interface ConfigKeyDef<T> {
-  readonly default: T;
-  readonly parse: (raw: string) => T | undefined; // undefined = invalid
-  readonly validate: (value: unknown) => T | undefined; // undefined = invalid
-}
-
-function key<T>(def: ConfigKeyDef<T>): ConfigKeyDef<T> {
-  return def;
-}
-
-function parseBool(s: string): boolean | undefined {
-  return s === "true" || s === "1" ? true : s === "false" || s === "0" ? false : undefined;
-}
-
-// =============================================================================
-// Config Schema
+// Type Aliases
 // =============================================================================
 
 /**
@@ -47,102 +29,6 @@ export type ConfigAgentType = "claude" | "opencode" | null;
  */
 export type AutoUpdatePreference = "always" | "never";
 
-/**
- * The single source of truth for all configuration keys.
- *
- * Any key can appear in config.json, env vars, or CLI flags.
- * Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
- */
-export const CONFIG = {
-  agent: key<ConfigAgentType>({
-    default: null,
-    parse: (s) => (s === "claude" || s === "opencode" ? s : s === "" ? null : undefined),
-    validate: (v) => (v === null || v === "claude" || v === "opencode" ? v : undefined),
-  }),
-  "auto-update": key<AutoUpdatePreference>({
-    default: "always",
-    parse: (s) => (s === "always" || s === "never" ? s : undefined),
-    validate: (v) => (v === "always" || v === "never" ? v : undefined),
-  }),
-  "version.claude": key<string | null>({
-    default: null,
-    parse: (s) => (s === "" ? null : s),
-    validate: (v) => (v === null || typeof v === "string" ? v : undefined),
-  }),
-  "version.opencode": key<string | null>({
-    default: null,
-    parse: (s) => (s === "" ? null : s),
-    validate: (v) => (v === null || typeof v === "string" ? v : undefined),
-  }),
-  "version.code-server": key<string | null>({
-    default: null,
-    parse: (s) => (s === "" ? null : s),
-    validate: (v) => (v === null || typeof v === "string" ? v : undefined),
-  }),
-  "telemetry.enabled": key<boolean>({
-    default: true,
-    parse: parseBool,
-    validate: (v) => (typeof v === "boolean" ? v : undefined),
-  }),
-  "telemetry.distinct-id": key<string | undefined>({
-    default: undefined,
-    parse: (s) => (s === "" ? undefined : s),
-    validate: (v) => (typeof v === "string" ? v : undefined),
-  }),
-  "log.level": key<string>({
-    default: "warn",
-    parse: parseLogLevelSpec,
-    validate: (v) => (typeof v === "string" ? parseLogLevelSpec(v) : undefined),
-  }),
-  "log.output": key<string>({
-    default: "file",
-    parse: parseLogOutput,
-    validate: (v) => (typeof v === "string" ? parseLogOutput(v) : undefined),
-  }),
-  "electron.flags": key<string | undefined>({
-    default: undefined,
-    parse: (s) => (s === "" ? undefined : s),
-    validate: (v) => (typeof v === "string" ? v : undefined),
-  }),
-  "experimental.auto-pr-workspaces": key<boolean>({
-    default: false,
-    parse: parseBool,
-    validate: (v) => (typeof v === "boolean" ? v : undefined),
-  }),
-  "experimental.pr-auto-workspace.template-path": key<string | null>({
-    default: null,
-    parse: (s) => (s === "" ? null : s),
-    validate: (v) => (v === null || typeof v === "string" ? v : undefined),
-  }),
-  help: key<boolean>({
-    default: false,
-    parse: parseBool,
-    validate: (v) => (typeof v === "boolean" ? v : undefined),
-  }),
-} as const satisfies Record<string, ConfigKeyDef<unknown>>;
-
-// =============================================================================
-// Derived Types
-// =============================================================================
-
-export type ConfigKey = keyof typeof CONFIG;
-
-export type ConfigValues = {
-  readonly [K in ConfigKey]: (typeof CONFIG)[K] extends ConfigKeyDef<infer T> ? T : never;
-};
-
-/**
- * Set of all valid config keys, derived from the schema.
- */
-export const CONFIG_KEYS: ReadonlySet<ConfigKey> = new Set(Object.keys(CONFIG) as ConfigKey[]);
-
-/**
- * Default configuration values, derived from the schema.
- */
-export const DEFAULT_CONFIG_VALUES: Readonly<ConfigValues> = Object.fromEntries(
-  (Object.keys(CONFIG) as ConfigKey[]).map((k) => [k, CONFIG[k].default])
-) as ConfigValues;
-
 // =============================================================================
 // Name Derivation
 // =============================================================================
@@ -156,29 +42,6 @@ export function envVarToConfigKey(envVar: string): string | undefined {
   return envVar.slice(3).toLowerCase().replace(/__/g, ".").replace(/_/g, "-");
 }
 
-/**
- * Parse a raw string value for a given config key using the schema's parser.
- * Returns undefined if the key is unknown or the value is invalid.
- */
-export function parseConfigValue(key: ConfigKey, raw: string): ConfigValues[ConfigKey] | undefined {
-  const def = CONFIG[key];
-  if (!def) return undefined;
-  return def.parse(raw) as ConfigValues[ConfigKey] | undefined;
-}
-
-/**
- * Validate an unknown JSON value for a given config key using the schema's validator.
- * Returns undefined if the key is unknown or the value is invalid.
- */
-export function validateConfigValue(
-  key: ConfigKey,
-  value: unknown
-): ConfigValues[ConfigKey] | undefined {
-  const def = CONFIG[key];
-  if (!def) return undefined;
-  return def.validate(value) as ConfigValues[ConfigKey] | undefined;
-}
-
 // =============================================================================
 // Help Text
 // =============================================================================
@@ -186,11 +49,16 @@ export function validateConfigValue(
 /**
  * Generate a human-readable config usage guide.
  *
- * `defaults` should be the effective config values (accounting for
+ * `definitions` provides the set of registered config keys.
+ * `defaults` should be the effective default values (accounting for
  * isDevelopment, isPackaged, etc.) so users see the actual defaults
  * that apply to their environment.
  */
-export function generateHelpText(configFilePath: string, defaults: Readonly<ConfigValues>): string {
+export function generateHelpText(
+  configFilePath: string,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
+  defaults: Readonly<Record<string, unknown>>
+): string {
   const lines: string[] = [
     "CodeHydra Configuration",
     "=======================",
@@ -204,7 +72,7 @@ export function generateHelpText(configFilePath: string, defaults: Readonly<Conf
     "",
   ];
 
-  for (const key of Object.keys(CONFIG) as ConfigKey[]) {
+  for (const key of definitions.keys()) {
     const value = defaults[key];
     const valueStr = value === undefined ? "—" : String(value);
     lines.push(`  ${key.padEnd(24)} default: ${valueStr}`);

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -3,15 +3,15 @@
  */
 
 export {
-  CONFIG,
-  type ConfigValues,
-  type ConfigKey,
+  type ConfigKeyDefinition,
+  type ComputedDefaultContext,
+  parseBool,
+} from "./config-definition";
+
+export {
   type ConfigAgentType,
-  CONFIG_KEYS,
-  DEFAULT_CONFIG_VALUES,
+  type AutoUpdatePreference,
   envVarToConfigKey,
-  parseConfigValue,
-  validateConfigValue,
   generateHelpText,
 } from "./config-values";
 


### PR DESCRIPTION
- Each module now registers its own config key definitions via a `register-config` hook in `app:start`, replacing the centralized `CONFIG` schema in `config-values.ts`
- Added `ConfigKeyDefinition` interface in new `config-definition.ts`
- Added `register-config` collect hook before `before-ready` in app-start operation
- Config module collects definitions from all modules, builds definition map, seeds effective values with static defaults
- Each consuming module (logging, telemetry, auto-updater, code-server, claude-agent, opencode-agent, electron-lifecycle, auto-pr) returns its own definitions via `register-config`
- Config values changed from typed `ConfigValues` to `Record<string, unknown>` — modules cast at their consumption points
- Removed centralized `CONFIG` object, `ConfigKey`, `ConfigValues`, `CONFIG_KEYS`, `DEFAULT_CONFIG_VALUES`, `parseConfigValue`, `validateConfigValue` from config-values.ts
- Config module tests use test-specific definitions (`test.string`, `test.level`, etc.) instead of duplicating real module definitions; migration tests use real key definitions since `parseConfigFile` is inherently tied to production key names