### PR TITLE
fix: better process cleanup under linux/macos

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,6 +100,8 @@ import { createOpenCodeAgentModule } from "./modules/opencode-agent-module";
 import { createMetadataModule } from "./modules/metadata-module";
 import { createKeepFilesModule } from "./modules/keepfiles-module";
 import { createWindowsFileLockModule } from "./modules/windows-file-lock-module";
+import { createLinuxProcessCleanupModule } from "./modules/linux-process-cleanup-module";
+import { createMacOSProcessCleanupModule } from "./modules/macos-process-cleanup-module";
 import { createWindowTitleModule } from "./modules/window-title-module";
 import { createTelemetryModule } from "./modules/telemetry-module";
 import { createAutoUpdaterModule } from "./modules/auto-updater-module";
@@ -481,10 +483,21 @@ const keepFilesModule = createKeepFilesModule({
   keepFilesService,
   logger: apiLogger,
 });
-const deleteWindowsLockModule = createWindowsFileLockModule({
-  workspaceLockHandler,
-  logger: apiLogger,
-});
+const deleteWindowsLockModule =
+  platformInfo.platform === "win32"
+    ? createWindowsFileLockModule({
+        workspaceLockHandler: workspaceLockHandler!,
+        logger: apiLogger,
+      })
+    : undefined;
+const linuxProcessCleanupModule =
+  platformInfo.platform === "linux"
+    ? createLinuxProcessCleanupModule({ processRunner, logger: apiLogger })
+    : undefined;
+const macosProcessCleanupModule =
+  platformInfo.platform === "darwin"
+    ? createMacOSProcessCleanupModule({ processRunner, logger: apiLogger })
+    : undefined;
 const windowTitleModule = createWindowTitleModule(
   (title: string) => windowManager.setTitle(title),
   buildInfo.gitBranch ?? buildInfo.version
@@ -639,7 +652,9 @@ dispatcher.registerModule(badgeModule);
 dispatcher.registerModule(workspaceSelectionModule);
 dispatcher.registerModule(metadataModule);
 dispatcher.registerModule(keepFilesModule);
-dispatcher.registerModule(deleteWindowsLockModule);
+if (deleteWindowsLockModule) dispatcher.registerModule(deleteWindowsLockModule);
+if (linuxProcessCleanupModule) dispatcher.registerModule(linuxProcessCleanupModule);
+if (macosProcessCleanupModule) dispatcher.registerModule(macosProcessCleanupModule);
 dispatcher.registerModule(remoteProjectModule);
 dispatcher.registerModule(localProjectModule);
 dispatcher.registerModule(gitWorktreeWorkspaceModule);

--- a/src/main/modules/linux-process-cleanup-module.integration.test.ts
+++ b/src/main/modules/linux-process-cleanup-module.integration.test.ts
@@ -1,0 +1,312 @@
+// @vitest-environment node
+/**
+ * Integration tests for LinuxProcessCleanupModule.
+ *
+ * Tests verify: detection parsing, kill invocation, and module release hook behavior
+ * through mocked ProcessRunner (runs on all platforms).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  type DeleteWorkspaceIntent,
+  type ReleaseHookResult,
+} from "../operations/delete-workspace";
+import {
+  createLinuxProcessCleanupModule,
+  detectLinuxCwdProcesses,
+  killUnixProcesses,
+} from "./linux-process-cleanup-module";
+import { SILENT_LOGGER } from "../../services/logging";
+import { createBehavioralLogger } from "../../services/logging/logging.test-utils";
+import { createMockProcessRunner } from "../../services/platform/process.state-mock";
+import type { MockProcessRunner } from "../../services/platform/process.state-mock";
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function makeDeleteIntent(overrides?: Partial<DeleteWorkspaceIntent["payload"]>): Intent {
+  return {
+    type: "workspace:delete",
+    payload: {
+      projectId: "proj-1",
+      workspaceName: "feature-1",
+      workspacePath: "/workspaces/feature-1",
+      projectPath: "/projects/my-app",
+      keepBranch: true,
+      force: false,
+      removeWorktree: true,
+      ...overrides,
+    },
+  } as unknown as Intent;
+}
+
+const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
+  DELETE_WORKSPACE_OPERATION_ID,
+  "release",
+  {
+    hookContext: (ctx) => ({
+      intent: ctx.intent,
+      projectPath: "/projects/my-app",
+      workspacePath:
+        ((ctx.intent as DeleteWorkspaceIntent).payload as { workspacePath?: string })
+          .workspacePath ?? "",
+    }),
+  }
+);
+
+function createReleaseSetup(runner: MockProcessRunner, logger = SILENT_LOGGER) {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  dispatcher.registerOperation("workspace:delete", releaseOperation);
+
+  const module = createLinuxProcessCleanupModule({
+    processRunner: runner,
+    logger,
+  });
+  dispatcher.registerModule(module);
+
+  return dispatcher;
+}
+
+// =============================================================================
+// detectLinuxCwdProcesses
+// =============================================================================
+
+describe("detectLinuxCwdProcesses", () => {
+  it("parses tab-separated output into DetectedProcess array", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({
+        stdout:
+          "1234\tbash\t/workspaces/feature-1\tbash --login\n5678\tnode\t/workspaces/feature-1/subdir\tnode index.js\n",
+        exitCode: 0,
+      }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([
+      { pid: 1234, name: "bash", cwd: "/workspaces/feature-1", cmdline: "bash --login" },
+      { pid: 5678, name: "node", cwd: "/workspaces/feature-1/subdir", cmdline: "node index.js" },
+    ]);
+  });
+
+  it("returns empty array for empty output", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: 0 }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on non-zero exit code", async () => {
+    const logger = createBehavioralLogger();
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", stderr: "error", exitCode: 2 }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", logger);
+
+    expect(result).toEqual([]);
+    const warnings = logger.getMessagesByLevel("warn");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toBe("Process detection failed");
+  });
+
+  it("returns empty array on timeout", async () => {
+    const logger = createBehavioralLogger();
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: null, running: true }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", logger);
+
+    expect(result).toEqual([]);
+    const warnings = logger.getMessagesByLevel("warn");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toBe("Process detection timed out");
+  });
+
+  it("filters out own process PID", async () => {
+    const ownPid = process.pid;
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({
+        stdout: `${ownPid}\tbash\t/workspaces/feature-1\tbash\n9999\tnode\t/workspaces/feature-1\tnode\n`,
+        exitCode: 0,
+      }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pid).toBe(9999);
+  });
+
+  it("skips malformed lines", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({
+        stdout:
+          "not-a-pid\tbash\t/workspaces/feature-1\n\n1234\tbash\t/workspaces/feature-1\tbash\n",
+        exitCode: 0,
+      }),
+    });
+
+    const result = await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pid).toBe(1234);
+  });
+
+  it("passes workspace path via TARGET_PATH env var", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: 0 }),
+    });
+
+    await detectLinuxCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    const spawned = runner.$.spawned(0);
+    expect(spawned.$.env).toBeDefined();
+    expect(spawned.$.env!.TARGET_PATH).toBe("/workspaces/feature-1");
+  });
+});
+
+// =============================================================================
+// killUnixProcesses
+// =============================================================================
+
+describe("killUnixProcesses", () => {
+  it("runs kill -TERM with correct PID args", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ exitCode: 0 }),
+    });
+
+    await killUnixProcesses(runner, [1234, 5678], SILENT_LOGGER);
+
+    expect(runner).toHaveSpawned([{ command: "kill", args: ["-TERM", "1234", "5678"] }]);
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ exitCode: 1, stderr: "No such process" }),
+    });
+
+    await expect(killUnixProcesses(runner, [1234], SILENT_LOGGER)).rejects.toThrow(
+      "kill -TERM failed"
+    );
+  });
+
+  it("does nothing when pids array is empty", async () => {
+    const runner = createMockProcessRunner();
+
+    await killUnixProcesses(runner, [], SILENT_LOGGER);
+
+    expect(() => runner.$.spawned(0)).toThrow();
+  });
+});
+
+// =============================================================================
+// Module release hook
+// =============================================================================
+
+describe("LinuxProcessCleanupModule Integration", () => {
+  let runner: MockProcessRunner;
+
+  beforeEach(() => {
+    runner = createMockProcessRunner();
+  });
+
+  describe("delete-workspace -> release", () => {
+    it("detects and kills CWD-blocking processes", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            // Detection: return processes
+            return {
+              stdout: "1234\tbash\t/workspaces/feature-1\tbash\n",
+              exitCode: 0,
+            };
+          }
+          // Kill: success
+          return { exitCode: 0 };
+        },
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent());
+
+      // Verify detection was called (bash -c <script>)
+      const detectProc = runner.$.spawned(0);
+      expect(detectProc.$.command).toBe("bash");
+
+      // Verify kill was called
+      const killProc = runner.$.spawned(1);
+      expect(killProc.$.command).toBe("kill");
+      expect(killProc.$.args).toEqual(["-TERM", "1234"]);
+    });
+
+    it("skips when force=true", async () => {
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent({ force: true }));
+
+      // No processes spawned
+      expect(() => runner.$.spawned(0)).toThrow();
+    });
+
+    it("swallows errors from detection", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ exitCode: null, running: true }),
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeDeleteIntent());
+
+      // No error propagated
+      expect(result).toEqual({});
+    });
+
+    it("swallows errors from kill", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            return {
+              stdout: "1234\tbash\t/workspaces/feature-1\tbash\n",
+              exitCode: 0,
+            };
+          }
+          // Kill fails
+          return { exitCode: 1, stderr: "Operation not permitted" };
+        },
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeDeleteIntent());
+
+      // No error propagated
+      expect(result).toEqual({});
+    });
+
+    it("skips kill when no processes detected", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ stdout: "", exitCode: 0 }),
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent());
+
+      // Only detection was spawned, no kill
+      expect(runner.$.spawned(0).$.command).toBe("bash");
+      expect(() => runner.$.spawned(1)).toThrow();
+    });
+  });
+});

--- a/src/main/modules/linux-process-cleanup-module.ts
+++ b/src/main/modules/linux-process-cleanup-module.ts
@@ -1,0 +1,175 @@
+/**
+ * LinuxProcessCleanupModule — Kills processes whose CWD is under the workspace path during deletion.
+ *
+ * Hooks:
+ * - delete-workspace → release: Scan /proc for CWD matches, kill with SIGTERM (best-effort)
+ *
+ * Detection uses a shell script that reads /proc/[pid]/cwd symlinks.
+ * Workspace path is passed via TARGET_PATH env var to avoid shell injection.
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { Logger } from "../../services/logging/types";
+import type { ProcessRunner, ProcessResult } from "../../services/platform/process";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  type DeleteWorkspaceIntent,
+  type DeletePipelineHookInput,
+  type ReleaseHookResult,
+} from "../operations/delete-workspace";
+
+/** Detected process info from /proc scan. */
+export interface DetectedProcess {
+  readonly pid: number;
+  readonly name: string;
+  readonly cwd: string;
+  readonly cmdline: string;
+}
+
+const DETECT_TIMEOUT_MS = 10_000;
+const KILL_TIMEOUT_MS = 5_000;
+
+/**
+ * Shell script that scans /proc for processes whose CWD starts with TARGET_PATH.
+ * Output: tab-separated lines: PID\tNAME\tCWD\tCMDLINE
+ */
+const DETECT_SCRIPT = `
+for pid_dir in /proc/[0-9]*/; do
+  pid=$(basename "$pid_dir")
+  cwd=$(readlink "$pid_dir/cwd" 2>/dev/null) || continue
+  case "$cwd" in "$TARGET_PATH"|"$TARGET_PATH/"*)
+    name=$(cat "$pid_dir/comm" 2>/dev/null || echo "unknown")
+    cmdline=$(tr '\\0' ' ' < "$pid_dir/cmdline" 2>/dev/null || echo "")
+    printf '%s\\t%s\\t%s\\t%s\\n' "$pid" "$name" "$cwd" "$cmdline"
+  ;; esac
+done
+`;
+
+/**
+ * Parse tab-separated /proc scan output into DetectedProcess array.
+ * Filters out the current process PID.
+ */
+function parseProcOutput(stdout: string): DetectedProcess[] {
+  const ownPid = process.pid;
+  const results: DetectedProcess[] = [];
+
+  for (const line of stdout.split("\n")) {
+    if (line.trim() === "") continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+
+    const pid = Number(parts[0]);
+    if (Number.isNaN(pid) || pid === ownPid) continue;
+
+    results.push({
+      pid,
+      name: parts[1] ?? "unknown",
+      cwd: parts[2] ?? "",
+      cmdline: parts[3] ?? "",
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Detect processes whose CWD is under the given workspace path using /proc.
+ * Exported for testing.
+ */
+export async function detectLinuxCwdProcesses(
+  processRunner: ProcessRunner,
+  workspacePath: string,
+  logger: Logger
+): Promise<DetectedProcess[]> {
+  const env: NodeJS.ProcessEnv = { ...process.env, TARGET_PATH: workspacePath };
+  const proc = processRunner.run("bash", ["-c", DETECT_SCRIPT], { env });
+  const result: ProcessResult = await proc.wait(DETECT_TIMEOUT_MS);
+
+  if (result.running) {
+    logger.warn("Process detection timed out", { workspacePath });
+    await proc.kill(1000, 1000);
+    return [];
+  }
+
+  if (result.exitCode !== 0 && result.exitCode !== null) {
+    logger.warn("Process detection failed", {
+      workspacePath,
+      exitCode: result.exitCode,
+      stderr: result.stderr,
+    });
+    return [];
+  }
+
+  return parseProcOutput(result.stdout);
+}
+
+/**
+ * Kill a list of PIDs with SIGTERM via `kill`.
+ * Exported for testing.
+ */
+export async function killUnixProcesses(
+  processRunner: ProcessRunner,
+  pids: readonly number[],
+  logger: Logger
+): Promise<void> {
+  if (pids.length === 0) return;
+
+  const args = ["-TERM", ...pids.map(String)];
+  const proc = processRunner.run("kill", args);
+  const result = await proc.wait(KILL_TIMEOUT_MS);
+
+  if (result.exitCode !== 0 && result.exitCode !== null) {
+    const error = `kill -TERM failed: exit ${result.exitCode} — ${result.stderr}`;
+    logger.warn(error, { pids: pids.join(",") });
+    throw new Error(error);
+  }
+}
+
+interface LinuxProcessCleanupModuleDeps {
+  readonly processRunner: ProcessRunner;
+  readonly logger: Logger;
+}
+
+export function createLinuxProcessCleanupModule(deps: LinuxProcessCleanupModuleDeps): IntentModule {
+  return {
+    name: "linux-process-cleanup",
+    hooks: {
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        release: {
+          handler: async (ctx: HookContext): Promise<ReleaseHookResult> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
+            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+
+            if (payload.force) {
+              return {};
+            }
+
+            try {
+              const detected = await detectLinuxCwdProcesses(
+                deps.processRunner,
+                workspacePath,
+                deps.logger
+              );
+
+              if (detected.length > 0) {
+                deps.logger.info("Killing CWD-blocking processes before deletion", {
+                  workspacePath,
+                  pids: detected.map((p) => p.pid).join(","),
+                });
+                await killUnixProcesses(
+                  deps.processRunner,
+                  detected.map((p) => p.pid),
+                  deps.logger
+                );
+              }
+            } catch {
+              // Non-fatal: detection/kill failure shouldn't block deletion
+            }
+            return {};
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/main/modules/macos-process-cleanup-module.integration.test.ts
+++ b/src/main/modules/macos-process-cleanup-module.integration.test.ts
@@ -1,0 +1,353 @@
+// @vitest-environment node
+/**
+ * Integration tests for MacOSProcessCleanupModule.
+ *
+ * Tests verify: lsof output parsing, kill invocation, and module release hook behavior
+ * through mocked ProcessRunner (runs on all platforms).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import type { Intent } from "../intents/infrastructure/types";
+import { createMinimalOperation } from "../intents/infrastructure/operation.test-utils";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  type DeleteWorkspaceIntent,
+  type ReleaseHookResult,
+} from "../operations/delete-workspace";
+import {
+  createMacOSProcessCleanupModule,
+  detectMacOSCwdProcesses,
+  killUnixProcesses,
+} from "./macos-process-cleanup-module";
+import { SILENT_LOGGER } from "../../services/logging";
+import { createBehavioralLogger } from "../../services/logging/logging.test-utils";
+import { createMockProcessRunner } from "../../services/platform/process.state-mock";
+import type { MockProcessRunner } from "../../services/platform/process.state-mock";
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function makeDeleteIntent(overrides?: Partial<DeleteWorkspaceIntent["payload"]>): Intent {
+  return {
+    type: "workspace:delete",
+    payload: {
+      projectId: "proj-1",
+      workspaceName: "feature-1",
+      workspacePath: "/workspaces/feature-1",
+      projectPath: "/projects/my-app",
+      keepBranch: true,
+      force: false,
+      removeWorktree: true,
+      ...overrides,
+    },
+  } as unknown as Intent;
+}
+
+const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
+  DELETE_WORKSPACE_OPERATION_ID,
+  "release",
+  {
+    hookContext: (ctx) => ({
+      intent: ctx.intent,
+      projectPath: "/projects/my-app",
+      workspacePath:
+        ((ctx.intent as DeleteWorkspaceIntent).payload as { workspacePath?: string })
+          .workspacePath ?? "",
+    }),
+  }
+);
+
+function createReleaseSetup(runner: MockProcessRunner, logger = SILENT_LOGGER) {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  dispatcher.registerOperation("workspace:delete", releaseOperation);
+
+  const module = createMacOSProcessCleanupModule({
+    processRunner: runner,
+    logger,
+  });
+  dispatcher.registerModule(module);
+
+  return dispatcher;
+}
+
+// =============================================================================
+// detectMacOSCwdProcesses
+// =============================================================================
+
+describe("detectMacOSCwdProcesses", () => {
+  it("parses lsof -Fpnc output for matching processes", async () => {
+    const lsofOutput = [
+      "p1234",
+      "cbash",
+      "n/workspaces/feature-1",
+      "p5678",
+      "cnode",
+      "n/workspaces/feature-1/subdir",
+    ].join("\n");
+
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: lsofOutput, exitCode: 0 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([
+      { pid: 1234, name: "bash", cwd: "/workspaces/feature-1" },
+      { pid: 5678, name: "node", cwd: "/workspaces/feature-1/subdir" },
+    ]);
+  });
+
+  it("filters out processes outside workspace path", async () => {
+    const lsofOutput = [
+      "p1234",
+      "cbash",
+      "n/workspaces/feature-1",
+      "p5678",
+      "cnode",
+      "n/workspaces/other-workspace",
+      "p9999",
+      "czsh",
+      "n/home/user",
+    ].join("\n");
+
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: lsofOutput, exitCode: 0 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pid).toBe(1234);
+  });
+
+  it("returns empty array when no matches", async () => {
+    const lsofOutput = ["p1234", "cbash", "n/other/path"].join("\n");
+
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: lsofOutput, exitCode: 0 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([]);
+  });
+
+  it("treats lsof exit code 1 as no files found (not error)", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: 1 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on lsof failure (exit > 1)", async () => {
+    const logger = createBehavioralLogger();
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", stderr: "lsof error", exitCode: 2 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", logger);
+
+    expect(result).toEqual([]);
+    const warnings = logger.getMessagesByLevel("warn");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toBe("Process detection failed");
+  });
+
+  it("returns empty array on timeout", async () => {
+    const logger = createBehavioralLogger();
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: null, running: true }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", logger);
+
+    expect(result).toEqual([]);
+    const warnings = logger.getMessagesByLevel("warn");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toBe("Process detection timed out");
+  });
+
+  it("filters out own process PID", async () => {
+    const ownPid = process.pid;
+    const lsofOutput = [
+      `p${ownPid}`,
+      "cbash",
+      `n/workspaces/feature-1`,
+      "p9999",
+      "cnode",
+      "n/workspaces/feature-1",
+    ].join("\n");
+
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: lsofOutput, exitCode: 0 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pid).toBe(9999);
+  });
+
+  it("does not match workspace path as substring prefix", async () => {
+    const lsofOutput = ["p1234", "cbash", "n/workspaces/feature-10"].join("\n");
+
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: lsofOutput, exitCode: 0 }),
+    });
+
+    const result = await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(result).toEqual([]);
+  });
+
+  it("invokes lsof with correct arguments", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ stdout: "", exitCode: 0 }),
+    });
+
+    await detectMacOSCwdProcesses(runner, "/workspaces/feature-1", SILENT_LOGGER);
+
+    expect(runner).toHaveSpawned([{ command: "lsof", args: ["-d", "cwd", "+c", "0", "-Fpnc"] }]);
+  });
+});
+
+// =============================================================================
+// killUnixProcesses
+// =============================================================================
+
+describe("killUnixProcesses", () => {
+  it("runs kill -TERM with correct PID args", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ exitCode: 0 }),
+    });
+
+    await killUnixProcesses(runner, [1234, 5678], SILENT_LOGGER);
+
+    expect(runner).toHaveSpawned([{ command: "kill", args: ["-TERM", "1234", "5678"] }]);
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const runner = createMockProcessRunner({
+      onSpawn: () => ({ exitCode: 1, stderr: "No such process" }),
+    });
+
+    await expect(killUnixProcesses(runner, [1234], SILENT_LOGGER)).rejects.toThrow(
+      "kill -TERM failed"
+    );
+  });
+
+  it("does nothing when pids array is empty", async () => {
+    const runner = createMockProcessRunner();
+
+    await killUnixProcesses(runner, [], SILENT_LOGGER);
+
+    expect(() => runner.$.spawned(0)).toThrow();
+  });
+});
+
+// =============================================================================
+// Module release hook
+// =============================================================================
+
+describe("MacOSProcessCleanupModule Integration", () => {
+  let runner: MockProcessRunner;
+
+  beforeEach(() => {
+    runner = createMockProcessRunner();
+  });
+
+  describe("delete-workspace -> release", () => {
+    it("detects and kills CWD-blocking processes", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            // Detection: return processes via lsof output
+            return {
+              stdout: "p1234\ncbash\nn/workspaces/feature-1\n",
+              exitCode: 0,
+            };
+          }
+          // Kill: success
+          return { exitCode: 0 };
+        },
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent());
+
+      // Verify detection was called (lsof)
+      const detectProc = runner.$.spawned(0);
+      expect(detectProc.$.command).toBe("lsof");
+
+      // Verify kill was called
+      const killProc = runner.$.spawned(1);
+      expect(killProc.$.command).toBe("kill");
+      expect(killProc.$.args).toEqual(["-TERM", "1234"]);
+    });
+
+    it("skips when force=true", async () => {
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent({ force: true }));
+
+      // No processes spawned
+      expect(() => runner.$.spawned(0)).toThrow();
+    });
+
+    it("swallows errors from detection", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ exitCode: null, running: true }),
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeDeleteIntent());
+
+      // No error propagated
+      expect(result).toEqual({});
+    });
+
+    it("swallows errors from kill", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            return {
+              stdout: "p1234\ncbash\nn/workspaces/feature-1\n",
+              exitCode: 0,
+            };
+          }
+          // Kill fails
+          return { exitCode: 1, stderr: "Operation not permitted" };
+        },
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeDeleteIntent());
+
+      // No error propagated
+      expect(result).toEqual({});
+    });
+
+    it("skips kill when no processes detected", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ stdout: "", exitCode: 0 }),
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      await dispatcher.dispatch(makeDeleteIntent());
+
+      // Only detection was spawned, no kill
+      expect(runner.$.spawned(0).$.command).toBe("lsof");
+      expect(() => runner.$.spawned(1)).toThrow();
+    });
+  });
+});

--- a/src/main/modules/macos-process-cleanup-module.ts
+++ b/src/main/modules/macos-process-cleanup-module.ts
@@ -1,0 +1,173 @@
+/**
+ * MacOSProcessCleanupModule — Kills processes whose CWD is under the workspace path during deletion.
+ *
+ * Hooks:
+ * - delete-workspace → release: Use lsof to find CWD matches, kill with SIGTERM (best-effort)
+ *
+ * Detection uses `lsof -d cwd +c 0 -Fpnc` for machine-parseable output.
+ * lsof exit code 1 means "no files found" and is not treated as an error.
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { Logger } from "../../services/logging/types";
+import type { ProcessRunner, ProcessResult } from "../../services/platform/process";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  type DeleteWorkspaceIntent,
+  type DeletePipelineHookInput,
+  type ReleaseHookResult,
+} from "../operations/delete-workspace";
+
+/** Detected process info from lsof. */
+export interface DetectedProcess {
+  readonly pid: number;
+  readonly name: string;
+  readonly cwd: string;
+}
+
+const DETECT_TIMEOUT_MS = 10_000;
+const KILL_TIMEOUT_MS = 5_000;
+
+/**
+ * Parse lsof -Fpnc output into DetectedProcess array.
+ * Format: lines starting with p=PID, c=command, n=path.
+ * Each process entry starts with a 'p' line.
+ * Filters by workspace path prefix and excludes current process PID.
+ */
+function parseLsofOutput(stdout: string, workspacePath: string): DetectedProcess[] {
+  const ownPid = process.pid;
+  const results: DetectedProcess[] = [];
+  let currentPid: number | undefined;
+  let currentName = "unknown";
+
+  for (const line of stdout.split("\n")) {
+    if (line.length === 0) continue;
+
+    const prefix = line[0];
+    const value = line.slice(1);
+
+    switch (prefix) {
+      case "p":
+        currentPid = Number(value);
+        currentName = "unknown";
+        break;
+      case "c":
+        currentName = value;
+        break;
+      case "n":
+        if (
+          currentPid !== undefined &&
+          !Number.isNaN(currentPid) &&
+          currentPid !== ownPid &&
+          (value === workspacePath || value.startsWith(workspacePath + "/"))
+        ) {
+          results.push({ pid: currentPid, name: currentName, cwd: value });
+        }
+        break;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Detect processes whose CWD is under the given workspace path using lsof.
+ * Exported for testing.
+ */
+export async function detectMacOSCwdProcesses(
+  processRunner: ProcessRunner,
+  workspacePath: string,
+  logger: Logger
+): Promise<DetectedProcess[]> {
+  const proc = processRunner.run("lsof", ["-d", "cwd", "+c", "0", "-Fpnc"]);
+  const result: ProcessResult = await proc.wait(DETECT_TIMEOUT_MS);
+
+  if (result.running) {
+    logger.warn("Process detection timed out", { workspacePath });
+    await proc.kill(1000, 1000);
+    return [];
+  }
+
+  // lsof exit code 1 = "no files found" (not an error)
+  if (result.exitCode !== null && result.exitCode !== 0 && result.exitCode !== 1) {
+    logger.warn("Process detection failed", {
+      workspacePath,
+      exitCode: result.exitCode,
+      stderr: result.stderr,
+    });
+    return [];
+  }
+
+  return parseLsofOutput(result.stdout, workspacePath);
+}
+
+/**
+ * Kill a list of PIDs with SIGTERM via `kill`.
+ * Exported for testing.
+ */
+export async function killUnixProcesses(
+  processRunner: ProcessRunner,
+  pids: readonly number[],
+  logger: Logger
+): Promise<void> {
+  if (pids.length === 0) return;
+
+  const args = ["-TERM", ...pids.map(String)];
+  const proc = processRunner.run("kill", args);
+  const result = await proc.wait(KILL_TIMEOUT_MS);
+
+  if (result.exitCode !== 0 && result.exitCode !== null) {
+    const error = `kill -TERM failed: exit ${result.exitCode} — ${result.stderr}`;
+    logger.warn(error, { pids: pids.join(",") });
+    throw new Error(error);
+  }
+}
+
+interface MacOSProcessCleanupModuleDeps {
+  readonly processRunner: ProcessRunner;
+  readonly logger: Logger;
+}
+
+export function createMacOSProcessCleanupModule(deps: MacOSProcessCleanupModuleDeps): IntentModule {
+  return {
+    name: "macos-process-cleanup",
+    hooks: {
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        release: {
+          handler: async (ctx: HookContext): Promise<ReleaseHookResult> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
+            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+
+            if (payload.force) {
+              return {};
+            }
+
+            try {
+              const detected = await detectMacOSCwdProcesses(
+                deps.processRunner,
+                workspacePath,
+                deps.logger
+              );
+
+              if (detected.length > 0) {
+                deps.logger.info("Killing CWD-blocking processes before deletion", {
+                  workspacePath,
+                  pids: detected.map((p) => p.pid).join(","),
+                });
+                await killUnixProcesses(
+                  deps.processRunner,
+                  detected.map((p) => p.pid),
+                  deps.logger
+                );
+              }
+            } catch {
+              // Non-fatal: detection/kill failure shouldn't block deletion
+            }
+            return {};
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/main/modules/windows-file-lock-module.integration.test.ts
+++ b/src/main/modules/windows-file-lock-module.integration.test.ts
@@ -2,8 +2,7 @@
 /**
  * Integration tests for WindowsFileLockModule through the Dispatcher.
  *
- * Tests verify: dispatcher -> operation -> release/detect/flush hooks -> lockHandler calls,
- * including no-op behavior when handler is undefined (non-Windows).
+ * Tests verify: dispatcher -> operation -> release/detect/flush hooks -> lockHandler calls.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -113,7 +112,7 @@ class FlushOperation implements Operation<Intent, FlushHookResult> {
 // Test Setup Helpers
 // =============================================================================
 
-function createReleaseSetup(lockHandler: WorkspaceLockHandler | undefined, logger = SILENT_LOGGER) {
+function createReleaseSetup(lockHandler: WorkspaceLockHandler, logger = SILENT_LOGGER) {
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
   dispatcher.registerOperation("workspace:delete", releaseOperation);
@@ -127,7 +126,7 @@ function createReleaseSetup(lockHandler: WorkspaceLockHandler | undefined, logge
   return dispatcher;
 }
 
-function createDetectSetup(lockHandler: WorkspaceLockHandler | undefined, logger = SILENT_LOGGER) {
+function createDetectSetup(lockHandler: WorkspaceLockHandler, logger = SILENT_LOGGER) {
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
   dispatcher.registerOperation("workspace:delete", detectOperation);
@@ -142,7 +141,7 @@ function createDetectSetup(lockHandler: WorkspaceLockHandler | undefined, logger
 }
 
 function createFlushSetup(
-  lockHandler: WorkspaceLockHandler | undefined,
+  lockHandler: WorkspaceLockHandler,
   blockingPids: readonly number[],
   logger = SILENT_LOGGER
 ) {
@@ -270,19 +269,5 @@ describe("WindowsFileLockModule Integration", () => {
 
       expect(handler.killProcesses).not.toHaveBeenCalled();
     });
-  });
-
-  // ---------------------------------------------------------------------------
-  // no-op when handler is undefined (parameterized)
-  // ---------------------------------------------------------------------------
-
-  it.each([
-    { hook: "release", createSetup: () => createReleaseSetup(undefined) },
-    { hook: "detect", createSetup: () => createDetectSetup(undefined) },
-    { hook: "flush", createSetup: () => createFlushSetup(undefined, [1234]) },
-  ])("$hook is a no-op when handler is undefined", async ({ createSetup }) => {
-    const dispatcher = createSetup();
-    const result = await dispatcher.dispatch(makeDeleteIntent());
-    expect(result).toEqual({});
   });
 });

--- a/src/main/modules/windows-file-lock-module.ts
+++ b/src/main/modules/windows-file-lock-module.ts
@@ -5,8 +5,6 @@
  * - delete-workspace → release: CWD-only scan + kill blocking processes (best-effort)
  * - delete-workspace → detect: full handle detection
  * - delete-workspace → flush: kill PIDs collected by detect
- *
- * All hooks are no-ops when workspaceLockHandler is undefined (non-Windows).
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
@@ -26,7 +24,7 @@ import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../shared/error-utils";
 
 interface WindowsFileLockModuleDeps {
-  readonly workspaceLockHandler: WorkspaceLockHandler | undefined;
+  readonly workspaceLockHandler: WorkspaceLockHandler;
   readonly logger: Logger;
 }
 
@@ -40,7 +38,7 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
-            if (payload.force || !deps.workspaceLockHandler) {
+            if (payload.force) {
               return {};
             }
 
@@ -64,8 +62,6 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
         },
         detect: {
           handler: async (ctx: HookContext): Promise<DetectHookResult> => {
-            if (!deps.workspaceLockHandler) return {};
-
             const { workspacePath } = ctx as DeletePipelineHookInput;
 
             try {
@@ -82,8 +78,6 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
         },
         flush: {
           handler: async (ctx: HookContext): Promise<FlushHookResult> => {
-            if (!deps.workspaceLockHandler) return {};
-
             const { blockingPids } = ctx as FlushHookInput;
             if (blockingPids.length > 0) {
               try {


### PR DESCRIPTION
- Add LinuxProcessCleanupModule: scans /proc/[pid]/cwd symlinks via shell script to detect processes with CWD under workspace path
- Add MacOSProcessCleanupModule: uses `lsof -d cwd` for CWD detection on macOS
- Both modules hook into delete pipeline's `release` hook and SIGTERM detected processes (best-effort, non-fatal)
- Tighten WindowsFileLockModule to require WorkspaceLockHandler (no longer optional with undefined guards)
- Register cleanup modules conditionally by platform in index.ts
- Integration tests for all three platform modules