### PR TITLE
chore(ship): add label at PR creation to avoid check-label race

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -202,21 +202,19 @@ Determine PR title using the standard convention:
 resolves #123
 ```
 
-Create PR:
+Determine the label from `changelog_category`:
+
+- `"feature"`: `enhancement`
+- `"bugfix"`: `bug`
+- `null` (internal): `internal`
+
+Create PR with the label included:
 
 ```bash
-gh pr create --repo stefanhoelzl/codehydra --title "<title>" --body "<body>"
+gh pr create --repo stefanhoelzl/codehydra --title "<title>" --label "<label>" --body "<body>"
 ```
 
 Capture the PR URL and number from output.
-
-#### 3d. Label the PR
-
-After PR creation, apply a label based on `changelog_category`:
-
-- `"feature"`: `gh pr edit --repo stefanhoelzl/codehydra <number> --add-label "enhancement"`
-- `"bugfix"`: `gh pr edit --repo stefanhoelzl/codehydra <number> --add-label "bug"`
-- `null` (internal): `gh pr edit --repo stefanhoelzl/codehydra <number> --add-label "internal"`
 
 ### 4. Enable Auto-merge
 


### PR DESCRIPTION
- Use `--label` flag on `gh pr create` instead of separate `gh pr edit --add-label` after creation
- Eliminates race condition where check-label CI workflow fails on `opened` event before label is applied