### PR TITLE
refactor(delete): replace retry loop with blockingPids-based retry dispatch

### DIFF
--- a/src/main/api/registry-types.ts
+++ b/src/main/api/registry-types.ts
@@ -66,6 +66,8 @@ export interface WorkspaceRemovePayload {
   readonly skipSwitch?: boolean;
   /** If true, force remove (skip cleanup, ignore errors). Replaces old forceRemove. */
   readonly force?: boolean;
+  /** PIDs from a previous failed attempt. Flush hook kills these before re-attempting delete. */
+  readonly blockingPids?: readonly number[];
 }
 
 /** workspaces.getStatus, workspaces.getAgentSession, workspaces.getMetadata, workspaces.restartAgentServer */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -141,6 +141,7 @@ import {
   DeleteWorkspaceOperation,
   INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETED,
+  EVENT_WORKSPACE_DELETE_FAILED,
 } from "./operations/delete-workspace";
 import type { DeleteWorkspaceIntent, DeleteWorkspacePayload } from "./operations/delete-workspace";
 import {
@@ -410,7 +411,7 @@ const idempotencyModule = createIdempotencyModule([
       const { workspacePath } = p as DeleteWorkspacePayload;
       return workspacePath;
     },
-    resetOn: EVENT_WORKSPACE_DELETED,
+    resetOn: [EVENT_WORKSPACE_DELETED, EVENT_WORKSPACE_DELETE_FAILED],
     isForced: (intent) => (intent as DeleteWorkspaceIntent).payload.force,
   },
   {
@@ -599,8 +600,7 @@ dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
 dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
 
-const deleteOp = new DeleteWorkspaceOperation();
-dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOp);
+dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
 
 dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
 dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
@@ -624,7 +624,6 @@ const ipcEventBridge = createIpcEventBridge({
   dispatcher,
   agentStatusManager,
   globalWorktreeProvider,
-  deleteOp,
 });
 
 // 10. Register all modules + get API interface

--- a/src/main/intents/infrastructure/idempotency-module.integration.test.ts
+++ b/src/main/intents/infrastructure/idempotency-module.integration.test.ts
@@ -283,4 +283,38 @@ describe("createIdempotencyModule", () => {
       await dispatcher.dispatch({ type: "test:delete", payload: { path: "/x" } }).accepted
     ).toBe(false);
   });
+
+  it("per-key with resetOn array: any listed event resets the key", async () => {
+    const { dispatcher } = setup([
+      {
+        intentType: "test:delete",
+        getKey: (p) => (p as { path: string }).path,
+        resetOn: ["test:deleted", "test:delete-failed"],
+      },
+    ]);
+
+    let emitFn: ((event: DomainEvent) => void) | undefined;
+    dispatcher.registerOperation("test:delete", {
+      id: "delete-op",
+      execute: async (ctx: OperationContext<Intent>) => {
+        emitFn = ctx.emit;
+      },
+    });
+
+    // Dispatch /a (tracked)
+    await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } });
+
+    // Blocked
+    expect(
+      await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } }).accepted
+    ).toBe(false);
+
+    // Reset via second event type (delete-failed)
+    emitFn!({ type: "test:delete-failed", payload: { path: "/a" } });
+
+    // Now unblocked
+    expect(
+      await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } }).accepted
+    ).toBe(true);
+  });
 });

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -192,11 +192,6 @@ function createStatusTestSetup(): StatusTestSetup {
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-    deleteOp: {
-      hasPendingRetry: vi.fn().mockReturnValue(false),
-      signalDismiss: vi.fn(),
-      signalRetry: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["deleteOp"],
   });
   const resolveModule = createMockResolveModule();
 
@@ -266,11 +261,6 @@ function createLifecycleTestSetup(
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-    deleteOp: {
-      hasPendingRetry: vi.fn().mockReturnValue(false),
-      signalDismiss: vi.fn(),
-      signalRetry: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["deleteOp"],
   });
 
   // Wire quit module to prevent app.quit() error on shutdown
@@ -454,11 +444,6 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["deleteOp"],
     });
 
     const progressPayload = {
@@ -507,11 +492,6 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["deleteOp"],
     });
 
     // Should not throw when sendToUI is a no-op
@@ -605,11 +585,6 @@ describe("IpcEventBridge - lifecycle", () => {
         globalWorktreeProvider: {
           listWorktrees: vi.fn(),
         } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-        deleteOp: {
-          hasPendingRetry: vi.fn().mockReturnValue(false),
-          signalDismiss: vi.fn(),
-          signalRetry: vi.fn(),
-        } as unknown as IpcEventBridgeDeps["deleteOp"],
       });
 
       const quitModule: IntentModule = {
@@ -678,11 +653,6 @@ describe("IpcEventBridge - lifecycle", () => {
         globalWorktreeProvider: {
           listWorktrees: vi.fn(),
         } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-        deleteOp: {
-          hasPendingRetry: vi.fn().mockReturnValue(false),
-          signalDismiss: vi.fn(),
-          signalRetry: vi.fn(),
-        } as unknown as IpcEventBridgeDeps["deleteOp"],
       });
 
       const quitModule: IntentModule = {
@@ -752,11 +722,6 @@ describe("IpcEventBridge - setup:error", () => {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["deleteOp"],
     });
 
     // Hook module that throws to trigger the setup:error domain event
@@ -818,11 +783,6 @@ describe("IpcEventBridge - setup:error", () => {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["deleteOp"],
     });
 
     const errorWithCode = Object.assign(new Error("Network timeout"), { code: "ETIMEDOUT" });
@@ -879,11 +839,6 @@ function createApiTestSetup(overrides?: { pluginServer?: IpcEventBridgeDeps["plu
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
-    deleteOp: {
-      hasPendingRetry: vi.fn().mockReturnValue(false),
-      signalDismiss: vi.fn(),
-      signalRetry: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["deleteOp"],
   });
 
   dispatcher.registerModule(ipcEventBridge);

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -103,11 +103,6 @@ export interface IpcEventBridgeDeps {
     getStatus(wp: WorkspacePath): { status: string } | undefined;
   };
   readonly globalWorktreeProvider: GitWorktreeProvider;
-  readonly deleteOp: {
-    hasPendingRetry(wp: string): boolean;
-    signalDismiss(wp: string): void;
-    signalRetry(wp: string): void;
-  };
 }
 
 /**
@@ -278,17 +273,6 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
   apiRegistry.register(
     "workspaces.remove",
     async (payload: WorkspaceRemovePayload) => {
-      // If pipeline is waiting for user choice, signal it instead of dispatching new intent.
-      if (deps.deleteOp.hasPendingRetry(payload.workspacePath)) {
-        if (payload.force) {
-          deps.deleteOp.signalDismiss(payload.workspacePath);
-          // Fall through to dispatch force intent after pipeline exits
-        } else {
-          deps.deleteOp.signalRetry(payload.workspacePath);
-          return { started: true };
-        }
-      }
-
       const intent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
@@ -297,6 +281,7 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
           force: payload.force ?? false,
           removeWorktree: true,
           ...(payload.skipSwitch !== undefined && { skipSwitch: payload.skipSwitch }),
+          ...(payload.blockingPids !== undefined && { blockingPids: payload.blockingPids }),
         },
       };
 

--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -2,9 +2,10 @@
  * Integration tests for DeleteWorkspaceOperation.
  *
  * Tests the full delete-workspace pipeline through dispatcher.dispatch():
- * - Operation orchestrates hooks (shutdown -> release -> delete)
- * - On delete failure: detect -> emit -> wait -> flush -> delete (retry loop)
- * - Interceptor enforces idempotency (per-workspace)
+ * - Operation orchestrates hooks (shutdown -> release -> [flush] -> delete)
+ * - On delete failure: detect -> emit delete-failed -> return
+ * - On retry: blockingPids in payload -> flush -> delete
+ * - Interceptor enforces idempotency (per-workspace), reset by deleted/delete-failed events
  * - Event subscribers update state and emit IPC events
  * - Progress callback captures DeletionProgress objects
  *
@@ -23,9 +24,14 @@ import {
   DELETE_WORKSPACE_OPERATION_ID,
   INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETED,
+  EVENT_WORKSPACE_DELETE_FAILED,
   EVENT_WORKSPACE_DELETION_PROGRESS,
 } from "./delete-workspace";
-import type { WorkspaceDeletedEvent, WorkspaceDeletionProgressEvent } from "./delete-workspace";
+import type {
+  WorkspaceDeletedEvent,
+  WorkspaceDeleteFailedEvent,
+  WorkspaceDeletionProgressEvent,
+} from "./delete-workspace";
 import type {
   DeleteWorkspaceIntent,
   ShutdownHookResult,
@@ -318,7 +324,6 @@ function createTestWorkspaceFileService(): IWorkspaceFileService {
 
 interface TestHarness {
   dispatcher: Dispatcher;
-  deleteOp: DeleteWorkspaceOperation;
   progressCaptures: DeletionProgress[];
   appState: MockAppState;
   testState: TestAppState;
@@ -375,8 +380,7 @@ function createTestHarness(options?: {
   // Register operations
   dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-  const deleteOp = new DeleteWorkspaceOperation();
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOp);
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
   dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 
@@ -412,6 +416,10 @@ function createTestHarness(options?: {
     events: {
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceDeletedEvent).payload;
+        inProgressDeletions.delete(payload.workspacePath);
+      },
+      [EVENT_WORKSPACE_DELETE_FAILED]: (event: DomainEvent) => {
+        const payload = (event as WorkspaceDeleteFailedEvent).payload;
         inProgressDeletions.delete(payload.workspacePath);
       },
     },
@@ -823,7 +831,6 @@ function createTestHarness(options?: {
 
   return {
     dispatcher,
-    deleteOp,
     progressCaptures,
     appState,
     testState,
@@ -1031,7 +1038,7 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     expect(finalProgress.blockingProcesses).toBeUndefined();
   });
 
-  it("test 22: delete fails → detect finds blockers → progress shows process list → signal retry → flush kills PIDs → delete succeeds", async () => {
+  it("test 22: delete fails → detect finds blockers → progress shows blockers → returns failure → retry with blockingPids → flush → delete succeeds", async () => {
     const blockingProcesses: BlockingProcess[] = [
       { pid: 5678, name: "node.exe", commandLine: "node server.js", files: ["file.txt"], cwd: "." },
     ];
@@ -1055,18 +1062,12 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     };
 
     const harness = createTestHarness({ workspaceLockHandler });
-    // Override the worktree module's provider
     harness.globalProviderMock.globalProvider.removeWorkspace = globalProvider.removeWorkspace;
 
+    // First attempt: fails, detects blockers, returns
     const intent = buildDeleteIntent();
-
-    // Start deletion (will block at waitForRetryChoice)
-    const dispatchPromise = harness.dispatcher.dispatch(intent);
-
-    // Wait for the pipeline to reach the retry wait
-    await vi.waitFor(() => {
-      expect(harness.deleteOp.hasPendingRetry(WORKSPACE_PATH)).toBe(true);
-    });
+    const result1 = await harness.dispatcher.dispatch(intent);
+    expect(result1).toEqual({ started: true });
 
     // Verify progress shows blocking processes
     const progressWithBlockers = harness.progressCaptures.find(
@@ -1077,17 +1078,18 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     expect(progressWithBlockers!.completed).toBe(true);
     expect(progressWithBlockers!.hasErrors).toBe(true);
 
-    // Verify detecting-blockers operation in progress
+    // Verify detecting-blockers operation
     const detectOp = progressWithBlockers!.operations.find((op) => op.id === "detecting-blockers");
     expect(detectOp).toBeDefined();
     expect(detectOp!.status).toBe("error");
 
-    // Signal retry
-    harness.deleteOp.signalRetry(WORKSPACE_PATH);
+    // Idempotency reset by workspace:delete-failed event
+    expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
 
-    // Wait for completion
-    const result = await dispatchPromise;
-    expect(result).toEqual({ started: true });
+    // Retry with blockingPids
+    const retryIntent = buildDeleteIntent({ blockingPids: [5678] });
+    const result2 = await harness.dispatcher.dispatch(retryIntent);
+    expect(result2).toEqual({ started: true });
 
     // Flush killed the PIDs
     expect(workspaceLockHandler.killProcesses).toHaveBeenCalledWith([5678]);
@@ -1101,7 +1103,7 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     expect(finalProgress.hasErrors).toBe(false);
   });
 
-  it("test 23: delete fails → detect → signal dismiss → pipeline exits with hasErrors", async () => {
+  it("test 23: delete fails → detect finds blockers → pipeline exits with hasErrors, no workspace:deleted emitted", async () => {
     const blockingProcesses: BlockingProcess[] = [
       { pid: 9999, name: "code.exe", commandLine: "code .", files: ["file.txt"], cwd: null },
     ];
@@ -1119,18 +1121,7 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     });
     const intent = buildDeleteIntent();
 
-    // Start deletion
-    const dispatchPromise = harness.dispatcher.dispatch(intent);
-
-    // Wait for retry prompt
-    await vi.waitFor(() => {
-      expect(harness.deleteOp.hasPendingRetry(WORKSPACE_PATH)).toBe(true);
-    });
-
-    // Signal dismiss
-    harness.deleteOp.signalDismiss(WORKSPACE_PATH);
-
-    const result = await dispatchPromise;
+    const result = await harness.dispatcher.dispatch(intent);
     expect(result).toEqual({ started: true });
 
     // Workspace should NOT be removed from state (no workspace:deleted event)
@@ -1139,9 +1130,19 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     // No IPC workspace:removed event
     const ipcEvent = harness.emittedEvents.find((e) => e.event === "workspace:removed");
     expect(ipcEvent).toBeUndefined();
+
+    // Idempotency was reset by delete-failed event (allows retry)
+    expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
+
+    // Progress shows blockers
+    const progressWithBlockers = harness.progressCaptures.find(
+      (p) => p.blockingProcesses && p.blockingProcesses.length > 0
+    );
+    expect(progressWithBlockers).toBeDefined();
+    expect(progressWithBlockers!.blockingProcesses![0]!.pid).toBe(9999);
   });
 
-  it("test 24: multiple retry loop: detect → retry → flush → delete(fails) → detect → retry → flush → delete(succeeds)", async () => {
+  it("test 24: multiple retry dispatches: first fails → retry with PIDs fails → retry again → succeeds", async () => {
     const blockingProcesses: BlockingProcess[] = [
       { pid: 1111, name: "node.exe", commandLine: "node", files: ["a.js"], cwd: null },
     ];
@@ -1167,24 +1168,21 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     const harness = createTestHarness({ workspaceLockHandler });
     harness.globalProviderMock.globalProvider.removeWorkspace = globalProvider.removeWorkspace;
 
-    const intent = buildDeleteIntent();
-    const dispatchPromise = harness.dispatcher.dispatch(intent);
+    // First attempt: fails
+    const result1 = await harness.dispatcher.dispatch(buildDeleteIntent());
+    expect(result1).toEqual({ started: true });
+    expect(deleteAttempts).toBe(1);
+    expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
 
-    // First retry cycle
-    await vi.waitFor(() => {
-      expect(harness.deleteOp.hasPendingRetry(WORKSPACE_PATH)).toBe(true);
-    });
-    harness.deleteOp.signalRetry(WORKSPACE_PATH);
+    // Second attempt (retry with PIDs): also fails
+    const result2 = await harness.dispatcher.dispatch(buildDeleteIntent({ blockingPids: [1111] }));
+    expect(result2).toEqual({ started: true });
+    expect(deleteAttempts).toBe(2);
+    expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
 
-    // Second retry cycle (second delete also fails)
-    await vi.waitFor(() => {
-      expect(harness.deleteOp.hasPendingRetry(WORKSPACE_PATH)).toBe(true);
-    });
-    harness.deleteOp.signalRetry(WORKSPACE_PATH);
-
-    // Third delete succeeds
-    const result = await dispatchPromise;
-    expect(result).toEqual({ started: true });
+    // Third attempt: succeeds
+    const result3 = await harness.dispatcher.dispatch(buildDeleteIntent({ blockingPids: [1111] }));
+    expect(result3).toEqual({ started: true });
     expect(deleteAttempts).toBe(3);
 
     // Final progress: success
@@ -1304,7 +1302,7 @@ describe("DeleteWorkspaceOperation.inProgressSpinner", () => {
     );
   });
 
-  it("test 26: retry loop emits in-progress for detecting-blockers, killing-blockers, and cleanup-workspace", async () => {
+  it("test 26: first attempt emits detecting-blockers in-progress; retry with blockingPids emits killing-blockers in-progress", async () => {
     const blockingProcesses: BlockingProcess[] = [
       { pid: 4444, name: "node.exe", commandLine: "node", files: ["f.js"], cwd: null },
     ];
@@ -1329,35 +1327,26 @@ describe("DeleteWorkspaceOperation.inProgressSpinner", () => {
     const harness = createTestHarness({ workspaceLockHandler });
     harness.globalProviderMock.globalProvider.removeWorkspace = globalProvider.removeWorkspace;
 
-    const intent = buildDeleteIntent();
-    const dispatchPromise = harness.dispatcher.dispatch(intent);
+    // First attempt: fails, detect runs
+    await harness.dispatcher.dispatch(buildDeleteIntent());
 
-    await vi.waitFor(() => {
-      expect(harness.deleteOp.hasPendingRetry(WORKSPACE_PATH)).toBe(true);
-    });
-
-    // Before user choice: should have emitted detecting-blockers as in-progress
+    // Should have emitted detecting-blockers as in-progress
     const detectInProgress = harness.progressCaptures.find(
       (p) => p.operations.find((op) => op.id === "detecting-blockers")?.status === "in-progress"
     );
     expect(detectInProgress).toBeDefined();
 
-    harness.deleteOp.signalRetry(WORKSPACE_PATH);
-    await dispatchPromise;
+    // Clear captures for retry
+    harness.progressCaptures.length = 0;
 
-    // After retry: should have emitted killing-blockers as in-progress
+    // Retry with blockingPids
+    await harness.dispatcher.dispatch(buildDeleteIntent({ blockingPids: [4444] }));
+
+    // Should have emitted killing-blockers as in-progress
     const flushInProgress = harness.progressCaptures.find(
       (p) => p.operations.find((op) => op.id === "killing-blockers")?.status === "in-progress"
     );
     expect(flushInProgress).toBeDefined();
-
-    // After retry: should have emitted cleanup-workspace as in-progress (retry delete)
-    const retryDeleteInProgress = harness.progressCaptures.find(
-      (p) =>
-        p.operations.some((op) => op.id === "killing-blockers") &&
-        p.operations.find((op) => op.id === "cleanup-workspace")?.status === "in-progress"
-    );
-    expect(retryDeleteInProgress).toBeDefined();
   });
 });
 

--- a/src/main/operations/delete-workspace.ts
+++ b/src/main/operations/delete-workspace.ts
@@ -6,17 +6,19 @@
  * 2. Dispatch project:resolve — resolves projectPath to projectId
  * 3. "shutdown" hook — ViewModule (switch + destroy view), AgentModule (kill terminals, stop server, clear MCP/TUI)
  * 4. "release" hook — WindowsLockModule (detect CWD + kill) [Windows-only]
- * 5. "delete" hook — WorktreeModule (remove git worktree), CodeServerModule (delete .code-workspace file)
+ * 5. If blockingPids provided (retry): "flush" hook — kill provided PIDs
+ * 6. "delete" hook — WorktreeModule (remove git worktree), CodeServerModule (delete .code-workspace file)
  *
- * If delete fails (and not force), enters a retry loop:
- * 6. "detect" — Full blocking process detection (RM + CWD + handles)
- * 7. Emit progress with blockers, wait for user choice (Kill & Retry or Dismiss)
- * 8. "flush" — Kill collected PIDs
- * 9. "delete" — Re-attempt
- * Loop back to 6 if delete fails again.
+ * If delete fails (and not force):
+ * 7. "detect" — Full blocking process detection (RM + CWD + handles)
+ * 8. Emit progress with blockers, emit workspace:delete-failed, return
+ *
+ * On retry, the UI dispatches a new intent with blockingPids from the previous failure.
+ * The flush hook kills those PIDs before re-attempting delete.
  *
  * Each handler returns a typed result; the operation merges results and tracks errors.
  * On success (or force=true), emits a workspace:deleted domain event for state cleanup.
+ * On failure, emits workspace:delete-failed to reset idempotency for retry.
  *
  * No provider dependencies - hook handlers do the actual work.
  */
@@ -49,6 +51,8 @@ export interface DeleteWorkspacePayload {
   /** Whether to remove the git worktree. true = full pipeline, false = shutdown only (runtime teardown). */
   readonly removeWorktree: boolean;
   readonly skipSwitch?: boolean;
+  /** PIDs from a previous failed attempt. When present, flush hook kills these before delete. */
+  readonly blockingPids?: readonly number[];
 }
 
 export interface DeleteWorkspaceIntent extends Intent<{ started: true }> {
@@ -75,6 +79,17 @@ export interface WorkspaceDeletedEvent extends DomainEvent {
 }
 
 export const EVENT_WORKSPACE_DELETED = "workspace:deleted" as const;
+
+export const EVENT_WORKSPACE_DELETE_FAILED = "workspace:delete-failed" as const;
+
+export interface WorkspaceDeleteFailedPayload {
+  readonly workspacePath: string;
+}
+
+export interface WorkspaceDeleteFailedEvent extends DomainEvent {
+  readonly type: typeof EVENT_WORKSPACE_DELETE_FAILED;
+  readonly payload: WorkspaceDeleteFailedPayload;
+}
 
 export const EVENT_WORKSPACE_DELETION_PROGRESS = "workspace:deletion-progress" as const;
 
@@ -293,42 +308,6 @@ export class DeleteWorkspaceOperation implements Operation<
 > {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
 
-  /** Pending retry resolvers keyed by workspace path. */
-  private readonly retryResolvers = new Map<string, (choice: "retry" | "dismiss") => void>();
-
-  /**
-   * Wait for user choice (Kill & Retry or Dismiss) for a workspace.
-   * Resolves when signalRetry or signalDismiss is called.
-   */
-  waitForRetryChoice(wsPath: string): Promise<"retry" | "dismiss"> {
-    return new Promise<"retry" | "dismiss">((resolve) => {
-      this.retryResolvers.set(wsPath, resolve);
-    });
-  }
-
-  /** Signal that the user chose Kill & Retry. */
-  signalRetry(wsPath: string): void {
-    const resolver = this.retryResolvers.get(wsPath);
-    if (resolver) {
-      this.retryResolvers.delete(wsPath);
-      resolver("retry");
-    }
-  }
-
-  /** Signal that the user chose Dismiss. */
-  signalDismiss(wsPath: string): void {
-    const resolver = this.retryResolvers.get(wsPath);
-    if (resolver) {
-      this.retryResolvers.delete(wsPath);
-      resolver("dismiss");
-    }
-  }
-
-  /** Check if a workspace has a pending retry choice. */
-  hasPendingRetry(wsPath: string): boolean {
-    return this.retryResolvers.has(wsPath);
-  }
-
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
     const { payload } = ctx.intent;
 
@@ -359,8 +338,14 @@ export class DeleteWorkspaceOperation implements Operation<
     } else {
       const result = await this.runPipeline(ctx, ctx.emit);
 
-      // Normal mode: only emit if no errors
-      if (!result.hasErrors) {
+      if (result.hasErrors) {
+        // Emit delete-failed to reset idempotency, allowing retry dispatch
+        const failedEvent: WorkspaceDeleteFailedEvent = {
+          type: EVENT_WORKSPACE_DELETE_FAILED,
+          payload: { workspacePath: payload.workspacePath },
+        };
+        ctx.emit(failedEvent);
+      } else {
         emitEvent(result.identity);
       }
     }
@@ -451,6 +436,27 @@ export class DeleteWorkspaceOperation implements Operation<
       "cleanup-workspace"
     );
 
+    // --- Flush (kill provided PIDs from previous attempt) ---
+    let flush: MergedFlush | undefined;
+    if (payload.blockingPids && payload.blockingPids.length > 0) {
+      this.emitPipelineProgress(
+        emit,
+        identity,
+        payload,
+        { shutdown, release },
+        false,
+        false,
+        "killing-blockers"
+      );
+      const flushCtx: FlushHookInput = {
+        ...pipelineCtx,
+        blockingPids: payload.blockingPids,
+      };
+      const { results: flushResults, errors: flushCollectErrors } =
+        await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);
+      flush = mergeFlush(flushResults, flushCollectErrors);
+    }
+
     // --- Delete ---
     const { results: deleteResults, errors: deleteCollectErrors } =
       await ctx.hooks.collect<DeleteHookResult>("delete", pipelineCtx);
@@ -459,7 +465,14 @@ export class DeleteWorkspaceOperation implements Operation<
     const deleteFailed = del.errors.length > 0;
     if (!deleteFailed) {
       // Success
-      this.emitPipelineProgress(emit, identity, payload, { shutdown, release, del }, true, false);
+      this.emitPipelineProgress(
+        emit,
+        identity,
+        payload,
+        { shutdown, release, del, ...(flush && { flush }) },
+        true,
+        false
+      );
       return { hasErrors: false, identity };
     }
 
@@ -477,96 +490,30 @@ export class DeleteWorkspaceOperation implements Operation<
       return { hasErrors, identity };
     }
 
-    // --- Retry loop: detect → emit → wait → flush → delete ---
-    let currentDel = del;
-    for (;;) {
-      // Detect
-      this.emitPipelineProgress(
-        emit,
-        identity,
-        payload,
-        { shutdown, release, del: currentDel },
-        false,
-        false,
-        "detecting-blockers"
-      );
-      const { results: detectResults, errors: detectCollectErrors } =
-        await ctx.hooks.collect<DetectHookResult>("detect", pipelineCtx);
-      const detect = mergeDetect(detectResults, detectCollectErrors);
+    // --- Detect blockers (full scan after failure) ---
+    this.emitPipelineProgress(
+      emit,
+      identity,
+      payload,
+      { shutdown, release, del },
+      false,
+      false,
+      "detecting-blockers"
+    );
+    const { results: detectResults, errors: detectCollectErrors } =
+      await ctx.hooks.collect<DetectHookResult>("detect", pipelineCtx);
+    const detect = mergeDetect(detectResults, detectCollectErrors);
 
-      // Emit progress with blockers and wait for user choice
-      this.emitPipelineProgress(
-        emit,
-        identity,
-        payload,
-        { shutdown, release, del: currentDel, detect },
-        true,
-        true
-      );
-
-      const choice = await this.waitForRetryChoice(payload.workspacePath);
-      if (choice === "dismiss") {
-        return { hasErrors: true, identity };
-      }
-
-      // Flush (kill collected PIDs)
-      this.emitPipelineProgress(
-        emit,
-        identity,
-        payload,
-        { shutdown, release, del: currentDel, detect },
-        false,
-        false,
-        "killing-blockers"
-      );
-      const blockingPids = detect.blockingProcesses?.map((p) => p.pid) ?? [];
-      const flushCtx: FlushHookInput = {
-        ...pipelineCtx,
-        blockingPids,
-      };
-      const { results: flushResults, errors: flushCollectErrors } =
-        await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);
-      const flush = mergeFlush(flushResults, flushCollectErrors);
-
-      // Emit progress showing kill completed
-      this.emitPipelineProgress(emit, identity, payload, {
-        shutdown,
-        release,
-        del: currentDel,
-        detect,
-        flush,
-      });
-
-      // Re-attempt delete
-      this.emitPipelineProgress(
-        emit,
-        identity,
-        payload,
-        { shutdown, release, del: currentDel, detect, flush },
-        false,
-        false,
-        "cleanup-workspace"
-      );
-      const { results: retryDeleteResults, errors: retryDeleteCollectErrors } =
-        await ctx.hooks.collect<DeleteHookResult>("delete", pipelineCtx);
-      const retryDel = mergeDelete(retryDeleteResults, retryDeleteCollectErrors);
-
-      if (retryDel.errors.length === 0) {
-        // Success
-        this.emitPipelineProgress(
-          emit,
-          identity,
-          payload,
-          { shutdown, release, del: retryDel },
-          true,
-          false
-        );
-        return { hasErrors: false, identity };
-      }
-
-      // Still failing — loop back to detect
-      currentDel = retryDel;
-    }
+    // Emit progress with blockers and return failure
+    this.emitPipelineProgress(
+      emit,
+      identity,
+      payload,
+      { shutdown, release, del, detect },
+      true,
+      true
+    );
+    return { hasErrors: true, identity };
   }
 
   /**

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -219,11 +219,6 @@ function createTestSetup(): TestSetup {
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-    deleteOp: {
-      hasPendingRetry: vi.fn().mockReturnValue(false),
-      signalDismiss: vi.fn(),
-      signalRetry: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["deleteOp"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -206,11 +206,6 @@ function createTestSetup(): TestSetup {
     globalWorktreeProvider: {
       listWorktrees: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-    deleteOp: {
-      hasPendingRetry: vi.fn().mockReturnValue(false),
-      signalDismiss: vi.fn(),
-      signalRetry: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["deleteOp"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -109,11 +109,6 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["deleteOp"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -339,11 +339,6 @@ function createTestSetup(opts?: {
       globalWorktreeProvider: {
         listWorktrees: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
-      deleteOp: {
-        hasPendingRetry: vi.fn().mockReturnValue(false),
-        signalDismiss: vi.fn(),
-        signalRetry: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["deleteOp"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -191,7 +191,10 @@ describe("preload API", () => {
       mockIpcRenderer.invoke.mockResolvedValue(mockResult);
 
       const workspaces = exposedApi.workspaces as {
-        remove: (workspacePath: string, options?: { keepBranch?: boolean }) => Promise<unknown>;
+        remove: (
+          workspacePath: string,
+          options?: { keepBranch?: boolean; blockingPids?: readonly number[] }
+        ) => Promise<unknown>;
       };
       const result = await workspaces.remove("/test/.worktrees/feature", { keepBranch: true });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -66,6 +66,7 @@ contextBridge.exposeInMainWorld("api", {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
+        blockingPids?: readonly number[];
       }
     ): Promise<{ started: boolean }> =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_REMOVE, {

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -257,10 +257,12 @@
     logger.debug("Retrying deletion", {
       workspaceName: activeDeletionState.workspaceName,
     });
-    // Fire-and-forget - signals the waiting pipeline via workspaces.remove handler
+    // Dispatch new intent with blockingPids from previous failure
+    const pids = activeDeletionState.blockingProcesses?.map((p) => p.pid);
     void api.workspaces.remove(activeDeletionState.workspacePath, {
       keepBranch: activeDeletionState.keepBranch,
       skipSwitch: true,
+      ...(pids && { blockingPids: pids }),
     });
   }
 

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -94,6 +94,7 @@ export interface IWorkspaceApi {
       keepBranch?: boolean;
       skipSwitch?: boolean;
       force?: boolean;
+      blockingPids?: readonly number[];
     }
   ): Promise<{ started: boolean }>;
   /**

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -59,6 +59,7 @@ export interface Api {
         keepBranch?: boolean;
         skipSwitch?: boolean;
         force?: boolean;
+        blockingPids?: readonly number[];
       }
     ): Promise<{ started: boolean }>;
     getStatus(workspacePath: string): Promise<WorkspaceStatus>;


### PR DESCRIPTION
- Remove blocking retry loop from DeleteWorkspaceOperation
- On delete failure, emit workspace:delete-failed (resetting idempotency) and return
- On retry, UI passes detected blockingPids in intent payload to flush without re-scanning
- Eliminate bridge-layer signaling (waitForRetryChoice, signalRetry, signalDismiss)
- Enable future selective process killing