### PR TITLE
feat(shortcut): add dev-only DevTools shortcuts via shortcut mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -422,21 +422,6 @@ const { module: viewModule, readyHandler } = createViewModule({
   windowManager,
   buildInfo,
   uiHtmlPath,
-  devToolsHandler: buildInfo.isDevelopment
-    ? () => {
-        const uiHandle = viewManager.getUIViewHandle();
-        viewLayer.onBeforeInputEvent(uiHandle, (input, preventDefault) => {
-          if (input.control && input.shift && input.key === "I") {
-            if (viewLayer.isDevToolsOpened(uiHandle)) {
-              viewLayer.closeDevTools(uiHandle);
-            } else {
-              viewLayer.openDevTools(uiHandle, { mode: "detach" });
-            }
-            preventDefault();
-          }
-        });
-      }
-    : null,
 });
 
 const codeServerModule = createCodeServerModule({
@@ -572,6 +557,7 @@ const shortcutModule = createShortcutModule({
   getWindowHandle: () => windowManager.getWindowHandle(),
   dispatch: (intent) => dispatcher.dispatch(intent),
   logger: loggingService.createLogger("shortcut"),
+  isDevelopment: buildInfo.isDevelopment,
 });
 
 // 9. ApiRegistry + Operation registration

--- a/src/main/modules/shortcut-module.integration.test.ts
+++ b/src/main/modules/shortcut-module.integration.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+/**
+ * Integration tests for ShortcutModule DevTools toggling.
+ *
+ * Tests the onRawShortcutKey callback wiring that enables
+ * Alt+X → D/W DevTools shortcuts in development mode.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
+import {
+  INTENT_APP_START,
+  APP_START_OPERATION_ID,
+  type AppStartIntent,
+} from "../operations/app-start";
+import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
+import { SILENT_LOGGER } from "../../services/logging";
+import { createShortcutModule, type ShortcutModuleDeps } from "./shortcut-module";
+import type { ViewHandle, WindowHandle } from "../../services/shell/types";
+import type { KeyboardInput, Unsubscribe } from "../../services/shell/view";
+import type { UIMode } from "../../shared/ipc";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createViewHandle(id: string): ViewHandle {
+  return { id, __brand: "ViewHandle" as const };
+}
+
+function createWindowHandle(id: string = "window-1"): WindowHandle {
+  return { id, __brand: "WindowHandle" as const };
+}
+
+/**
+ * Captures before-input-event callbacks so we can simulate keyboard input
+ * after the controller is constructed.
+ */
+function createMockViewLayer() {
+  const inputCallbacks = new Map<
+    string,
+    (input: KeyboardInput, preventDefault: () => void) => void
+  >();
+
+  return {
+    onBeforeInputEvent: vi.fn(
+      (
+        handle: ViewHandle,
+        callback: (input: KeyboardInput, preventDefault: () => void) => void
+      ): Unsubscribe => {
+        inputCallbacks.set(handle.id, callback);
+        return vi.fn();
+      }
+    ),
+    onDestroyed: vi.fn((): Unsubscribe => vi.fn()),
+    openDevTools: vi.fn(),
+    closeDevTools: vi.fn(),
+    isDevToolsOpened: vi.fn().mockReturnValue(false),
+    /** Simulate a key press on a registered view */
+    simulateKey(viewId: string, key: string): void {
+      const cb = inputCallbacks.get(viewId);
+      if (!cb) throw new Error(`No input callback for view ${viewId}`);
+      cb(
+        {
+          type: "keyDown",
+          key,
+          isAutoRepeat: false,
+          control: false,
+          shift: false,
+          alt: false,
+          meta: false,
+        },
+        vi.fn()
+      );
+    },
+  };
+}
+
+function createMockViewManager(uiHandle: ViewHandle) {
+  let currentMode: UIMode = "shortcut";
+  let activePath: string | null = "/test/workspace";
+  const wsHandle = createViewHandle("ws-view");
+
+  return {
+    focusUI: vi.fn(),
+    getUIViewHandle: vi.fn().mockReturnValue(uiHandle),
+    getMode: vi.fn(() => currentMode),
+    sendToUI: vi.fn(),
+    getWorkspaceView: vi.fn((path: string) => (path === activePath ? wsHandle : null)),
+    getActiveWorkspacePath: vi.fn(() => activePath),
+    /** Test helper to set the active workspace path */
+    _setActivePath(path: string | null) {
+      activePath = path;
+    },
+    /** Test helper to set the mode */
+    _setMode(mode: UIMode) {
+      currentMode = mode;
+    },
+    /** The workspace view handle */
+    _wsHandle: wsHandle,
+  };
+}
+
+function createMockWindowLayer() {
+  return {
+    onBlur: vi.fn((): Unsubscribe => vi.fn()),
+  };
+}
+
+interface TestHarness {
+  viewLayer: ReturnType<typeof createMockViewLayer>;
+  viewManager: ReturnType<typeof createMockViewManager>;
+  dispatcher: Dispatcher;
+  uiHandle: ViewHandle;
+}
+
+async function createHarness(isDevelopment: boolean): Promise<TestHarness> {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  const uiHandle = createViewHandle("ui-view");
+  const viewLayer = createMockViewLayer();
+  const viewManager = createMockViewManager(uiHandle);
+  const windowLayer = createMockWindowLayer();
+
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    createMinimalOperation(APP_START_OPERATION_ID, "init")
+  );
+  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+
+  const module = createShortcutModule({
+    viewManager: viewManager as unknown as ShortcutModuleDeps["viewManager"],
+    viewLayer: viewLayer as unknown as ShortcutModuleDeps["viewLayer"],
+    windowLayer,
+    getWindowHandle: () => createWindowHandle(),
+    dispatch: (intent) => dispatcher.dispatch(intent),
+    logger: SILENT_LOGGER,
+    isDevelopment,
+  });
+
+  dispatcher.registerModule(module);
+
+  await dispatcher.dispatch({
+    type: INTENT_APP_START,
+    payload: {},
+  } as AppStartIntent);
+
+  return { viewLayer, viewManager, dispatcher, uiHandle };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ShortcutModule DevTools integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("isDevelopment: true", () => {
+    it("D toggles UI DevTools open", async () => {
+      const { viewLayer, uiHandle } = await createHarness(true);
+
+      viewLayer.simulateKey("ui-view", "d");
+
+      expect(viewLayer.openDevTools).toHaveBeenCalledWith(uiHandle, { mode: "detach" });
+    });
+
+    it("D toggles UI DevTools closed when already open", async () => {
+      const { viewLayer, uiHandle } = await createHarness(true);
+      viewLayer.isDevToolsOpened.mockReturnValue(true);
+
+      viewLayer.simulateKey("ui-view", "d");
+
+      expect(viewLayer.closeDevTools).toHaveBeenCalledWith(uiHandle);
+      expect(viewLayer.openDevTools).not.toHaveBeenCalled();
+    });
+
+    it("D is case-insensitive", async () => {
+      const { viewLayer, uiHandle } = await createHarness(true);
+
+      viewLayer.simulateKey("ui-view", "D");
+
+      expect(viewLayer.openDevTools).toHaveBeenCalledWith(uiHandle, { mode: "detach" });
+    });
+
+    it("W toggles active workspace DevTools open", async () => {
+      const { viewLayer, viewManager } = await createHarness(true);
+
+      viewLayer.simulateKey("ui-view", "w");
+
+      expect(viewLayer.openDevTools).toHaveBeenCalledWith(viewManager._wsHandle, {
+        mode: "detach",
+      });
+    });
+
+    it("W toggles workspace DevTools closed when already open", async () => {
+      const { viewLayer, viewManager } = await createHarness(true);
+      viewLayer.isDevToolsOpened.mockReturnValue(true);
+
+      viewLayer.simulateKey("ui-view", "w");
+
+      expect(viewLayer.closeDevTools).toHaveBeenCalledWith(viewManager._wsHandle);
+    });
+
+    it("W is consumed even when no active workspace", async () => {
+      const { viewLayer, viewManager } = await createHarness(true);
+      viewManager._setActivePath(null);
+
+      viewLayer.simulateKey("ui-view", "w");
+
+      // Key consumed (no DevTools call, but no shortcut emission either)
+      expect(viewLayer.openDevTools).not.toHaveBeenCalled();
+      expect(viewLayer.closeDevTools).not.toHaveBeenCalled();
+      expect(viewManager.sendToUI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isDevelopment: false", () => {
+    it("D does not trigger DevTools", async () => {
+      const { viewLayer } = await createHarness(false);
+
+      viewLayer.simulateKey("ui-view", "d");
+
+      expect(viewLayer.openDevTools).not.toHaveBeenCalled();
+      expect(viewLayer.closeDevTools).not.toHaveBeenCalled();
+    });
+
+    it("W does not trigger DevTools", async () => {
+      const { viewLayer } = await createHarness(false);
+
+      viewLayer.simulateKey("ui-view", "w");
+
+      expect(viewLayer.openDevTools).not.toHaveBeenCalled();
+      expect(viewLayer.closeDevTools).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/modules/shortcut-module.ts
+++ b/src/main/modules/shortcut-module.ts
@@ -26,13 +26,33 @@ import { ApiIpcChannels } from "../../shared/ipc";
 export interface ShortcutModuleDeps {
   readonly viewManager: Pick<
     IViewManager,
-    "focusUI" | "getUIViewHandle" | "getMode" | "sendToUI" | "getWorkspaceView"
+    | "focusUI"
+    | "getUIViewHandle"
+    | "getMode"
+    | "sendToUI"
+    | "getWorkspaceView"
+    | "getActiveWorkspacePath"
   >;
-  readonly viewLayer: Pick<ViewLayer, "onBeforeInputEvent" | "onDestroyed">;
+  readonly viewLayer: Pick<
+    ViewLayer,
+    "onBeforeInputEvent" | "onDestroyed" | "openDevTools" | "closeDevTools" | "isDevToolsOpened"
+  >;
   readonly windowLayer: Pick<WindowLayer, "onBlur">;
   readonly getWindowHandle: () => WindowHandle;
   readonly dispatch: (intent: { type: string; payload: unknown }) => PromiseLike<unknown>;
   readonly logger: Logger;
+  readonly isDevelopment?: boolean;
+}
+
+function toggleDevTools(
+  viewLayer: Pick<ViewLayer, "openDevTools" | "closeDevTools" | "isDevToolsOpened">,
+  handle: ViewHandle
+): void {
+  if (viewLayer.isDevToolsOpened(handle)) {
+    viewLayer.closeDevTools(handle);
+  } else {
+    viewLayer.openDevTools(handle, { mode: "detach" });
+  }
 }
 
 export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
@@ -68,6 +88,26 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
                 onBlur(handle: WindowHandle, callback: () => void): Unsubscribe;
               },
               windowHandle: deps.getWindowHandle(),
+              ...(deps.isDevelopment && {
+                onRawShortcutKey: (key: string): boolean => {
+                  const lower = key.toLowerCase();
+                  if (lower === "d") {
+                    toggleDevTools(deps.viewLayer, deps.viewManager.getUIViewHandle());
+                    return true;
+                  }
+                  if (lower === "w") {
+                    const activePath = deps.viewManager.getActiveWorkspacePath();
+                    if (activePath) {
+                      const wsHandle = deps.viewManager.getWorkspaceView(activePath);
+                      if (wsHandle) {
+                        toggleDevTools(deps.viewLayer, wsHandle);
+                      }
+                    }
+                    return true;
+                  }
+                  return false;
+                },
+              }),
             });
 
             // Register UI view

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -1115,8 +1115,6 @@ describe("ViewModule Integration", () => {
         create: vi.fn(),
         maximizeAsync: vi.fn().mockResolvedValue(undefined),
       };
-      const devToolsHandler = vi.fn();
-
       const { module } = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
         logger: SILENT_LOGGER,
@@ -1126,7 +1124,6 @@ describe("ViewModule Integration", () => {
         menuLayer,
         windowManager,
         uiHtmlPath: "file:///app/ui.html",
-        devToolsHandler,
       });
 
       dispatcher.registerModule(module);
@@ -1146,7 +1143,6 @@ describe("ViewModule Integration", () => {
         "file:///app/ui.html"
       );
       expect(viewManager.focusUI).toHaveBeenCalled();
-      expect(devToolsHandler).toHaveBeenCalled();
     });
 
     it("skips optional deps when not provided", async () => {

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -99,9 +99,8 @@ interface MountSignal {
  * Shell layers are nullable because they may not exist in test environments
  * or when the app quits before full initialization.
  *
- * Lifecycle deps (menuLayer, windowManager, buildInfo, pathProvider, uiHtmlPath,
- * electronApp, devToolsHandler) are nullable so existing call sites that
- * don't need them pass unchanged.
+ * Lifecycle deps (menuLayer, windowManager, buildInfo, uiHtmlPath) are nullable
+ * so existing call sites that don't need them pass unchanged.
  */
 export interface ViewModuleDeps {
   readonly viewManager: IViewManager & { create(): void };
@@ -124,7 +123,6 @@ export interface ViewModuleDeps {
     gitBranch?: string;
   } | null;
   readonly uiHtmlPath?: string | null;
-  readonly devToolsHandler?: (() => void) | null;
 }
 
 /**
@@ -204,11 +202,6 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
 
             // Focus UI
             viewManager.focusUI();
-
-            // Set up devtools handler
-            if (deps.devToolsHandler) {
-              deps.devToolsHandler();
-            }
           },
         },
         "show-ui": {

--- a/src/main/shortcut-controller.integration.test.ts
+++ b/src/main/shortcut-controller.integration.test.ts
@@ -507,6 +507,131 @@ describe("ShortcutController Integration", () => {
     });
   });
 
+  describe("onRawShortcutKey interception", () => {
+    it("is called before normalizeKey in shortcut mode and consumes key when returns true", () => {
+      const onRawShortcutKey = vi.fn().mockReturnValue(true);
+      const shortcutResult = createMockDeps("shortcut");
+      shortcutResult.deps = { ...shortcutResult.deps, onRawShortcutKey };
+      const shortcutController = new ShortcutController(shortcutResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        shortcutController.registerView(handle);
+
+        simulateInput(shortcutResult.callbacks, "view-1", createKeyboardInput("d", "keyDown"));
+
+        expect(onRawShortcutKey).toHaveBeenCalledWith("d");
+        expect(shortcutResult.mocks.onShortcut).not.toHaveBeenCalled();
+      } finally {
+        shortcutController.dispose();
+      }
+    });
+
+    it("falls through to normalizeKey/onShortcut when returns false", () => {
+      const onRawShortcutKey = vi.fn().mockReturnValue(false);
+      const shortcutResult = createMockDeps("shortcut");
+      shortcutResult.deps = { ...shortcutResult.deps, onRawShortcutKey };
+      const shortcutController = new ShortcutController(shortcutResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        shortcutController.registerView(handle);
+
+        simulateInput(
+          shortcutResult.callbacks,
+          "view-1",
+          createKeyboardInput("ArrowUp", "keyDown")
+        );
+
+        expect(onRawShortcutKey).toHaveBeenCalledWith("ArrowUp");
+        expect(shortcutResult.mocks.onShortcut).toHaveBeenCalledWith("up");
+      } finally {
+        shortcutController.dispose();
+      }
+    });
+
+    it("is not called outside shortcut mode", () => {
+      const onRawShortcutKey = vi.fn().mockReturnValue(true);
+      mockResult.deps = { ...mockResult.deps, onRawShortcutKey };
+      const wsController = new ShortcutController(mockResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        wsController.registerView(handle);
+
+        simulateInput(mockResult.callbacks, "view-1", createKeyboardInput("d", "keyDown"));
+
+        expect(onRawShortcutKey).not.toHaveBeenCalled();
+      } finally {
+        wsController.dispose();
+      }
+    });
+
+    it("is not called on keyUp", () => {
+      const onRawShortcutKey = vi.fn().mockReturnValue(true);
+      const shortcutResult = createMockDeps("shortcut");
+      shortcutResult.deps = { ...shortcutResult.deps, onRawShortcutKey };
+      const shortcutController = new ShortcutController(shortcutResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        shortcutController.registerView(handle);
+
+        simulateInput(shortcutResult.callbacks, "view-1", createKeyboardInput("d", "keyUp"));
+
+        expect(onRawShortcutKey).not.toHaveBeenCalled();
+      } finally {
+        shortcutController.dispose();
+      }
+    });
+
+    it("is not called on auto-repeat", () => {
+      const onRawShortcutKey = vi.fn().mockReturnValue(true);
+      const shortcutResult = createMockDeps("shortcut");
+      shortcutResult.deps = { ...shortcutResult.deps, onRawShortcutKey };
+      const shortcutController = new ShortcutController(shortcutResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        shortcutController.registerView(handle);
+
+        simulateInput(
+          shortcutResult.callbacks,
+          "view-1",
+          createKeyboardInput("d", "keyDown", { isAutoRepeat: true })
+        );
+
+        expect(onRawShortcutKey).not.toHaveBeenCalled();
+      } finally {
+        shortcutController.dispose();
+      }
+    });
+
+    it("normal behavior preserved when callback not provided", () => {
+      const shortcutResult = createMockDeps("shortcut");
+      const shortcutController = new ShortcutController(shortcutResult.deps);
+
+      try {
+        const handle = createViewHandle("view-1");
+        shortcutController.registerView(handle);
+
+        // "d" is not a recognized shortcut key, should be ignored
+        simulateInput(shortcutResult.callbacks, "view-1", createKeyboardInput("d", "keyDown"));
+        expect(shortcutResult.mocks.onShortcut).not.toHaveBeenCalled();
+
+        // ArrowUp IS a recognized shortcut key
+        simulateInput(
+          shortcutResult.callbacks,
+          "view-1",
+          createKeyboardInput("ArrowUp", "keyDown")
+        );
+        expect(shortcutResult.mocks.onShortcut).toHaveBeenCalledWith("up");
+      } finally {
+        shortcutController.dispose();
+      }
+    });
+  });
+
   describe("edge cases", () => {
     it("auto-repeat events are ignored", () => {
       const handle = createViewHandle("view-1");

--- a/src/main/shortcut-controller.ts
+++ b/src/main/shortcut-controller.ts
@@ -64,6 +64,8 @@ export interface ShortcutControllerDeps {
   getMode: () => UIMode;
   /** Callback when a shortcut key is pressed in shortcut mode */
   onShortcut?: (key: ShortcutKey) => void;
+  /** Intercepts raw key before normalizeKey in shortcut mode. Return true to consume. */
+  onRawShortcutKey?: (key: string) => boolean;
   /** Logger for debugging */
   logger?: Logger;
   /** ViewLayer methods for event subscription */
@@ -203,6 +205,10 @@ export class ShortcutController {
     // Shortcut key detection in shortcut mode
     // NOTE: This runs before Alt+X detection because shortcut mode is already active
     if (currentMode === "shortcut") {
+      // Raw key interception (e.g., dev-only DevTools shortcuts)
+      if (this.deps.onRawShortcutKey?.(input.key)) {
+        return;
+      }
       const normalizedKey = normalizeKey(input.key);
       if (normalizedKey !== null) {
         // NOTE: Do NOT call event.preventDefault() - see Electron bug #37336


### PR DESCRIPTION
- Add `onRawShortcutKey` interception point to `ShortcutController` (fires before `normalizeKey` in shortcut mode)
- Wire DevTools toggling in `ShortcutModule`: Alt+X → D (sidebar), Alt+X → W (workspace)
- Only active when `isDevelopment: true`
- Remove old Ctrl+Shift+I `devToolsHandler` from `ViewModule`