### PR TITLE
fix: Recover from stuck busy status after failed compaction

### DIFF
--- a/src/agents/claude/server-manager.integration.test.ts
+++ b/src/agents/claude/server-manager.integration.test.ts
@@ -391,6 +391,130 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
     });
 
+    it("Notification(idle_prompt) recovers from failed compaction", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Automatic compaction: busy → PreCompact (stays busy, sets flag)
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+
+      // Compaction fails — no SessionStart follows, only a Notification
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "idle_prompt",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
+    it("Notification(idle_prompt) clears ignoreNextSessionStart flag", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Automatic compaction sets flag
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+
+      // idle_prompt clears the flag
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "idle_prompt",
+      });
+
+      // Next SessionStart should go idle normally (flag was cleared)
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy", "idle"]);
+    });
+
+    it("Notification(permission_prompt) transitions to idle", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "permission_prompt",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
+    it("Notification(elicitation_dialog) transitions to idle", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "elicitation_dialog",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
+    it("Notification(auth_success) does not change status", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "auth_success",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
+    });
+
+    it("Notification(idle_prompt) is no-op when already idle", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Get to idle state
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      // idle_prompt when already idle should not fire callback
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "idle_prompt",
+      });
+
+      expect(statusChanges).toEqual(["idle"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
+    });
+
     it("PreToolUse does not change status without prior PermissionRequest", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];

--- a/src/agents/claude/server-manager.ts
+++ b/src/agents/claude/server-manager.ts
@@ -652,6 +652,20 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       state.ignoreNextSessionStart = false;
     }
 
+    // Notification types that indicate the agent is waiting for user input.
+    // idle_prompt: agent is at its idle prompt (recovers from failed compaction).
+    // permission_prompt: agent is waiting for permission (redundant with PermissionRequest).
+    // elicitation_dialog: agent is waiting for MCP elicitation input.
+    if (
+      hookName === "Notification" &&
+      (payload.notification_type === "idle_prompt" ||
+        payload.notification_type === "permission_prompt" ||
+        payload.notification_type === "elicitation_dialog")
+    ) {
+      newStatus = "idle";
+      state.ignoreNextSessionStart = false;
+    }
+
     this.logger.debug("Hook received", {
       hookName,
       workspacePath: normalizedPath,

--- a/src/agents/claude/types.ts
+++ b/src/agents/claude/types.ts
@@ -45,6 +45,8 @@ export interface ClaudeCodeHookPayload {
   readonly tool_input?: unknown;
   /** Tool result for PostToolUse hook */
   readonly tool_result?: unknown;
+  /** Notification type for Notification hook */
+  readonly notification_type?: string;
 }
 
 /**


### PR DESCRIPTION
- Handle `idle_prompt`, `permission_prompt`, and `elicitation_dialog` Notification hooks as idle transitions
- When compaction fails, no SessionStart/Stop hook follows PreCompact; the only signal is a Notification with `notification_type=idle_prompt`, which was previously ignored
- Clear `ignoreNextSessionStart` flag on these notifications to prevent cascading state issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)