### PR TITLE
fix: Prevent terminal dialog when re-creating workspace with same name

### DIFF
--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -111,6 +111,7 @@ function openAgentTerminal(
     name: terminalName,
     location: { viewColumn: vscode.ViewColumn.Active },
     env: env,
+    isTransient: true,
   });
 
   agentTerminal.show();


### PR DESCRIPTION
- Mark agent terminal as transient (`isTransient: true`) so VS Code doesn't persist/restore it across sessions
- Prevents "Cancel or Terminate" confirmation dialog when disposing restored terminals during workspace re-creation