### PR TITLE
refactor(auto-pr): consolidate config into single template-path key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,20 +298,20 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                               | Default  | Description                                                               |
-| --------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `agent`                           | `null`   | Agent selection: claude\|opencode                                         |
-| `auto-update`                     | `always` | Auto-update preference: always\|never                                     |
-| `version.claude`                  | `null`   | Claude agent version override                                             |
-| `version.opencode`                | `null`   | OpenCode agent version override                                           |
-| `version.code-server`             | `null`   | Code-server version override (null = built-in)                            |
-| `telemetry.enabled`               | `true`   | Enable telemetry (false in dev/unpackaged)                                |
-| `telemetry.distinct-id`           | —        | Telemetry user ID (auto-generated)                                        |
-| `log.level`                       | `warn`   | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)   |
-| `log.output`                      | `file`   | Output destinations: `file`, `console`, or `file,console`                 |
-| `electron.flags`                  | —        | Electron switches (e.g., `--disable-gpu`)                                 |
-| `experimental.auto-pr-workspaces` | `false`  | Auto-create workspaces for PRs requesting your review (requires `gh` CLI) |
-| `help`                            | `false`  | Print config help and exit                                                |
+| Key                                  | Default  | Description                                                                       |
+| ------------------------------------ | -------- | --------------------------------------------------------------------------------- |
+| `agent`                              | `null`   | Agent selection: claude\|opencode                                                 |
+| `auto-update`                        | `always` | Auto-update preference: always\|never                                             |
+| `version.claude`                     | `null`   | Claude agent version override                                                     |
+| `version.opencode`                   | `null`   | OpenCode agent version override                                                   |
+| `version.code-server`                | `null`   | Code-server version override (null = built-in)                                    |
+| `telemetry.enabled`                  | `true`   | Enable telemetry (false in dev/unpackaged)                                        |
+| `telemetry.distinct-id`              | —        | Telemetry user ID (auto-generated)                                                |
+| `log.level`                          | `warn`   | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)           |
+| `log.output`                         | `file`   | Output destinations: `file`, `console`, or `file,console`                         |
+| `electron.flags`                     | —        | Electron switches (e.g., `--disable-gpu`)                                         |
+| `experimental.auto-pr-template-path` | `null`   | Path to Liquid template for auto-PR workspaces; set to enable (requires `gh` CLI) |
+| `help`                               | `false`  | Print config help and exit                                                        |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/src/main/modules/auto-pr-module.integration.test.ts
+++ b/src/main/modules/auto-pr-module.integration.test.ts
@@ -58,24 +58,18 @@ import { createAutoPrModule } from "./auto-pr-module";
  */
 class MinimalActivateOperation implements Operation<AppStartIntent, void> {
   readonly id = APP_START_OPERATION_ID;
-  configEnabled: boolean;
-  extraConfigValues: Record<string, unknown>;
+  configValues: Record<string, unknown>;
 
-  constructor(configEnabled: boolean, extraConfigValues?: Record<string, unknown>) {
-    this.configEnabled = configEnabled;
-    this.extraConfigValues = extraConfigValues ?? {};
+  constructor(configValues?: Record<string, unknown>) {
+    this.configValues = configValues ?? {};
   }
 
   async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
     // Simulate config module emitting config:updated during init phase
-    const values: Record<string, unknown> = { ...this.extraConfigValues };
-    if (this.configEnabled) {
-      values["experimental.auto-pr-workspaces"] = true;
-    }
-    if (Object.keys(values).length > 0) {
+    if (Object.keys(this.configValues).length > 0) {
       const configEvent: ConfigUpdatedEvent = {
         type: EVENT_CONFIG_UPDATED,
-        payload: { values },
+        payload: { values: this.configValues },
       };
       ctx.emit(configEvent);
     }
@@ -225,14 +219,29 @@ interface TestSetup {
   deleteWorkspaceOp: TrackingDeleteWorkspaceOperation;
 }
 
+const DEFAULT_TEMPLATE_PATH = "/data/review.liquid";
+const DEFAULT_TEMPLATE_CONTENT = "Review PR #{{ number }}: {{ title }}";
+
 function createTestSetup(options?: {
   ghAuthFails?: boolean;
-  configEnabled?: boolean;
+  disabled?: boolean;
   existingState?: string;
   templatePath?: string | null;
   templateContent?: string;
 }): TestSetup {
-  const configEnabled = options?.configEnabled ?? true;
+  // By default the module is enabled (templatePath set). Use disabled: true to test disabled state.
+  const tplPath = options?.disabled
+    ? null
+    : options?.templatePath !== undefined
+      ? options.templatePath
+      : DEFAULT_TEMPLATE_PATH;
+  // Only use default content when templatePath is not explicitly overridden (or content is provided)
+  const tplContent =
+    options?.templateContent !== undefined
+      ? options.templateContent
+      : options?.templatePath !== undefined
+        ? undefined
+        : DEFAULT_TEMPLATE_CONTENT;
 
   const processRunner = createMockProcessRunner({
     onSpawn: (command, args) => {
@@ -253,8 +262,8 @@ function createTestSetup(options?: {
   if (options?.existingState) {
     fsEntries["/data/auto-pr-workspaces.json"] = file(options.existingState);
   }
-  if (options?.templatePath && options.templateContent !== undefined) {
-    fsEntries[options.templatePath] = file(options.templateContent);
+  if (tplPath && tplContent !== undefined) {
+    fsEntries[tplPath] = file(tplContent);
   }
   const fs = createFileSystemMock({ entries: fsEntries });
 
@@ -265,14 +274,11 @@ function createTestSetup(options?: {
   const openWorkspaceOp = new TrackingOpenWorkspaceOperation();
   const deleteWorkspaceOp = new TrackingDeleteWorkspaceOperation();
 
-  const extraConfig: Record<string, unknown> = {};
-  if (options?.templatePath !== undefined) {
-    extraConfig["experimental.pr-auto-workspace.template-path"] = options.templatePath;
+  const configValues: Record<string, unknown> = {};
+  if (tplPath !== null) {
+    configValues["experimental.auto-pr-template-path"] = tplPath;
   }
-  dispatcher.registerOperation(
-    INTENT_APP_START,
-    new MinimalActivateOperation(configEnabled, extraConfig)
-  );
+  dispatcher.registerOperation(INTENT_APP_START, new MinimalActivateOperation(configValues));
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
   dispatcher.registerOperation(INTENT_OPEN_PROJECT, openProjectOp);
   dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, openWorkspaceOp);
@@ -318,8 +324,8 @@ afterEach(() => {
 
 describe("AutoPrModule Integration", () => {
   describe("activation", () => {
-    it("does nothing when config is disabled", async () => {
-      const { dispatcher, httpClient } = createTestSetup({ configEnabled: false });
+    it("does nothing when no template path configured", async () => {
+      const { dispatcher, httpClient } = createTestSetup({ disabled: true });
 
       await dispatcher.dispatch(startIntent());
 
@@ -374,7 +380,7 @@ describe("AutoPrModule Integration", () => {
       expect(openWorkspaceOp.dispatched[0]!.payload.workspaceName).toBe("pr-42/feature-login");
       expect(openWorkspaceOp.dispatched[0]!.payload.stealFocus).toBe(false);
       expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
-        prompt: "",
+        prompt: "Review PR #42: Add login feature",
         agent: "plan",
       });
     });
@@ -543,10 +549,10 @@ describe("AutoPrModule Integration", () => {
     });
   });
 
-  describe("initial prompt and plan mode", () => {
+  describe("initial prompt and template behavior", () => {
     const TEMPLATE_PATH = "/data/review.liquid";
 
-    function setupWithPr(options?: { templatePath: string | null; templateContent: string }) {
+    function setupWithPr(options?: { templatePath?: string | null; templateContent?: string }) {
       const setup = createTestSetup(options);
       setup.httpClient.setResponse(SEARCH_URL, {
         body: searchResponse([
@@ -566,17 +572,6 @@ describe("AutoPrModule Integration", () => {
       return setup;
     }
 
-    it("uses plan mode with empty prompt when no template configured", async () => {
-      const { dispatcher, openWorkspaceOp } = setupWithPr();
-
-      await dispatcher.dispatch(startIntent());
-
-      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
-        prompt: "",
-        agent: "plan",
-      });
-    });
-
     it("renders template file with PR detail data when template-path configured", async () => {
       const { dispatcher, openWorkspaceOp } = setupWithPr({
         templatePath: TEMPLATE_PATH,
@@ -591,9 +586,71 @@ describe("AutoPrModule Integration", () => {
       });
     });
 
-    it("falls back to empty prompt when template file not found", async () => {
-      const setup = createTestSetup({ templatePath: "/data/nonexistent.liquid" });
-      setup.httpClient.setResponse(SEARCH_URL, {
+    it("skips workspace creation when template file not found", async () => {
+      const { dispatcher, openProjectOp, openWorkspaceOp, fs } = setupWithPr({
+        templatePath: "/data/nonexistent.liquid",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      // No workspace created — template read failure means empty prompt → skip
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      // Null entry recorded in state
+      expect(fs).toHaveFileContaining(
+        "/data/auto-pr-workspaces.json",
+        '"https://github.com/org/repo/pull/42": null'
+      );
+    });
+
+    it("skips workspace creation on template render failure", async () => {
+      const { dispatcher, openProjectOp, openWorkspaceOp, fs } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "{% invalid_tag %}",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      // No workspace created — render failure means empty prompt → skip
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining(
+        "/data/auto-pr-workspaces.json",
+        '"https://github.com/org/repo/pull/42": null'
+      );
+    });
+
+    it("skips workspace creation when template renders to whitespace-only", async () => {
+      const { dispatcher, openProjectOp, openWorkspaceOp, fs } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "   \n  ",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining(
+        "/data/auto-pr-workspaces.json",
+        '"https://github.com/org/repo/pull/42": null'
+      );
+    });
+
+    it("does not re-evaluate template for previously skipped PR", async () => {
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: {
+          "https://github.com/org/repo/pull/42": null,
+        },
+      });
+
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({
+        existingState,
+        templatePath: TEMPLATE_PATH,
+        templateContent: "Review PR #{{ number }}",
+      });
+
+      httpClient.setResponse(SEARCH_URL, {
         body: searchResponse([
           {
             number: 42,
@@ -602,34 +659,12 @@ describe("AutoPrModule Integration", () => {
           },
         ]),
       });
-      setup.httpClient.setResponse(PR_DETAIL_URL, {
-        body: prDetailResponse("feature-login", "main"),
-      });
-      setup.httpClient.setResponse(REPO_DETAIL_URL, {
-        body: repoDetailResponse("https://github.com/org/repo.git"),
-      });
-      const { dispatcher, openWorkspaceOp } = setup;
 
       await dispatcher.dispatch(startIntent());
 
-      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
-        prompt: "",
-        agent: "plan",
-      });
-    });
-
-    it("falls back to empty prompt on template render failure", async () => {
-      const { dispatcher, openWorkspaceOp } = setupWithPr({
-        templatePath: TEMPLATE_PATH,
-        templateContent: "{% invalid_tag %}",
-      });
-
-      await dispatcher.dispatch(startIntent());
-
-      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
-        prompt: "",
-        agent: "plan",
-      });
+      // Should not fetch PR detail (skipped without re-evaluation)
+      expect(httpClient).not.toHaveRequested(PR_DETAIL_URL);
+      expect(openProjectOp.dispatched).toHaveLength(0);
     });
 
     it("picks up template-path config for workspace creation", async () => {
@@ -644,6 +679,26 @@ describe("AutoPrModule Integration", () => {
         prompt: "Branch: feature-login",
         agent: "plan",
       });
+    });
+  });
+
+  describe("template-skipped PR cleanup", () => {
+    it("cleans up template-skipped null entry when PR disappears", async () => {
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: {
+          "https://github.com/org/repo/pull/42": null,
+        },
+      });
+
+      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({ existingState });
+
+      httpClient.setResponse(SEARCH_URL, { body: searchResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(deleteWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining("/data/auto-pr-workspaces.json", '"workspaces": {}');
     });
   });
 

--- a/src/main/modules/auto-pr-module.ts
+++ b/src/main/modules/auto-pr-module.ts
@@ -2,14 +2,16 @@
  * AutoPrModule - Polls GitHub for PRs where the user is a requested reviewer
  * and automatically creates/deletes workspaces to match.
  *
- * Gated behind the `experimental.auto-pr-workspaces` config key.
+ * Enabled when `experimental.auto-pr-template-path` is set to a Liquid template path.
+ * When the template renders to empty/whitespace for a PR, that PR is skipped and
+ * recorded as dismissed (null entry) to avoid re-computing the template every poll cycle.
  *
  * Hooks:
  * - app:start -> "activate": acquire gh token, load state, run initial poll, start timer
  * - app:shutdown -> "stop": clear poll timer
  *
  * Events:
- * - config:updated: react to experimental.auto-pr-workspaces toggle
+ * - config:updated: react to experimental.auto-pr-template-path changes
  * - workspace:deleted: clean up mapping if a PR workspace is manually deleted
  */
 
@@ -35,11 +37,11 @@ import type { ProcessRunner } from "../../services/platform/process";
 import type { HttpClient } from "../../services/platform/network";
 import type { FileSystemLayer } from "../../services/platform/filesystem";
 import type { Logger } from "../../services/logging/types";
-import type { InitialPrompt } from "../../shared/api/types";
+import type { NormalizedInitialPrompt } from "../../shared/api/types";
 import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../shared/error-utils";
 import { renderTemplate } from "../../services/template/liquid-renderer";
-import { parseBool, type ConfigKeyDefinition } from "../../services/config/config-definition";
+import type { ConfigKeyDefinition } from "../../services/config/config-definition";
 
 // =============================================================================
 // Persistence Types
@@ -141,7 +143,6 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let enabled = false;
   // Tracked from config:updated events (fires during app:start init phase, before activate)
-  let configEnabled = false;
   let templatePath: string | null = null;
   // Prevents the event handler from triggering activation during initial startup
   let initialActivationDone = false;
@@ -266,12 +267,11 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
   // ------ Workspace Lifecycle ------
 
-  async function buildInitialPrompt(prDetail: Record<string, unknown>): Promise<InitialPrompt> {
-    if (templatePath === null) {
-      return { prompt: "", agent: "plan" };
-    }
+  async function buildInitialPrompt(
+    prDetail: Record<string, unknown>
+  ): Promise<NormalizedInitialPrompt> {
     try {
-      const templateContent = await deps.fs.readFile(templatePath);
+      const templateContent = await deps.fs.readFile(templatePath!);
       const rendered = renderTemplate(templateContent, prDetail);
       return { prompt: rendered, agent: "plan" };
     } catch (error) {
@@ -297,6 +297,17 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     deps.logger.info("Creating PR workspace", { prUrl, workspaceName });
 
     try {
+      // Build prompt first — skip workspace entirely if template resolves to empty
+      const initialPrompt = await buildInitialPrompt(prDetail);
+      if (!initialPrompt.prompt.trim()) {
+        deps.logger.info("Skipping PR workspace (template resolved to empty)", { prUrl });
+        state = {
+          ...state,
+          workspaces: { ...state.workspaces, [prUrl]: null },
+        };
+        return;
+      }
+
       // Open the project (clones if not already open)
       const project = await deps.dispatcher.dispatch({
         type: INTENT_OPEN_PROJECT,
@@ -307,8 +318,6 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
         deps.logger.warn("project:open returned null for PR workspace", { cloneUrl });
         return;
       }
-
-      const initialPrompt = await buildInitialPrompt(prDetail);
 
       // Create the workspace
       const wsResult = await deps.dispatcher.dispatch({
@@ -392,6 +401,8 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
     deps.logger.debug("Polling GitHub for review-requested PRs");
 
+    const stateBefore = state;
+
     let items: GitHubSearchItem[];
     try {
       items = await fetchReviewRequestedPrs();
@@ -414,7 +425,7 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       if (entry) {
         await deletePrWorkspace(prUrl, entry);
       } else {
-        // null entry (dismissed by user) — just remove the key
+        // null entry (dismissed by user or template-skipped) — just remove the key
         const remaining = Object.fromEntries(
           Object.entries(state.workspaces).filter(([key]) => key !== prUrl)
         );
@@ -449,14 +460,8 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       );
     }
 
-    // Persist after all changes
-    if (
-      disappearedUrls.length > 0 ||
-      items.some((i) => {
-        const url = i.pull_request?.html_url ?? i.html_url;
-        return state.workspaces[url]?.createdAt !== undefined;
-      })
-    ) {
+    // Persist if state changed (new workspaces, deletions, or template-skipped null entries)
+    if (state !== stateBefore) {
       await saveState();
     }
   }
@@ -482,11 +487,11 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
   // ------ Activation / Deactivation ------
 
   async function activate(): Promise<void> {
-    if (!configEnabled) {
+    if (templatePath === null) {
       return;
     }
 
-    deps.logger.info("experimental.auto-pr-workspaces is enabled");
+    deps.logger.info("experimental.auto-pr-template-path is set, enabling auto-PR");
 
     token = await acquireToken();
     if (!token) return;
@@ -516,13 +521,7 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
           handler: async (): Promise<RegisterConfigResult> => ({
             definitions: [
               {
-                name: "experimental.auto-pr-workspaces",
-                default: false,
-                parse: parseBool,
-                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
-              },
-              {
-                name: "experimental.pr-auto-workspace.template-path",
+                name: "experimental.auto-pr-template-path",
                 default: null,
                 parse: (s: string) => (s === "" ? null : s),
                 validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
@@ -549,19 +548,15 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     events: {
       [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
         const { values } = (event as ConfigUpdatedEvent).payload;
-        if ("experimental.pr-auto-workspace.template-path" in values) {
-          templatePath =
-            (values["experimental.pr-auto-workspace.template-path"] as string | null) ?? null;
-        }
-        if ("experimental.auto-pr-workspaces" in values) {
-          const newValue = values["experimental.auto-pr-workspaces"];
-          configEnabled = newValue === true;
+        if ("experimental.auto-pr-template-path" in values) {
+          const prev = templatePath;
+          templatePath = (values["experimental.auto-pr-template-path"] as string | null) ?? null;
           // Only react to runtime toggles (after initial activate hook has run).
           // During startup, the activate hook handles initial activation.
           if (!initialActivationDone) return;
-          if (newValue === true && !enabled) {
+          if (prev === null && templatePath !== null && !enabled) {
             void activate();
-          } else if (newValue === false && enabled) {
+          } else if (prev !== null && templatePath === null && enabled) {
             deactivate();
           }
         }


### PR DESCRIPTION
- Suppress re-creation of manually deleted PR workspaces by recording null entries in state
- Replace `experimental.auto-pr-workspaces` and `experimental.pr-auto-workspace.template-path` with single `experimental.auto-pr-template-path` key
- Skip workspace creation when template renders to empty/whitespace, recording as dismissed
- Simplify state save logic using reference equality on immutable state