### PR TITLE
fix: accessibility improved by removing non-existing elements from dom

### DIFF
--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -141,6 +141,10 @@ describe("MainView close project integration", () => {
       });
       await vi.runAllTimersAsync();
 
+      // Expand sidebar (project header buttons are only in DOM when expanded)
+      const sidebar = document.querySelector(".sidebar")!;
+      await fireEvent.mouseEnter(sidebar);
+
       // Find and click the close button for the project with workspaces
       // Button has id="close-project-${project.id}"
       const closeButton = document.getElementById(`close-project-${projectWithWorkspaces.id}`);
@@ -164,6 +168,10 @@ describe("MainView close project integration", () => {
         expect(projectsStore.loadingState.value).toBe("loaded");
       });
       await vi.runAllTimersAsync();
+
+      // Expand sidebar (project header buttons are only in DOM when expanded)
+      const sidebar = document.querySelector(".sidebar")!;
+      await fireEvent.mouseEnter(sidebar);
 
       // Find and click the close button for the empty project
       const closeButton = document.getElementById(`close-project-${projectWithoutWorkspaces.id}`);

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -122,7 +122,9 @@
         <Icon name="chevron-right" size={12} />
       </span>
     {/if}
-    <h2>PROJECTS</h2>
+    {#if isExpanded}
+      <h2>PROJECTS</h2>
+    {/if}
   </header>
 
   <div class="sidebar-content">
@@ -140,37 +142,39 @@
     {:else}
       <ul class="project-list">
         {#each projects as project, projectIndex (project.path)}
-          {#if projectIndex > 0}
+          {#if isExpanded && projectIndex > 0}
             <vscode-divider></vscode-divider>
           {/if}
           {@const projectTitle = project.remoteUrl ?? project.path}
           <li class="project-item">
-            <div class="project-header">
-              <span class="project-icon" title={projectTitle}>
-                <Icon name={project.remoteUrl ? "source-control" : "folder-opened"} size={14} />
-              </span>
-              <span class="project-name" title={projectTitle}>{project.name}</span>
-              <div class="project-actions">
-                <button
-                  type="button"
-                  class="action-btn"
-                  id={`add-ws-${project.id}`}
-                  aria-label="Add workspace"
-                  onclick={() => handleAddWorkspace(project.id)}
-                >
-                  <Icon name="add" size={14} />
-                </button>
-                <button
-                  type="button"
-                  class="action-btn"
-                  id={`close-project-${project.id}`}
-                  aria-label="Close project"
-                  onclick={() => onCloseProject(project.id)}
-                >
-                  <Icon name="trash" size={14} />
-                </button>
+            {#if isExpanded}
+              <div class="project-header">
+                <span class="project-icon" title={projectTitle}>
+                  <Icon name={project.remoteUrl ? "source-control" : "folder-opened"} size={14} />
+                </span>
+                <span class="project-name" title={projectTitle}>{project.name}</span>
+                <div class="project-actions">
+                  <button
+                    type="button"
+                    class="action-btn"
+                    id={`add-ws-${project.id}`}
+                    aria-label="Add workspace"
+                    onclick={() => handleAddWorkspace(project.id)}
+                  >
+                    <Icon name="add" size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    class="action-btn"
+                    id={`close-project-${project.id}`}
+                    aria-label="Close project"
+                    onclick={() => onCloseProject(project.id)}
+                  >
+                    <Icon name="trash" size={14} />
+                  </button>
+                </div>
               </div>
-            </div>
+            {/if}
             <ul class="workspace-list">
               {#each project.workspaces as workspace, workspaceIndex (workspace.path)}
                 {@const globalIndex = getWorkspaceGlobalIndex(

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -1042,6 +1042,61 @@ describe("Sidebar component", () => {
       const indicators = container.querySelectorAll('[role="status"]');
       expect(indicators.length).toBeGreaterThan(0);
     });
+
+    it("project header buttons not in DOM when minimized", () => {
+      render(Sidebar, { props: propsWithWorkspaces() });
+
+      // Sidebar is minimized (totalWorkspaces > 0, uiMode is workspace, no hover)
+      expect(screen.queryByLabelText("Add workspace")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Close project")).not.toBeInTheDocument();
+    });
+
+    it("project header buttons appear in DOM when expanded via hover", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+      const sidebar = container.querySelector(".sidebar");
+
+      await fireEvent.mouseEnter(sidebar!);
+      expect(sidebar).toHaveClass("expanded");
+
+      expect(screen.getByLabelText("Add workspace")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close project")).toBeInTheDocument();
+    });
+
+    it("h2 heading not in DOM when minimized", () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
+      expect(screen.queryByRole("heading", { name: /projects/i })).not.toBeInTheDocument();
+    });
+
+    it("h2 heading in DOM when expanded", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+      const sidebar = container.querySelector(".sidebar");
+
+      await fireEvent.mouseEnter(sidebar!);
+
+      expect(screen.getByRole("heading", { name: /projects/i })).toBeInTheDocument();
+    });
+
+    it("vscode-divider not in DOM when minimized", () => {
+      const ws1 = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
+      const ws2 = createMockWorkspace({ path: "/test2/.worktrees/ws2", name: "ws2" });
+      const project1 = createMockProject({
+        path: "/test" as ProjectPath,
+        workspaces: [ws1],
+      });
+      const project2 = createMockProject({
+        path: "/test2" as ProjectPath,
+        workspaces: [ws2],
+      });
+
+      const { container } = render(Sidebar, {
+        props: { ...defaultProps, projects: [project1, project2], totalWorkspaces: 2 },
+      });
+
+      expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
+      expect(container.querySelector("vscode-divider")).not.toBeInTheDocument();
+    });
   });
 
   describe("deletion indicator", () => {


### PR DESCRIPTION
- Remove project headers, h2 heading, and dividers from DOM when sidebar is collapsed using `{#if isExpanded}` conditionals
- Prevents keyboard Tab and screen reader access to invisible elements clipped by `overflow: clip`
- Only minimized status indicator buttons remain reachable in the 20px visible strip
- Update MainView integration tests to expand sidebar before clicking project header buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)