### PR TITLE
fix: Improved claude session continuation

### DIFF
--- a/src/agents/claude/provider.integration.test.ts
+++ b/src/agents/claude/provider.integration.test.ts
@@ -310,6 +310,26 @@ describe("ClaudeCodeProvider integration", () => {
       const env = provider.getEnvironmentVariables();
       expect(env).not.toHaveProperty("_CH_INITIAL_PROMPT_FILE");
     });
+
+    it("includes no-session marker path when marker is set", async () => {
+      const port = await serverManager.startServer(workspacePath);
+
+      await serverManager.setNoSessionMarker(workspacePath);
+
+      await provider.connect(port);
+
+      const env = provider.getEnvironmentVariables();
+      expect(env).toHaveProperty("_CH_CLAUDE_NO_SESSION_MARKER_PATH");
+      expect(env._CH_CLAUDE_NO_SESSION_MARKER_PATH).toContain("no-session");
+    });
+
+    it("omits no-session marker path when no marker is set", async () => {
+      const port = await serverManager.startServer(workspacePath);
+      await provider.connect(port);
+
+      const env = provider.getEnvironmentVariables();
+      expect(env).not.toHaveProperty("_CH_CLAUDE_NO_SESSION_MARKER_PATH");
+    });
   });
 
   describe("markActive", () => {

--- a/src/agents/claude/provider.ts
+++ b/src/agents/claude/provider.ts
@@ -175,6 +175,12 @@ export class ClaudeCodeProvider implements AgentProvider {
       envVars._CH_INITIAL_PROMPT_FILE = initialPromptPath.toNative();
     }
 
+    // Include no-session marker path if set (new workspaces only)
+    const noSessionMarkerPath = this.serverManager.getNoSessionMarkerPath(this.workspacePath);
+    if (noSessionMarkerPath !== undefined) {
+      envVars._CH_CLAUDE_NO_SESSION_MARKER_PATH = noSessionMarkerPath.toNative();
+    }
+
     return envVars;
   }
 

--- a/src/agents/claude/server-manager.integration.test.ts
+++ b/src/agents/claude/server-manager.integration.test.ts
@@ -908,4 +908,44 @@ describe("ClaudeCodeServerManager integration", () => {
       mockFileSystem.$.mkdtempShouldFail = false;
     });
   });
+
+  describe("no-session marker", () => {
+    it("setNoSessionMarker stores path retrievable via getNoSessionMarkerPath", async () => {
+      await serverManager.startServer("/workspace/feature-a");
+
+      await serverManager.setNoSessionMarker("/workspace/feature-a");
+
+      const path = serverManager.getNoSessionMarkerPath("/workspace/feature-a");
+      expect(path).toBeDefined();
+      expect(path?.toString()).toContain("claude/no-session/");
+    });
+
+    it("getNoSessionMarkerPath returns undefined when no marker set", async () => {
+      await serverManager.startServer("/workspace/feature-a");
+
+      const path = serverManager.getNoSessionMarkerPath("/workspace/feature-a");
+      expect(path).toBeUndefined();
+    });
+
+    it("getNoSessionMarkerPath returns undefined for unknown workspace", () => {
+      const path = serverManager.getNoSessionMarkerPath("/workspace/unknown");
+      expect(path).toBeUndefined();
+    });
+
+    it("setNoSessionMarker logs warning for unknown workspace", async () => {
+      await expect(serverManager.setNoSessionMarker("/workspace/unknown")).resolves.not.toThrow();
+    });
+
+    it("marker file is created as empty file", async () => {
+      await serverManager.startServer("/workspace/feature-a");
+
+      await serverManager.setNoSessionMarker("/workspace/feature-a");
+
+      const path = serverManager.getNoSessionMarkerPath("/workspace/feature-a");
+      expect(path).toBeDefined();
+
+      const content = await mockFileSystem.readFile(path!);
+      expect(content).toBe("");
+    });
+  });
 });

--- a/src/agents/claude/server-manager.ts
+++ b/src/agents/claude/server-manager.ts
@@ -49,6 +49,8 @@ export interface WorkspaceState {
   ignoreNextSessionStart?: boolean;
   /** Path to the initial prompt file (for getInitialPromptPath) */
   initialPromptPath?: Path;
+  /** Path to the no-session marker file (for getNoSessionMarkerPath) */
+  noSessionMarkerPath?: Path;
 }
 
 /**
@@ -468,6 +470,60 @@ export class ClaudeCodeServerManager implements AgentServerManager {
   getInitialPromptPath(workspacePath: string): Path | undefined {
     const normalizedPath = new Path(workspacePath).toString();
     return this.workspaces.get(normalizedPath)?.initialPromptPath;
+  }
+
+  /**
+   * Create a no-session marker file for a new workspace.
+   * The marker tells the wrapper to skip --continue on first launch.
+   * It is deleted by the wrapper on first invocation so subsequent runs
+   * will attempt session resume.
+   *
+   * @param workspacePath - Absolute path to the workspace
+   */
+  async setNoSessionMarker(workspacePath: string): Promise<void> {
+    const normalizedPath = new Path(workspacePath).toString();
+    const state = this.workspaces.get(normalizedPath);
+
+    if (!state) {
+      this.logger.warn("setNoSessionMarker called for unknown workspace", {
+        workspacePath: normalizedPath,
+      });
+      return;
+    }
+
+    try {
+      const markerDir = this.pathProvider.tempPath("claude/no-session");
+      await this.fileSystem.mkdir(markerDir);
+
+      const safeWorkspaceName = this.getConfigDirName(normalizedPath);
+      const markerPath = new Path(markerDir, safeWorkspaceName);
+      await this.fileSystem.writeFile(markerPath, "");
+
+      state.noSessionMarkerPath = markerPath;
+
+      this.logger.debug("No-session marker created", {
+        workspacePath: normalizedPath,
+        path: markerPath.toString(),
+      });
+    } catch (error) {
+      this.logger.error(
+        "Failed to create no-session marker",
+        { workspacePath: normalizedPath },
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get the path to the no-session marker file for a workspace.
+   * Returns undefined if no marker was set.
+   *
+   * @param workspacePath - Absolute path to the workspace
+   * @returns Path to the marker file, or undefined
+   */
+  getNoSessionMarkerPath(workspacePath: string): Path | undefined {
+    const normalizedPath = new Path(workspacePath).toString();
+    return this.workspaces.get(normalizedPath)?.noSessionMarkerPath;
   }
 
   /**

--- a/src/agents/claude/wrapper.integration.test.ts
+++ b/src/agents/claude/wrapper.integration.test.ts
@@ -14,6 +14,7 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
   unlinkSync: vi.fn(),
   rmdirSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
 }));
 
 // Use dynamic import to ensure mock is set up before wrapper is loaded

--- a/src/agents/claude/wrapper.test.ts
+++ b/src/agents/claude/wrapper.test.ts
@@ -4,11 +4,14 @@
  * Tests buildInitialPromptArgs function.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   buildInitialPromptArgs,
   buildPermissionArgs,
-  shouldContinue,
+  consumeNoSessionMarker,
   type InitialPromptConfig,
 } from "./wrapper";
 
@@ -92,23 +95,34 @@ describe("buildInitialPromptArgs", () => {
   });
 });
 
-describe("shouldContinue", () => {
+describe("consumeNoSessionMarker", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "ch-wrapper-test-"));
+    delete process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH;
+  });
+
   afterEach(() => {
-    delete process.env._CH_CLAUDE_CONTINUE;
+    delete process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH;
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("returns true when _CH_CLAUDE_CONTINUE is '1'", () => {
-    process.env._CH_CLAUDE_CONTINUE = "1";
-    expect(shouldContinue()).toBe(true);
+  it("returns false when env var is not set", () => {
+    expect(consumeNoSessionMarker()).toBe(false);
   });
 
-  it("returns false when _CH_CLAUDE_CONTINUE is not set", () => {
-    delete process.env._CH_CLAUDE_CONTINUE;
-    expect(shouldContinue()).toBe(false);
+  it("returns true and deletes marker when file exists", () => {
+    const markerPath = join(tempDir, "no-session-marker");
+    writeFileSync(markerPath, "");
+    process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH = markerPath;
+
+    expect(consumeNoSessionMarker()).toBe(true);
+    expect(existsSync(markerPath)).toBe(false);
   });
 
-  it("returns false when _CH_CLAUDE_CONTINUE is '0'", () => {
-    process.env._CH_CLAUDE_CONTINUE = "0";
-    expect(shouldContinue()).toBe(false);
+  it("returns false when env var is set but file does not exist", () => {
+    process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH = join(tempDir, "nonexistent");
+    expect(consumeNoSessionMarker()).toBe(false);
   });
 });

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -17,10 +17,11 @@
  * - _CH_MCP_PORT: Main MCP server port
  * - _CH_WORKSPACE_PATH: Workspace path for MCP header
  * - _CH_INITIAL_PROMPT_FILE: Path to initial prompt JSON file (optional)
+ * - _CH_CLAUDE_NO_SESSION_MARKER_PATH: Path to no-session marker (optional, new workspaces only)
  */
 
 import { spawnSync, execSync } from "node:child_process";
-import { readFileSync, unlinkSync, rmdirSync } from "node:fs";
+import { readFileSync, unlinkSync, rmdirSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { request } from "node:http";
 
@@ -260,11 +261,21 @@ export function runClaude(
 }
 
 /**
- * Check if the wrapper should attempt --continue for session resume.
- * Returns true when _CH_CLAUDE_CONTINUE=1 (reopened workspace with prior session).
+ * Consume the no-session marker file if present.
+ * Returns true when the marker exists (new workspace, no prior session),
+ * meaning --continue should be skipped. Deletes the marker so subsequent
+ * runs will attempt --continue.
  */
-function shouldContinue(): boolean {
-  return process.env._CH_CLAUDE_CONTINUE === "1";
+function consumeNoSessionMarker(): boolean {
+  const markerPath = process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH;
+  if (!markerPath) return false;
+  if (!existsSync(markerPath)) return false;
+  try {
+    unlinkSync(markerPath);
+  } catch {
+    // Ignore deletion errors
+  }
+  return true;
 }
 
 /**
@@ -407,7 +418,7 @@ async function main(): Promise<never> {
   // Skip --continue attempt for new workspaces (no prior session to resume)
   const result = runClaude(claudeBinary, args, {
     shell: isWindows,
-    skipContinue: !shouldContinue(),
+    skipContinue: consumeNoSessionMarker(),
   });
 
   // 8. Notify wrapper end (Claude has exited)
@@ -438,5 +449,5 @@ export {
   getInitialPromptConfig,
   buildInitialPromptArgs,
   buildPermissionArgs,
-  shouldContinue,
+  consumeNoSessionMarker,
 };

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -148,6 +148,15 @@ export interface AgentServerManager {
    */
   setInitialPrompt?(workspacePath: string, config: NormalizedInitialPrompt): Promise<void>;
 
+  /**
+   * Create a no-session marker for a new workspace.
+   * Optional - only Claude Code implements this method.
+   * The marker signals the wrapper to skip --continue on first launch.
+   *
+   * @param workspacePath - Absolute path to the workspace
+   */
+  setNoSessionMarker?(workspacePath: string): Promise<void>;
+
   /** Configure MCP server connection for agent integration */
   setMcpConfig(config: McpConfig): void;
 

--- a/src/main/modules/claude-agent-module.integration.test.ts
+++ b/src/main/modules/claude-agent-module.integration.test.ts
@@ -259,6 +259,8 @@ function createMockClaudeServerManager() {
     getHooksConfigPath: vi.fn().mockReturnValue({ toNative: () => "/hooks.json" }),
     getMcpConfigPath: vi.fn().mockReturnValue({ toNative: () => "/mcp.json" }),
     getInitialPromptPath: vi.fn().mockReturnValue(undefined),
+    setNoSessionMarker: vi.fn().mockResolvedValue(undefined),
+    getNoSessionMarkerPath: vi.fn().mockReturnValue(undefined),
   };
 }
 
@@ -798,8 +800,8 @@ describe("ClaudeAgentModule", () => {
       expect(mockSM.setInitialPrompt).toHaveBeenCalled();
     });
 
-    it("includes _CH_CLAUDE_CONTINUE env var for reopened workspaces", async () => {
-      const { dispatcher, module } = createTestSetup();
+    it("calls setNoSessionMarker for new workspaces", async () => {
+      const { dispatcher, module, mockSM } = createTestSetup();
       await activateModule(dispatcher, module);
 
       dispatcher.registerOperation(
@@ -810,7 +812,31 @@ describe("ClaudeAgentModule", () => {
         })
       );
 
-      const result = (await dispatcher.dispatch({
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678",
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as unknown as OpenWorkspaceIntent);
+
+      expect(mockSM.setNoSessionMarker).toHaveBeenCalledWith("/test/workspace");
+    });
+
+    it("does not call setNoSessionMarker for existing workspaces", async () => {
+      const { dispatcher, module, mockSM } = createTestSetup();
+      await activateModule(dispatcher, module);
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      await dispatcher.dispatch({
         type: "workspace:open",
         payload: {
           projectId: "test-12345678",
@@ -823,35 +849,9 @@ describe("ClaudeAgentModule", () => {
             metadata: {},
           },
         },
-      } as unknown as OpenWorkspaceIntent)) as SetupHookResult | undefined;
+      } as unknown as OpenWorkspaceIntent);
 
-      expect(result).toBeDefined();
-      expect(result!.envVars).toHaveProperty("_CH_CLAUDE_CONTINUE", "1");
-    });
-
-    it("does not include _CH_CLAUDE_CONTINUE for new workspaces", async () => {
-      const { dispatcher, module } = createTestSetup();
-      await activateModule(dispatcher, module);
-
-      dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
-        })
-      );
-
-      const result = (await dispatcher.dispatch({
-        type: "workspace:open",
-        payload: {
-          projectId: "test-12345678",
-          workspaceName: "feature-1",
-          base: "main",
-        },
-      } as unknown as OpenWorkspaceIntent)) as SetupHookResult | undefined;
-
-      expect(result).toBeDefined();
-      expect(result!.envVars).not.toHaveProperty("_CH_CLAUDE_CONTINUE");
+      expect(mockSM.setNoSessionMarker).not.toHaveBeenCalled();
     });
 
     it("returns undefined when inactive", async () => {

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -368,17 +368,20 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
               await serverManager.setInitialPrompt(workspacePath, normalizedPrompt);
             }
 
+            // Create no-session marker for new workspaces (skips --continue on first launch)
+            if (
+              intent.payload.existingWorkspace === undefined &&
+              serverManager.setNoSessionMarker
+            ) {
+              await serverManager.setNoSessionMarker(workspacePath);
+            }
+
             const agentProvider = deps.agentStatusManager.getProvider(
               workspacePath as WorkspacePath
             );
             const envVars: Record<string, string> = {
               ...(agentProvider?.getEnvironmentVariables() ?? {}),
             };
-
-            // Signal reopened workspaces to use --continue for session resume
-            if (intent.payload.existingWorkspace !== undefined) {
-              envVars._CH_CLAUDE_CONTINUE = "1";
-            }
 
             return { envVars, agentType: "claude" };
           },


### PR DESCRIPTION
- Replace `_CH_CLAUDE_CONTINUE` env var with temp marker file for session resume signaling
- New workspaces get a "no-session" marker in `tempPath`; wrapper deletes it on first run so subsequent runs try `--continue`
- Fixes session resume not working when users exit and re-run `ch-claude` in new workspace terminals (env vars are fixed at terminal creation time)