### PR TITLE
fix: VSCode editor was not working on first workspace creation

### DIFF
--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -233,25 +233,6 @@ describe("ViewManager", () => {
       expect(handle.__brand).toBe("ViewHandle");
     });
 
-    it("registers dom-ready handler that disables EditContext", () => {
-      const deps = createViewManagerDeps();
-      const manager = createViewManager(deps);
-
-      const wsHandle = manager.createWorkspaceView(
-        "/path/to/workspace",
-        "http://127.0.0.1:8080/?folder=/path",
-        "/path/to/project"
-      );
-
-      // Spy on executeJavaScript to verify it's called on dom-ready
-      const executeJsSpy = vi.spyOn(deps.viewLayer, "executeJavaScript");
-
-      // Trigger dom-ready event on the workspace view
-      deps.viewLayer.$.triggerDomReady(wsHandle);
-
-      expect(executeJsSpy).toHaveBeenCalledWith(wsHandle, "delete globalThis.EditContext");
-    });
-
     it("loads URL on first activation", () => {
       const deps = createViewManagerDeps();
       const manager = createViewManager(deps);
@@ -301,9 +282,10 @@ describe("ViewManager", () => {
   });
 
   describe("preloadWorkspaceUrl", () => {
-    it("loads URL without attaching view", () => {
+    it("attaches view at z-index 0 during load", () => {
       const deps = createViewManagerDeps();
       const manager = createViewManager(deps);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -313,10 +295,10 @@ describe("ViewManager", () => {
 
       manager.preloadWorkspaceUrl("/path/to/workspace");
 
-      // URL should be loaded but still not attached
+      // URL should be loaded, view attached at z-0 (stays attached until activated)
       expect(deps.viewLayer).toHaveView(wsHandle.id, {
         url: "http://127.0.0.1:8080/?folder=/path",
-        attachedTo: null,
+        attachedTo: windowId,
       });
     });
 
@@ -970,6 +952,7 @@ describe("ViewManager", () => {
     it("attaches view if workspace is active", () => {
       const deps = createViewManagerDeps();
       const manager = createViewManager(deps);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
 
       const wsHandle = manager.createWorkspaceView(
         "/path/to/workspace",
@@ -978,16 +961,17 @@ describe("ViewManager", () => {
         true // isNew - starts loading
       );
 
-      // Activate (won't attach because loading)
+      // Activate triggers loadViewUrl (attaches at z-0 for rAF)
       manager.setActiveWorkspace("/path/to/workspace");
 
-      expect(deps.viewLayer).toHaveView(wsHandle.id, { attachedTo: null }); // Not attached during loading
+      // View is attached at z-0 during initialization
+      expect(deps.viewLayer).toHaveView(wsHandle.id, { attachedTo: windowId });
 
-      // Mark as loaded
+      // Mark as loaded → re-attaches on top
       manager.setWorkspaceLoaded("/path/to/workspace");
 
       expect(deps.viewLayer).toHaveView(wsHandle.id, {
-        attachedTo: deps.windowLayer._createdWindowHandle.id,
+        attachedTo: windowId,
       });
     });
 
@@ -1008,6 +992,51 @@ describe("ViewManager", () => {
         manager.setWorkspaceLoaded("/path/to/workspace");
         manager.setWorkspaceLoaded("/path/to/workspace");
       }).not.toThrow();
+    });
+
+    it("attaches view at z-index 0 before URL load", () => {
+      const deps = createViewManagerDeps();
+      const manager = createViewManager(deps);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
+
+      const wsHandle = manager.createWorkspaceView(
+        "/path/to/workspace",
+        "http://127.0.0.1:8080/?folder=/path",
+        "/path/to/project",
+        true // isNew
+      );
+
+      // Activate triggers loadViewUrl
+      manager.setActiveWorkspace("/path/to/workspace");
+
+      // View should be attached (at z-index 0, behind UI layer)
+      const children = deps.viewLayer.$.windowChildren.get(windowId);
+      expect(children).toContain(wsHandle.id);
+
+      // Minimal bounds (1x1) to avoid white flash while still enabling rAF
+      expect(deps.viewLayer).toHaveView(wsHandle.id, {
+        bounds: { x: 0, y: 0, width: 1, height: 1 },
+      });
+    });
+
+    it("detaches inactive view when workspace finishes loading", () => {
+      const deps = createViewManagerDeps();
+      const manager = createViewManager(deps);
+
+      const wsHandle = manager.createWorkspaceView(
+        "/path/to/workspace",
+        "http://127.0.0.1:8080/?folder=/path",
+        "/path/to/project",
+        true // isNew
+      );
+
+      // Preload (not activate) — view attached at z-0
+      manager.preloadWorkspaceUrl("/path/to/workspace");
+
+      // Mark as loaded — inactive workspace should be detached
+      manager.setWorkspaceLoaded("/path/to/workspace");
+
+      expect(deps.viewLayer).toHaveView(wsHandle.id, { attachedTo: null });
     });
   });
 

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -354,14 +354,6 @@ export class ViewManager implements IViewManager {
       return true; // Allow navigation within code-server
     });
 
-    // Disable EditContext API before VS Code editor initializes.
-    // EditContext (Chromium 121+) is incompatible with code-server's web context,
-    // causing the editor to ignore all keyboard input. Removing it from the JS
-    // context at dom-ready ensures VS Code falls back to the legacy input method.
-    this.viewLayer.onDomReady(viewHandle, () => {
-      void this.viewLayer.executeJavaScript(viewHandle, "delete globalThis.EditContext");
-    });
-
     // Store workspace state
     this.workspaceStates.set(workspacePath, {
       handle: viewHandle,
@@ -500,8 +492,12 @@ export class ViewManager implements IViewManager {
       height,
     });
 
-    // Only update active workspace bounds (O(1) - inactive views are detached)
-    if (this.activeWorkspacePath !== null) {
+    // Only update active workspace bounds (O(1) - inactive views are detached).
+    // Skip loading workspaces: they're at z-0 with 1x1 bounds.
+    if (
+      this.activeWorkspacePath !== null &&
+      !this.loadingWorkspaces.has(this.activeWorkspacePath)
+    ) {
       const state = this.workspaceStates.get(this.activeWorkspacePath);
       if (state) {
         this.viewLayer.setBounds(state.handle, {
@@ -532,6 +528,20 @@ export class ViewManager implements IViewManager {
 
     const workspaceName = basename(workspacePath);
     this.logger.info("Loading URL", { workspace: workspaceName, url: state.url });
+
+    // Attach at z-index 0 (behind UI layer) so requestAnimationFrame fires
+    // during VS Code initialization (code-server 4.109+ workaround).
+    try {
+      if (!this.windowLayer.isDestroyed(this.windowHandle)) {
+        this.viewLayer.attachToWindow(state.handle, this.windowHandle);
+        // Use minimal bounds so the view is invisible at z-0 (prevents white
+        // flash from code-server's HTML rendering before CSS loads). The 1x1
+        // surface is enough for Chromium's compositor to fire rAF callbacks.
+        this.viewLayer.setBounds(state.handle, { x: 0, y: 0, width: 1, height: 1 });
+      }
+    } catch {
+      // Window may be closing
+    }
 
     // Load the URL (fire-and-forget)
     void this.viewLayer.loadURL(state.handle, state.url);
@@ -877,6 +887,7 @@ export class ViewManager implements IViewManager {
     // If this workspace is active, attach the view and focus it
     if (this.activeWorkspacePath === workspacePath) {
       this.attachView(workspacePath);
+      this.updateBounds();
 
       // Maintain z-order if in dialog, shortcut, or hover mode
       // (UI must stay on top of workspace views)
@@ -912,6 +923,9 @@ export class ViewManager implements IViewManager {
           this.viewLayer.focus(state.handle);
         }
       }
+    } else {
+      // Inactive workspace: detach the z-0 temporary attachment from loadViewUrl()
+      this.detachView(workspacePath);
     }
 
     const workspaceName = basename(workspacePath);


### PR DESCRIPTION
- Attach WebContentsView at z-index 0 with 1×1 bounds during URL load so Chromium's compositor fires requestAnimationFrame callbacks
- VS Code 1.109+ uses rAF to initialize NativeEditContext/TextAreaEditContext; detached views never fire rAF, breaking editor input on first creation
- Remove the `delete globalThis.EditContext` workaround since proper rAF initialization makes it unnecessary
- Detach inactive views after loading completes to maintain existing behavior
- Skip `updateBounds()` for loading workspaces to preserve the 1×1 temporary bounds