### PR TITLE
chore(path-provider): remove dead setupMarkerPath, claudeCodeConfigDir, getBundledNodePath

### DIFF
--- a/src/services/platform/path-provider.test-utils.ts
+++ b/src/services/platform/path-provider.test-utils.ts
@@ -21,7 +21,6 @@ export interface MockPathProviderOptions {
   vscodeDir?: Path | string;
   vscodeExtensionsDir?: Path | string;
   vscodeUserDataDir?: Path | string;
-  setupMarkerPath?: Path | string;
   electronDataDir?: Path | string;
   binDir?: Path | string;
 
@@ -33,7 +32,6 @@ export interface MockPathProviderOptions {
   binRuntimeDir?: Path | string;
   scriptsRuntimeDir?: Path | string;
   extensionsRuntimeDir?: Path | string;
-  claudeCodeConfigDir?: Path | string;
   claudeCodeHookHandlerPath?: Path | string;
   claudeCodeWrapperPath?: Path | string;
   configPath?: Path | string;
@@ -42,10 +40,6 @@ export interface MockPathProviderOptions {
   getProjectWorkspacesDir?: (projectPath: string | Path) => Path;
   getBinaryBaseDir?: (type: "code-server" | "opencode" | "claude") => Path;
   getBinaryDir?: (type: "code-server" | "opencode" | "claude", version: string) => Path;
-  getBundledNodePath?: (codeServerVersion: string) => Path;
-
-  // Platform for binary path construction (defaults to "linux")
-  platform?: "darwin" | "linux" | "win32";
 }
 
 /**
@@ -68,7 +62,6 @@ function ensurePath(value: Path | string | undefined, defaultValue: string): Pat
 export function createMockPathProvider(overrides?: MockPathProviderOptions): PathProvider {
   // Bundle paths (binaries) - use bundlesRootDir
   const bundlesRootDir = ensurePath(overrides?.bundlesRootDir, "/test/bundles");
-  const platform = overrides?.platform ?? "linux";
 
   // Data paths - use dataRootDir
   const dataRootDir = ensurePath(overrides?.dataRootDir, "/test/app-data");
@@ -92,11 +85,6 @@ export function createMockPathProvider(overrides?: MockPathProviderOptions): Pat
     return new Path(bundlesRootDir, type, version);
   };
 
-  const defaultGetBundledNodePath = (codeServerVersion: string): Path => {
-    const codeServerDir = defaultGetBinaryDir("code-server", codeServerVersion);
-    return new Path(codeServerDir, "lib", platform === "win32" ? "node.exe" : "node");
-  };
-
   return {
     dataRootDir,
     projectsDir,
@@ -109,10 +97,6 @@ export function createMockPathProvider(overrides?: MockPathProviderOptions): Pat
     vscodeUserDataDir: ensurePath(
       overrides?.vscodeUserDataDir,
       `${vscodeDir.toString()}/user-data`
-    ),
-    setupMarkerPath: ensurePath(
-      overrides?.setupMarkerPath,
-      `${dataRootDir.toString()}/.setup-completed`
     ),
     electronDataDir: ensurePath(overrides?.electronDataDir, `${dataRootDir.toString()}/electron`),
     binDir: ensurePath(overrides?.binDir, `${dataRootDir.toString()}/bin`),
@@ -128,7 +112,6 @@ export function createMockPathProvider(overrides?: MockPathProviderOptions): Pat
     scriptsRuntimeDir: ensurePath(overrides?.scriptsRuntimeDir, "/mock/assets/scripts"),
     extensionsRuntimeDir: ensurePath(overrides?.extensionsRuntimeDir, "/mock/assets"),
 
-    claudeCodeConfigDir: ensurePath(overrides?.claudeCodeConfigDir, "/test/app-data/claude-code"),
     claudeCodeHookHandlerPath: ensurePath(
       overrides?.claudeCodeHookHandlerPath,
       "/mock/assets/bin/claude-code-hook-handler.cjs"
@@ -143,6 +126,5 @@ export function createMockPathProvider(overrides?: MockPathProviderOptions): Pat
     getProjectWorkspacesDir: overrides?.getProjectWorkspacesDir ?? defaultGetProjectWorkspacesDir,
     getBinaryBaseDir: overrides?.getBinaryBaseDir ?? defaultGetBinaryBaseDir,
     getBinaryDir: overrides?.getBinaryDir ?? defaultGetBinaryDir,
-    getBundledNodePath: overrides?.getBundledNodePath ?? defaultGetBundledNodePath,
   };
 }

--- a/src/services/platform/path-provider.test.ts
+++ b/src/services/platform/path-provider.test.ts
@@ -23,7 +23,6 @@ describe("createMockPathProvider", () => {
     expect(pathProvider.vscodeDir.toString()).toBe("/test/app-data/vscode");
     expect(pathProvider.vscodeExtensionsDir.toString()).toBe("/test/app-data/vscode/extensions");
     expect(pathProvider.vscodeUserDataDir.toString()).toBe("/test/app-data/vscode/user-data");
-    expect(pathProvider.setupMarkerPath.toString()).toBe("/test/app-data/.setup-completed");
     expect(pathProvider.electronDataDir.toString()).toBe("/test/app-data/electron");
     expect(pathProvider.vscodeAssetsDir.toString()).toBe("/mock/assets");
     expect(pathProvider.scriptsDir.toString()).toBe("/mock/assets/scripts");
@@ -47,11 +46,6 @@ describe("createMockPathProvider", () => {
     );
     expect(pathProvider.getBinaryDir("opencode", "1.0.223").toString()).toBe(
       "/test/bundles/opencode/1.0.223"
-    );
-
-    // Test getBundledNodePath
-    expect(pathProvider.getBundledNodePath("4.107.0").toString()).toBe(
-      "/test/bundles/code-server/4.107.0/lib/node"
     );
   });
 
@@ -89,7 +83,6 @@ describe("createMockPathProvider", () => {
       vscodeDir: "/c",
       vscodeExtensionsDir: "/d",
       vscodeUserDataDir: "/e",
-      setupMarkerPath: "/f",
       electronDataDir: "/g",
       vscodeAssetsDir: "/h",
       scriptsDir: "/h/scripts",
@@ -102,7 +95,6 @@ describe("createMockPathProvider", () => {
     expect(pathProvider.vscodeDir.toString()).toBe("/c");
     expect(pathProvider.vscodeExtensionsDir.toString()).toBe("/d");
     expect(pathProvider.vscodeUserDataDir.toString()).toBe("/e");
-    expect(pathProvider.setupMarkerPath.toString()).toBe("/f");
     expect(pathProvider.electronDataDir.toString()).toBe("/g");
     expect(pathProvider.vscodeAssetsDir.toString()).toBe("/h");
     expect(pathProvider.scriptsDir.toString()).toBe("/h/scripts");
@@ -156,7 +148,6 @@ describe("createMockPathProvider", () => {
     expect(pathProvider.vscodeDir).toBeInstanceOf(Path);
     expect(pathProvider.vscodeExtensionsDir).toBeInstanceOf(Path);
     expect(pathProvider.vscodeUserDataDir).toBeInstanceOf(Path);
-    expect(pathProvider.setupMarkerPath).toBeInstanceOf(Path);
     expect(pathProvider.electronDataDir).toBeInstanceOf(Path);
     expect(pathProvider.vscodeAssetsDir).toBeInstanceOf(Path);
     expect(pathProvider.scriptsDir).toBeInstanceOf(Path);
@@ -165,7 +156,6 @@ describe("createMockPathProvider", () => {
     expect(typeof pathProvider.getProjectWorkspacesDir).toBe("function");
     expect(typeof pathProvider.getBinaryBaseDir).toBe("function");
     expect(typeof pathProvider.getBinaryDir).toBe("function");
-    expect(typeof pathProvider.getBundledNodePath).toBe("function");
   });
 });
 
@@ -196,7 +186,6 @@ describe("DefaultPathProvider", () => {
       expect(pathProvider.vscodeDir.toString()).toMatch(/app-data\/vscode$/);
       expect(pathProvider.vscodeExtensionsDir.toString()).toMatch(/app-data\/vscode\/extensions$/);
       expect(pathProvider.vscodeUserDataDir.toString()).toMatch(/app-data\/vscode\/user-data$/);
-      expect(pathProvider.setupMarkerPath.toString()).toMatch(/app-data\/\.setup-completed$/);
       expect(pathProvider.electronDataDir.toString()).toMatch(/app-data\/electron$/);
       expect(pathProvider.appIconPath.toString()).toMatch(/resources\/icon\.png$/);
       expect(pathProvider.binDir.toString()).toMatch(/app-data\/bin$/);
@@ -214,15 +203,6 @@ describe("DefaultPathProvider", () => {
       expect(pathProvider.getBinaryDir("opencode", OPENCODE_VERSION).toString()).toMatch(
         new RegExp(`\\.local/share/codehydra/opencode/${OPENCODE_VERSION}$`)
       );
-    });
-
-    it("returns bundled Node path for Unix", () => {
-      const buildInfo = createMockBuildInfo({ isDevelopment: true, appPath: "/test/app" });
-      const platformInfo = createMockPlatformInfo({ platform: "linux" });
-      const pathProvider = new DefaultPathProvider(buildInfo, platformInfo);
-
-      expect(pathProvider.getBundledNodePath(CODE_SERVER_VERSION).toString()).toMatch(/lib\/node$/);
-      expect(pathProvider.getBundledNodePath(CODE_SERVER_VERSION).toString()).not.toMatch(/\.exe$/);
     });
 
     it("returns vscodeAssetsDir and scriptsDir based on appPath", () => {
@@ -308,9 +288,6 @@ describe("DefaultPathProvider", () => {
       expect(pathProvider.vscodeUserDataDir.toString()).toBe(
         "/home/testuser/.local/share/codehydra/vscode/user-data"
       );
-      expect(pathProvider.setupMarkerPath.toString()).toBe(
-        "/home/testuser/.local/share/codehydra/.setup-completed"
-      );
       expect(pathProvider.electronDataDir.toString()).toBe(
         "/home/testuser/.local/share/codehydra/electron"
       );
@@ -385,9 +362,6 @@ describe("DefaultPathProvider", () => {
       expect(pathProvider.vscodeUserDataDir.toString()).toBe(
         "/Users/testuser/Library/Application Support/Codehydra/vscode/user-data"
       );
-      expect(pathProvider.setupMarkerPath.toString()).toBe(
-        "/Users/testuser/Library/Application Support/Codehydra/.setup-completed"
-      );
       expect(pathProvider.electronDataDir.toString()).toBe(
         "/Users/testuser/Library/Application Support/Codehydra/electron"
       );
@@ -439,23 +413,6 @@ describe("DefaultPathProvider", () => {
       );
       expect(pathProvider.vscodeDir.toString()).toBe(
         "c:/users/testuser/appdata/roaming/codehydra/vscode"
-      );
-    });
-
-    it("returns bundled Node path with .exe extension", () => {
-      const buildInfo = createMockBuildInfo({
-        isDevelopment: false,
-        isPackaged: true,
-        appPath: "C:/Program Files/Codehydra/resources/app.asar",
-      });
-      const platformInfo = createMockPlatformInfo({
-        platform: "win32",
-        homeDir: "C:/Users/TestUser",
-      });
-      const pathProvider = new DefaultPathProvider(buildInfo, platformInfo);
-
-      expect(pathProvider.getBundledNodePath(CODE_SERVER_VERSION).toString()).toMatch(
-        /lib\/node\.exe$/
       );
     });
   });

--- a/src/services/platform/path-provider.ts
+++ b/src/services/platform/path-provider.ts
@@ -31,9 +31,6 @@ export interface PathProvider {
   /** Directory for VS Code user data: `<dataRoot>/vscode/user-data/` */
   readonly vscodeUserDataDir: Path;
 
-  /** Path to setup marker: `<dataRoot>/.setup-completed` */
-  readonly setupMarkerPath: Path;
-
   /** Directory for Electron data: `<dataRoot>/electron/` */
   readonly electronDataDir: Path;
 
@@ -73,9 +70,6 @@ export interface PathProvider {
    */
   readonly extensionsRuntimeDir: Path;
 
-  /** Directory for Claude Code configs: `<dataRoot>/claude-code/` */
-  readonly claudeCodeConfigDir: Path;
-
   /** Path to Claude Code hook handler script: `<binRuntimeDir>/claude-code-hook-handler.cjs` */
   readonly claudeCodeHookHandlerPath: Path;
 
@@ -107,13 +101,6 @@ export interface PathProvider {
    * @returns `<bundlesRoot>/<type>/<version>/` as Path
    */
   getBinaryDir(type: "code-server" | "opencode" | "claude", version: string): Path;
-
-  /**
-   * Get the bundled Node.js path from a specific code-server version.
-   * @param codeServerVersion - Version of code-server
-   * @returns Path to the bundled node executable
-   */
-  getBundledNodePath(codeServerVersion: string): Path;
 }
 
 /**
@@ -133,7 +120,6 @@ export class DefaultPathProvider implements PathProvider {
   readonly vscodeDir: Path;
   readonly vscodeExtensionsDir: Path;
   readonly vscodeUserDataDir: Path;
-  readonly setupMarkerPath: Path;
   readonly electronDataDir: Path;
   readonly vscodeAssetsDir: Path;
   readonly scriptsDir: Path;
@@ -143,23 +129,17 @@ export class DefaultPathProvider implements PathProvider {
   readonly binRuntimeDir: Path;
   readonly scriptsRuntimeDir: Path;
   readonly extensionsRuntimeDir: Path;
-  readonly claudeCodeConfigDir: Path;
   readonly claudeCodeHookHandlerPath: Path;
   readonly claudeCodeWrapperPath: Path;
   readonly configPath: Path;
 
   /** Bundles root for binary paths */
   private readonly bundlesRoot: Path;
-  /** Platform for bundled node path construction */
-  private readonly platform: "darwin" | "linux" | "win32";
 
   constructor(buildInfo: BuildInfo, platformInfo: PlatformInfo) {
     // Compute different roots for different types of data
     const bundlesRootDirStr = this.computeBundlesRootDir(platformInfo);
     const dataRootDirStr = this.computeDataRootDir(buildInfo, platformInfo);
-
-    // Store platform for dynamic path methods
-    this.platform = platformInfo.platform as "darwin" | "linux" | "win32";
 
     // Bundles root for binary paths (always production paths)
     this.bundlesRoot = new Path(bundlesRootDirStr);
@@ -173,7 +153,6 @@ export class DefaultPathProvider implements PathProvider {
     this.vscodeDir = new Path(this.dataRootDir, "vscode");
     this.vscodeExtensionsDir = new Path(this.vscodeDir, "extensions");
     this.vscodeUserDataDir = new Path(this.vscodeDir, "user-data");
-    this.setupMarkerPath = new Path(this.dataRootDir, ".setup-completed");
     this.electronDataDir = new Path(this.dataRootDir, "electron");
     this.binDir = new Path(this.dataRootDir, "bin");
 
@@ -197,11 +176,10 @@ export class DefaultPathProvider implements PathProvider {
       : this.vscodeAssetsDir;
 
     // Claude Code paths
-    this.claudeCodeConfigDir = new Path(this.dataRootDir, "claude-code");
     this.claudeCodeHookHandlerPath = new Path(this.binRuntimeDir, "claude-code-hook-handler.cjs");
     this.claudeCodeWrapperPath = new Path(
       this.binDir,
-      this.platform === "win32" ? "ch-claude.cmd" : "ch-claude"
+      platformInfo.platform === "win32" ? "ch-claude.cmd" : "ch-claude"
     );
 
     // Application config
@@ -242,11 +220,6 @@ export class DefaultPathProvider implements PathProvider {
 
   getBinaryDir(type: "code-server" | "opencode" | "claude", version: string): Path {
     return new Path(this.bundlesRoot, type, version);
-  }
-
-  getBundledNodePath(codeServerVersion: string): Path {
-    const codeServerDir = this.getBinaryDir("code-server", codeServerVersion);
-    return new Path(codeServerDir, "lib", this.platform === "win32" ? "node.exe" : "node");
   }
 
   /**

--- a/src/services/vscode-setup/extension-manager.integration.test.ts
+++ b/src/services/vscode-setup/extension-manager.integration.test.ts
@@ -40,7 +40,6 @@ function createMockPathProvider(): PathProvider {
     vscodeUserDataDir: new Path("/app/vscode/user-data"),
     binDir: new Path("/app/bin"),
     binAssetsDir: new Path("/app/assets/bin"),
-    setupMarkerPath: new Path("/app/setup.json"),
     electronDataDir: new Path("/app/electron"),
     scriptsRuntimeDir: new Path("/app/scripts"),
     appIconPath: new Path("/app/icon.png"),


### PR DESCRIPTION
- Remove `setupMarkerPath` property from PathProvider interface and DefaultPathProvider
- Remove `claudeCodeConfigDir` property from PathProvider interface and DefaultPathProvider
- Remove `getBundledNodePath()` method from PathProvider interface and DefaultPathProvider
- Clean up associated test-utils mock factory and test assertions
- Remove stale `setupMarkerPath` from inline mock in extension-manager test