### PR TITLE
refactor(scripts): convert check-path-length from CJS to ESM

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,12 +42,6 @@ export default tseslint.config(
       },
     },
   },
-  {
-    files: ["**/*.cjs"],
-    rules: {
-      "@typescript-eslint/no-require-imports": "off",
-    },
-  },
   // VS Code extensions - allow underscore-prefixed unused vars (interface implementations)
   {
     files: ["extensions/**/*.ts", "extensions/**/*.svelte"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "out/main/index.cjs",
   "packageManager": "pnpm@10.11.0",
   "scripts": {
-    "preinstall": "node scripts/check-path-length.cjs",
+    "preinstall": "node scripts/check-path-length.js",
     "bootstrap": "pnpm install && pnpm build",
     "dev": "pnpm build && electron-vite dev",
     "build:wrappers": "vite build --config vite.config.bin.ts",

--- a/scripts/check-path-length.js
+++ b/scripts/check-path-length.js
@@ -2,7 +2,6 @@
  * Windows MAX_PATH Check
  *
  * Runs before pnpm install to warn users about potential path length issues.
- * Uses CommonJS (.cjs) to work regardless of package.json "type" setting.
  *
  * This script:
  * 1. Exits silently on non-Windows platforms
@@ -15,7 +14,7 @@ if (process.platform !== "win32") {
   process.exit(0);
 }
 
-const { execSync } = require("child_process");
+import { execSync } from "node:child_process";
 
 // Threshold based on real failure: install failed at 91 character base path
 const PATH_LENGTH_THRESHOLD = 90;


### PR DESCRIPTION
- Rename `check-path-length.cjs` to `.js` and switch from `require()` to ESM `import`
- Update `preinstall` script reference in `package.json`
- Remove now-unused `**/*.cjs` eslint override (no project-owned `.cjs` files remain)