### PR TITLE
feat(ui): add "More options" to create workspace dialog

### DIFF
--- a/src/agents/claude/wrapper.test.ts
+++ b/src/agents/claude/wrapper.test.ts
@@ -79,4 +79,10 @@ describe("buildInitialPromptArgs", () => {
     const args = buildInitialPromptArgs(config);
     expect(args).toEqual(["Line 1\nLine 2\nLine 3"]);
   });
+
+  it("omits empty prompt but includes agent flag", () => {
+    const config: InitialPromptConfig = { prompt: "", agent: "plan" };
+    const args = buildInitialPromptArgs(config);
+    expect(args).toEqual(["--agent", "plan"]);
+  });
 });

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -120,7 +120,10 @@ function buildPermissionArgs(agent?: string): string[] {
  * @returns Array of CLI arguments (prompt, --model, --agent flags as needed)
  */
 function buildInitialPromptArgs(config: InitialPromptConfig): string[] {
-  const args: string[] = [config.prompt];
+  const args: string[] = [];
+  if (config.prompt) {
+    args.push(config.prompt);
+  }
 
   if (config.model !== undefined) {
     args.push("--model", config.model);

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -139,7 +139,12 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(mockWorkspace);
 
       const workspaces = exposedApi.workspaces as {
-        create: (projectId: string, name: string, base: string) => Promise<unknown>;
+        create: (
+          projectId: string,
+          name: string,
+          base: string,
+          options?: { initialPrompt?: unknown; keepInBackground?: boolean }
+        ) => Promise<unknown>;
       };
       const result = await workspaces.create("my-app-12345678", "feature", "main");
 
@@ -149,6 +154,36 @@ describe("preload API", () => {
         base: "main",
       });
       expect(result).toEqual(mockWorkspace);
+    });
+
+    it("workspaces.create forwards options to IPC payload", async () => {
+      mockIpcRenderer.invoke.mockResolvedValue({
+        projectId: "my-app-12345678",
+        name: "feature",
+        branch: "feature",
+        path: "/ws/feature",
+      });
+
+      const workspaces = exposedApi.workspaces as {
+        create: (
+          projectId: string,
+          name: string,
+          base: string,
+          options?: { initialPrompt?: unknown; stealFocus?: boolean }
+        ) => Promise<unknown>;
+      };
+      await workspaces.create("my-app-12345678", "feature", "main", {
+        initialPrompt: { prompt: "Build the login page", agent: "plan" },
+        stealFocus: false,
+      });
+
+      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("api:workspace:create", {
+        projectPath: "my-app-12345678",
+        name: "feature",
+        base: "main",
+        initialPrompt: { prompt: "Build the login page", agent: "plan" },
+        stealFocus: false,
+      });
     });
 
     it("workspaces.remove calls api:workspace:remove", async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ import type {
   AgentSelectedPayload,
 } from "../shared/ipc";
 import type { ShortcutKey } from "../shared/shortcuts";
+import type { InitialPrompt } from "../shared/api/types";
 
 /**
  * Function to unsubscribe from an event.
@@ -47,8 +48,18 @@ contextBridge.exposeInMainWorld("api", {
       ipcRenderer.invoke(ApiIpcChannels.PROJECT_FETCH_BASES, { projectPath }),
   },
   workspaces: {
-    create: (projectPath: string, name: string, base: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, { projectPath, name, base }),
+    create: (
+      projectPath: string,
+      name: string,
+      base: string,
+      options?: { initialPrompt?: InitialPrompt; stealFocus?: boolean }
+    ) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, {
+        projectPath,
+        name,
+        base,
+        ...options,
+      }),
     remove: (
       workspacePath: string,
       options?: {

--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -6,13 +6,12 @@
   import Icon from "./Icon.svelte";
   import {
     workspaces,
-    ui,
     projects as projectsApi,
     type Workspace,
     type ProjectId,
     type Project,
   } from "$lib/api";
-  import { validateWorkspaceName } from "@shared/api/types";
+  import { validateWorkspaceName, type InitialPrompt } from "@shared/api/types";
   import { closeDialog, openGitCloneDialog } from "$lib/stores/dialogs.svelte.js";
   import { getProjectById, projects } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
@@ -61,6 +60,25 @@
   let touched = $state(false);
   let createButtonRef: HTMLElement | undefined = $state();
   let nameInputRef: { focus: () => void } | undefined = $state();
+
+  // More options state
+  let showMoreOptions = $state(false);
+  let initialPrompt = $state("");
+  let agentMode = $state<"" | "plan">("");
+  let openInBackground = $state(false);
+  let agentModeRef: HTMLElement | undefined = $state();
+
+  // Direct event listener for vscode-single-select: its change event doesn't bubble,
+  // but Svelte 5 delegates 'change' to the document root, so onchange= misses it.
+  $effect(() => {
+    const el = agentModeRef;
+    if (!el) return;
+    const handler = (e: Event) => {
+      agentMode = (e.target as HTMLSelectElement).value as "" | "plan";
+    };
+    el.addEventListener("change", handler);
+    return () => el.removeEventListener("change", handler);
+  });
 
   // Get existing workspace names for duplicate validation (uses selectedProjectId)
   const existingNames = $derived.by(() => {
@@ -131,6 +149,16 @@
     setTimeout(() => createButtonRef?.focus(), 0);
   }
 
+  // Toggle more options visibility
+  function toggleMoreOptions(): void {
+    showMoreOptions = !showMoreOptions;
+    // Re-focus the toggle after DOM updates (it moves between actions row and content area)
+    setTimeout(() => {
+      const toggle = document.querySelector(".more-options-toggle") as HTMLElement | null;
+      toggle?.focus();
+    }, 0);
+  }
+
   // Handle form submission
   async function handleSubmit(): Promise<void> {
     // isFormValid includes hasProject check, so selectedProject is defined
@@ -141,9 +169,25 @@
 
     try {
       logger.debug("Dialog submitted", { type: "create-workspace" });
-      const workspace = await workspaces.create(selectedProject.path, name, selectedBranch);
-      // Switch to the newly created workspace to load its view
-      await ui.switchWorkspace(workspace.path);
+
+      // Build options from "More options" fields
+      const options: { initialPrompt?: InitialPrompt; stealFocus?: boolean } = {};
+      const trimmedPrompt = initialPrompt.trim();
+      if (trimmedPrompt || agentMode) {
+        options.initialPrompt = agentMode
+          ? { prompt: trimmedPrompt, agent: agentMode }
+          : trimmedPrompt;
+      }
+      if (openInBackground) {
+        options.stealFocus = false;
+      }
+
+      await workspaces.create(
+        selectedProject.path,
+        name,
+        selectedBranch,
+        Object.keys(options).length > 0 ? options : undefined
+      );
       closeDialog();
     } catch (error) {
       const message = getErrorMessage(error);
@@ -197,6 +241,18 @@
   const descriptionId = "create-workspace-desc";
   const nameErrorId = "name-error";
 </script>
+
+{#snippet moreOptionsToggle()}
+  <button
+    class="more-options-toggle"
+    onclick={toggleMoreOptions}
+    disabled={isSubmitting}
+    type="button"
+  >
+    <Icon name={showMoreOptions ? "chevron-down" : "chevron-right"} />
+    More options
+  </button>
+{/snippet}
 
 <Dialog {open} onClose={handleCancel} busy={isSubmitting} {titleId} {descriptionId}>
   {#snippet title()}
@@ -284,6 +340,51 @@
       {/if}
     </div>
 
+    {#if showMoreOptions}
+      {@render moreOptionsToggle()}
+
+      <div class="more-options-box">
+        <div class="ch-form-field">
+          <label for="initial-prompt" class="ch-form-label">Initial prompt</label>
+          <vscode-textarea
+            id="initial-prompt"
+            value={initialPrompt}
+            oninput={(e: Event) => {
+              initialPrompt = (e.target as HTMLTextAreaElement).value;
+            }}
+            disabled={isSubmitting}
+            rows={3}
+            resize="vertical"
+            placeholder="Optional prompt to send after creation"
+          ></vscode-textarea>
+        </div>
+
+        <div class="ch-form-field">
+          <label for="agent-mode" class="ch-form-label">Agent</label>
+          <vscode-single-select
+            id="agent-mode"
+            bind:this={agentModeRef}
+            value={agentMode}
+            disabled={isSubmitting}
+          >
+            <vscode-option value="">Full permissions</vscode-option>
+            <vscode-option value="plan">Plan mode (read-only)</vscode-option>
+          </vscode-single-select>
+        </div>
+
+        <div class="ch-checkbox-row">
+          <vscode-checkbox
+            checked={openInBackground}
+            onchange={(e: Event) => {
+              openInBackground = (e.target as HTMLElement & { checked: boolean }).checked;
+            }}
+            disabled={isSubmitting}
+            label="Open in background"
+          ></vscode-checkbox>
+        </div>
+      </div>
+    {/if}
+
     {#if isSubmitting}
       <div class="ch-status-message" aria-live="polite">Creating workspace...</div>
     {/if}
@@ -308,6 +409,9 @@
     <vscode-button secondary={true} onclick={handleCancel} disabled={isSubmitting}>
       Cancel
     </vscode-button>
+    {#if !showMoreOptions}
+      {@render moreOptionsToggle()}
+    {/if}
   {/snippet}
 </Dialog>
 
@@ -340,5 +444,39 @@
   /* Placeholder textfield when no project selected */
   .project-row :global(.no-project-placeholder) {
     flex: 1;
+  }
+
+  .more-options-box {
+    border: 1px solid var(--ch-input-border);
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 0;
+  }
+
+  .more-options-toggle {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    color: var(--ch-foreground);
+    opacity: 0.8;
+    cursor: pointer;
+    margin-right: auto;
+  }
+
+  .more-options-toggle:hover {
+    opacity: 1;
+  }
+
+  .more-options-toggle:focus-visible {
+    opacity: 1;
+    outline: 1px solid var(--ch-focus-border);
+    outline-offset: 2px;
+  }
+
+  .more-options-toggle:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 </style>

--- a/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.test.ts
@@ -16,7 +16,6 @@ const {
   mockCloseDialog,
   mockProjectsStore,
   mockGetProjectById,
-  mockSwitchWorkspace,
   basesUpdatedHandlers,
 } = vi.hoisted(() => ({
   mockCreateWorkspace: vi.fn(),
@@ -24,7 +23,6 @@ const {
   mockCloseDialog: vi.fn(),
   mockProjectsStore: vi.fn(),
   mockGetProjectById: vi.fn(),
-  mockSwitchWorkspace: vi.fn(),
   // Store handlers to trigger bases-updated events in tests
   basesUpdatedHandlers: new Set<(event: { projectPath: string; bases: BaseInfo[] }) => void>(),
 }));
@@ -52,9 +50,6 @@ vi.mock("$lib/api", () => ({
   },
   projects: {
     fetchBases: mockFetchBases,
-  },
-  ui: {
-    switchWorkspace: mockSwitchWorkspace,
   },
   // Event subscription mock for BranchDropdown
   on: (event: string, handler: (event: { projectPath: string; bases: BaseInfo[] }) => void) => {
@@ -197,7 +192,6 @@ describe("CreateWorkspaceDialog component", () => {
       branch: name,
       projectId: testProjectId,
     }));
-    mockSwitchWorkspace.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -495,7 +489,8 @@ describe("CreateWorkspaceDialog component", () => {
       expect(mockCreateWorkspace).toHaveBeenCalledWith(
         "/test/project",
         "valid-name",
-        expect.any(String)
+        expect.any(String),
+        undefined
       );
     });
 
@@ -535,7 +530,12 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
 
       // Form should submit because name is valid and branch is pre-selected
-      expect(mockCreateWorkspace).toHaveBeenCalledWith("/test/project", "my-feature", "main");
+      expect(mockCreateWorkspace).toHaveBeenCalledWith(
+        "/test/project",
+        "my-feature",
+        "main",
+        undefined
+      );
     });
 
     it("form does not submit while already submitting", async () => {
@@ -650,7 +650,7 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
     });
 
-    it("api.createWorkspace called with correct params", async () => {
+    it("api.createWorkspace called with correct params (no options when collapsed)", async () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       await completeAllLoading();
 
@@ -663,10 +663,15 @@ describe("CreateWorkspaceDialog component", () => {
 
       await completeAllLoading();
 
-      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main");
+      expect(workspaces.create).toHaveBeenCalledWith(
+        "/test/project",
+        "my-feature",
+        "main",
+        undefined
+      );
     });
 
-    it("success switches to new workspace and closes dialog", async () => {
+    it("success closes dialog", async () => {
       render(CreateWorkspaceDialog, { props: defaultProps });
       await completeAllLoading();
 
@@ -679,8 +684,7 @@ describe("CreateWorkspaceDialog component", () => {
 
       await completeAllLoading();
 
-      // Should switch to the newly created workspace (uses workspace.path)
-      expect(mockSwitchWorkspace).toHaveBeenCalledWith("/test/project/.worktrees/my-feature");
+      // Workspace switching is handled by backend/domain events, dialog just closes
       expect(mockCloseDialog).toHaveBeenCalled();
     });
   });
@@ -1091,7 +1095,205 @@ describe("CreateWorkspaceDialog component", () => {
       await completeAllLoading();
 
       // Form should be submitted because name is valid and branch is pre-selected
-      expect(mockCreateWorkspace).toHaveBeenCalledWith("/test/project", "my-feature", "main");
+      expect(mockCreateWorkspace).toHaveBeenCalledWith(
+        "/test/project",
+        "my-feature",
+        "main",
+        undefined
+      );
+    });
+  });
+
+  describe("more options", () => {
+    // Helper to fill a valid form (name + branch selection)
+    async function fillValidForm(nameValue: string = "valid-name"): Promise<void> {
+      const nameInput = getNameInput();
+      await fireEvent.input(nameInput, { target: { value: nameValue } });
+      await fireEvent.keyDown(nameInput, { key: "Enter" });
+
+      const branchDropdown = getBranchDropdown();
+      await fireEvent.focus(branchDropdown);
+      await fireEvent.keyDown(branchDropdown, { key: "ArrowDown" });
+      await fireEvent.keyDown(branchDropdown, { key: "Enter" });
+      await completeAllLoading();
+    }
+
+    /**
+     * Helper to get the "More options" toggle button.
+     */
+    function getMoreOptionsToggle(): HTMLButtonElement {
+      const button = document.querySelector(".more-options-toggle") as HTMLButtonElement;
+      if (!button) throw new Error("More options toggle not found");
+      return button;
+    }
+
+    it("renders 'More options' toggle in collapsed state by default", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      const toggle = getMoreOptionsToggle();
+      expect(toggle).toBeInTheDocument();
+      expect(toggle.textContent).toContain("More options");
+
+      // Options box should not be visible
+      expect(document.querySelector(".more-options-box")).not.toBeInTheDocument();
+    });
+
+    it("toggle shows and hides the options box", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      const toggle = getMoreOptionsToggle();
+
+      // Click to expand
+      await fireEvent.click(toggle);
+      expect(document.querySelector(".more-options-box")).toBeInTheDocument();
+
+      // Click again to collapse
+      const toggleAfter = getMoreOptionsToggle();
+      await fireEvent.click(toggleAfter);
+      expect(document.querySelector(".more-options-box")).not.toBeInTheDocument();
+    });
+
+    it("submitting with initial prompt passes string-form options", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      // Expand more options
+      await fireEvent.click(getMoreOptionsToggle());
+
+      // Fill initial prompt
+      const textarea = document.querySelector("#initial-prompt") as HTMLTextAreaElement;
+      await fireEvent.input(textarea, { target: { value: "Build the login page" } });
+
+      // Fill valid form
+      await fillValidForm("my-feature");
+
+      // Submit
+      const okButton = screen.getByRole("button", { name: /create/i });
+      await fireEvent.click(okButton);
+      await completeAllLoading();
+
+      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main", {
+        initialPrompt: "Build the login page",
+      });
+    });
+
+    it("submitting with agent mode builds object-form InitialPrompt", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      // Expand more options
+      await fireEvent.click(getMoreOptionsToggle());
+
+      // Fill initial prompt
+      const textarea = document.querySelector("#initial-prompt") as HTMLTextAreaElement;
+      await fireEvent.input(textarea, { target: { value: "Plan the feature" } });
+
+      // Select plan mode - dispatch a non-bubbling change event like the real
+      // vscode-single-select does (vscode-select-base.js dispatches new Event('change')
+      // without { bubbles: true }). This verifies the component handles non-bubbling
+      // events correctly (Svelte 5 delegates 'change' events to the document root,
+      // so onchange= handlers miss non-bubbling events).
+      const select = document.querySelector("#agent-mode") as HTMLElement;
+      Object.defineProperty(select, "value", { value: "plan", writable: true, configurable: true });
+      select.dispatchEvent(new Event("change"));
+
+      // Fill valid form
+      await fillValidForm("my-feature");
+
+      // Submit
+      const okButton = screen.getByRole("button", { name: /create/i });
+      await fireEvent.click(okButton);
+      await completeAllLoading();
+
+      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main", {
+        initialPrompt: { prompt: "Plan the feature", agent: "plan" },
+      });
+    });
+
+    it("submitting with open in background passes stealFocus: false", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      // Expand more options
+      await fireEvent.click(getMoreOptionsToggle());
+
+      // Check open in background
+      const checkbox = document.querySelector("vscode-checkbox") as HTMLElement & {
+        checked: boolean;
+      };
+      await fireEvent.change(checkbox, { target: { checked: true } });
+
+      // Fill valid form
+      await fillValidForm("my-feature");
+
+      // Submit
+      const okButton = screen.getByRole("button", { name: /create/i });
+      await fireEvent.click(okButton);
+      await completeAllLoading();
+
+      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main", {
+        stealFocus: false,
+      });
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+
+    it("submitting with agent mode but no prompt passes object-form InitialPrompt with empty prompt", async () => {
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      // Expand more options
+      await fireEvent.click(getMoreOptionsToggle());
+
+      // Select plan mode without entering a prompt (non-bubbling event like real element)
+      const select = document.querySelector("#agent-mode") as HTMLElement;
+      Object.defineProperty(select, "value", { value: "plan", writable: true, configurable: true });
+      select.dispatchEvent(new Event("change"));
+
+      // Fill valid form
+      await fillValidForm("my-feature");
+
+      // Submit
+      const okButton = screen.getByRole("button", { name: /create/i });
+      await fireEvent.click(okButton);
+      await completeAllLoading();
+
+      expect(workspaces.create).toHaveBeenCalledWith("/test/project", "my-feature", "main", {
+        initialPrompt: { prompt: "", agent: "plan" },
+      });
+    });
+
+    it("more options fields are disabled when submitting", async () => {
+      mockCreateWorkspace.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 1000))
+      );
+
+      render(CreateWorkspaceDialog, { props: defaultProps });
+      await completeAllLoading();
+
+      // Expand more options
+      await fireEvent.click(getMoreOptionsToggle());
+
+      // Fill valid form
+      await fillValidForm("my-feature");
+
+      // Submit
+      const okButton = screen.getByRole("button", { name: /create/i });
+      await fireEvent.click(okButton);
+
+      // Check fields are disabled
+      const textarea = document.querySelector("#initial-prompt") as HTMLElement;
+      const select = document.querySelector("#agent-mode") as HTMLElement;
+      const checkbox = document.querySelector("vscode-checkbox") as HTMLElement;
+      const toggle = getMoreOptionsToggle();
+
+      expect(textarea).toHaveAttribute("disabled");
+      expect(select).toHaveAttribute("disabled");
+      expect(checkbox).toHaveAttribute("disabled");
+      expect(toggle).toBeDisabled();
+
+      await completeAllLoading();
     });
   });
 

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -13,6 +13,7 @@ import type {
   WorkspaceRef,
   WorkspaceStatus,
   BaseInfo as ApiBaseInfo,
+  InitialPrompt,
 } from "./api/types";
 
 /**
@@ -38,7 +39,12 @@ export interface Api {
     fetchBases(projectPath: string): Promise<{ readonly bases: readonly ApiBaseInfo[] }>;
   };
   workspaces: {
-    create(projectPath: string, name: string, base: string): Promise<Workspace>;
+    create(
+      projectPath: string,
+      name: string,
+      base: string,
+      options?: { initialPrompt?: InitialPrompt; stealFocus?: boolean }
+    ): Promise<Workspace>;
     /**
      * Start workspace removal (fire-and-forget).
      * Progress is emitted via workspace:deletion-progress events.


### PR DESCRIPTION
- Expose initialPrompt, agent mode, and keepInBackground in the create workspace dialog via a collapsible "More options" section
- When collapsed, the toggle sits in the actions row; when expanded, it moves to the content area above a bordered options box