### PR TITLE
fix: no more screen flashing on workspace creation

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/renderer/index.html"),
+          background: resolve(__dirname, "src/renderer/background.html"),
         },
       },
     },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -373,6 +373,7 @@ const viewManager = new ViewManager({
   config: {
     uiPreloadPath: nodePath.join(__dirname, "../preload/index.cjs"),
     codeServerPort: 0,
+    backgroundHtmlPath: nodePath.join(__dirname, "../renderer/background.html"),
   },
   logger: loggingService.createLogger("view"),
 });

--- a/src/main/managers/view-manager.integration.test.ts
+++ b/src/main/managers/view-manager.integration.test.ts
@@ -20,7 +20,7 @@ import {
   createWindowLayerInternalMock,
   type MockWindowLayerInternal,
 } from "../../services/shell/window.state-mock";
-import type { WindowHandle } from "../../services/shell/types";
+import { createViewHandle, type WindowHandle } from "../../services/shell/types";
 import { createMockWindowManager } from "./window-manager.test-utils";
 
 // Mock external-url
@@ -74,6 +74,7 @@ function createViewManagerDeps(): ViewManagerDeps & {
     config: {
       uiPreloadPath: "/path/to/preload.js",
       codeServerPort: 8080,
+      backgroundHtmlPath: "/path/to/background.html",
     },
     logger: SILENT_LOGGER,
   };
@@ -117,7 +118,7 @@ describe("ViewManager", () => {
 
       const uiHandle = manager.getUIViewHandle();
       expect(uiHandle.id).toMatch(/^view-\d+$/);
-      expect(deps.viewLayer).toHaveViews([uiHandle.id]);
+      expect(deps.viewLayer.isAvailable(uiHandle)).toBe(true);
     });
 
     it("sets transparent background on UI layer", () => {
@@ -146,6 +147,62 @@ describe("ViewManager", () => {
     });
   });
 
+  describe("background view", () => {
+    /**
+     * Helper to get the background view ID (always at index 0 in window children).
+     */
+    function getBackgroundViewId(deps: ReturnType<typeof createViewManagerDeps>): string {
+      const windowId = deps.windowLayer._createdWindowHandle.id;
+      const children = deps.viewLayer.$.windowChildren.get(windowId) ?? [];
+      expect(children.length).toBeGreaterThanOrEqual(2);
+      // Background view is always at index 0 (bottom of z-stack)
+      const id = children[0] as string;
+      return id;
+    }
+
+    it("is created and attached at z-0 during create()", () => {
+      const deps = createViewManagerDeps();
+      const manager = createViewManager(deps);
+
+      const uiHandle = manager.getUIViewHandle();
+      const backgroundViewId = getBackgroundViewId(deps);
+
+      // Background view should be at index 0 (bottom), not the UI view
+      expect(backgroundViewId).not.toBe(uiHandle.id);
+
+      // Background view should have transparent Electron bg (CSS handles color)
+      expect(deps.viewLayer).toHaveView(backgroundViewId, {
+        backgroundColor: "#00000000",
+      });
+    });
+
+    it("has its bounds updated on resize", () => {
+      const deps = createViewManagerDeps();
+      vi.mocked(deps.windowManager.getBounds).mockReturnValue({ width: 1400, height: 900 });
+      const manager = createViewManager(deps);
+
+      manager.updateBounds();
+
+      const backgroundViewId = getBackgroundViewId(deps);
+
+      expect(deps.viewLayer).toHaveView(backgroundViewId, {
+        bounds: { x: 0, y: 0, width: 1400, height: 900 },
+      });
+    });
+
+    it("is destroyed on destroy()", () => {
+      const deps = createViewManagerDeps();
+      const manager = createViewManager(deps);
+
+      const backgroundViewId = getBackgroundViewId(deps);
+
+      manager.destroy();
+
+      // Background view should no longer be available
+      expect(deps.viewLayer.isAvailable(createViewHandle(backgroundViewId))).toBe(false);
+    });
+  });
+
   describe("getUIViewHandle", () => {
     it("returns the UI layer ViewHandle", () => {
       const deps = createViewManagerDeps();
@@ -169,9 +226,8 @@ describe("ViewManager", () => {
         "/path/to/project"
       );
 
-      const uiHandle = manager.getUIViewHandle();
-      // Should have 2 views: UI + workspace
-      expect(deps.viewLayer).toHaveViews([uiHandle.id, wsHandle.id]);
+      // Workspace view should exist
+      expect(deps.viewLayer.isAvailable(wsHandle)).toBe(true);
 
       // Workspace view should NOT be attached
       expect(deps.viewLayer).toHaveView(wsHandle.id, { attachedTo: null });
@@ -701,7 +757,7 @@ describe("ViewManager", () => {
       });
     });
 
-    it("keeps UI view at index 0 in workspace mode (DirectComposition workaround)", () => {
+    it("keeps UI view at index 1 in workspace mode (above background view)", () => {
       const deps = createViewManagerDeps();
       const manager = createViewManager(deps);
       const windowId = deps.windowLayer._createdWindowHandle.id;
@@ -714,10 +770,10 @@ describe("ViewManager", () => {
       manager.setWorkspaceLoaded("/path/to/workspace");
       manager.setActiveWorkspace("/path/to/workspace");
 
-      // UI view should be at index 0 (bottom)
+      // UI view should be at index 1 (above background view at 0)
       const uiHandle = manager.getUIViewHandle();
       const children = deps.viewLayer.$.windowChildren.get(windowId);
-      expect(children?.[0]).toBe(uiHandle.id);
+      expect(children?.[1]).toBe(uiHandle.id);
     });
 
     it("null workspace detaches current", () => {

--- a/src/main/managers/view-manager.ts
+++ b/src/main/managers/view-manager.ts
@@ -55,6 +55,12 @@ const VIEW_BACKGROUND_COLOR = "#1e1e1e";
 const NAVIGATION_TIMEOUT_MS = 2000;
 
 /**
+ * Z-index for the UI layer when positioned at the bottom of the view stack.
+ * Index 0 is reserved for the background view, so the UI sits at index 1.
+ */
+const Z_UI_BOTTOM = 1;
+
+/**
  * Configuration for creating a ViewManager.
  */
 export interface ViewManagerConfig {
@@ -62,6 +68,8 @@ export interface ViewManagerConfig {
   readonly uiPreloadPath: string;
   /** Code-server port number */
   readonly codeServerPort: number;
+  /** Path to the background HTML page (theme-colored backdrop) */
+  readonly backgroundHtmlPath: string;
 }
 
 /**
@@ -109,6 +117,7 @@ export class ViewManager implements IViewManager {
   private readonly sessionLayer: SessionLayer;
   private readonly config: ViewManagerConfig;
   private uiViewHandle!: ViewHandle;
+  private backgroundViewHandle!: ViewHandle;
   private codeServerPort: number;
   private windowHandle!: WindowHandle;
   /**
@@ -183,10 +192,28 @@ export class ViewManager implements IViewManager {
     // Set transparent background for UI layer
     viewLayer.setBackgroundColor(this.uiViewHandle, "#00000000");
 
+    // Create background view (theme-colored backdrop to prevent white flash)
+    this.backgroundViewHandle = viewLayer.createView({
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+      },
+    });
+
+    // Transparent Electron background — CSS handles the actual color via variables.css
+    viewLayer.setBackgroundColor(this.backgroundViewHandle, "#00000000");
+
     // Get window handle
     this.windowHandle = windowManager.getWindowHandle();
 
-    // Add UI layer to window
+    // Add background view at z-0 (bottom of all views)
+    viewLayer.attachToWindow(this.backgroundViewHandle, this.windowHandle, 0);
+
+    // Load the background HTML page (theme colors via CSS)
+    void viewLayer.loadURL(this.backgroundViewHandle, `file://${config.backgroundHtmlPath}`);
+
+    // Add UI layer to window (on top of background)
     viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
 
     // Subscribe to resize events
@@ -484,6 +511,14 @@ export class ViewManager implements IViewManager {
     const width = Math.max(bounds.width, MIN_WIDTH);
     const height = Math.max(bounds.height, MIN_HEIGHT);
 
+    // Background view: full window (theme-colored backdrop)
+    this.viewLayer.setBounds(this.backgroundViewHandle, {
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+
     // UI layer: full window (so dialogs can overlay everything)
     this.viewLayer.setBounds(this.uiViewHandle, {
       x: 0,
@@ -657,7 +692,7 @@ export class ViewManager implements IViewManager {
         // so the transparent sidebar strip is rendered on startup
         try {
           if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, 0, {
+            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM, {
               force: true,
             });
           }
@@ -769,7 +804,7 @@ export class ViewManager implements IViewManager {
       switch (newMode) {
         case "workspace":
           // Move UI to bottom (index 0) - workspace on top
-          this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, 0);
+          this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM);
           // Focus the active workspace
           this.focusActiveWorkspace();
           break;
@@ -907,7 +942,7 @@ export class ViewManager implements IViewManager {
         // so the transparent sidebar strip is rendered on startup
         try {
           if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, 0, {
+            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM, {
               force: true,
             });
           }
@@ -1026,6 +1061,13 @@ export class ViewManager implements IViewManager {
     // Destroy all workspace views (fire-and-forget - app is shutting down)
     for (const path of this.workspaceStates.keys()) {
       void this.destroyWorkspaceView(path);
+    }
+
+    // Destroy background view
+    try {
+      this.viewLayer.destroy(this.backgroundViewHandle);
+    } catch {
+      // Ignore errors during cleanup - view may be in an inconsistent state
     }
 
     // Destroy UI view

--- a/src/renderer/background.html
+++ b/src/renderer/background.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="./lib/styles/variables.css" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: var(--ch-background);
+      }
+    </style>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
- Add a permanent background WebContentsView at z-0 that loads `variables.css` with `background: var(--ch-background)`
- This covers the window's white background during the gap between workspace view creation (1x1 bounds) and the loading overlay rendering
- Theme changes handled automatically via CSS `prefers-color-scheme` — no hardcoded colors
- Bump UI view z-index from 0 to 1 (`Z_UI_BOTTOM` constant) to accommodate the new background view