### PR TITLE
refactor(mcp): replace ICoreApi with flat McpApiHandlers interface

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,6 +85,7 @@ import type { ClaudeCodeServerManager } from "../agents/claude/server-manager";
 import type { OpenCodeServerManager } from "../agents/opencode/server-manager";
 import { PluginServer } from "../services/plugin-server";
 import { McpServerManager } from "../services/mcp-server";
+import { createMcpHandlers } from "./modules/mcp-handlers";
 import { WindowManager } from "./managers/window-manager";
 import { ViewManager } from "./managers/view-manager";
 import { BadgeManager } from "./managers/badge-manager";
@@ -392,15 +393,10 @@ const badgeManager = new BadgeManager(
 // Mutable reference: set after module wiring + registry.getInterface(), read by lazy closures
 let codeHydraApi: ICodeHydraApi | null = null;
 
-// McpServerManager with lazy API factory (API is not available until after module wiring)
+// McpServerManager with handlers factory that dispatches intents directly
 const mcpServerManager = new McpServerManager(
   networkLayer,
-  () => {
-    if (!codeHydraApi) {
-      throw new Error("API not initialized");
-    }
-    return codeHydraApi;
-  },
+  () => createMcpHandlers(dispatcher, pluginServer),
   loggingService.createLogger("mcp")
 );
 

--- a/src/main/modules/mcp-handlers.integration.test.ts
+++ b/src/main/modules/mcp-handlers.integration.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment node
+/**
+ * Integration tests for createMcpHandlers.
+ *
+ * Tests verify each handler dispatches the correct intent type and payload,
+ * and that executeCommand delegates to the PluginServer.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+import type { Intent } from "../intents/infrastructure/types";
+import type { OperationContext, Operation } from "../intents/infrastructure/operation";
+
+import {
+  INTENT_GET_WORKSPACE_STATUS,
+  GET_WORKSPACE_STATUS_OPERATION_ID,
+} from "../operations/get-workspace-status";
+import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "../operations/get-metadata";
+import { INTENT_SET_METADATA, SET_METADATA_OPERATION_ID } from "../operations/set-metadata";
+import {
+  INTENT_GET_AGENT_SESSION,
+  GET_AGENT_SESSION_OPERATION_ID,
+} from "../operations/get-agent-session";
+import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../operations/restart-agent";
+import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
+import {
+  INTENT_DELETE_WORKSPACE,
+  DELETE_WORKSPACE_OPERATION_ID,
+} from "../operations/delete-workspace";
+import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+
+import { createMcpHandlers } from "./mcp-handlers";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Create a test operation that captures the intent and returns a mock result.
+ */
+function createCapturingOperation<TIntent extends Intent = Intent, TResult = void>(
+  operationId: string,
+  capturedIntents: Intent[],
+  result: TResult
+): Operation<TIntent, TResult> {
+  return {
+    id: operationId,
+    async execute(ctx: OperationContext<TIntent>): Promise<TResult> {
+      capturedIntents.push(ctx.intent);
+      return result;
+    },
+  };
+}
+
+function createMockPluginServer() {
+  return {
+    sendCommand: vi.fn().mockResolvedValue({ success: true, data: "result" }),
+  };
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+function createTestSetup() {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+  const pluginServer = createMockPluginServer();
+  const capturedIntents: Intent[] = [];
+
+  dispatcher.registerOperation(
+    INTENT_GET_WORKSPACE_STATUS,
+    createCapturingOperation(GET_WORKSPACE_STATUS_OPERATION_ID, capturedIntents, {
+      isDirty: false,
+      agent: { type: "none" as const },
+    })
+  );
+
+  dispatcher.registerOperation(
+    INTENT_GET_METADATA,
+    createCapturingOperation(GET_METADATA_OPERATION_ID, capturedIntents, {
+      base: "main",
+    } as Readonly<Record<string, string>>)
+  );
+
+  dispatcher.registerOperation(
+    INTENT_SET_METADATA,
+    createCapturingOperation(SET_METADATA_OPERATION_ID, capturedIntents, undefined as void)
+  );
+
+  dispatcher.registerOperation(
+    INTENT_GET_AGENT_SESSION,
+    createCapturingOperation(GET_AGENT_SESSION_OPERATION_ID, capturedIntents, {
+      port: 14001,
+      sessionId: "test-session",
+    })
+  );
+
+  dispatcher.registerOperation(
+    INTENT_RESTART_AGENT,
+    createCapturingOperation(RESTART_AGENT_OPERATION_ID, capturedIntents, 14001)
+  );
+
+  dispatcher.registerOperation(
+    INTENT_OPEN_WORKSPACE,
+    createCapturingOperation(OPEN_WORKSPACE_OPERATION_ID, capturedIntents, {
+      projectId: "test-12345678" as ProjectId,
+      name: "feature" as WorkspaceName,
+      branch: "feature",
+      metadata: { base: "main" },
+      path: "/workspaces/feature",
+    })
+  );
+
+  dispatcher.registerOperation(
+    INTENT_DELETE_WORKSPACE,
+    createCapturingOperation(DELETE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
+  );
+
+  return { dispatcher, hookRegistry, pluginServer, capturedIntents };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("createMcpHandlers", () => {
+  describe("getStatus", () => {
+    it("dispatches GetWorkspaceStatusIntent with correct payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.getStatus("/workspace/path");
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_GET_WORKSPACE_STATUS);
+      expect(capturedIntents[0]!.payload).toEqual({ workspacePath: "/workspace/path" });
+      expect(result).toEqual({ isDirty: false, agent: { type: "none" } });
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("dispatches GetMetadataIntent with correct payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.getMetadata("/workspace/path");
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_GET_METADATA);
+      expect(capturedIntents[0]!.payload).toEqual({ workspacePath: "/workspace/path" });
+      expect(result).toEqual({ base: "main" });
+    });
+  });
+
+  describe("setMetadata", () => {
+    it("dispatches SetMetadataIntent with correct payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await handlers.setMetadata("/workspace/path", "note", "test value");
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_SET_METADATA);
+      expect(capturedIntents[0]!.payload).toEqual({
+        workspacePath: "/workspace/path",
+        key: "note",
+        value: "test value",
+      });
+    });
+  });
+
+  describe("getAgentSession", () => {
+    it("dispatches GetAgentSessionIntent with correct payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.getAgentSession("/workspace/path");
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_GET_AGENT_SESSION);
+      expect(capturedIntents[0]!.payload).toEqual({ workspacePath: "/workspace/path" });
+      expect(result).toEqual({ port: 14001, sessionId: "test-session" });
+    });
+  });
+
+  describe("restartAgentServer", () => {
+    it("dispatches RestartAgentIntent with correct payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.restartAgentServer("/workspace/path");
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_RESTART_AGENT);
+      expect(capturedIntents[0]!.payload).toEqual({ workspacePath: "/workspace/path" });
+      expect(result).toBe(14001);
+    });
+  });
+
+  describe("createWorkspace", () => {
+    it("dispatches OpenWorkspaceIntent with mapped payload", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.createWorkspace({
+        callerWorkspacePath: "/caller/workspace",
+        name: "feature",
+        base: "main",
+        stealFocus: false,
+      });
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_OPEN_WORKSPACE);
+      expect(capturedIntents[0]!.payload).toEqual({
+        callerWorkspacePath: "/caller/workspace",
+        workspaceName: "feature",
+        base: "main",
+        stealFocus: false,
+      });
+      expect(result.name).toBe("feature");
+    });
+
+    it("includes initialPrompt when provided", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await handlers.createWorkspace({
+        callerWorkspacePath: "/caller/workspace",
+        name: "feature",
+        base: "main",
+        initialPrompt: "Implement the feature",
+      });
+
+      expect(capturedIntents[0]!.payload).toMatchObject({
+        initialPrompt: "Implement the feature",
+      });
+    });
+  });
+
+  describe("deleteWorkspace", () => {
+    it("dispatches DeleteWorkspaceIntent and returns started: true on accept", async () => {
+      const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.deleteWorkspace("/workspace/path", { keepBranch: false });
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_DELETE_WORKSPACE);
+      expect(capturedIntents[0]!.payload).toMatchObject({
+        workspacePath: "/workspace/path",
+        keepBranch: false,
+        force: false,
+        removeWorktree: true,
+      });
+      expect(result).toEqual({ started: true });
+    });
+
+    it("returns started: false when interceptor rejects", async () => {
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      const pluginServer = createMockPluginServer();
+
+      dispatcher.registerOperation(
+        INTENT_DELETE_WORKSPACE,
+        createCapturingOperation(DELETE_WORKSPACE_OPERATION_ID, [], { started: true })
+      );
+
+      // Add interceptor that cancels delete
+      dispatcher.addInterceptor({
+        id: "block-delete",
+        async before(intent) {
+          if (intent.type === INTENT_DELETE_WORKSPACE) return null;
+          return intent;
+        },
+      });
+
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+      const result = await handlers.deleteWorkspace("/workspace/path", { keepBranch: true });
+
+      expect(result).toEqual({ started: false });
+    });
+  });
+
+  describe("executeCommand", () => {
+    it("delegates to pluginServer.sendCommand", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.executeCommand("/workspace/path", "test.command", ["arg1"]);
+
+      expect(pluginServer.sendCommand).toHaveBeenCalledWith("/workspace/path", "test.command", [
+        "arg1",
+      ]);
+      expect(result).toBe("result");
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.sendCommand.mockResolvedValue({
+        success: false,
+        error: "Command not found",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(handlers.executeCommand("/workspace/path", "unknown.command")).rejects.toThrow(
+        "Command not found"
+      );
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(handlers.executeCommand("/workspace/path", "test.command")).rejects.toThrow(
+        "Plugin server not available"
+      );
+    });
+  });
+});

--- a/src/main/modules/mcp-handlers.ts
+++ b/src/main/modules/mcp-handlers.ts
@@ -1,0 +1,137 @@
+/**
+ * MCP API handlers factory.
+ *
+ * Creates a flat McpApiHandlers implementation that dispatches intents,
+ * following the same pattern as ipc-event-bridge.ts bridge handlers.
+ */
+
+import type { Dispatcher } from "../intents/infrastructure/dispatcher";
+import type { PluginServer } from "../../services/plugin-server/plugin-server";
+import type { McpApiHandlers } from "../../services/mcp-server/types";
+import type { Workspace } from "../../shared/api/types";
+import { INTENT_GET_WORKSPACE_STATUS } from "../operations/get-workspace-status";
+import type { GetWorkspaceStatusIntent } from "../operations/get-workspace-status";
+import { INTENT_GET_METADATA } from "../operations/get-metadata";
+import type { GetMetadataIntent } from "../operations/get-metadata";
+import { INTENT_SET_METADATA } from "../operations/set-metadata";
+import type { SetMetadataIntent } from "../operations/set-metadata";
+import { INTENT_GET_AGENT_SESSION } from "../operations/get-agent-session";
+import type { GetAgentSessionIntent } from "../operations/get-agent-session";
+import { INTENT_RESTART_AGENT } from "../operations/restart-agent";
+import type { RestartAgentIntent } from "../operations/restart-agent";
+import { INTENT_OPEN_WORKSPACE } from "../operations/open-workspace";
+import type { OpenWorkspaceIntent } from "../operations/open-workspace";
+import { INTENT_DELETE_WORKSPACE } from "../operations/delete-workspace";
+import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
+
+/**
+ * Create McpApiHandlers that dispatch intents via the Dispatcher.
+ *
+ * @param dispatcher - The intent dispatcher
+ * @param pluginServer - Plugin server for executeCommand (may be null)
+ */
+export function createMcpHandlers(
+  dispatcher: Dispatcher,
+  pluginServer: PluginServer | null
+): McpApiHandlers {
+  return {
+    async getStatus(workspacePath) {
+      const intent: GetWorkspaceStatusIntent = {
+        type: INTENT_GET_WORKSPACE_STATUS,
+        payload: { workspacePath },
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (!result) {
+        throw new Error("Get workspace status dispatch returned no result");
+      }
+      return result;
+    },
+
+    async getMetadata(workspacePath) {
+      const intent: GetMetadataIntent = {
+        type: INTENT_GET_METADATA,
+        payload: { workspacePath },
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (!result) {
+        throw new Error("Get metadata dispatch returned no result");
+      }
+      return result;
+    },
+
+    async setMetadata(workspacePath, key, value) {
+      const intent: SetMetadataIntent = {
+        type: INTENT_SET_METADATA,
+        payload: { workspacePath, key, value },
+      };
+      await dispatcher.dispatch(intent);
+    },
+
+    async getAgentSession(workspacePath) {
+      const intent: GetAgentSessionIntent = {
+        type: INTENT_GET_AGENT_SESSION,
+        payload: { workspacePath },
+      };
+      return dispatcher.dispatch(intent);
+    },
+
+    async restartAgentServer(workspacePath) {
+      const intent: RestartAgentIntent = {
+        type: INTENT_RESTART_AGENT,
+        payload: { workspacePath },
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (result === undefined) {
+        throw new Error("Restart agent dispatch returned no result");
+      }
+      return result;
+    },
+
+    async createWorkspace(options) {
+      const intent: OpenWorkspaceIntent = {
+        type: INTENT_OPEN_WORKSPACE,
+        payload: {
+          callerWorkspacePath: options.callerWorkspacePath,
+          workspaceName: options.name,
+          base: options.base,
+          ...(options.initialPrompt !== undefined && { initialPrompt: options.initialPrompt }),
+          ...(options.stealFocus !== undefined && { stealFocus: options.stealFocus }),
+        },
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (!result) {
+        throw new Error("Create workspace dispatch returned no result");
+      }
+      return result as Workspace;
+    },
+
+    async deleteWorkspace(workspacePath, options) {
+      const intent: DeleteWorkspaceIntent = {
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath,
+          keepBranch: options.keepBranch,
+          force: false,
+          removeWorktree: true,
+        },
+      };
+      const handle = dispatcher.dispatch(intent);
+      if (!(await handle.accepted)) {
+        return { started: false };
+      }
+      void handle;
+      return { started: true };
+    },
+
+    async executeCommand(workspacePath, command, args) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.sendCommand(workspacePath, command, args);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+  };
+}

--- a/src/services/mcp-server/index.ts
+++ b/src/services/mcp-server/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Types
-export type { McpErrorCode, McpError, IMcpServer } from "./types";
+export type { McpErrorCode, McpError, IMcpServer, McpApiHandlers } from "./types";
 export type { IDisposable } from "../../shared/types";
 
 // MCP Server

--- a/src/services/mcp-server/mcp-server-manager.test.ts
+++ b/src/services/mcp-server/mcp-server-manager.test.ts
@@ -5,29 +5,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { McpServerManager } from "./mcp-server-manager";
 import type { MockPortManager } from "../platform/network.test-utils";
-import type { ICoreApi, IWorkspaceApi, IProjectApi } from "../../shared/api/interfaces";
+import type { McpApiHandlers } from "./types";
 import type { McpServerFactory } from "./mcp-server";
 import type { McpServer as McpServerSdk } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMockLogger } from "../logging";
 import { createPortManagerMock } from "../platform/network.test-utils";
 
 /**
- * Create a mock ICoreApi.
+ * Create a mock McpApiHandlers.
  */
-function createMockCoreApi(): ICoreApi {
+function createMockMcpHandlers(): McpApiHandlers {
   return {
-    workspaces: {
-      create: vi.fn(),
-      remove: vi.fn(),
-      get: vi.fn(),
-      getStatus: vi.fn(),
-      getOpencodePort: vi.fn(),
-      setMetadata: vi.fn(),
-      getMetadata: vi.fn(),
-    } as unknown as IWorkspaceApi,
-    projects: {} as IProjectApi,
-    on: vi.fn().mockReturnValue(() => {}),
-    dispose: vi.fn(),
+    getStatus: vi.fn(),
+    getMetadata: vi.fn(),
+    setMetadata: vi.fn(),
+    getAgentSession: vi.fn(),
+    restartAgentServer: vi.fn(),
+    createWorkspace: vi.fn(),
+    deleteWorkspace: vi.fn(),
+    executeCommand: vi.fn(),
   };
 }
 
@@ -46,14 +42,14 @@ function createMockMcpSdk(): McpServerSdk {
 
 describe("McpServerManager", () => {
   let portManager: MockPortManager;
-  let api: ICoreApi;
+  let handlers: McpApiHandlers;
   let logger: ReturnType<typeof createMockLogger>;
   let mockSdkFactory: McpServerFactory;
   let activeManager: McpServerManager | null = null;
 
   beforeEach(() => {
     portManager = createPortManagerMock([12345]);
-    api = createMockCoreApi();
+    handlers = createMockMcpHandlers();
     logger = createMockLogger();
     mockSdkFactory = () => createMockMcpSdk();
     activeManager = null;
@@ -69,13 +65,13 @@ describe("McpServerManager", () => {
 
   describe("constructor", () => {
     it("creates manager with all dependencies", () => {
-      const manager = new McpServerManager(portManager, () => api, logger);
+      const manager = new McpServerManager(portManager, () => handlers, logger);
 
       expect(manager).toBeInstanceOf(McpServerManager);
     });
 
     it("creates manager without logger", () => {
-      const manager = new McpServerManager(portManager, () => api);
+      const manager = new McpServerManager(portManager, () => handlers);
 
       expect(manager).toBeInstanceOf(McpServerManager);
     });
@@ -83,7 +79,7 @@ describe("McpServerManager", () => {
 
   describe("start", () => {
     it("allocates port via PortManager", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -95,7 +91,7 @@ describe("McpServerManager", () => {
     });
 
     it("returns allocated port", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -105,7 +101,7 @@ describe("McpServerManager", () => {
     });
 
     it("prevents double-start", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -121,14 +117,14 @@ describe("McpServerManager", () => {
 
   describe("stop", () => {
     it("stops cleanly when not started", async () => {
-      const manager = new McpServerManager(portManager, () => api, logger);
+      const manager = new McpServerManager(portManager, () => handlers, logger);
 
       // Should not throw
       await expect(manager.stop()).resolves.not.toThrow();
     });
 
     it("clears port after stop", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -142,7 +138,7 @@ describe("McpServerManager", () => {
     it("allows restart after stop", async () => {
       // Provide two ports for start/stop/restart cycle
       const restartPortManager = createPortManagerMock([12345, 54321]);
-      activeManager = new McpServerManager(restartPortManager, () => api, logger, {
+      activeManager = new McpServerManager(restartPortManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -157,13 +153,13 @@ describe("McpServerManager", () => {
 
   describe("getPort", () => {
     it("returns null before start", () => {
-      const manager = new McpServerManager(portManager, () => api, logger);
+      const manager = new McpServerManager(portManager, () => handlers, logger);
 
       expect(manager.getPort()).toBeNull();
     });
 
     it("returns port after start", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -175,7 +171,7 @@ describe("McpServerManager", () => {
 
   describe("isRunning", () => {
     it("returns false before start", () => {
-      const manager = new McpServerManager(portManager, () => api, logger);
+      const manager = new McpServerManager(portManager, () => handlers, logger);
 
       expect(manager.isRunning()).toBe(false);
     });
@@ -183,7 +179,7 @@ describe("McpServerManager", () => {
 
   describe("dispose", () => {
     it("stops the manager", async () => {
-      activeManager = new McpServerManager(portManager, () => api, logger, {
+      activeManager = new McpServerManager(portManager, () => handlers, logger, {
         serverFactory: mockSdkFactory,
       });
 
@@ -199,7 +195,7 @@ describe("McpServerManager", () => {
       // Empty port list causes "No ports available" error on first call
       const failingPortManager = createPortManagerMock([]);
 
-      const manager = new McpServerManager(failingPortManager, () => api, logger);
+      const manager = new McpServerManager(failingPortManager, () => handlers, logger);
 
       await expect(manager.start()).rejects.toThrow("No ports available");
       expect(manager.getPort()).toBeNull();

--- a/src/services/mcp-server/mcp-server-manager.ts
+++ b/src/services/mcp-server/mcp-server-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import type { PortManager } from "../platform/network";
-import type { ICoreApi } from "../../shared/api/interfaces";
+import type { McpApiHandlers } from "./types";
 import type { Logger } from "../logging";
 import { SILENT_LOGGER } from "../logging";
 import type { IDisposable } from "../../shared/types";
@@ -29,7 +29,7 @@ export interface McpServerManagerConfig {
  */
 export class McpServerManager implements IDisposable {
   private readonly portManager: PortManager;
-  private readonly apiFactory: () => ICoreApi;
+  private readonly handlersFactory: () => McpApiHandlers;
   private readonly logger: Logger;
   private readonly serverFactory: McpServerFactory;
 
@@ -38,12 +38,12 @@ export class McpServerManager implements IDisposable {
 
   constructor(
     portManager: PortManager,
-    apiFactory: () => ICoreApi,
+    handlersFactory: () => McpApiHandlers,
     logger?: Logger,
     config?: McpServerManagerConfig
   ) {
     this.portManager = portManager;
-    this.apiFactory = apiFactory;
+    this.handlersFactory = handlersFactory;
     this.logger = logger ?? SILENT_LOGGER;
     this.serverFactory = config?.serverFactory ?? createDefaultMcpServer;
   }
@@ -68,7 +68,7 @@ export class McpServerManager implements IDisposable {
       this.logger.info("Allocated port", { port: this.port });
 
       // Create and start the MCP server
-      this.mcpServer = new McpServer(this.apiFactory(), this.serverFactory, this.logger);
+      this.mcpServer = new McpServer(this.handlersFactory(), this.serverFactory, this.logger);
       await this.mcpServer.start(this.port);
 
       this.logger.info("Manager started", {

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -5,11 +5,10 @@
  */
 
 import { createServer } from "node:net";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { McpServer, createDefaultMcpServer } from "./mcp-server";
-import type { ICoreApi } from "../../shared/api/interfaces";
+import type { McpApiHandlers } from "./types";
 import { createMockLogger } from "../logging";
-import { createMockCoreApi } from "../test-utils";
 import { delay } from "@shared/test-fixtures";
 
 /**
@@ -31,10 +30,26 @@ async function findFreePort(): Promise<number> {
   });
 }
 
+/**
+ * Create a mock McpApiHandlers for boundary testing.
+ */
+function createMockMcpHandlers(): McpApiHandlers {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
+    setMetadata: vi.fn().mockResolvedValue(undefined),
+    getAgentSession: vi.fn().mockResolvedValue(null),
+    restartAgentServer: vi.fn().mockResolvedValue(14001),
+    createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
+    deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe("McpServer Boundary Tests", () => {
   let server: McpServer;
   let port: number;
-  let mockApi: ICoreApi;
+  let mockHandlers: McpApiHandlers;
   let logger: ReturnType<typeof createMockLogger>;
 
   const testWorkspacePath = "/home/user/projects/my-app/.worktrees/feature-branch";
@@ -48,10 +63,10 @@ describe("McpServer Boundary Tests", () => {
 
   beforeEach(async () => {
     port = await findFreePort();
-    mockApi = createMockCoreApi();
+    mockHandlers = createMockMcpHandlers();
     logger = createMockLogger();
 
-    server = new McpServer(mockApi, createDefaultMcpServer, logger);
+    server = new McpServer(mockHandlers, createDefaultMcpServer, logger);
     await server.start(port);
   });
 

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -9,56 +9,30 @@ import {
   SERVER_INSTRUCTIONS,
   type McpServerFactory,
 } from "./mcp-server";
-import type { ICoreApi, IWorkspaceApi, IProjectApi } from "../../shared/api/interfaces";
+import type { McpApiHandlers } from "./types";
 import { type ProjectId, initialPromptSchema } from "../../shared/api/types";
 import { createMockLogger } from "../logging";
 
 /**
- * Create a mock ICoreApi for testing.
+ * Create a mock McpApiHandlers for testing.
  */
-function createMockCoreApi(overrides?: {
-  workspaces?: Partial<IWorkspaceApi>;
-  projects?: Partial<IProjectApi>;
-}): ICoreApi {
-  const defaultWorkspaces: IWorkspaceApi = {
-    create: vi.fn().mockResolvedValue({
+function createMockMcpHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
+    setMetadata: vi.fn().mockResolvedValue(undefined),
+    getAgentSession: vi.fn().mockResolvedValue(14001),
+    restartAgentServer: vi.fn().mockResolvedValue(14001),
+    createWorkspace: vi.fn().mockResolvedValue({
       name: "test",
       path: "/path",
       branch: "main",
       metadata: { base: "main" },
       projectId: "test-12345678" as ProjectId,
     }),
-    remove: vi.fn().mockResolvedValue({ started: true }),
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
-    getAgentSession: vi.fn().mockResolvedValue(14001),
-    restartAgentServer: vi.fn().mockResolvedValue(14001),
-    setMetadata: vi.fn().mockResolvedValue(undefined),
-    getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
+    deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),
-  };
-
-  const defaultProjects: IProjectApi = {
-    open: vi.fn().mockResolvedValue({
-      id: "test-12345678" as ProjectId,
-      name: "test",
-      path: "/path",
-      workspaces: [],
-    }),
-    close: vi.fn().mockResolvedValue(undefined),
-    clone: vi.fn().mockResolvedValue({
-      id: "test-12345678" as ProjectId,
-      name: "test",
-      path: "/path",
-      workspaces: [],
-    }),
-    fetchBases: vi.fn().mockResolvedValue({ bases: [] }),
-  };
-
-  return {
-    workspaces: { ...defaultWorkspaces, ...overrides?.workspaces },
-    projects: { ...defaultProjects, ...overrides?.projects },
-    on: vi.fn().mockReturnValue(() => {}),
-    dispose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
   };
 }
 
@@ -86,13 +60,13 @@ function createMockMcpSdk() {
 }
 
 describe("McpServer", () => {
-  let mockApi: ICoreApi;
+  let mockHandlers: McpApiHandlers;
   let mockLogger: ReturnType<typeof createMockLogger>;
   let mockMcpSdk: ReturnType<typeof createMockMcpSdk>;
   let mockFactory: McpServerFactory;
 
   beforeEach(() => {
-    mockApi = createMockCoreApi();
+    mockHandlers = createMockMcpHandlers();
     mockLogger = createMockLogger();
     mockMcpSdk = createMockMcpSdk();
     mockFactory = () => mockMcpSdk as unknown as ReturnType<typeof createDefaultMcpServer>;
@@ -100,31 +74,31 @@ describe("McpServer", () => {
 
   describe("constructor", () => {
     it("creates server with injected dependencies", () => {
-      const server = new McpServer(mockApi, mockFactory, mockLogger);
+      const server = new McpServer(mockHandlers, mockFactory, mockLogger);
       expect(server).toBeInstanceOf(McpServer);
     });
 
     it("creates server without logger", () => {
-      const server = new McpServer(mockApi, mockFactory);
+      const server = new McpServer(mockHandlers, mockFactory);
       expect(server).toBeInstanceOf(McpServer);
     });
 
     it("creates server with default factory", () => {
-      const server = new McpServer(mockApi);
+      const server = new McpServer(mockHandlers);
       expect(server).toBeInstanceOf(McpServer);
     });
   });
 
   describe("isRunning", () => {
     it("returns false before start", () => {
-      const server = new McpServer(mockApi, mockFactory, mockLogger);
+      const server = new McpServer(mockHandlers, mockFactory, mockLogger);
       expect(server.isRunning()).toBe(false);
     });
   });
 
   describe("tool registration", () => {
     it("registers all required tools when started", async () => {
-      const server = new McpServer(mockApi, mockFactory, mockLogger);
+      const server = new McpServer(mockHandlers, mockFactory, mockLogger);
 
       // Start and immediately stop to trigger registration
       await server.start(0); // Port 0 = let OS assign
@@ -146,11 +120,11 @@ describe("McpServer", () => {
       expect(tools.length).toBe(9);
     });
 
-    it("workspace_restart_agent_server tool calls API and returns port", async () => {
+    it("workspace_restart_agent_server tool calls handler and returns port", async () => {
       const workspacePath = "/project/workspaces/test-workspace";
 
       // Create server
-      const server = new McpServer(mockApi, mockFactory, mockLogger);
+      const server = new McpServer(mockHandlers, mockFactory, mockLogger);
 
       await server.start(0);
       await server.stop();
@@ -166,8 +140,8 @@ describe("McpServer", () => {
         { authInfo: { extra: { workspacePath } } }
       );
 
-      // Verify API was called
-      expect(mockApi.workspaces.restartAgentServer).toHaveBeenCalled();
+      // Verify handler was called
+      expect(mockHandlers.restartAgentServer).toHaveBeenCalled();
 
       // Verify result contains the port number
       expect(result).toEqual({
@@ -178,7 +152,7 @@ describe("McpServer", () => {
 
   describe("dispose", () => {
     it("stops the server", async () => {
-      const server = new McpServer(mockApi, mockFactory, mockLogger);
+      const server = new McpServer(mockHandlers, mockFactory, mockLogger);
 
       await server.start(0);
       expect(server.isRunning()).toBe(true);

--- a/src/services/mcp-server/mcp-server.ts
+++ b/src/services/mcp-server/mcp-server.ts
@@ -22,8 +22,7 @@ import {
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
-import type { IMcpServer, McpError } from "./types";
-import type { ICoreApi } from "../../shared/api/interfaces";
+import type { IMcpServer, McpError, McpApiHandlers } from "./types";
 import type { Logger, LogContext } from "../logging";
 import { SILENT_LOGGER, logAtLevel } from "../logging";
 import type { LogLevel } from "../logging/types";
@@ -78,7 +77,7 @@ export function createDefaultMcpServer(): McpServerSdk {
  * Workspace resolution is delegated to the intent system via workspacePath-based API methods.
  */
 export class McpServer implements IMcpServer {
-  private readonly api: ICoreApi;
+  private readonly handlers: McpApiHandlers;
   private readonly serverFactory: McpServerFactory;
   private readonly logger: Logger;
 
@@ -91,11 +90,11 @@ export class McpServer implements IMcpServer {
   private registeredTools: RegisteredTool[] = [];
 
   constructor(
-    api: ICoreApi,
+    handlers: McpApiHandlers,
     serverFactory: McpServerFactory = createDefaultMcpServer,
     logger?: Logger
   ) {
-    this.api = api;
+    this.handlers = handlers;
     this.serverFactory = serverFactory;
     this.logger = logger ?? SILENT_LOGGER;
   }
@@ -283,9 +282,7 @@ export class McpServer implements IMcpServer {
           description: "Get the current workspace status including dirty flag and agent status",
           inputSchema: z.object({}),
         },
-        this.createWorkspaceHandler(async (workspacePath) =>
-          this.api.workspaces.getStatus(workspacePath)
-        )
+        this.createWorkspaceHandler(async (workspacePath) => this.handlers.getStatus(workspacePath))
       )
     );
 
@@ -298,7 +295,7 @@ export class McpServer implements IMcpServer {
           inputSchema: z.object({}),
         },
         this.createWorkspaceHandler(async (workspacePath) =>
-          this.api.workspaces.getMetadata(workspacePath)
+          this.handlers.getMetadata(workspacePath)
         )
       )
     );
@@ -322,7 +319,7 @@ export class McpServer implements IMcpServer {
         },
         this.createWorkspaceHandler(
           async (workspacePath, args: { key: string; value: string | null }) => {
-            await this.api.workspaces.setMetadata(workspacePath, args.key, args.value);
+            await this.handlers.setMetadata(workspacePath, args.key, args.value);
             return null;
           }
         )
@@ -338,7 +335,7 @@ export class McpServer implements IMcpServer {
           inputSchema: z.object({}),
         },
         this.createWorkspaceHandler(async (workspacePath) =>
-          this.api.workspaces.getAgentSession(workspacePath)
+          this.handlers.getAgentSession(workspacePath)
         )
       )
     );
@@ -353,7 +350,7 @@ export class McpServer implements IMcpServer {
           inputSchema: z.object({}),
         },
         this.createWorkspaceHandler(async (workspacePath) =>
-          this.api.workspaces.restartAgentServer(workspacePath)
+          this.handlers.restartAgentServer(workspacePath)
         )
       )
     );
@@ -422,8 +419,10 @@ export class McpServer implements IMcpServer {
             }
 
             // Create workspace with callerWorkspacePath (intent resolves project)
-            const result = await this.api.workspaces.create(undefined, name, base, {
+            const result = await this.handlers.createWorkspace({
               callerWorkspacePath: workspacePath,
+              name,
+              base,
               ...(finalPrompt !== undefined && { initialPrompt: finalPrompt }),
               stealFocus,
             });
@@ -450,7 +449,7 @@ export class McpServer implements IMcpServer {
           }),
         },
         this.createWorkspaceHandler(async (workspacePath, args: { keepBranch: boolean }) => {
-          return this.api.workspaces.remove(workspacePath, {
+          return this.handlers.deleteWorkspace(workspacePath, {
             keepBranch: args.keepBranch,
           });
         })
@@ -487,7 +486,7 @@ export class McpServer implements IMcpServer {
         },
         this.createWorkspaceHandler(
           async (workspacePath, args: { command: string; args?: unknown[] | undefined }) =>
-            this.api.workspaces.executeCommand(workspacePath, args.command, args.args)
+            this.handlers.executeCommand(workspacePath, args.command, args.args)
         )
       )
     );
@@ -556,7 +555,7 @@ export class McpServer implements IMcpServer {
   private async getCallerModel(workspacePath: string): Promise<PromptModel | undefined> {
     try {
       // Get caller's OpenCode session
-      const session = await this.api.workspaces.getAgentSession(workspacePath);
+      const session = await this.handlers.getAgentSession(workspacePath);
 
       if (!session) {
         this.logger.debug("Cannot determine model: no OpenCode session running", {

--- a/src/services/mcp-server/tools.test.ts
+++ b/src/services/mcp-server/tools.test.ts
@@ -6,13 +6,11 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import type { ICoreApi, IProjectApi } from "../../shared/api/interfaces";
 import type { WorkspaceStatus } from "../../shared/api/types";
-import type { McpError } from "./types";
+import type { McpApiHandlers, McpError } from "./types";
 import type { Logger, LogContext } from "../logging";
 import type { LogLevel } from "../logging/types";
 import { createBehavioralLogger } from "../logging/logging.test-utils";
-import { createMockWorkspaceApi } from "../test-utils";
 
 /**
  * Tool result type from MCP SDK.
@@ -58,11 +56,28 @@ interface SimulatedToolContext {
 }
 
 /**
+ * Create mock McpApiHandlers with sensible defaults.
+ */
+function createMockHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
+    setMetadata: vi.fn().mockResolvedValue(undefined),
+    getAgentSession: vi.fn().mockResolvedValue(null),
+    restartAgentServer: vi.fn().mockResolvedValue(14001),
+    createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
+    deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+/**
  * Simulate tool handlers for testing.
  * This mimics the tool registration logic from McpServer.
- * Tools now pass workspacePath directly to API methods.
+ * Tools now call flat McpApiHandlers methods.
  */
-function createToolHandlers(api: ICoreApi) {
+function createToolHandlers(handlers: McpApiHandlers) {
   // Handle undefined specially since JSON.stringify(undefined) returns undefined (not a string)
   const successResult = <T>(data: T): ToolResult => ({
     content: [{ type: "text", text: data === undefined ? "null" : JSON.stringify(data) }],
@@ -84,7 +99,7 @@ function createToolHandlers(api: ICoreApi) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        const status = await api.workspaces.getStatus(context.workspacePath);
+        const status = await handlers.getStatus(context.workspacePath);
         return successResult(status);
       } catch (error) {
         return handleError(error);
@@ -96,7 +111,7 @@ function createToolHandlers(api: ICoreApi) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        const metadata = await api.workspaces.getMetadata(context.workspacePath);
+        const metadata = await handlers.getMetadata(context.workspacePath);
         return successResult(metadata);
       } catch (error) {
         return handleError(error);
@@ -111,20 +126,20 @@ function createToolHandlers(api: ICoreApi) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        await api.workspaces.setMetadata(context.workspacePath, args.key, args.value);
+        await handlers.setMetadata(context.workspacePath, args.key, args.value);
         return successResult(null);
       } catch (error) {
         return handleError(error);
       }
     },
 
-    workspace_get_opencode_port: async (context: SimulatedToolContext): Promise<ToolResult> => {
+    workspace_get_agent_session: async (context: SimulatedToolContext): Promise<ToolResult> => {
       if (!context.workspacePath) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        const port = await api.workspaces.getAgentSession(context.workspacePath);
-        return successResult(port);
+        const session = await handlers.getAgentSession(context.workspacePath);
+        return successResult(session);
       } catch (error) {
         return handleError(error);
       }
@@ -138,7 +153,7 @@ function createToolHandlers(api: ICoreApi) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        const result = await api.workspaces.remove(context.workspacePath, {
+        const result = await handlers.deleteWorkspace(context.workspacePath, {
           keepBranch: args.keepBranch ?? false,
         });
         return successResult(result);
@@ -155,7 +170,7 @@ function createToolHandlers(api: ICoreApi) {
         return errorResult("workspace-not-found", "Missing workspace path");
       }
       try {
-        const result = await api.workspaces.executeCommand(
+        const result = await handlers.executeCommand(
           context.workspacePath,
           args.command,
           args.args
@@ -239,21 +254,14 @@ describe("MCP Tools", () => {
         agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
       };
 
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         getStatus: vi.fn().mockResolvedValue(expectedStatus),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_get_status(context);
+      const result = await toolHandlers.workspace_get_status(context);
       const parsed = parseToolResult<WorkspaceStatus>(result);
 
       expect(parsed.success).toBe(true);
@@ -264,17 +272,11 @@ describe("MCP Tools", () => {
     });
 
     it("returns error when workspace not found", async () => {
-      const api: ICoreApi = {
-        workspaces: createMockWorkspaceApi(),
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const mockHandlers = createMockHandlers();
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createEmptyContext();
 
-      const result = await handlers.workspace_get_status(context);
+      const result = await toolHandlers.workspace_get_status(context);
       const parsed = parseToolResult<WorkspaceStatus>(result);
 
       expect(parsed.success).toBe(false);
@@ -284,21 +286,14 @@ describe("MCP Tools", () => {
     });
 
     it("propagates API errors correctly", async () => {
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         getStatus: vi.fn().mockRejectedValue(new Error("API error")),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_get_status(context);
+      const result = await toolHandlers.workspace_get_status(context);
       const parsed = parseToolResult<WorkspaceStatus>(result);
 
       expect(parsed.success).toBe(false);
@@ -313,21 +308,14 @@ describe("MCP Tools", () => {
     it("returns metadata object on success", async () => {
       const expectedMetadata = { base: "main", note: "test workspace" };
 
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         getMetadata: vi.fn().mockResolvedValue(expectedMetadata),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_get_metadata(context);
+      const result = await toolHandlers.workspace_get_metadata(context);
       const parsed = parseToolResult<Record<string, string>>(result);
 
       expect(parsed.success).toBe(true);
@@ -341,21 +329,14 @@ describe("MCP Tools", () => {
   describe("workspace_set_metadata", () => {
     it("sets metadata successfully", async () => {
       const setMetadataMock = vi.fn().mockResolvedValue(undefined);
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         setMetadata: setMetadataMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_set_metadata(context, {
+      const result = await toolHandlers.workspace_set_metadata(context, {
         key: "note",
         value: "test value",
       });
@@ -367,21 +348,14 @@ describe("MCP Tools", () => {
 
     it("deletes metadata when value is null", async () => {
       const setMetadataMock = vi.fn().mockResolvedValue(undefined);
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         setMetadata: setMetadataMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      await handlers.workspace_set_metadata(context, {
+      await toolHandlers.workspace_set_metadata(context, {
         key: "note",
         value: null,
       });
@@ -390,21 +364,14 @@ describe("MCP Tools", () => {
     });
 
     it("propagates validation errors from API", async () => {
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         setMetadata: vi.fn().mockRejectedValue(new Error("Invalid key format")),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_set_metadata(context, {
+      const result = await toolHandlers.workspace_set_metadata(context, {
         key: "123invalid",
         value: "test",
       });
@@ -417,23 +384,16 @@ describe("MCP Tools", () => {
     });
   });
 
-  describe("workspace_get_opencode_session", () => {
+  describe("workspace_get_agent_session", () => {
     it("returns session info on success", async () => {
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         getAgentSession: vi.fn().mockResolvedValue({ port: 14001, sessionId: "test-session-id" }),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_get_opencode_port(context);
+      const result = await toolHandlers.workspace_get_agent_session(context);
       const parsed = parseToolResult<{ port: number; sessionId: string }>(result);
 
       expect(parsed.success).toBe(true);
@@ -443,21 +403,14 @@ describe("MCP Tools", () => {
     });
 
     it("returns null when server not running", async () => {
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         getAgentSession: vi.fn().mockResolvedValue(null),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_get_opencode_port(context);
+      const result = await toolHandlers.workspace_get_agent_session(context);
       const parsed = parseToolResult<{ port: number; sessionId: string } | null>(result);
 
       expect(parsed.success).toBe(true);
@@ -468,23 +421,16 @@ describe("MCP Tools", () => {
   });
 
   describe("workspace_delete", () => {
-    it("calls API with correct params", async () => {
-      const removeMock = vi.fn().mockResolvedValue({ started: true });
-      const workspaceApi = createMockWorkspaceApi({
-        remove: removeMock,
+    it("calls handler with correct params", async () => {
+      const deleteWorkspaceMock = vi.fn().mockResolvedValue({ started: true });
+      const mockHandlers = createMockHandlers({
+        deleteWorkspace: deleteWorkspaceMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_delete(context, { keepBranch: false });
+      const result = await toolHandlers.workspace_delete(context, { keepBranch: false });
       const parsed = parseToolResult<{ started: boolean }>(result);
 
       expect(parsed.success).toBe(true);
@@ -492,70 +438,54 @@ describe("MCP Tools", () => {
         expect(parsed.data.started).toBe(true);
       }
 
-      expect(removeMock).toHaveBeenCalledWith(context.workspacePath, { keepBranch: false });
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(context.workspacePath, {
+        keepBranch: false,
+      });
     });
 
     it("respects keepBranch option", async () => {
-      const removeMock = vi.fn().mockResolvedValue({ started: true });
-      const workspaceApi = createMockWorkspaceApi({
-        remove: removeMock,
+      const deleteWorkspaceMock = vi.fn().mockResolvedValue({ started: true });
+      const mockHandlers = createMockHandlers({
+        deleteWorkspace: deleteWorkspaceMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      await handlers.workspace_delete(context, { keepBranch: true });
+      await toolHandlers.workspace_delete(context, { keepBranch: true });
 
-      expect(removeMock).toHaveBeenCalledWith(context.workspacePath, { keepBranch: true });
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(context.workspacePath, {
+        keepBranch: true,
+      });
     });
 
     it("defaults keepBranch to false", async () => {
-      const removeMock = vi.fn().mockResolvedValue({ started: true });
-      const workspaceApi = createMockWorkspaceApi({
-        remove: removeMock,
+      const deleteWorkspaceMock = vi.fn().mockResolvedValue({ started: true });
+      const mockHandlers = createMockHandlers({
+        deleteWorkspace: deleteWorkspaceMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      await handlers.workspace_delete(context, {});
+      await toolHandlers.workspace_delete(context, {});
 
-      expect(removeMock).toHaveBeenCalledWith(context.workspacePath, { keepBranch: false });
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(context.workspacePath, {
+        keepBranch: false,
+      });
     });
   });
 
   describe("workspace_execute_command", () => {
     it("returns command result on success", async () => {
-      const executeCommandMock = vi.fn().mockResolvedValue("command result");
-      const workspaceApi = createMockWorkspaceApi({
-        executeCommand: executeCommandMock,
+      const mockHandlers = createMockHandlers({
+        executeCommand: vi.fn().mockResolvedValue("command result"),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "test.command",
       });
       const parsed = parseToolResult<unknown>(result);
@@ -567,22 +497,14 @@ describe("MCP Tools", () => {
     });
 
     it("returns null for commands that return null", async () => {
-      const executeCommandMock = vi.fn().mockResolvedValue(null);
-      const workspaceApi = createMockWorkspaceApi({
-        executeCommand: executeCommandMock,
+      const mockHandlers = createMockHandlers({
+        executeCommand: vi.fn().mockResolvedValue(null),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "workbench.action.files.saveAll",
       });
       const parsed = parseToolResult<unknown>(result);
@@ -595,22 +517,14 @@ describe("MCP Tools", () => {
 
     it("handles undefined result correctly (converts to null string)", async () => {
       // Most VS Code commands return undefined - verify the result has a valid string text field
-      const executeCommandMock = vi.fn().mockResolvedValue(undefined);
-      const workspaceApi = createMockWorkspaceApi({
-        executeCommand: executeCommandMock,
+      const mockHandlers = createMockHandlers({
+        executeCommand: vi.fn().mockResolvedValue(undefined),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "workbench.action.files.saveAll",
       });
 
@@ -632,23 +546,16 @@ describe("MCP Tools", () => {
       }
     });
 
-    it("passes command and args to API", async () => {
+    it("passes command and args to handler", async () => {
       const executeCommandMock = vi.fn().mockResolvedValue(undefined);
-      const workspaceApi = createMockWorkspaceApi({
+      const mockHandlers = createMockHandlers({
         executeCommand: executeCommandMock,
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      await handlers.workspace_execute_command(context, {
+      await toolHandlers.workspace_execute_command(context, {
         command: "vscode.open",
         args: ["/path/to/file", { preview: true }],
       });
@@ -660,17 +567,11 @@ describe("MCP Tools", () => {
     });
 
     it("returns error when workspace not found", async () => {
-      const api: ICoreApi = {
-        workspaces: createMockWorkspaceApi(),
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const mockHandlers = createMockHandlers();
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createEmptyContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "test.command",
       });
       const parsed = parseToolResult<unknown>(result);
@@ -682,24 +583,14 @@ describe("MCP Tools", () => {
     });
 
     it("propagates API errors correctly", async () => {
-      const executeCommandMock = vi
-        .fn()
-        .mockRejectedValue(new Error("Command not found: invalid.command"));
-      const workspaceApi = createMockWorkspaceApi({
-        executeCommand: executeCommandMock,
+      const mockHandlers = createMockHandlers({
+        executeCommand: vi.fn().mockRejectedValue(new Error("Command not found: invalid.command")),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "invalid.command",
       });
       const parsed = parseToolResult<unknown>(result);
@@ -712,22 +603,14 @@ describe("MCP Tools", () => {
     });
 
     it("propagates timeout errors correctly", async () => {
-      const executeCommandMock = vi.fn().mockRejectedValue(new Error("Command timed out"));
-      const workspaceApi = createMockWorkspaceApi({
-        executeCommand: executeCommandMock,
+      const mockHandlers = createMockHandlers({
+        executeCommand: vi.fn().mockRejectedValue(new Error("Command timed out")),
       });
 
-      const api: ICoreApi = {
-        workspaces: workspaceApi,
-        projects: {} as IProjectApi,
-        on: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
-      };
-
-      const handlers = createToolHandlers(api);
+      const toolHandlers = createToolHandlers(mockHandlers);
       const context = createContext();
 
-      const result = await handlers.workspace_execute_command(context, {
+      const result = await toolHandlers.workspace_execute_command(context, {
         command: "slow.command",
       });
       const parsed = parseToolResult<unknown>(result);

--- a/src/services/mcp-server/types.ts
+++ b/src/services/mcp-server/types.ts
@@ -3,6 +3,12 @@
  */
 
 import type { IDisposable } from "../../shared/types";
+import type {
+  WorkspaceStatus,
+  AgentSession,
+  Workspace,
+  InitialPrompt,
+} from "../../shared/api/types";
 
 // =============================================================================
 // MCP Error Types
@@ -23,6 +29,39 @@ export type McpErrorCode =
 export interface McpError {
   readonly code: McpErrorCode;
   readonly message: string;
+}
+
+// =============================================================================
+// MCP API Handlers
+// =============================================================================
+
+/**
+ * Flat handler interface for MCP server operations.
+ * Each method maps to an MCP tool. The MCP server calls these handlers
+ * instead of going through the centralized API facade.
+ */
+export interface McpApiHandlers {
+  getStatus(workspacePath: string): Promise<WorkspaceStatus>;
+  getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>>;
+  setMetadata(workspacePath: string, key: string, value: string | null): Promise<void>;
+  getAgentSession(workspacePath: string): Promise<AgentSession | null>;
+  restartAgentServer(workspacePath: string): Promise<number>;
+  createWorkspace(options: {
+    callerWorkspacePath: string;
+    name: string;
+    base: string;
+    initialPrompt?: InitialPrompt;
+    stealFocus?: boolean;
+  }): Promise<Workspace>;
+  deleteWorkspace(
+    workspacePath: string,
+    options: { keepBranch: boolean }
+  ): Promise<{ started: boolean }>;
+  executeCommand(
+    workspacePath: string,
+    command: string,
+    args?: readonly unknown[]
+  ): Promise<unknown>;
 }
 
 // =============================================================================


### PR DESCRIPTION
- Add `McpApiHandlers` flat interface to `types.ts` replacing nested `ICoreApi` dependency
- Update `McpServer` and `McpServerManager` to accept `McpApiHandlers` instead of `ICoreApi`
- Create `mcp-handlers.ts` factory that dispatches intents directly via the Dispatcher
- Wire `createMcpHandlers(dispatcher, pluginServer)` in `index.ts`, eliminating the lazy `codeHydraApi` reference
- Update all MCP server tests to use flat mock handlers instead of nested `ICoreApi` mocks
- Add integration tests for the new handlers factory verifying correct intent dispatch