### PR TITLE
fix: workspace deletion failing for stale worktrees

### DIFF
--- a/src/services/git/git-worktree-provider.test.ts
+++ b/src/services/git/git-worktree-provider.test.ts
@@ -267,7 +267,7 @@ describe("GitWorktreeProvider error injection", () => {
   });
 
   describe("removeWorkspace", () => {
-    it("deletes branch even when worktree removal fails", async () => {
+    it("falls back to rm + prune when git worktree remove fails", async () => {
       const worktreePath = new Path("/data/workspaces/feature-x");
       const mockClient = createMockGitClient({
         repositories: {
@@ -278,34 +278,33 @@ describe("GitWorktreeProvider error injection", () => {
           },
         },
       });
-      // Override removeWorktree to fail
-      mockClient.removeWorktree = vi
-        .fn()
-        .mockRejectedValue(new Error("Permission denied: files locked"));
-      // Override deleteBranch to remove branch from state (bypasses checkout check for this test)
+      mockClient.removeWorktree = vi.fn().mockRejectedValue(new Error("git error"));
       const repo = mockClient.$.repositories.get(PROJECT_ROOT.toString());
+      mockClient.pruneWorktrees = vi.fn().mockImplementation(async () => {
+        repo?.worktrees.delete(worktreePath.toString());
+      });
       mockClient.deleteBranch = vi.fn().mockImplementation(async () => {
         repo?.branches.delete("feature-x");
       });
 
+      const spyFs = createSpyFileSystemLayer();
       const provider = await GitWorktreeProvider.create(
         PROJECT_ROOT,
         mockClient,
         WORKSPACES_DIR,
-        mockFs,
+        spyFs,
         mockLogger
       );
 
-      // Should throw because worktree removal failed
-      await expect(provider.removeWorkspace(PROJECT_ROOT, worktreePath, true)).rejects.toThrow(
-        "Permission denied: files locked"
-      );
+      const result = await provider.removeWorkspace(PROJECT_ROOT, worktreePath, true);
 
-      // But branch should still be deleted before the error is thrown
-      expect(mockClient).not.toHaveBranch(PROJECT_ROOT, "feature-x");
+      expect(result.workspaceRemoved).toBe(true);
+      expect(result.baseDeleted).toBe(true);
+      expect(spyFs.rm).toHaveBeenCalledWith(worktreePath, { recursive: true, force: true });
+      expect(mockClient.pruneWorktrees).toHaveBeenCalledWith(PROJECT_ROOT);
     });
 
-    it("throws worktree error even when branch deletion succeeds", async () => {
+    it("throws original error when fallback also fails", async () => {
       const worktreePath = new Path("/data/workspaces/feature-x");
       const mockClient = createMockGitClient({
         repositories: {
@@ -316,28 +315,24 @@ describe("GitWorktreeProvider error injection", () => {
           },
         },
       });
-      // Override removeWorktree to fail
-      mockClient.removeWorktree = vi.fn().mockRejectedValue(new Error("Removal failed"));
-      // Override deleteBranch to remove branch from state (bypasses checkout check for this test)
-      const repo = mockClient.$.repositories.get(PROJECT_ROOT.toString());
-      mockClient.deleteBranch = vi.fn().mockImplementation(async () => {
-        repo?.branches.delete("feature-x");
-      });
+      mockClient.removeWorktree = vi.fn().mockRejectedValue(new Error("Worktree error"));
+      mockClient.deleteBranch = vi.fn().mockRejectedValue(new Error("Branch error"));
+
+      const spyFs = createSpyFileSystemLayer();
+      spyFs.rm = vi.fn().mockRejectedValue(new Error("rm failed"));
 
       const provider = await GitWorktreeProvider.create(
         PROJECT_ROOT,
         mockClient,
         WORKSPACES_DIR,
-        mockFs,
+        spyFs,
         mockLogger
       );
 
-      // Should throw worktree error after branch is deleted
+      // Should throw the original worktree error (not the rm error)
       await expect(provider.removeWorkspace(PROJECT_ROOT, worktreePath, true)).rejects.toThrow(
-        "Removal failed"
+        "Worktree error"
       );
-      // Branch should still be deleted
-      expect(mockClient).not.toHaveBranch(PROJECT_ROOT, "feature-x");
     });
 
     it("throws branch error when worktree succeeds but branch deletion fails", async () => {
@@ -365,35 +360,6 @@ describe("GitWorktreeProvider error injection", () => {
       // Should throw branch error since worktree succeeded
       await expect(provider.removeWorkspace(PROJECT_ROOT, worktreePath, true)).rejects.toThrow(
         "Branch deletion failed"
-      );
-    });
-
-    it("throws worktree error when both worktree and branch deletion fail", async () => {
-      const worktreePath = new Path("/data/workspaces/feature-x");
-      const mockClient = createMockGitClient({
-        repositories: {
-          [PROJECT_ROOT.toString()]: {
-            branches: ["main", "feature-x"],
-            currentBranch: "main",
-            worktrees: [{ name: "feature-x", path: worktreePath.toString(), branch: "feature-x" }],
-          },
-        },
-      });
-      // Override both to fail
-      mockClient.removeWorktree = vi.fn().mockRejectedValue(new Error("Worktree error"));
-      mockClient.deleteBranch = vi.fn().mockRejectedValue(new Error("Branch error"));
-
-      const provider = await GitWorktreeProvider.create(
-        PROJECT_ROOT,
-        mockClient,
-        WORKSPACES_DIR,
-        mockFs,
-        mockLogger
-      );
-
-      // Should throw worktree error (takes precedence)
-      await expect(provider.removeWorkspace(PROJECT_ROOT, worktreePath, true)).rejects.toThrow(
-        "Worktree error"
       );
     });
   });

--- a/src/services/git/git-worktree-provider.ts
+++ b/src/services/git/git-worktree-provider.ts
@@ -50,19 +50,6 @@ export class GitWorktreeProvider {
   private readonly workspaceRegistry: Map<string, Path> = new Map();
 
   /**
-   * Check if error is a Windows long-path related error from git.
-   * These errors occur when git worktree remove can't delete directories
-   * with paths > 260 characters.
-   */
-  private isWindowsLongPathError(error: Error): boolean {
-    const message = error.message.toLowerCase();
-    return (
-      message.includes("filename too long") ||
-      (message.includes("directory not empty") && message.includes("failed to delete"))
-    );
-  }
-
-  /**
    * Apply base fallback to metadata if not present.
    * Fallback priority: config > branch > name
    */
@@ -529,21 +516,14 @@ export class GitWorktreeProvider {
       try {
         await this.gitClient.removeWorktree(projectRoot, workspacePath);
       } catch (error) {
-        const err = error as Error;
-        // On Windows, git may fail to delete directories with long paths (>260 chars)
-        // Error messages: "Filename too long" or "Directory not empty"
-        // Fall back to manual deletion + prune
-        if (this.isWindowsLongPathError(err)) {
-          try {
-            await this.fileSystemLayer.rm(workspacePath, { recursive: true, force: true });
-            await this.gitClient.pruneWorktrees(projectRoot);
-            this.logger.info("Removed workspace via fallback", { path: workspacePath.toString() });
-          } catch {
-            // Fallback also failed - save original error
-            worktreeError = err;
-          }
-        } else {
-          worktreeError = err;
+        // git worktree remove can fail for various reasons (stale .git,
+        // Windows long paths, locked files, etc.) — fall back to rm + prune
+        try {
+          await this.fileSystemLayer.rm(workspacePath, { recursive: true, force: true });
+          await this.gitClient.pruneWorktrees(projectRoot);
+          this.logger.info("Removed workspace via fallback", { path: workspacePath.toString() });
+        } catch {
+          worktreeError = error as Error;
         }
       }
     }


### PR DESCRIPTION
- Always fall back to manual rm + prune when `git worktree remove` fails, instead of matching specific English error messages
- Handles stale worktrees (missing `.git` file), Windows long paths, and any other failure mode
- Removes fragile, locale-dependent error message matching (`isWindowsLongPathError`, `isStaleWorktreeError`)
- If the fallback also fails, the original error is preserved and thrown