### PR TITLE
refactor(intents): move project-open dedup into idempotency pipeline

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,7 +143,14 @@ import {
   EVENT_WORKSPACE_DELETED,
 } from "./operations/delete-workspace";
 import type { DeleteWorkspaceIntent, DeleteWorkspacePayload } from "./operations/delete-workspace";
-import { OpenProjectOperation, INTENT_OPEN_PROJECT } from "./operations/open-project";
+import {
+  OpenProjectOperation,
+  INTENT_OPEN_PROJECT,
+  EVENT_PROJECT_OPENED,
+  EVENT_PROJECT_OPEN_FAILED,
+} from "./operations/open-project";
+import type { OpenProjectPayload } from "./operations/open-project";
+import { expandGitUrl } from "../services/project/url-utils";
 import { CloseProjectOperation, INTENT_CLOSE_PROJECT } from "./operations/close-project";
 import { SwitchWorkspaceOperation, INTENT_SWITCH_WORKSPACE } from "./operations/switch-workspace";
 import {
@@ -405,6 +412,16 @@ const idempotencyModule = createIdempotencyModule([
     },
     resetOn: EVENT_WORKSPACE_DELETED,
     isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,
+  },
+  {
+    intentType: INTENT_OPEN_PROJECT,
+    getKey: (p) => {
+      const payload = p as OpenProjectPayload;
+      if (payload.path) return payload.path.toString();
+      if (payload.git) return expandGitUrl(payload.git);
+      return undefined; // select-folder case: no dedup
+    },
+    resetOn: [EVENT_PROJECT_OPENED, EVENT_PROJECT_OPEN_FAILED],
   },
 ]);
 

--- a/src/main/intents/infrastructure/idempotency-module.integration.test.ts
+++ b/src/main/intents/infrastructure/idempotency-module.integration.test.ts
@@ -165,6 +165,100 @@ describe("createIdempotencyModule", () => {
     expect(await h3.accepted).toBe(true);
   });
 
+  it("per-key: getKey returning undefined skips the rule", async () => {
+    const { dispatcher } = setup([
+      {
+        intentType: "test:open",
+        getKey: (p) => (p as { path?: string }).path,
+      },
+    ]);
+    dispatcher.registerOperation("test:open", noopOperation("open-op"));
+
+    // Payload without path → getKey returns undefined → rule skipped
+    const h1 = dispatcher.dispatch({ type: "test:open", payload: {} });
+    expect(await h1.accepted).toBe(true);
+
+    // Second dispatch also passes (no key was tracked)
+    const h2 = dispatcher.dispatch({ type: "test:open", payload: {} });
+    expect(await h2.accepted).toBe(true);
+
+    // Payload with path → key tracked normally
+    const h3 = dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
+    expect(await h3.accepted).toBe(true);
+
+    // Duplicate path blocked
+    const h4 = dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
+    expect(await h4.accepted).toBe(false);
+  });
+
+  it("per-key with resetOn array: resets on any listed event", async () => {
+    const { dispatcher } = setup([
+      {
+        intentType: "test:open",
+        getKey: (p) => (p as { path: string }).path,
+        resetOn: ["test:opened", "test:open-failed"],
+      },
+    ]);
+
+    let emitFn: ((event: DomainEvent) => void) | undefined;
+    dispatcher.registerOperation("test:open", {
+      id: "open-op",
+      execute: async (ctx: OperationContext<Intent>) => {
+        emitFn = ctx.emit;
+      },
+    });
+
+    // Dispatch /a → tracked
+    await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
+    expect(await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } }).accepted).toBe(
+      false
+    );
+
+    // Reset /a via the first event type
+    emitFn!({ type: "test:opened", payload: { path: "/a" } });
+    expect(await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } }).accepted).toBe(
+      true
+    );
+
+    // Block again, then reset via the second event type
+    expect(await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } }).accepted).toBe(
+      false
+    );
+    emitFn!({ type: "test:open-failed", payload: { path: "/a" } });
+    expect(await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } }).accepted).toBe(
+      true
+    );
+  });
+
+  it("per-key reset: event with undefined key is ignored", async () => {
+    const { dispatcher } = setup([
+      {
+        intentType: "test:open",
+        getKey: (p) => (p as { path?: string }).path,
+        resetOn: "test:open-failed",
+      },
+    ]);
+
+    let emitFn: ((event: DomainEvent) => void) | undefined;
+    dispatcher.registerOperation("test:open", {
+      id: "open-op",
+      execute: async (ctx: OperationContext<Intent>) => {
+        emitFn = ctx.emit;
+      },
+    });
+
+    // Track /a
+    await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
+
+    // Reset event with no path → getKey returns undefined → no keys cleared
+    emitFn!({ type: "test:open-failed", payload: {} });
+
+    // /a still blocked
+    expect(await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } }).accepted).toBe(
+      false
+    );
+  });
+
   it("multiple rules: handles different intent types independently", async () => {
     const { dispatcher } = setup([
       { intentType: "test:shutdown" },

--- a/src/main/intents/infrastructure/idempotency-module.ts
+++ b/src/main/intents/infrastructure/idempotency-module.ts
@@ -22,10 +22,10 @@ import type { IntentModule, EventDeclarations } from "./module";
 export interface IdempotencyRule {
   /** Intent type this rule applies to. */
   readonly intentType: string;
-  /** Extract a tracking key from the intent payload. Omit for singleton (boolean flag). */
-  readonly getKey?: (payload: unknown) => string;
-  /** Domain event type that resets tracking state. Uses getKey on event payload for per-key reset. */
-  readonly resetOn?: string;
+  /** Extract a tracking key from the intent payload. Omit for singleton (boolean flag). Return undefined to skip the rule for this payload. */
+  readonly getKey?: (payload: unknown) => string | undefined;
+  /** Domain event type(s) that reset tracking state. Uses getKey on event payload for per-key reset. */
+  readonly resetOn?: string | readonly string[];
   /** Return true to bypass the idempotency block (intent still gets tracked). */
   readonly isForced?: (intent: Intent) => boolean;
 }
@@ -66,11 +66,14 @@ export function createIdempotencyModule(rules: readonly IdempotencyRule[]): Inte
   const resetRulesByEvent = new Map<string, IdempotencyRule[]>();
   for (const rule of rules) {
     if (rule.resetOn) {
-      const list = resetRulesByEvent.get(rule.resetOn);
-      if (list) {
-        list.push(rule);
-      } else {
-        resetRulesByEvent.set(rule.resetOn, [rule]);
+      const eventTypes = typeof rule.resetOn === "string" ? [rule.resetOn] : rule.resetOn;
+      for (const eventType of eventTypes) {
+        const list = resetRulesByEvent.get(eventType);
+        if (list) {
+          list.push(rule);
+        } else {
+          resetRulesByEvent.set(eventType, [rule]);
+        }
       }
     }
   }
@@ -81,7 +84,9 @@ export function createIdempotencyModule(rules: readonly IdempotencyRule[]): Inte
       for (const rule of resetRules) {
         if (rule.getKey) {
           const key = rule.getKey(event.payload);
-          perKeyFlags.get(rule.intentType)?.delete(key);
+          if (key !== undefined) {
+            perKeyFlags.get(rule.intentType)?.delete(key);
+          }
         } else {
           singletonFlags.set(rule.intentType, false);
         }
@@ -104,6 +109,9 @@ export function createIdempotencyModule(rules: readonly IdempotencyRule[]): Inte
           if (rule.getKey) {
             // Per-key mode
             const key = rule.getKey(intent.payload);
+            if (key === undefined) {
+              return intent; // getKey opted out for this payload
+            }
             const keys = perKeyFlags.get(rule.intentType)!;
 
             if (rule.isForced?.(intent)) {

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -86,7 +86,6 @@ import type { AppShutdownIntent } from "../operations/app-shutdown";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
 import type { GitWorktreeProvider } from "../../services/git/git-worktree-provider";
 import { Path } from "../../services/platform/path";
-import { expandGitUrl } from "../../services/project/url-utils";
 
 /**
  * Dependencies for the IpcEventBridge module.
@@ -124,9 +123,6 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
 
   // Closure state for lifecycle management
   let apiEventCleanupFn: Unsubscribe | null = null;
-
-  // Closure state for deduplicating in-progress project opens/clones
-  const inProgressOpens = new Set<string>();
 
   const events: EventDeclarations = {
     [EVENT_METADATA_CHANGED]: (event: DomainEvent) => {
@@ -449,27 +445,17 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
   apiRegistry.register(
     "projects.open",
     async (payload: ProjectOpenPayload) => {
-      // When path is provided, deduplicate in-progress opens
-      const key = payload.path ? new Path(payload.path).toString() : null;
-      if (key) {
-        if (inProgressOpens.has(key)) {
-          throw new Error("Project open already in progress");
-        }
-        inProgressOpens.add(key);
+      const intent: OpenProjectIntent = {
+        type: INTENT_OPEN_PROJECT,
+        payload: {
+          ...(payload.path !== undefined && { path: new Path(payload.path) }),
+        },
+      };
+      const handle = dispatcher.dispatch(intent);
+      if (!(await handle.accepted)) {
+        throw new Error("Project open already in progress");
       }
-      try {
-        const intent: OpenProjectIntent = {
-          type: INTENT_OPEN_PROJECT,
-          payload: {
-            ...(payload.path !== undefined && { path: new Path(payload.path) }),
-          },
-        };
-        return await dispatcher.dispatch(intent);
-      } finally {
-        if (key) {
-          inProgressOpens.delete(key);
-        }
-      }
+      return await handle;
     },
     { ipc: ApiIpcChannels.PROJECT_OPEN }
   );
@@ -477,24 +463,19 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
   apiRegistry.register(
     "projects.clone",
     async (payload: ProjectClonePayload) => {
-      const key = expandGitUrl(payload.url);
-      if (inProgressOpens.has(key)) {
+      const intent: OpenProjectIntent = {
+        type: INTENT_OPEN_PROJECT,
+        payload: { git: payload.url },
+      };
+      const handle = dispatcher.dispatch(intent);
+      if (!(await handle.accepted)) {
         throw new Error("Clone already in progress");
       }
-      inProgressOpens.add(key);
-      try {
-        const intent: OpenProjectIntent = {
-          type: INTENT_OPEN_PROJECT,
-          payload: { git: payload.url },
-        };
-        const result = await dispatcher.dispatch(intent);
-        if (!result) {
-          throw new Error("Clone project dispatch returned no result");
-        }
-        return result;
-      } finally {
-        inProgressOpens.delete(key);
+      const result = await handle;
+      if (!result) {
+        throw new Error("Clone project dispatch returned no result");
       }
+      return result;
     },
     { ipc: ApiIpcChannels.PROJECT_CLONE }
   );

--- a/src/main/operations/open-project.integration.test.ts
+++ b/src/main/operations/open-project.integration.test.ts
@@ -31,6 +31,7 @@ import {
   OPEN_PROJECT_OPERATION_ID,
   INTENT_OPEN_PROJECT,
   EVENT_PROJECT_OPENED,
+  EVENT_PROJECT_OPEN_FAILED,
 } from "./open-project";
 import type {
   OpenProjectIntent,
@@ -40,6 +41,7 @@ import type {
   RegisterHookInput,
   RegisterHookResult,
   ProjectOpenedEvent,
+  ProjectOpenFailedEvent,
 } from "./open-project";
 import {
   OpenWorkspaceOperation,
@@ -1046,5 +1048,126 @@ describe("OpenProjectOperation", () => {
     await harness.dispatcher.dispatch(intent);
 
     expect(selectFolderSpy).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // project:open-failed event
+  // ---------------------------------------------------------------------------
+
+  it("emits project:open-failed on error with reason and intent-origin fields", async () => {
+    const harness = createTestHarness({ validateThrows: true });
+
+    const failedEvents: DomainEvent[] = [];
+    harness.dispatcher.subscribe(EVENT_PROJECT_OPEN_FAILED, (event) => {
+      failedEvents.push(event);
+    });
+
+    const intent = buildOpenIntent({ path: new Path("/invalid/path") });
+    await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Not a valid git repository");
+
+    expect(failedEvents).toHaveLength(1);
+    const event = failedEvents[0] as ProjectOpenFailedEvent;
+    expect(event.type).toBe(EVENT_PROJECT_OPEN_FAILED);
+    expect(event.payload.reason).toBe("Not a valid git repository");
+    expect(event.payload.path).toEqual(new Path("/invalid/path"));
+    expect(event.payload.git).toBeUndefined();
+  });
+
+  it("emits project:open-failed on clone error with git field", async () => {
+    const harness = createTestHarness({ cloneThrows: true });
+
+    const failedEvents: DomainEvent[] = [];
+    harness.dispatcher.subscribe(EVENT_PROJECT_OPEN_FAILED, (event) => {
+      failedEvents.push(event);
+    });
+
+    const intent = buildOpenIntent({ git: "https://bad-host.example/bad/repo.git" });
+    await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Failed to clone");
+
+    expect(failedEvents).toHaveLength(1);
+    const event = failedEvents[0] as ProjectOpenFailedEvent;
+    expect(event.payload.reason).toContain("Failed to clone");
+    expect(event.payload.git).toBe("https://bad-host.example/bad/repo.git");
+    expect(event.payload.path).toBeUndefined();
+  });
+
+  it("emits project:open-failed with already-open reason when project is already open", async () => {
+    // Create harness where the resolve module signals alreadyOpen
+    const hookRegistry = new HookRegistry();
+    const dispatcher = new Dispatcher(hookRegistry);
+
+    dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
+    dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
+    dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+
+    // Resolve module that always returns alreadyOpen: true
+    const alreadyOpenModule: IntentModule = {
+      name: "test",
+      hooks: {
+        [OPEN_PROJECT_OPERATION_ID]: {
+          resolve: {
+            handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+              const intent = ctx.intent as OpenProjectIntent;
+              const { path } = intent.payload;
+              if (!path) return {};
+              return { projectPath: path.toString(), alreadyOpen: true };
+            },
+          },
+          register: {
+            handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+              const { projectPath: p } = ctx as RegisterHookInput;
+              return { projectId: testProjectId(p), name: new Path(p).basename };
+            },
+          },
+          discover: {
+            handler: async (): Promise<DiscoverHookResult> => {
+              return { workspaces: [] };
+            },
+          },
+        },
+      },
+    };
+
+    dispatcher.registerModule(alreadyOpenModule);
+
+    const openedEvents: DomainEvent[] = [];
+    const failedEvents: DomainEvent[] = [];
+    dispatcher.subscribe(EVENT_PROJECT_OPENED, (event) => {
+      openedEvents.push(event);
+    });
+    dispatcher.subscribe(EVENT_PROJECT_OPEN_FAILED, (event) => {
+      failedEvents.push(event);
+    });
+
+    const result = await dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+
+    // Returns project data (it's not a hard failure)
+    expect(result).toBeDefined();
+
+    // No project:opened event (already open)
+    expect(openedEvents).toHaveLength(0);
+
+    // project:open-failed emitted with already-open reason
+    expect(failedEvents).toHaveLength(1);
+    const event = failedEvents[0] as ProjectOpenFailedEvent;
+    expect(event.payload.reason).toBe("already-open");
+    expect(event.payload.path).toEqual(new Path(PROJECT_PATH));
+  });
+
+  it("project:opened event includes intent-origin fields", async () => {
+    const harness = createTestHarness();
+
+    const receivedEvents: DomainEvent[] = [];
+    harness.dispatcher.subscribe(EVENT_PROJECT_OPENED, (event) => {
+      receivedEvents.push(event);
+    });
+
+    await harness.dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+
+    expect(receivedEvents).toHaveLength(1);
+    const event = receivedEvents[0] as ProjectOpenedEvent;
+    expect(event.payload.project.id).toBe(PROJECT_ID);
+    expect(event.payload.path).toEqual(new Path(PROJECT_PATH));
+    expect(event.payload.git).toBeUndefined();
   });
 });

--- a/src/main/operations/open-project.ts
+++ b/src/main/operations/open-project.ts
@@ -51,6 +51,10 @@ export const INTENT_OPEN_PROJECT = "project:open" as const;
 
 export interface ProjectOpenedPayload {
   readonly project: Project;
+  /** Original intent path, for idempotency reset. */
+  readonly path?: Path;
+  /** Original intent git URL, for idempotency reset. */
+  readonly git?: string;
 }
 
 export interface ProjectOpenedEvent extends DomainEvent {
@@ -59,6 +63,22 @@ export interface ProjectOpenedEvent extends DomainEvent {
 }
 
 export const EVENT_PROJECT_OPENED = "project:opened" as const;
+
+export interface ProjectOpenFailedPayload {
+  /** Original intent path, for idempotency reset. */
+  readonly path?: Path;
+  /** Original intent git URL, for idempotency reset. */
+  readonly git?: string;
+  /** Reason the open failed (error message or "already-open"). */
+  readonly reason: string;
+}
+
+export interface ProjectOpenFailedEvent extends DomainEvent {
+  readonly type: "project:open-failed";
+  readonly payload: ProjectOpenFailedPayload;
+}
+
+export const EVENT_PROJECT_OPEN_FAILED = "project:open-failed" as const;
 
 // =============================================================================
 // Hook Result & Input Types
@@ -116,6 +136,12 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
   async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project | null> {
     const { intent } = ctx;
 
+    // Intent-origin fields for idempotency reset events
+    const origin = {
+      ...(intent.payload.path !== undefined && { path: intent.payload.path }),
+      ...(intent.payload.git !== undefined && { git: intent.payload.git }),
+    };
+
     // 0. Select folder: when no path or git URL provided, run "select-folder" hook
     let effectiveIntent = intent;
     if (!intent.payload.path && !intent.payload.git) {
@@ -142,133 +168,151 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       };
     }
 
-    // 1. Resolve: clone if URL, validate git, return projectPath + remoteUrl
-    const resolveCtx: HookContext = { intent: effectiveIntent };
-    const { results: resolveResults, errors: resolveErrors } =
-      await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-    if (resolveErrors.length === 1) {
-      throw resolveErrors[0]!;
-    }
-    if (resolveErrors.length > 1) {
-      throw new AggregateError(resolveErrors, "project:open resolve hooks failed");
-    }
-    let projectPath: string | undefined;
-    let resolvedRemoteUrl: string | undefined;
-    let alreadyOpen = false;
-    for (const r of resolveResults) {
-      if (r.projectPath && !projectPath) projectPath = r.projectPath;
-      if (r.remoteUrl !== undefined) resolvedRemoteUrl = r.remoteUrl;
-      if (r.alreadyOpen) alreadyOpen = true;
-    }
-    if (!projectPath) {
-      throw new Error("Resolve hook did not provide projectPath");
-    }
+    try {
+      // 1. Resolve: clone if URL, validate git, return projectPath + remoteUrl
+      const resolveCtx: HookContext = { intent: effectiveIntent };
+      const { results: resolveResults, errors: resolveErrors } =
+        await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+      if (resolveErrors.length === 1) {
+        throw resolveErrors[0]!;
+      }
+      if (resolveErrors.length > 1) {
+        throw new AggregateError(resolveErrors, "project:open resolve hooks failed");
+      }
+      let projectPath: string | undefined;
+      let resolvedRemoteUrl: string | undefined;
+      let alreadyOpen = false;
+      for (const r of resolveResults) {
+        if (r.projectPath && !projectPath) projectPath = r.projectPath;
+        if (r.remoteUrl !== undefined) resolvedRemoteUrl = r.remoteUrl;
+        if (r.alreadyOpen) alreadyOpen = true;
+      }
+      if (!projectPath) {
+        throw new Error("Resolve hook did not provide projectPath");
+      }
 
-    // 2. Register: generate ID, store state, persist
-    const registerCtx: RegisterHookInput = {
-      intent: effectiveIntent,
-      projectPath,
-      ...(resolvedRemoteUrl !== undefined && { remoteUrl: resolvedRemoteUrl }),
-    };
-    const { results: registerResults, errors: registerErrors } =
-      await ctx.hooks.collect<RegisterHookResult>("register", registerCtx);
-    if (registerErrors.length === 1) {
-      throw registerErrors[0]!;
-    }
-    if (registerErrors.length > 1) {
-      throw new AggregateError(registerErrors, "project:open register hooks failed");
-    }
-    let projectId: ProjectId | undefined;
-    let name: string | undefined;
-    for (const r of registerResults) {
-      if (r.projectId) projectId = r.projectId;
-      if (r.name !== undefined) name = r.name;
-      if (r.alreadyOpen) alreadyOpen = true;
-    }
-    if (!projectId) {
-      throw new Error("Register hook did not provide projectId");
-    }
+      // 2. Register: generate ID, store state, persist
+      const registerCtx: RegisterHookInput = {
+        intent: effectiveIntent,
+        projectPath,
+        ...(resolvedRemoteUrl !== undefined && { remoteUrl: resolvedRemoteUrl }),
+      };
+      const { results: registerResults, errors: registerErrors } =
+        await ctx.hooks.collect<RegisterHookResult>("register", registerCtx);
+      if (registerErrors.length === 1) {
+        throw registerErrors[0]!;
+      }
+      if (registerErrors.length > 1) {
+        throw new AggregateError(registerErrors, "project:open register hooks failed");
+      }
+      let projectId: ProjectId | undefined;
+      let name: string | undefined;
+      for (const r of registerResults) {
+        if (r.projectId) projectId = r.projectId;
+        if (r.name !== undefined) name = r.name;
+        if (r.alreadyOpen) alreadyOpen = true;
+      }
+      if (!projectId) {
+        throw new Error("Register hook did not provide projectId");
+      }
 
-    // 3. Discover: find existing workspaces
-    const discoverCtx: DiscoverHookInput = { intent: effectiveIntent, projectPath };
-    const { results: discoverResults, errors: discoverErrors } =
-      await ctx.hooks.collect<DiscoverHookResult>("discover", discoverCtx);
-    if (discoverErrors.length === 1) {
-      throw discoverErrors[0]!;
-    }
-    if (discoverErrors.length > 1) {
-      throw new AggregateError(discoverErrors, "project:open discover hooks failed");
-    }
-    const workspaces: InternalWorkspace[] = [];
-    let defaultBaseBranch: string | undefined;
-    for (const r of discoverResults) {
-      if (r.workspaces) workspaces.push(...r.workspaces);
-      if (r.defaultBaseBranch !== undefined) defaultBaseBranch = r.defaultBaseBranch;
-    }
+      // 3. Discover: find existing workspaces
+      const discoverCtx: DiscoverHookInput = { intent: effectiveIntent, projectPath };
+      const { results: discoverResults, errors: discoverErrors } =
+        await ctx.hooks.collect<DiscoverHookResult>("discover", discoverCtx);
+      if (discoverErrors.length === 1) {
+        throw discoverErrors[0]!;
+      }
+      if (discoverErrors.length > 1) {
+        throw new AggregateError(discoverErrors, "project:open discover hooks failed");
+      }
+      const workspaces: InternalWorkspace[] = [];
+      let defaultBaseBranch: string | undefined;
+      for (const r of discoverResults) {
+        if (r.workspaces) workspaces.push(...r.workspaces);
+        if (r.defaultBaseBranch !== undefined) defaultBaseBranch = r.defaultBaseBranch;
+      }
 
-    // Build Project return value
-    const project: Project = {
-      id: projectId,
-      path: projectPath,
-      name: name ?? new Path(projectPath).basename,
-      workspaces: toIpcWorkspaces(workspaces, projectId),
-      ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
-      ...(resolvedRemoteUrl !== undefined && { remoteUrl: resolvedRemoteUrl }),
-    };
+      // Build Project return value
+      const project: Project = {
+        id: projectId,
+        path: projectPath,
+        name: name ?? new Path(projectPath).basename,
+        workspaces: toIpcWorkspaces(workspaces, projectId),
+        ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+        ...(resolvedRemoteUrl !== undefined && { remoteUrl: resolvedRemoteUrl }),
+      };
 
-    // When already open, register + discover ran (idempotent) but skip side effects
-    if (!alreadyOpen) {
-      // Dispatch workspace:open per discovered workspace (best-effort)
-      for (const workspace of workspaces) {
-        try {
-          const existingWorkspace: ExistingWorkspaceData = {
-            path: workspace.path.toString(),
-            name: workspace.name,
-            branch: workspace.branch,
-            metadata: workspace.metadata,
-          };
+      // When already open, register + discover ran (idempotent) but skip side effects
+      if (!alreadyOpen) {
+        // Dispatch workspace:open per discovered workspace (best-effort)
+        for (const workspace of workspaces) {
+          try {
+            const existingWorkspace: ExistingWorkspaceData = {
+              path: workspace.path.toString(),
+              name: workspace.name,
+              branch: workspace.branch,
+              metadata: workspace.metadata,
+            };
 
-          const openWsIntent: OpenWorkspaceIntent = {
-            type: INTENT_OPEN_WORKSPACE,
+            const openWsIntent: OpenWorkspaceIntent = {
+              type: INTENT_OPEN_WORKSPACE,
+              payload: {
+                workspaceName: workspace.name,
+                base: workspace.metadata.base ?? "",
+                existingWorkspace,
+                projectPath,
+                stealFocus: false,
+              },
+            };
+
+            await ctx.dispatch(openWsIntent);
+          } catch {
+            // Best-effort: individual workspace:open failures don't fail the project open
+          }
+        }
+
+        // Emit project:opened event
+        const event: ProjectOpenedEvent = {
+          type: EVENT_PROJECT_OPENED,
+          payload: { project, ...origin },
+        };
+        ctx.emit(event);
+
+        // Dispatch workspace:switch for the first workspace
+        if (project.workspaces.length > 0) {
+          const firstWorkspace = project.workspaces[0]!;
+          const switchIntent: SwitchWorkspaceIntent = {
+            type: INTENT_SWITCH_WORKSPACE,
             payload: {
-              workspaceName: workspace.name,
-              base: workspace.metadata.base ?? "",
-              existingWorkspace,
-              projectPath,
-              stealFocus: false,
+              workspacePath: firstWorkspace.path,
             },
           };
-
-          await ctx.dispatch(openWsIntent);
-        } catch {
-          // Best-effort: individual workspace:open failures don't fail the project open
+          try {
+            await ctx.dispatch(switchIntent);
+          } catch {
+            // Best-effort: switch failure doesn't fail the project open
+          }
         }
+      } else {
+        // Project already open — emit failed event so idempotency key is released
+        ctx.emit({
+          type: EVENT_PROJECT_OPEN_FAILED,
+          payload: { ...origin, reason: "already-open" },
+        } as ProjectOpenFailedEvent);
       }
 
-      // Emit project:opened event
-      const event: ProjectOpenedEvent = {
-        type: EVENT_PROJECT_OPENED,
-        payload: { project },
-      };
-      ctx.emit(event);
-
-      // Dispatch workspace:switch for the first workspace
-      if (project.workspaces.length > 0) {
-        const firstWorkspace = project.workspaces[0]!;
-        const switchIntent: SwitchWorkspaceIntent = {
-          type: INTENT_SWITCH_WORKSPACE,
-          payload: {
-            workspacePath: firstWorkspace.path,
-          },
-        };
-        try {
-          await ctx.dispatch(switchIntent);
-        } catch {
-          // Best-effort: switch failure doesn't fail the project open
-        }
-      }
+      return project;
+    } catch (e) {
+      // Emit failed event so idempotency key is released on error
+      ctx.emit({
+        type: EVENT_PROJECT_OPEN_FAILED,
+        payload: {
+          ...origin,
+          reason: e instanceof Error ? e.message : String(e),
+        },
+      } as ProjectOpenFailedEvent);
+      throw e;
     }
-
-    return project;
   }
 }


### PR DESCRIPTION
- Replace ad-hoc `inProgressOpens` Set in IPC bridge with a per-key idempotency rule on `INTENT_OPEN_PROJECT`
- Extend `IdempotencyRule.resetOn` to accept `string | readonly string[]`
- Extend `IdempotencyRule.getKey` to return `string | undefined` (undefined skips the rule)
- Add `EVENT_PROJECT_OPEN_FAILED` domain event so the idempotency key resets on both success and error paths
- Add intent-origin fields (`path`, `git`) to `ProjectOpenedPayload` for idempotency reset
- Simplify bridge handlers to use `handle.accepted` for dedup detection