### PR TITLE
feat(intents): extract fetch-bases into dedicated GetProjectBases intent

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,6 +139,7 @@ import {
   INTENT_GET_ACTIVE_WORKSPACE,
 } from "./operations/get-active-workspace";
 import { OpenWorkspaceOperation, INTENT_OPEN_WORKSPACE } from "./operations/open-workspace";
+import { GetProjectBasesOperation, INTENT_GET_PROJECT_BASES } from "./operations/get-project-bases";
 import {
   DeleteWorkspaceOperation,
   INTENT_DELETE_WORKSPACE,
@@ -613,6 +614,7 @@ dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperat
 dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
 dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
+dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
 
 dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
 
@@ -637,7 +639,6 @@ const ipcEventBridge = createIpcEventBridge({
   logger: apiLogger,
   dispatcher,
   agentStatusManager,
-  globalWorktreeProvider,
 });
 
 // 10. Register all modules + get API interface

--- a/src/main/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/main/modules/git-worktree-workspace-module.integration.test.ts
@@ -25,6 +25,8 @@ import { CLOSE_PROJECT_OPERATION_ID } from "../operations/close-project";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
 import type { OpenWorkspaceIntent } from "../operations/open-workspace";
 import type { CreateHookResult } from "../operations/open-workspace";
+import { GET_PROJECT_BASES_OPERATION_ID } from "../operations/get-project-bases";
+import type { ListBasesHookResult } from "../operations/get-project-bases";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
 import type {
   DeleteWorkspaceIntent,
@@ -35,7 +37,6 @@ import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../operations/get-workspace-s
 import type { GetStatusHookInput, GetStatusHookResult } from "../operations/get-workspace-status";
 import { RESOLVE_WORKSPACE_OPERATION_ID } from "../operations/resolve-workspace";
 import { createGitWorktreeWorkspaceModule } from "./git-worktree-workspace-module";
-import type { FetchBasesHookResult } from "./git-worktree-workspace-module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { Path } from "../../services/platform/path";
 
@@ -53,6 +54,7 @@ function createMockGitWorktreeProvider() {
     isDirty: vi.fn().mockResolvedValue(false),
     listBases: vi.fn().mockResolvedValue([]),
     defaultBase: vi.fn().mockResolvedValue(undefined),
+    updateBases: vi.fn().mockResolvedValue(undefined),
     cleanupOrphanedWorkspaces: vi.fn().mockResolvedValue({ removedCount: 0, failedPaths: [] }),
     validateRepository: vi.fn().mockResolvedValue(undefined),
     ensureWorkspaceRegistered: vi.fn(),
@@ -178,16 +180,39 @@ class MinimalResolveWorkspaceOperation implements Operation<Intent, ResolveResul
   }
 }
 
-const fetchBasesOperation = createMinimalOperation<Intent, FetchBasesHookResult>(
-  OPEN_WORKSPACE_OPERATION_ID,
-  "fetch-bases",
-  {
-    hookContext: (ctx) => ({
-      intent: ctx.intent,
-      projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
-    }),
+/** Result from get-project-bases list + refresh dispatch. */
+interface GetProjectBasesTestResult {
+  readonly bases?: readonly { name: string; isRemote: boolean }[];
+  readonly defaultBaseBranch?: string;
+  readonly refreshed?: boolean;
+}
+
+/**
+ * Minimal get-project-bases operation: calls "list" hook, then optionally "refresh".
+ * The intent payload controls which hooks to run via a `hookPoint` field.
+ */
+class MinimalGetProjectBasesOperation implements Operation<Intent, GetProjectBasesTestResult> {
+  readonly id = GET_PROJECT_BASES_OPERATION_ID;
+
+  async execute(ctx: OperationContext<Intent>): Promise<GetProjectBasesTestResult> {
+    const payload = ctx.intent.payload as {
+      projectPath: string;
+      hookPoint?: "list" | "refresh";
+    };
+    const hookCtx = { intent: ctx.intent, projectPath: payload.projectPath };
+
+    if (payload.hookPoint === "refresh") {
+      const { errors } = await ctx.hooks.collect("refresh", hookCtx);
+      if (errors.length > 0) throw errors[0]!;
+      return { refreshed: true };
+    }
+
+    // Default: list
+    const { results, errors } = await ctx.hooks.collect<ListBasesHookResult>("list", hookCtx);
+    if (errors.length > 0) throw errors[0]!;
+    return results[0] ?? {};
   }
-);
+}
 
 /** Result from get-workspace-status: resolve-workspace + get. */
 interface GetStatusResult {
@@ -252,7 +277,7 @@ function createTestSetup(): TestSetup {
   dispatcher.registerOperation("workspace:open", openWorkspaceOperation);
   dispatcher.registerOperation("workspace:delete", new MinimalDeleteWorkspaceOperation());
   dispatcher.registerOperation("workspace:resolve", new MinimalResolveWorkspaceOperation());
-  dispatcher.registerOperation("open-workspace", fetchBasesOperation);
+  dispatcher.registerOperation("project:get-bases", new MinimalGetProjectBasesOperation());
   dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
 
   // Wire the module under test
@@ -308,14 +333,21 @@ async function dispatchResolveWorkspace(
   } as Intent)) as ResolveResult;
 }
 
-async function dispatchFetchBases(
+async function dispatchListBases(
   dispatcher: Dispatcher,
   projectPath: string
-): Promise<FetchBasesHookResult> {
+): Promise<GetProjectBasesTestResult> {
   return (await dispatcher.dispatch({
-    type: "open-workspace",
+    type: "project:get-bases",
     payload: { projectPath },
-  } as Intent)) as FetchBasesHookResult;
+  } as Intent)) as GetProjectBasesTestResult;
+}
+
+async function dispatchRefreshBases(dispatcher: Dispatcher, projectPath: string): Promise<void> {
+  await dispatcher.dispatch({
+    type: "project:get-bases",
+    payload: { projectPath, hookPoint: "refresh" },
+  } as Intent);
 }
 
 async function dispatchGetStatus(
@@ -637,10 +669,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // open-workspace -> fetch-bases
+  // get-project-bases -> list
   // ---------------------------------------------------------------------------
 
-  describe("open-workspace -> fetch-bases", () => {
+  describe("get-project-bases -> list", () => {
     it("returns bases and defaultBaseBranch from provider", async () => {
       const { dispatcher, provider } = setup;
       const projectPath = "/projects/my-app";
@@ -651,12 +683,27 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       ]);
       provider.defaultBase.mockResolvedValue("origin/main");
 
-      const result = await dispatchFetchBases(dispatcher, projectPath);
+      const result = await dispatchListBases(dispatcher, projectPath);
 
       expect(provider.listBases).toHaveBeenCalledWith(new Path(projectPath));
       expect(provider.defaultBase).toHaveBeenCalledWith(new Path(projectPath));
       expect(result.bases).toHaveLength(2);
       expect(result.defaultBaseBranch).toBe("origin/main");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // get-project-bases -> refresh
+  // ---------------------------------------------------------------------------
+
+  describe("get-project-bases -> refresh", () => {
+    it("calls updateBases on provider", async () => {
+      const { dispatcher, provider } = setup;
+      const projectPath = "/projects/my-app";
+
+      await dispatchRefreshBases(dispatcher, projectPath);
+
+      expect(provider.updateBases).toHaveBeenCalledWith(new Path(projectPath));
     });
   });
 

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -5,7 +5,8 @@
  * - resolve-workspace: shared workspace resolution (workspacePath → projectPath + workspaceName)
  * - open-project: register project, discover workspaces, fire-and-forget cleanup
  * - close-project: unregister project, clear state
- * - open-workspace: resolve caller, create worktree, fetch bases
+ * - open-workspace: resolve caller, create worktree
+ * - get-project-bases: list bases (local read), refresh bases (git fetch)
  * - delete-workspace: remove worktree
  * - switch-workspace: find candidates
  * - get-workspace-status: check dirty status
@@ -29,6 +30,12 @@ import type {
   ResolveCallerHookResult,
 } from "../operations/open-workspace";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
+import type {
+  ListBasesHookInput,
+  ListBasesHookResult,
+  RefreshBasesHookInput,
+} from "../operations/get-project-bases";
+import { GET_PROJECT_BASES_OPERATION_ID } from "../operations/get-project-bases";
 import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
 import type { DeleteHookResult, DeletePipelineHookInput } from "../operations/delete-workspace";
 import type { DiscoverHookResult, DiscoverHookInput } from "../operations/open-project";
@@ -53,26 +60,12 @@ import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../services/errors";
 
 // =============================================================================
-// Hook Context Types
-// =============================================================================
-
-interface FetchBasesInput extends HookContext {
-  readonly projectPath: string;
-}
-
-// =============================================================================
 // Hook Result Types
 // =============================================================================
 
 /** Result from the open-project "setup" hook point. */
 export interface WorkspaceSetupHookResult {
   readonly workspaces: readonly Workspace[];
-  readonly defaultBaseBranch?: string;
-}
-
-/** Result from the open-workspace "fetch-bases" hook point. */
-export interface FetchBasesHookResult {
-  readonly bases: readonly { name: string; isRemote: boolean }[];
   readonly defaultBaseBranch?: string;
 }
 
@@ -207,7 +200,7 @@ export function createGitWorktreeWorkspaceModule(
         },
       },
 
-      // open-workspace -> resolve-caller + create + fetch-bases
+      // open-workspace -> resolve-caller + create
       [OPEN_WORKSPACE_OPERATION_ID]: {
         "resolve-caller": {
           handler: async (ctx: HookContext): Promise<ResolveCallerHookResult> => {
@@ -283,10 +276,13 @@ export function createGitWorktreeWorkspaceModule(
             };
           },
         },
+      },
 
-        "fetch-bases": {
-          handler: async (ctx: HookContext): Promise<FetchBasesHookResult> => {
-            const { projectPath } = ctx as FetchBasesInput;
+      // get-project-bases -> list + refresh
+      [GET_PROJECT_BASES_OPERATION_ID]: {
+        list: {
+          handler: async (ctx: HookContext): Promise<ListBasesHookResult> => {
+            const { projectPath } = ctx as ListBasesHookInput;
             const projectPathObj = new Path(projectPath);
 
             const bases = await globalProvider.listBases(projectPathObj);
@@ -296,6 +292,12 @@ export function createGitWorktreeWorkspaceModule(
               bases,
               ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
             };
+          },
+        },
+        refresh: {
+          handler: async (ctx: HookContext): Promise<void> => {
+            const { projectPath } = ctx as RefreshBasesHookInput;
+            await globalProvider.updateBases(new Path(projectPath));
           },
         },
       },

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -189,9 +189,6 @@ function createStatusTestSetup(): StatusTestSetup {
     agentStatusManager: {
       getStatus: vi.fn(),
     } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-    globalWorktreeProvider: {
-      listWorktrees: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
   });
   const resolveModule = createMockResolveModule();
 
@@ -258,9 +255,6 @@ function createLifecycleTestSetup(
     agentStatusManager: {
       getStatus: vi.fn(),
     } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-    globalWorktreeProvider: {
-      listWorktrees: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
   });
 
   // Wire quit module to prevent app.quit() error on shutdown
@@ -416,6 +410,58 @@ describe("IpcEventBridge - workspace:deleted", () => {
 });
 
 // =============================================================================
+// Tests - bases:updated event
+// =============================================================================
+
+describe("IpcEventBridge - bases:updated", () => {
+  it("emits project:bases-updated on bases:updated domain event", () => {
+    const mockApiRegistry = createMockRegistry();
+    const ipcEventBridge = createIpcEventBridge({
+      apiRegistry: mockApiRegistry,
+      getApi: () => {
+        throw new Error("not wired");
+      },
+      sendToUI: vi.fn<(channel: string, ...args: unknown[]) => void>(),
+      pluginServer: null,
+      logger: SILENT_LOGGER,
+      dispatcher: {} as unknown as IpcEventBridgeDeps["dispatcher"],
+      agentStatusManager: {
+        getStatus: vi.fn(),
+      } as unknown as IpcEventBridgeDeps["agentStatusManager"],
+    });
+
+    const bases = [
+      { name: "main", isRemote: false },
+      { name: "origin/main", isRemote: true },
+    ];
+
+    // Call the event handler directly
+    ipcEventBridge.events!["bases:updated"]!({
+      type: "bases:updated",
+      payload: {
+        projectId: TEST_PROJECT_ID,
+        projectPath: TEST_PROJECT_PATH,
+        bases,
+      },
+    });
+
+    const basesEvents = mockApiRegistry
+      .getEmittedEvents()
+      .filter((e) => e.event === "project:bases-updated");
+    expect(basesEvents).toEqual([
+      {
+        event: "project:bases-updated",
+        payload: {
+          projectId: TEST_PROJECT_ID,
+          projectPath: TEST_PROJECT_PATH,
+          bases,
+        },
+      },
+    ]);
+  });
+});
+
+// =============================================================================
 // Tests - workspace:deletion-progress event
 // =============================================================================
 
@@ -441,9 +487,6 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
     });
 
     const progressPayload = {
@@ -489,9 +532,6 @@ describe("IpcEventBridge - workspace:deletion-progress", () => {
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
     });
 
     // Should not throw when sendToUI is a no-op
@@ -582,9 +622,6 @@ describe("IpcEventBridge - lifecycle", () => {
         agentStatusManager: {
           getStatus: vi.fn(),
         } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-        globalWorktreeProvider: {
-          listWorktrees: vi.fn(),
-        } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
       });
 
       const quitModule: IntentModule = {
@@ -650,9 +687,6 @@ describe("IpcEventBridge - lifecycle", () => {
         agentStatusManager: {
           getStatus: vi.fn(),
         } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-        globalWorktreeProvider: {
-          listWorktrees: vi.fn(),
-        } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
       });
 
       const quitModule: IntentModule = {
@@ -719,9 +753,6 @@ describe("IpcEventBridge - setup:error", () => {
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
     });
 
     // Hook module that throws to trigger the setup:error domain event
@@ -780,9 +811,6 @@ describe("IpcEventBridge - setup:error", () => {
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
     });
 
     const errorWithCode = Object.assign(new Error("Network timeout"), { code: "ETIMEDOUT" });
@@ -836,9 +864,6 @@ function createApiTestSetup(overrides?: { pluginServer?: IpcEventBridgeDeps["plu
     agentStatusManager: {
       getStatus: vi.fn(),
     } as unknown as IpcEventBridgeDeps["agentStatusManager"],
-    globalWorktreeProvider: {
-      listWorktrees: vi.fn(),
-    } as unknown as IpcEventBridgeDeps["globalWorktreeProvider"],
   });
 
   dispatcher.registerModule(ipcEventBridge);

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -66,6 +66,9 @@ import { EVENT_WORKSPACE_SWITCHED, INTENT_SWITCH_WORKSPACE } from "../operations
 import type { SwitchWorkspaceIntent } from "../operations/switch-workspace";
 import type { AgentStatusUpdatedEvent } from "../operations/update-agent-status";
 import { EVENT_AGENT_STATUS_UPDATED } from "../operations/update-agent-status";
+import type { BasesUpdatedEvent } from "../operations/get-project-bases";
+import { EVENT_BASES_UPDATED, INTENT_GET_PROJECT_BASES } from "../operations/get-project-bases";
+import type { GetProjectBasesIntent } from "../operations/get-project-bases";
 import { EVENT_SETUP_ERROR, EVENT_SETUP_PROGRESS } from "../operations/setup";
 import type { SetupErrorEvent, SetupProgressEvent } from "../operations/setup";
 import type { SetupErrorPayload, WorkspacePath } from "../../shared/ipc";
@@ -84,7 +87,6 @@ import type { GetActiveWorkspaceIntent } from "../operations/get-active-workspac
 import { INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
 import type { AppShutdownIntent } from "../operations/app-shutdown";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
-import type { GitWorktreeProvider } from "../../services/git/git-worktree-provider";
 import { Path } from "../../services/platform/path";
 
 /**
@@ -102,7 +104,6 @@ export interface IpcEventBridgeDeps {
   readonly agentStatusManager: {
     getStatus(wp: WorkspacePath): { status: string } | undefined;
   };
-  readonly globalWorktreeProvider: GitWorktreeProvider;
 }
 
 /**
@@ -194,6 +195,14 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
         ...(code !== undefined && { code }),
       };
       deps.sendToUI(ApiIpcChannels.LIFECYCLE_SETUP_ERROR, errorPayload);
+    },
+    [EVENT_BASES_UPDATED]: (event: DomainEvent) => {
+      const p = (event as BasesUpdatedEvent).payload;
+      apiRegistry.emit("project:bases-updated", {
+        projectId: p.projectId,
+        projectPath: p.projectPath,
+        bases: p.bases,
+      });
     },
     [EVENT_AGENT_STATUS_UPDATED]: (event: DomainEvent) => {
       const {
@@ -485,46 +494,15 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
   apiRegistry.register(
     "projects.fetchBases",
     async (payload: ProjectPathPayload) => {
-      // Dispatch workspace:open with incomplete payload (missing workspaceName/base)
-      // This triggers the project:resolve + fetch-bases path
-      const intent: OpenWorkspaceIntent = {
-        type: INTENT_OPEN_WORKSPACE,
-        payload: {
-          projectPath: payload.projectPath,
-        },
+      const intent: GetProjectBasesIntent = {
+        type: INTENT_GET_PROJECT_BASES,
+        payload: { projectPath: payload.projectPath, refresh: true },
       };
       const result = await dispatcher.dispatch(intent);
       if (!result) {
         throw new Error("Fetch bases dispatch returned no result");
       }
-      const basesResult = result as {
-        bases: readonly { name: string; isRemote: boolean }[];
-        defaultBaseBranch?: string;
-        projectPath: string;
-        projectId: import("../../shared/api/types").ProjectId;
-      };
-
-      // Fire-and-forget background update
-      void (async () => {
-        try {
-          const projectRoot = new Path(basesResult.projectPath);
-          await deps.globalWorktreeProvider.updateBases(projectRoot);
-          const updatedBases = await deps.globalWorktreeProvider.listBases(projectRoot);
-          apiRegistry.emit("project:bases-updated", {
-            projectId: basesResult.projectId,
-            projectPath: basesResult.projectPath,
-            bases: updatedBases,
-          });
-        } catch (error) {
-          logger.error(
-            "Failed to fetch bases for project",
-            { projectPath: payload.projectPath },
-            error instanceof Error ? error : undefined
-          );
-        }
-      })();
-
-      return { bases: basesResult.bases };
+      return { bases: result.bases };
     },
     { ipc: ApiIpcChannels.PROJECT_FETCH_BASES }
   );

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -216,9 +216,6 @@ function createTestSetup(): TestSetup {
     agentStatusManager: {
       getStatus: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
-    globalWorktreeProvider: {
-      listWorktrees: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/get-project-bases.integration.test.ts
+++ b/src/main/operations/get-project-bases.integration.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment node
+/**
+ * Integration tests for get-project-bases operation through the Dispatcher.
+ *
+ * Tests verify the full dispatch pipeline: intent -> hooks -> event -> result.
+ *
+ * Test plan items covered:
+ * - Dispatch with list hook returns cached bases
+ * - Emits bases:updated domain event with fresh data (after fire-and-forget refresh)
+ * - Refresh hook failure does not fail the operation
+ * - No refresh when refresh flag is false/omitted
+ * - project:resolve failure propagates
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+
+import {
+  GetProjectBasesOperation,
+  INTENT_GET_PROJECT_BASES,
+  GET_PROJECT_BASES_OPERATION_ID,
+  EVENT_BASES_UPDATED,
+} from "./get-project-bases";
+import type {
+  GetProjectBasesIntent,
+  GetProjectBasesResult,
+  ListBasesHookResult,
+  BasesUpdatedEvent,
+} from "./get-project-bases";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "./resolve-project";
+import type {
+  ResolveHookResult as ResolveProjectHookResult,
+  ResolveHookInput as ResolveProjectHookInput,
+} from "./resolve-project";
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import type { ProjectId } from "../../shared/api/types";
+
+// =============================================================================
+// Test Constants
+// =============================================================================
+
+const PROJECT_ID = "project-ea0135bc" as ProjectId;
+const PROJECT_ROOT = "/project";
+const CACHED_BASES = [
+  { name: "main", isRemote: false },
+  { name: "origin/main", isRemote: true },
+] as const;
+const FRESH_BASES = [
+  { name: "main", isRemote: false },
+  { name: "origin/main", isRemote: true },
+  { name: "origin/feature-x", isRemote: true },
+] as const;
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+interface TestSetupOptions {
+  refreshThrows?: boolean;
+  freshBases?: readonly { name: string; isRemote: boolean }[];
+  unknownProject?: boolean;
+}
+
+interface TestSetup {
+  dispatcher: Dispatcher;
+  refreshCalled: { value: boolean };
+}
+
+function createTestSetup(opts?: TestSetupOptions): TestSetup {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+  dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
+
+  // Shared project:resolve module
+  const resolveProjectModule: IntentModule = {
+    name: "test",
+    hooks: {
+      [RESOLVE_PROJECT_OPERATION_ID]: {
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+            const { projectPath } = ctx as ResolveProjectHookInput;
+            if (opts?.unknownProject || projectPath !== PROJECT_ROOT) {
+              return {};
+            }
+            return { projectId: PROJECT_ID, projectName: "test" };
+          },
+        },
+      },
+    },
+  };
+
+  // Track whether refresh was called
+  const refreshCalled = { value: false };
+  const freshBases = opts?.freshBases ?? FRESH_BASES;
+
+  // List hook returns cached bases (first call) or fresh bases (after refresh)
+  let listCallCount = 0;
+  const listModule: IntentModule = {
+    name: "test",
+    hooks: {
+      [GET_PROJECT_BASES_OPERATION_ID]: {
+        list: {
+          handler: async (): Promise<ListBasesHookResult> => {
+            listCallCount++;
+            // First call returns cached, subsequent calls return fresh
+            const bases = listCallCount === 1 ? [...CACHED_BASES] : [...freshBases];
+            return { bases, defaultBaseBranch: "main" };
+          },
+        },
+        refresh: {
+          handler: async (): Promise<void> => {
+            if (opts?.refreshThrows) {
+              throw new Error("git fetch failed");
+            }
+            refreshCalled.value = true;
+          },
+        },
+      },
+    },
+  };
+
+  dispatcher.registerModule(resolveProjectModule);
+  dispatcher.registerModule(listModule);
+
+  return { dispatcher, refreshCalled };
+}
+
+function createIntent(
+  projectPath = PROJECT_ROOT,
+  opts?: { refresh?: boolean; wait?: boolean }
+): GetProjectBasesIntent {
+  return {
+    type: INTENT_GET_PROJECT_BASES,
+    payload: {
+      projectPath,
+      ...(opts?.refresh !== undefined && { refresh: opts.refresh }),
+      ...(opts?.wait !== undefined && { wait: opts.wait }),
+    },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("GetProjectBases Operation", () => {
+  describe("dispatch with list hook returns cached bases", () => {
+    let setup: TestSetup;
+
+    beforeEach(() => {
+      setup = createTestSetup();
+    });
+
+    it("returns cached bases, defaultBaseBranch, projectPath, and projectId", async () => {
+      const result = (await setup.dispatcher.dispatch(
+        createIntent(PROJECT_ROOT, { refresh: true })
+      )) as GetProjectBasesResult;
+
+      expect(result.bases).toEqual(CACHED_BASES);
+      expect(result.defaultBaseBranch).toBe("main");
+      expect(result.projectPath).toBe(PROJECT_ROOT);
+      expect(result.projectId).toBe(PROJECT_ID);
+    });
+  });
+
+  describe("emits bases:updated domain event with fresh data after refresh", () => {
+    it("emits event after fire-and-forget refresh completes", async () => {
+      const setup = createTestSetup();
+      const events: DomainEvent[] = [];
+      setup.dispatcher.subscribe(EVENT_BASES_UPDATED, (event) => {
+        events.push(event);
+      });
+
+      await setup.dispatcher.dispatch(createIntent(PROJECT_ROOT, { refresh: true }));
+
+      // Wait for fire-and-forget to complete
+      await vi.waitFor(() => {
+        expect(events.length).toBe(1);
+      });
+
+      const freshEvent = events[0] as BasesUpdatedEvent;
+      expect(freshEvent.type).toBe(EVENT_BASES_UPDATED);
+      expect(freshEvent.payload.projectId).toBe(PROJECT_ID);
+      expect(freshEvent.payload.projectPath).toBe(PROJECT_ROOT);
+      expect(freshEvent.payload.bases).toEqual(FRESH_BASES);
+    });
+  });
+
+  describe("no refresh when flag is omitted", () => {
+    it("does not call refresh hook and emits no events", async () => {
+      const setup = createTestSetup();
+      const events: DomainEvent[] = [];
+      setup.dispatcher.subscribe(EVENT_BASES_UPDATED, (event) => {
+        events.push(event);
+      });
+
+      const result = (await setup.dispatcher.dispatch(createIntent())) as GetProjectBasesResult;
+
+      // Returns cached bases
+      expect(result.bases).toEqual(CACHED_BASES);
+
+      // Wait a tick to confirm no fire-and-forget ran
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No refresh called, no events emitted
+      expect(setup.refreshCalled.value).toBe(false);
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe("refresh hook failure does not fail the operation", () => {
+    it("returns cached bases even when refresh throws", async () => {
+      const setup = createTestSetup({ refreshThrows: true });
+      const events: DomainEvent[] = [];
+      setup.dispatcher.subscribe(EVENT_BASES_UPDATED, (event) => {
+        events.push(event);
+      });
+
+      const result = (await setup.dispatcher.dispatch(
+        createIntent(PROJECT_ROOT, { refresh: true })
+      )) as GetProjectBasesResult;
+
+      // Operation succeeds with cached data
+      expect(result.bases).toEqual(CACHED_BASES);
+      expect(result.projectId).toBe(PROJECT_ID);
+
+      // Wait a tick to let the fire-and-forget try/catch complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No events emitted (refresh failed before re-list)
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe("wait flag awaits refresh and returns fresh data", () => {
+    it("returns fresh bases when wait is true", async () => {
+      const setup = createTestSetup();
+      const events: DomainEvent[] = [];
+      setup.dispatcher.subscribe(EVENT_BASES_UPDATED, (event) => {
+        events.push(event);
+      });
+
+      const result = (await setup.dispatcher.dispatch(
+        createIntent(PROJECT_ROOT, { refresh: true, wait: true })
+      )) as GetProjectBasesResult;
+
+      // Returns fresh bases (after refresh + re-list)
+      expect(result.bases).toEqual(FRESH_BASES);
+      expect(result.projectPath).toBe(PROJECT_ROOT);
+      expect(result.projectId).toBe(PROJECT_ID);
+
+      // No events emitted (caller gets fresh data directly)
+      expect(events).toHaveLength(0);
+    });
+
+    it("falls back to cached bases when refresh throws", async () => {
+      const setup = createTestSetup({ refreshThrows: true });
+
+      const result = (await setup.dispatcher.dispatch(
+        createIntent(PROJECT_ROOT, { refresh: true, wait: true })
+      )) as GetProjectBasesResult;
+
+      // Falls back to cached data
+      expect(result.bases).toEqual(CACHED_BASES);
+      expect(result.projectId).toBe(PROJECT_ID);
+    });
+  });
+
+  describe("project:resolve failure propagates", () => {
+    it("throws when project is not found", async () => {
+      const setup = createTestSetup({ unknownProject: true });
+
+      await expect(setup.dispatcher.dispatch(createIntent())).rejects.toThrow(
+        "Project not found for path: /project"
+      );
+    });
+
+    it("throws for unrecognized project path", async () => {
+      const setup = createTestSetup();
+
+      await expect(setup.dispatcher.dispatch(createIntent("/nonexistent/project"))).rejects.toThrow(
+        "Project not found for path: /nonexistent/project"
+      );
+    });
+  });
+});

--- a/src/main/operations/get-project-bases.ts
+++ b/src/main/operations/get-project-bases.ts
@@ -1,0 +1,189 @@
+/**
+ * GetProjectBasesOperation - Returns cached branch bases for a project.
+ *
+ * Two hook points:
+ * 1. "list" — fast local read of cached bases + default base branch
+ * 2. "refresh" — slow remote fetch (git fetch)
+ *
+ * Flow:
+ * 1. Dispatch project:resolve to get projectId
+ * 2. hooks.collect("list") → bases, defaultBaseBranch
+ * 3. If refresh:
+ *    - wait=false (default): fire-and-forget refresh → re-list → emit bases:updated
+ *    - wait=true: await refresh → re-list → return fresh data (no event)
+ * 4. Return cached bases (or fresh bases when wait=true)
+ *
+ * No provider dependencies — hook handlers do the actual work.
+ */
+
+import type { Intent, DomainEvent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { ProjectId } from "../../shared/api/types";
+import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface GetProjectBasesPayload {
+  readonly projectPath: string;
+  readonly refresh?: boolean;
+  /** When true (and refresh is true), await the refresh and return fresh data. */
+  readonly wait?: boolean;
+}
+
+export interface GetProjectBasesResult {
+  readonly bases: readonly { name: string; isRemote: boolean }[];
+  readonly defaultBaseBranch?: string;
+  readonly projectPath: string;
+  readonly projectId: ProjectId;
+}
+
+export interface GetProjectBasesIntent extends Intent<GetProjectBasesResult> {
+  readonly type: "project:get-bases";
+  readonly payload: GetProjectBasesPayload;
+}
+
+export const INTENT_GET_PROJECT_BASES = "project:get-bases" as const;
+
+// =============================================================================
+// Event Types
+// =============================================================================
+
+export interface BasesUpdatedPayload {
+  readonly projectId: ProjectId;
+  readonly projectPath: string;
+  readonly bases: readonly { name: string; isRemote: boolean }[];
+}
+
+export interface BasesUpdatedEvent extends DomainEvent {
+  readonly type: "bases:updated";
+  readonly payload: BasesUpdatedPayload;
+}
+
+export const EVENT_BASES_UPDATED = "bases:updated" as const;
+
+// =============================================================================
+// Hook Point Types
+// =============================================================================
+
+export interface ListBasesHookInput extends HookContext {
+  readonly projectPath: string;
+}
+
+export interface ListBasesHookResult {
+  readonly bases?: readonly { name: string; isRemote: boolean }[];
+  readonly defaultBaseBranch?: string;
+}
+
+export interface RefreshBasesHookInput extends HookContext {
+  readonly projectPath: string;
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export const GET_PROJECT_BASES_OPERATION_ID = "get-project-bases";
+
+/** Merge hook results field-by-field. Throws if two handlers contribute the same field. */
+function mergeHookResults<T extends object>(results: readonly T[], hookPoint: string): Partial<T> {
+  const merged: Record<string, unknown> = {};
+  for (const result of results) {
+    for (const [key, value] of Object.entries(result)) {
+      if (value !== undefined) {
+        if (key in merged) {
+          throw new Error(`${hookPoint} hook conflict: "${key}" provided by multiple handlers`);
+        }
+        merged[key] = value;
+      }
+    }
+  }
+  return merged as Partial<T>;
+}
+
+export class GetProjectBasesOperation implements Operation<
+  GetProjectBasesIntent,
+  GetProjectBasesResult
+> {
+  readonly id = GET_PROJECT_BASES_OPERATION_ID;
+
+  async execute(ctx: OperationContext<GetProjectBasesIntent>): Promise<GetProjectBasesResult> {
+    const { projectPath, refresh } = ctx.intent.payload;
+
+    // 1. Dispatch project:resolve to get projectId
+    const { projectId } = await ctx.dispatch({
+      type: INTENT_RESOLVE_PROJECT,
+      payload: { projectPath },
+    } as ResolveProjectIntent);
+
+    // 2. Collect "list" hook — fast local read
+    const listCtx: ListBasesHookInput = { intent: ctx.intent, projectPath };
+    const { results: listResults, errors: listErrors } =
+      await ctx.hooks.collect<ListBasesHookResult>("list", listCtx);
+
+    if (listErrors.length > 0) throw listErrors[0]!;
+
+    const listMerged = mergeHookResults(listResults, "list");
+    const bases = listMerged.bases ?? [];
+    const defaultBaseBranch = listMerged.defaultBaseBranch;
+
+    // 3. Refresh if requested
+    if (refresh) {
+      const refreshAndRelist = async (): Promise<GetProjectBasesResult | undefined> => {
+        const refreshCtx: RefreshBasesHookInput = { intent: ctx.intent, projectPath };
+        const { errors: refreshErrors } = await ctx.hooks.collect("refresh", refreshCtx);
+        if (refreshErrors.length > 0) return undefined;
+
+        const { results: freshListResults } = await ctx.hooks.collect<ListBasesHookResult>(
+          "list",
+          listCtx
+        );
+        const freshMerged = mergeHookResults(freshListResults, "list");
+        const freshBases = freshMerged.bases ?? [];
+        return {
+          bases: freshBases,
+          ...(freshMerged.defaultBaseBranch !== undefined && {
+            defaultBaseBranch: freshMerged.defaultBaseBranch,
+          }),
+          projectPath,
+          projectId,
+        };
+      };
+
+      if (ctx.intent.payload.wait) {
+        // Await refresh and return fresh data; fall back to cached on error
+        try {
+          const freshResult = await refreshAndRelist();
+          if (freshResult) return freshResult;
+        } catch {
+          // Refresh failed — fall through to return cached
+        }
+      } else {
+        // Fire-and-forget: refresh in background, emit event with fresh data
+        void (async () => {
+          try {
+            const freshResult = await refreshAndRelist();
+            if (freshResult) {
+              const freshEvent: BasesUpdatedEvent = {
+                type: EVENT_BASES_UPDATED,
+                payload: { projectId, projectPath, bases: freshResult.bases },
+              };
+              ctx.emit(freshEvent);
+            }
+          } catch {
+            // Fire-and-forget: errors are silently swallowed
+          }
+        })();
+      }
+    }
+
+    // 4. Return cached result
+    return {
+      bases,
+      ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+      projectPath,
+      projectId,
+    };
+  }
+}

--- a/src/main/operations/open-workspace.integration.test.ts
+++ b/src/main/operations/open-workspace.integration.test.ts
@@ -21,7 +21,6 @@
  * #12: No keepfiles side effects when worktree creation fails
  * #15: existingWorkspace skips worktree creation
  * #16: existingWorkspace uses projectPath directly
- * #17: Incomplete payload returns bases
  * #18: project:resolve failure propagates error
  * #20: stealFocus=false with no active workspace dispatches switch
  * #21: stealFocus=false with active workspace skips switch
@@ -202,7 +201,6 @@ interface TestSetupOptions {
   serverManager?: MockServerManager;
   agentStatusManager?: MockAgentStatusManager;
   keepFilesService?: MockKeepFilesService;
-  fetchBasesModule?: IntentModule;
   throwOnCreate?: boolean;
   setupThrows?: boolean;
   workspaceUrl?: string;
@@ -286,31 +284,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
       },
     },
   };
-
-  // Default FetchBasesModule: "fetch-bases" hook — returns bases for dialog
-  const defaultFetchBasesModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [OPEN_WORKSPACE_OPERATION_ID]: {
-        "fetch-bases": {
-          handler: async (): Promise<{
-            bases: readonly { name: string; isRemote: boolean }[];
-            defaultBaseBranch?: string;
-          }> => {
-            return {
-              bases: [
-                { name: "main", isRemote: false },
-                { name: "origin/main", isRemote: true },
-              ],
-              defaultBaseBranch: "main",
-            };
-          },
-        },
-      },
-    },
-  };
-
-  const fetchBasesModule = opts?.fetchBasesModule ?? defaultFetchBasesModule;
 
   // GetActiveWorkspace module: returns configurable active workspace ref
   const activeWorkspaceRef = opts?.activeWorkspaceRef ?? null;
@@ -459,7 +432,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     resolveProjectResolveModule,
     switchViewModule,
     getActiveWorkspaceModule,
-    fetchBasesModule,
     worktreeModule,
     keepFilesModule,
     agentModule,
@@ -861,54 +833,6 @@ describe("OpenWorkspace Operation", () => {
     });
   });
 
-  describe("incomplete payload returns bases (#17)", () => {
-    it("returns bases when workspaceName is missing", async () => {
-      const setup = createTestSetup();
-
-      const intent: OpenWorkspaceIntent = {
-        type: INTENT_OPEN_WORKSPACE,
-        payload: {
-          projectPath: PROJECT_ROOT,
-          // No workspaceName or base
-        },
-      };
-
-      const result = await setup.dispatcher.dispatch(intent);
-
-      expect(result).toBeDefined();
-      // Result should be the bases object, not a Workspace
-      expect(result).toHaveProperty("bases");
-      const basesResult = result as {
-        bases: readonly { name: string; isRemote: boolean }[];
-        defaultBaseBranch?: string;
-      };
-      expect(basesResult.bases).toHaveLength(2);
-      expect(basesResult.bases[0]).toEqual({ name: "main", isRemote: false });
-      expect(basesResult.bases[1]).toEqual({ name: "origin/main", isRemote: true });
-      expect(basesResult.defaultBaseBranch).toBe("main");
-    });
-
-    it("returns bases when base is missing", async () => {
-      const setup = createTestSetup();
-
-      const intent: OpenWorkspaceIntent = {
-        type: INTENT_OPEN_WORKSPACE,
-        payload: {
-          projectPath: PROJECT_ROOT,
-          workspaceName: "feature-x",
-          // No base
-        },
-      };
-
-      const result = await setup.dispatcher.dispatch(intent);
-
-      expect(result).toBeDefined();
-      expect(result).toHaveProperty("bases");
-      const basesResult = result as { bases: readonly { name: string; isRemote: boolean }[] };
-      expect(basesResult.bases).toHaveLength(2);
-    });
-  });
-
   describe("project:resolve failure propagates error (#18)", () => {
     it("throws when project:resolve finds no project for path", async () => {
       const setup = createTestSetup();
@@ -997,18 +921,6 @@ describe("OpenWorkspace Operation", () => {
           },
         },
       };
-      const fetchBasesModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [OPEN_WORKSPACE_OPERATION_ID]: {
-            "fetch-bases": {
-              handler: async () => ({
-                bases: [{ name: "main", isRemote: false }],
-              }),
-            },
-          },
-        },
-      };
       const worktreeModule: IntentModule = {
         name: "test",
         hooks: {
@@ -1069,7 +981,6 @@ describe("OpenWorkspace Operation", () => {
       dispatcher.registerModule(resolveProjectResolveModule);
       dispatcher.registerModule(switchViewModule);
       dispatcher.registerModule(getActiveWorkspaceModule);
-      dispatcher.registerModule(fetchBasesModule);
       dispatcher.registerModule(worktreeModule);
       dispatcher.registerModule(agentModule);
       dispatcher.registerModule(extraEnvModule);

--- a/src/main/operations/open-workspace.ts
+++ b/src/main/operations/open-workspace.ts
@@ -1,9 +1,6 @@
 /**
  * OpenWorkspaceOperation - Orchestrates workspace opening.
  *
- * Replaces CreateWorkspaceOperation with an expanded pipeline that includes
- * project resolution and a fetch-bases path for incomplete payloads.
- *
  * Uses isolated hook contexts with collect() — each hook point returns typed
  * results that are merged field-by-field with conflict detection.
  *
@@ -11,10 +8,7 @@
  * 0. If callerWorkspacePath:
  *    Dispatch workspace:resolve to get projectPath
  * 1. Dispatch project:resolve to get projectId from projectPath
- * 2. If incomplete (missing workspaceName or base):
- *    "fetch-bases" → FetchBasesHookResult — returns bases for dialog (fatal, early return)
- * 3. If complete:
- *    "create" → CreateHookResult — worktree creation (fatal)
+ * 2. "create" → CreateHookResult — worktree creation (fatal)
  *    "setup" → SetupHookResult — keepfiles (best-effort, internal try/catch),
  *     agent server (fatal)
  *    "finalize" → FinalizeHookResult — workspace URL (fatal)
@@ -61,8 +55,8 @@ export interface OpenWorkspacePayload {
    * When present, resolved via dispatch to determine projectPath.
    */
   readonly callerWorkspacePath?: string;
-  readonly workspaceName?: string;
-  readonly base?: string;
+  readonly workspaceName: string;
+  readonly base: string;
   readonly initialPrompt?: InitialPrompt;
   /** If true, switch to the new workspace. If false, don't steal focus but still switch when
    *  no workspace is active. Default behavior (undefined): switch. */
@@ -73,14 +67,7 @@ export interface OpenWorkspacePayload {
   readonly projectPath?: string;
 }
 
-export type OpenWorkspaceResult =
-  | Workspace
-  | {
-      bases: readonly { name: string; isRemote: boolean }[];
-      defaultBaseBranch?: string;
-      projectPath: string;
-      projectId: ProjectId;
-    };
+export type OpenWorkspaceResult = Workspace;
 
 export interface OpenWorkspaceIntent extends Intent<OpenWorkspaceResult> {
   readonly type: "workspace:open";
@@ -132,11 +119,6 @@ export interface ResolveCallerHookInput extends HookContext {
 export interface ResolveCallerHookResult {
   readonly projectPath?: string;
   readonly workspaceName?: WorkspaceName;
-}
-
-/** Input context for the "fetch-bases" hook point (enriched with resolved project path). */
-export interface FetchBasesHookInput extends HookContext {
-  readonly projectPath: string;
 }
 
 /** Input context for the "create" hook point (enriched with resolved project path). */
@@ -217,33 +199,9 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
     } as ResolveProjectIntent);
     const resolvedProjectId = projResolved.projectId;
 
-    // Check if payload is incomplete (missing workspaceName or base)
-    const { workspaceName, base } = ctx.intent.payload;
-    if (workspaceName === undefined || base === undefined) {
-      // Hook: "fetch-bases" — return bases for dialog (fatal, early return)
-      const fetchBasesCtx: FetchBasesHookInput = {
-        intent: ctx.intent,
-        projectPath,
-      };
-      const { results: fetchBasesResults, errors: fetchBasesErrors } = await ctx.hooks.collect<{
-        bases?: readonly { name: string; isRemote: boolean }[];
-        defaultBaseBranch?: string;
-      }>("fetch-bases", fetchBasesCtx);
+    const { base } = ctx.intent.payload;
 
-      if (fetchBasesErrors.length > 0) throw fetchBasesErrors[0]!;
-
-      const fetchBases = mergeHookResults(fetchBasesResults, "fetch-bases");
-      return {
-        bases: fetchBases.bases ?? [],
-        ...(fetchBases.defaultBaseBranch !== undefined && {
-          defaultBaseBranch: fetchBases.defaultBaseBranch,
-        }),
-        projectPath,
-        projectId: resolvedProjectId,
-      };
-    }
-
-    // Hook 3a: "create" — worktree creation (fatal on error)
+    // Hook: "create" — worktree creation (fatal on error)
     const createCtx: CreateHookInput = { intent: ctx.intent, projectPath };
     const { results: createResults, errors: createErrors } =
       await ctx.hooks.collect<CreateHookResult>("create", createCtx);

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -203,9 +203,6 @@ function createTestSetup(): TestSetup {
     agentStatusManager: {
       getStatus: vi.fn(),
     } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
-    globalWorktreeProvider: {
-      listWorktrees: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -106,9 +106,6 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -336,9 +336,6 @@ function createTestSetup(opts?: {
       agentStatusManager: {
         getStatus: vi.fn(),
       } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
-      globalWorktreeProvider: {
-        listWorktrees: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["globalWorktreeProvider"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/renderer/lib/components/NameBranchDropdown.svelte
+++ b/src/renderer/lib/components/NameBranchDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { projects, type BaseInfo } from "$lib/api";
+  import { projects, on, type BaseInfo } from "$lib/api";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
 
   /**
@@ -47,18 +47,32 @@
   let branches = $state<readonly BaseInfo[]>([]);
   let error = $state<string | null>(null);
 
-  // Load branches on mount or when projectId changes
+  // Load branches on mount or when projectPath changes
   $effect(() => {
+    const currentProjectPath = projectPath;
     error = null;
 
     projects
-      .fetchBases(projectPath)
+      .fetchBases(currentProjectPath)
       .then((result: { bases: readonly BaseInfo[] }) => {
         branches = result.bases;
       })
       .catch((err: unknown) => {
         error = err instanceof Error ? err.message : "Failed to load branches";
       });
+
+    const unsubscribe = on<{ projectPath: string; bases: readonly BaseInfo[] }>(
+      "project:bases-updated",
+      (event) => {
+        if (event.projectPath === currentProjectPath) {
+          branches = event.bases;
+        }
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
   });
 
   /**

--- a/src/renderer/lib/components/NameBranchDropdown.test.ts
+++ b/src/renderer/lib/components/NameBranchDropdown.test.ts
@@ -8,8 +8,9 @@ import { tick } from "svelte";
 import type { BaseInfo } from "@shared/api/types";
 
 // Create mock functions with vi.hoisted - required for vitest mocking pattern
-const { mockFetchBases } = vi.hoisted(() => ({
+const { mockFetchBases, mockOn } = vi.hoisted(() => ({
   mockFetchBases: vi.fn(),
+  mockOn: vi.fn().mockReturnValue(() => {}),
 }));
 
 // Mock $lib/api - must be a static mock, not dynamic (no importOriginal)
@@ -17,6 +18,7 @@ vi.mock("$lib/api", () => ({
   projects: {
     fetchBases: mockFetchBases,
   },
+  on: mockOn,
 }));
 
 // Import component after mocks
@@ -416,6 +418,87 @@ describe("NameBranchDropdown component", () => {
 
       const input = screen.getByRole("combobox");
       expect(input).toHaveAttribute("data-autofocus");
+    });
+  });
+
+  describe("project:bases-updated event updates branches", () => {
+    it("subscribes to project:bases-updated and updates branch list", async () => {
+      const initialBranches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      const updatedBranches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+        { name: "origin/feature-new", isRemote: true, derives: "feature-new" },
+      ];
+
+      // Capture the on() callback so we can invoke it
+      let basesUpdatedHandler:
+        | ((event: { projectPath: string; bases: readonly BaseInfo[] }) => void)
+        | undefined;
+      mockOn.mockImplementation(
+        (
+          _event: string,
+          handler: (event: { projectPath: string; bases: readonly BaseInfo[] }) => void
+        ) => {
+          basesUpdatedHandler = handler;
+          return () => {};
+        }
+      );
+
+      await renderWithBranches(initialBranches);
+
+      // Verify subscription was made
+      expect(mockOn).toHaveBeenCalledWith("project:bases-updated", expect.any(Function));
+
+      // Simulate bases-updated event
+      basesUpdatedHandler!({
+        projectPath: testProjectPath,
+        bases: updatedBranches,
+      });
+      await tick();
+
+      // Open dropdown and verify updated branches
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.getByText("feature-auth")).toBeInTheDocument();
+      expect(screen.getByText("feature-new")).toBeInTheDocument();
+    });
+
+    it("ignores events for different project paths", async () => {
+      const initialBranches: BaseInfo[] = [
+        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
+      ];
+
+      let basesUpdatedHandler:
+        | ((event: { projectPath: string; bases: readonly BaseInfo[] }) => void)
+        | undefined;
+      mockOn.mockImplementation(
+        (
+          _event: string,
+          handler: (event: { projectPath: string; bases: readonly BaseInfo[] }) => void
+        ) => {
+          basesUpdatedHandler = handler;
+          return () => {};
+        }
+      );
+
+      await renderWithBranches(initialBranches);
+
+      // Simulate event for a different project
+      basesUpdatedHandler!({
+        projectPath: "/other/project",
+        bases: [{ name: "other-branch", isRemote: false, derives: "other-branch" }],
+      });
+      await tick();
+
+      // Open dropdown - should still show original branches only
+      const input = screen.getByRole("combobox");
+      await focusAndOpenDropdown(input);
+
+      expect(screen.getByText("feature-auth")).toBeInTheDocument();
+      expect(screen.queryByText("other-branch")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
- Extract fetch-bases logic from `workspace:open` into a dedicated `project:get-bases` intent with `GetProjectBasesOperation`
- Operation has `list` (fast cached read) and `refresh` (slow git fetch) hook points
- `refresh` flag triggers fire-and-forget background refresh with `bases:updated` event
- `wait` flag awaits refresh and returns fresh data directly
- `NameBranchDropdown` subscribes to `project:bases-updated` for live branch updates
- Remove `globalWorktreeProvider` from `IpcEventBridgeDeps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)