### PR TITLE
fix: No workspace selected when active workspace was finally deleted

### DIFF
--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -74,6 +74,12 @@ import {
   RESOLVE_WORKSPACE_OPERATION_ID,
   INTENT_RESOLVE_WORKSPACE,
 } from "./resolve-workspace";
+import {
+  GetActiveWorkspaceOperation,
+  GET_ACTIVE_WORKSPACE_OPERATION_ID,
+  INTENT_GET_ACTIVE_WORKSPACE,
+} from "./get-active-workspace";
+import type { GetActiveWorkspaceHookResult } from "./get-active-workspace";
 import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
 import {
   ResolveProjectOperation,
@@ -372,6 +378,7 @@ function createTestHarness(options?: {
   const deleteOp = new DeleteWorkspaceOperation();
   dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOp);
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 
   // Add interceptor via module (inline, matching bootstrap pattern)
   const inProgressDeletions = new Set<string>();
@@ -737,6 +744,27 @@ function createTestHarness(options?: {
     },
   };
 
+  const getActiveWorkspaceModule: IntentModule = {
+    name: "test",
+    hooks: {
+      [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
+        get: {
+          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
+            const path = activeWorkspace.path;
+            if (!path) return { workspaceRef: null };
+            return {
+              workspaceRef: {
+                projectId: PROJECT_ID,
+                workspaceName: extractWorkspaceName(path) as WorkspaceName,
+                path,
+              },
+            };
+          },
+        },
+      },
+    },
+  };
+
   const progressCaptureModule: IntentModule = {
     name: "test",
     events: {
@@ -779,6 +807,7 @@ function createTestHarness(options?: {
     progressCaptureModule,
     resolveWorkspaceModule,
     resolveProjectModule,
+    getActiveWorkspaceModule,
     deleteViewModule,
     deleteAgentModule,
     deleteWindowsLockModule,
@@ -1356,6 +1385,28 @@ describe("DeleteWorkspaceOperation.workspaceSwitching", () => {
     await harness.dispatcher.dispatch(intent);
 
     // Active workspace unchanged (still B)
+    expect(harness.activeWorkspace.path).toBe(WORKSPACE_PATH_B);
+  });
+
+  it("auto-switches when user navigates to workspace being deleted", async () => {
+    // Active workspace is B, deleting A — user is NOT on the deleted workspace initially
+    const harness = createTestHarness({
+      activeWorkspacePath: WORKSPACE_PATH_B,
+    });
+
+    // Simulate user navigating to workspace A during the delete hook
+    // (after the initial shutdown switch-away already ran, finding wasActive=false)
+    harness.globalProviderMock.globalProvider.removeWorkspace = vi
+      .fn()
+      .mockImplementation(async () => {
+        // User navigates to workspace A mid-deletion
+        harness.activeWorkspace.path = WORKSPACE_PATH;
+      });
+
+    const intent = buildDeleteIntent(); // deleting WORKSPACE_PATH (A)
+    await harness.dispatcher.dispatch(intent);
+
+    // autoSwitchIfBecameActive should have detected the change and switched back to B
     expect(harness.activeWorkspace.path).toBe(WORKSPACE_PATH_B);
   });
 

--- a/src/main/operations/delete-workspace.ts
+++ b/src/main/operations/delete-workspace.ts
@@ -36,6 +36,7 @@ import type { WorkspacePath } from "../../shared/ipc";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
 
 // =============================================================================
 // Intent Types
@@ -364,6 +365,7 @@ export class DeleteWorkspaceOperation implements Operation<
       }
     }
 
+    await this.autoSwitchIfBecameActive(ctx, payload.workspacePath);
     return { started: true };
   }
 
@@ -564,6 +566,30 @@ export class DeleteWorkspaceOperation implements Operation<
 
       // Still failing — loop back to detect
       currentDel = retryDel;
+    }
+  }
+
+  /**
+   * If the user navigated to the workspace after the initial switch-away,
+   * we must switch again before emitting workspace:deleted.
+   */
+  private async autoSwitchIfBecameActive(
+    ctx: OperationContext<DeleteWorkspaceIntent>,
+    workspacePath: string
+  ): Promise<void> {
+    try {
+      const activeRef = await ctx.dispatch({
+        type: INTENT_GET_ACTIVE_WORKSPACE,
+        payload: {},
+      } as GetActiveWorkspaceIntent);
+      if (activeRef?.path === workspacePath) {
+        await ctx.dispatch({
+          type: INTENT_SWITCH_WORKSPACE,
+          payload: { auto: true, currentPath: workspacePath, focus: true },
+        } as SwitchWorkspaceIntent);
+      }
+    } catch {
+      // Best-effort
     }
   }
 

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -655,4 +655,24 @@ describe("SwitchWorkspace Operation", () => {
       expect((receivedEvents[0] as WorkspaceSwitchedEvent).payload).toBeNull();
     });
   });
+
+  describe("auto-select when currentPath not in candidates", () => {
+    it("selects best candidate even when currentPath is already de-registered", async () => {
+      const setup = createTestSetup({
+        withAutoSelect: true,
+        projects: [createMultiWorkspaceProject()],
+      });
+      const { dispatcher, viewManager } = setup;
+
+      // currentPath doesn't match any candidate (workspace already de-registered)
+      const autoIntent: SwitchWorkspaceIntent = {
+        type: INTENT_SWITCH_WORKSPACE,
+        payload: { auto: true, currentPath: "/nonexistent", focus: true },
+      };
+      await dispatcher.dispatch(autoIntent);
+
+      // Should still switch to a valid workspace instead of null
+      expect(viewManager.activeWorkspacePath).not.toBeNull();
+    });
+  });
 });

--- a/src/main/operations/switch-workspace.ts
+++ b/src/main/operations/switch-workspace.ts
@@ -176,9 +176,8 @@ export function selectNextWorkspace(
     sorted.push(...list);
   }
 
-  // Find current workspace index
+  // Find current workspace index (-1 when currentPath was already de-registered)
   const currentIndex = sorted.findIndex((w) => w.workspacePath === currentWorkspacePath);
-  if (currentIndex === -1) return null;
 
   const getKey = (ws: WorkspaceCandidate, index: number): number => {
     let statusKey: number;
@@ -187,6 +186,8 @@ export function selectNextWorkspace(
     } else {
       statusKey = 2; // No scorer: treat all as "none"
     }
+    // When currentPath is not in candidates, use score-only (no positional proximity)
+    if (currentIndex === -1) return statusKey;
     const positionKey = (index - currentIndex + sorted.length) % sorted.length;
     return statusKey * sorted.length + positionKey;
   };


### PR DESCRIPTION
- Auto-switch away when user navigates to a workspace that is mid-deletion
- Fix `selectNextWorkspace` to fall back to score-only selection when `currentPath` is not in candidates (previously returned null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)