### PR TITLE
feat(session): preserve layout and resume agent on workspace reopen

### DIFF
--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -68,27 +68,49 @@ let terminalCloseListener: vscode.Disposable | null = null;
 /**
  * Open agent terminal in the editor area.
  * Creates a new terminal if none exists, otherwise focuses the existing one.
+ * On reopened workspaces (show=false), disposes any stale restored terminals
+ * (which have lost their name/env after code-server restart) and creates a
+ * fresh terminal with correct name, env vars, and command.
  *
  * @param agentType - The type of agent ("opencode" or "claude")
  * @param env - Environment variables to set for the terminal
+ * @param show - Whether to show/focus the terminal (default: true)
  */
-function openAgentTerminal(agentType: AgentType, env: Record<string, string>): void {
-  // If terminal exists and not disposed, just focus it
+function openAgentTerminal(
+  agentType: AgentType,
+  env: Record<string, string>,
+  show: boolean = true
+): void {
   if (agentTerminal) {
-    agentTerminal.show();
+    if (show) agentTerminal.show();
     return;
   }
 
   const terminalName = agentType === "claude" ? "Claude" : "OpenCode";
   const command = agentType === "claude" ? "ch-claude" : "ch-opencode";
 
-  // Create terminal in editor area using viewColumn
-  // isTransient prevents the terminal from being restored on VS Code restart
+  if (!show) {
+    // Reopened workspace: dispose stale restored terminals (empty creationOptions
+    // indicate a terminal restored after pty host reconnection failure)
+    let hadRestoredTerminal = false;
+    for (const t of vscode.window.terminals) {
+      const opts = t.creationOptions as vscode.TerminalOptions | undefined;
+      if (opts?.name === undefined) {
+        hadRestoredTerminal = true;
+        t.dispose();
+      }
+    }
+
+    if (!hadRestoredTerminal) {
+      // User had closed the terminal before restart — don't recreate it
+      return;
+    }
+  }
+
   agentTerminal = vscode.window.createTerminal({
     name: terminalName,
     location: { viewColumn: vscode.ViewColumn.Active },
     env: env,
-    isTransient: true,
   });
 
   agentTerminal.show();
@@ -471,20 +493,22 @@ function connectToPluginServer(port: number, workspacePath: string): void {
 
     await vscode.commands.executeCommand("setContext", "codehydra.isDevelopment", isDevelopment);
 
-    // Execute pre-terminal layout commands
-    const preLayoutCommands = [
-      "workbench.action.closeSidebar",
-      "workbench.action.closeAuxiliaryBar",
-      "workbench.action.editorLayoutSingle",
-      "workbench.action.closeAllEditors",
-      "codehydra.dictation.openPanel",
-    ];
-    for (const command of preLayoutCommands) {
-      try {
-        await vscode.commands.executeCommand(command);
-      } catch (err: unknown) {
-        const error = err instanceof Error ? err.message : String(err);
-        codehydraApi.log.warn("Layout command failed", { command, error });
+    // Execute pre-terminal layout commands (only for new workspaces)
+    if (config.resetWorkspace) {
+      const preLayoutCommands = [
+        "workbench.action.closeSidebar",
+        "workbench.action.closeAuxiliaryBar",
+        "workbench.action.editorLayoutSingle",
+        "workbench.action.closeAllEditors",
+        "codehydra.dictation.openPanel",
+      ];
+      for (const command of preLayoutCommands) {
+        try {
+          await vscode.commands.executeCommand(command);
+        } catch (err: unknown) {
+          const error = err instanceof Error ? err.message : String(err);
+          codehydraApi.log.warn("Layout command failed", { command, error });
+        }
       }
     }
 
@@ -492,10 +516,13 @@ function connectToPluginServer(port: number, workspacePath: string): void {
     if (config.env !== null && config.agentType !== null) {
       currentAgentType = config.agentType;
       currentAgentEnv = config.env;
-      openAgentTerminal(config.agentType, config.env);
-      // Wait for terminal to be ready before focusing
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await vscode.commands.executeCommand("workbench.action.terminal.focus");
+      openAgentTerminal(config.agentType, config.env, config.resetWorkspace);
+
+      // Focus the terminal only for new workspaces
+      if (config.resetWorkspace) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await vscode.commands.executeCommand("workbench.action.terminal.focus");
+      }
     }
 
     // Register debug commands in development mode

--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -35,6 +35,8 @@ export interface PluginConfig {
   readonly isDevelopment: boolean;
   readonly env: Record<string, string> | null;
   readonly agentType: AgentType | null;
+  /** True for new workspaces (reset editor layout), false for reopened (preserve layout) */
+  readonly resetWorkspace: boolean;
 }
 
 export interface SetMetadataRequest {

--- a/src/agents/claude/wrapper.integration.test.ts
+++ b/src/agents/claude/wrapper.integration.test.ts
@@ -307,4 +307,37 @@ describe("runClaude session resume", () => {
 
     expect(mock.calls[0]?.opts.shell).toBe(false);
   });
+
+  it("skips --continue attempt when skipContinue is true", () => {
+    const mock = createSpawnMock([0]);
+
+    const result = runClaude(
+      "claude",
+      ["--ide", "--settings", "/path"],
+      { shell: false, skipContinue: true },
+      mock
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(mock.calls).toHaveLength(1);
+    // Should NOT have --continue prepended
+    expect(mock.calls[0]?.args[0]).toBe("--ide");
+    expect(mock.calls[0]?.args).not.toContain("--continue");
+  });
+
+  it("attempts --continue when skipContinue is false", () => {
+    const mock = createSpawnMock([0]);
+
+    const result = runClaude(
+      "claude",
+      ["--ide", "--settings", "/path"],
+      { shell: false, skipContinue: false },
+      mock
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(mock.calls).toHaveLength(1);
+    // Should have --continue prepended
+    expect(mock.calls[0]?.args[0]).toBe("--continue");
+  });
 });

--- a/src/agents/claude/wrapper.test.ts
+++ b/src/agents/claude/wrapper.test.ts
@@ -4,8 +4,13 @@
  * Tests buildInitialPromptArgs function.
  */
 
-import { describe, it, expect } from "vitest";
-import { buildInitialPromptArgs, buildPermissionArgs, type InitialPromptConfig } from "./wrapper";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildInitialPromptArgs,
+  buildPermissionArgs,
+  shouldContinue,
+  type InitialPromptConfig,
+} from "./wrapper";
 
 describe("buildPermissionArgs", () => {
   it("returns --dangerously-skip-permissions when no agent", () => {
@@ -84,5 +89,26 @@ describe("buildInitialPromptArgs", () => {
     const config: InitialPromptConfig = { prompt: "", agent: "plan" };
     const args = buildInitialPromptArgs(config);
     expect(args).toEqual(["--agent", "plan"]);
+  });
+});
+
+describe("shouldContinue", () => {
+  afterEach(() => {
+    delete process.env._CH_CLAUDE_CONTINUE;
+  });
+
+  it("returns true when _CH_CLAUDE_CONTINUE is '1'", () => {
+    process.env._CH_CLAUDE_CONTINUE = "1";
+    expect(shouldContinue()).toBe(true);
+  });
+
+  it("returns false when _CH_CLAUDE_CONTINUE is not set", () => {
+    delete process.env._CH_CLAUDE_CONTINUE;
+    expect(shouldContinue()).toBe(false);
+  });
+
+  it("returns false when _CH_CLAUDE_CONTINUE is '0'", () => {
+    process.env._CH_CLAUDE_CONTINUE = "0";
+    expect(shouldContinue()).toBe(false);
   });
 });

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -154,6 +154,8 @@ export interface SpawnResult {
  */
 export interface RunClaudeOptions {
   shell: boolean;
+  /** Skip the automatic --continue attempt (new workspace with no prior session) */
+  skipContinue?: boolean;
 }
 
 /**
@@ -218,8 +220,8 @@ export function runClaude(
   options: RunClaudeOptions,
   deps: RunClaudeDeps = defaultDeps
 ): SpawnResult {
-  // Check if user already passed resume flags - skip auto-continue if so
-  if (hasUserResumeFlag(baseArgs)) {
+  // Check if user already passed resume flags or skipContinue is set
+  if (hasUserResumeFlag(baseArgs) || options.skipContinue) {
     const result = deps.spawnSync(claudeBinary, baseArgs, {
       stdio: "inherit",
       shell: options.shell,
@@ -255,6 +257,14 @@ export function runClaude(
     exitCode: retryResult.status,
     error: retryResult.error,
   };
+}
+
+/**
+ * Check if the wrapper should attempt --continue for session resume.
+ * Returns true when _CH_CLAUDE_CONTINUE=1 (reopened workspace with prior session).
+ */
+function shouldContinue(): boolean {
+  return process.env._CH_CLAUDE_CONTINUE === "1";
 }
 
 /**
@@ -394,7 +404,11 @@ async function main(): Promise<never> {
 
   // 7. Spawn Claude with automatic session resume
   // Use shell on Windows to resolve binary name via PATH (handles .cmd shims)
-  const result = runClaude(claudeBinary, args, { shell: isWindows });
+  // Skip --continue attempt for new workspaces (no prior session to resume)
+  const result = runClaude(claudeBinary, args, {
+    shell: isWindows,
+    skipContinue: !shouldContinue(),
+  });
 
   // 8. Notify wrapper end (Claude has exited)
   await notifyHook("WrapperEnd");
@@ -424,4 +438,5 @@ export {
   getInitialPromptConfig,
   buildInitialPromptArgs,
   buildPermissionArgs,
+  shouldContinue,
 };

--- a/src/main/modules/claude-agent-module.integration.test.ts
+++ b/src/main/modules/claude-agent-module.integration.test.ts
@@ -798,6 +798,62 @@ describe("ClaudeAgentModule", () => {
       expect(mockSM.setInitialPrompt).toHaveBeenCalled();
     });
 
+    it("includes _CH_CLAUDE_CONTINUE env var for reopened workspaces", async () => {
+      const { dispatcher, module } = createTestSetup();
+      await activateModule(dispatcher, module);
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      const result = (await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678",
+          workspaceName: "feature-1",
+          base: "main",
+          existingWorkspace: {
+            path: "/test/workspace",
+            name: "feature-1",
+            branch: "feature-1",
+            metadata: {},
+          },
+        },
+      } as unknown as OpenWorkspaceIntent)) as SetupHookResult | undefined;
+
+      expect(result).toBeDefined();
+      expect(result!.envVars).toHaveProperty("_CH_CLAUDE_CONTINUE", "1");
+    });
+
+    it("does not include _CH_CLAUDE_CONTINUE for new workspaces", async () => {
+      const { dispatcher, module } = createTestSetup();
+      await activateModule(dispatcher, module);
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      const result = (await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678",
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as unknown as OpenWorkspaceIntent)) as SetupHookResult | undefined;
+
+      expect(result).toBeDefined();
+      expect(result!.envVars).not.toHaveProperty("_CH_CLAUDE_CONTINUE");
+    });
+
     it("returns undefined when inactive", async () => {
       const { dispatcher, mockSM, module } = createTestSetup();
       // Simulate config:updated with opencode so module stays inactive

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -375,6 +375,11 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
               ...(agentProvider?.getEnvironmentVariables() ?? {}),
             };
 
+            // Signal reopened workspaces to use --continue for session resume
+            if (intent.payload.existingWorkspace !== undefined) {
+              envVars._CH_CLAUDE_CONTINUE = "1";
+            }
+
             return { envVars, agentType: "claude" };
           },
         },

--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -773,7 +773,53 @@ describe("CodeServerModule", () => {
       expect(deps.pluginServer!.setWorkspaceConfig).toHaveBeenCalledWith(
         "/test/project/.worktrees/feature-1",
         { OPENCODE_PORT: "8080" },
-        "opencode"
+        "opencode",
+        true
+      );
+    });
+
+    it("passes resetWorkspace=false for existing (reopened) workspaces", async () => {
+      const deps = createMockDeps();
+
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      const module = createCodeServerModule(deps);
+      dispatcher.registerModule(module);
+
+      // Start to set port
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      // Finalize with agentType
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalFinalizeOperation({
+          workspacePath: "/test/project/.worktrees/feature-1",
+          envVars: { OPENCODE_PORT: "8080" },
+          agentType: "opencode",
+        })
+      );
+
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678" as ProjectId,
+          workspaceName: "feature-1",
+          base: "main",
+          existingWorkspace: {
+            path: "/test/project/.worktrees/feature-1",
+            name: "feature-1",
+            branch: "feature-1",
+            metadata: {},
+          },
+        },
+      } as OpenWorkspaceIntent);
+
+      expect(deps.pluginServer!.setWorkspaceConfig).toHaveBeenCalledWith(
+        "/test/project/.worktrees/feature-1",
+        { OPENCODE_PORT: "8080" },
+        "opencode",
+        false
       );
     });
   });

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -33,7 +33,11 @@ import type {
   RegisterConfigResult,
 } from "../operations/app-start";
 import type { BinaryHookInput, ExtensionsHookInput } from "../operations/setup";
-import type { FinalizeHookInput, FinalizeHookResult } from "../operations/open-workspace";
+import type {
+  FinalizeHookInput,
+  FinalizeHookResult,
+  OpenWorkspaceIntent,
+} from "../operations/open-workspace";
 import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
 import type { DeleteHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
@@ -308,10 +312,13 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
             // Push config to PluginServer so connecting extensions get env vars + agent type
             if (pluginServer && finalizeCtx.agentType) {
+              const intent = ctx.intent as OpenWorkspaceIntent;
+              const resetWorkspace = intent.payload.existingWorkspace === undefined;
               pluginServer.setWorkspaceConfig(
                 finalizeCtx.workspacePath,
                 finalizeCtx.envVars,
-                finalizeCtx.agentType
+                finalizeCtx.agentType,
+                resetWorkspace
               );
             }
 

--- a/src/services/plugin-server/plugin-server.boundary.test.ts
+++ b/src/services/plugin-server/plugin-server.boundary.test.ts
@@ -819,7 +819,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("sends config with agent type when client connects", async () => {
       // Store workspace config before client connects
-      env.server.setWorkspaceConfig("/test/workspace", {}, "opencode");
+      env.server.setWorkspaceConfig("/test/workspace", {}, "opencode", true);
 
       const client = createClient("/test/workspace");
       const configPromise = new Promise<PluginConfig>((resolve) => {
@@ -837,7 +837,8 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       env.server.setWorkspaceConfig(
         "/test/workspace",
         { TEST_VAR: "test-value", ANOTHER_VAR: "another" },
-        "opencode"
+        "opencode",
+        true
       );
 
       const client = createClient("/test/workspace");
@@ -864,8 +865,18 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("handles concurrent workspace connections independently", async () => {
-      env.server.setWorkspaceConfig("/workspace/one", { WORKSPACE: "/workspace/one" }, "opencode");
-      env.server.setWorkspaceConfig("/workspace/two", { WORKSPACE: "/workspace/two" }, "opencode");
+      env.server.setWorkspaceConfig(
+        "/workspace/one",
+        { WORKSPACE: "/workspace/one" },
+        "opencode",
+        true
+      );
+      env.server.setWorkspaceConfig(
+        "/workspace/two",
+        { WORKSPACE: "/workspace/two" },
+        "opencode",
+        true
+      );
 
       const client1 = createClient("/workspace/one");
       const client2 = createClient("/workspace/two");

--- a/src/services/plugin-server/plugin-server.test.ts
+++ b/src/services/plugin-server/plugin-server.test.ts
@@ -37,20 +37,20 @@ describe("PluginServer", () => {
 
     it("stores config without throwing", () => {
       expect(() =>
-        server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode")
+        server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode", true)
       ).not.toThrow();
     });
 
     it("allows config to be overwritten", () => {
-      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode");
+      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode", true);
 
       expect(() =>
-        server.setWorkspaceConfig("/test/workspace", { PORT: "9090" }, "claude")
+        server.setWorkspaceConfig("/test/workspace", { PORT: "9090" }, "claude", false)
       ).not.toThrow();
     });
 
     it("removes config without throwing", () => {
-      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode");
+      server.setWorkspaceConfig("/test/workspace", { PORT: "8080" }, "opencode", true);
 
       expect(() => server.removeWorkspaceConfig("/test/workspace")).not.toThrow();
     });

--- a/src/services/plugin-server/plugin-server.ts
+++ b/src/services/plugin-server/plugin-server.ts
@@ -192,7 +192,7 @@ export class PluginServer {
    */
   private readonly workspaceConfigs = new Map<
     string,
-    { env: Record<string, string>; agentType: AgentType }
+    { env: Record<string, string>; agentType: AgentType; resetWorkspace: boolean }
   >();
 
   /**
@@ -332,14 +332,16 @@ export class PluginServer {
    * @param workspacePath - Workspace path (will be normalized)
    * @param env - Environment variables for terminal integration
    * @param agentType - Agent type for terminal launching
+   * @param resetWorkspace - True for new workspaces (reset layout), false for reopened
    */
   setWorkspaceConfig(
     workspacePath: string,
     env: Record<string, string>,
-    agentType: AgentType
+    agentType: AgentType,
+    resetWorkspace: boolean
   ): void {
     const normalized = new Path(workspacePath).toString();
-    this.workspaceConfigs.set(normalized, { env, agentType });
+    this.workspaceConfigs.set(normalized, { env, agentType, resetWorkspace });
   }
 
   /**
@@ -551,12 +553,14 @@ export class PluginServer {
       const storedConfig = this.workspaceConfigs.get(workspacePath);
       const env: Record<string, string> | null = storedConfig?.env ?? null;
       const agentType: AgentType | null = storedConfig?.agentType ?? null;
+      const resetWorkspace: boolean = storedConfig?.resetWorkspace ?? true;
 
       // Send config event with all startup data
       const config: PluginConfig = {
         isDevelopment: this.isDevelopment,
         env,
         agentType,
+        resetWorkspace,
       };
       socket.emit("config", config);
       this.logger.debug("Config sent", {

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -54,6 +54,8 @@ export interface PluginConfig {
   readonly env: Record<string, string> | null;
   /** Agent type for terminal launching (null if no agent configured) */
   readonly agentType: AgentType | null;
+  /** True for new workspaces (reset editor layout), false for reopened (preserve layout) */
+  readonly resetWorkspace: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
- Preserve editor layout when reopening existing workspaces (skip sidebar/editor reset)
- Resume prior Claude session with `--continue` via `_CH_CLAUDE_CONTINUE` env var
- Add `resetWorkspace` flag to PluginConfig protocol to distinguish new vs reopened workspaces
- Clean up stale restored terminals on workspace reopen
- New workspaces continue to get fresh layout and new agent session