### PR TITLE
chore: replace inline type imports with top-level import type declarations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,14 @@ export default tseslint.config(
     },
     rules: {
       "@typescript-eslint/ban-ts-comment": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSImportType",
+          message:
+            "Use a top-level `import type` declaration instead of inline import() type references.",
+        },
+      ],
     },
   },
   {

--- a/src/agents/claude/wrapper.integration.test.ts
+++ b/src/agents/claude/wrapper.integration.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
 import * as fs from "node:fs";
-import type { RunClaudeDeps } from "./wrapper";
+import type {
+  RunClaudeDeps,
+  getInitialPromptConfig as GetInitialPromptConfigFn,
+  runClaude as RunClaudeFn,
+} from "./wrapper";
 
 // Must mock fs before importing wrapper
 vi.mock("node:fs", () => ({
@@ -18,8 +22,8 @@ vi.mock("node:fs", () => ({
 }));
 
 // Use dynamic import to ensure mock is set up before wrapper is loaded
-let getInitialPromptConfig: typeof import("./wrapper").getInitialPromptConfig;
-let runClaude: typeof import("./wrapper").runClaude;
+let getInitialPromptConfig: typeof GetInitialPromptConfigFn;
+let runClaude: typeof RunClaudeFn;
 
 describe("getInitialPromptConfig integration", () => {
   const mockReadFileSync = vi.mocked(fs.readFileSync);

--- a/src/agents/opencode/client.test.ts
+++ b/src/agents/opencode/client.test.ts
@@ -13,6 +13,7 @@ import {
   isValidSessionStatus,
   isSessionStatusResponse,
 } from "./client";
+import type { SdkClientFactory as RealSdkClientFactory } from "./client";
 import type { SessionStatus as OurSessionStatus } from "./types";
 import {
   createSdkClientMock,
@@ -52,7 +53,7 @@ describe("OpenCodeClient", () => {
     return new OpenCodeClient(
       port,
       SILENT_LOGGER,
-      (customFactory ?? mockFactory) as unknown as import("./client").SdkClientFactory
+      (customFactory ?? mockFactory) as unknown as RealSdkClientFactory
     );
   }
 
@@ -1591,11 +1592,7 @@ describe("Permission Event Emission", () => {
   }
 
   function createClient(factory: SdkClientFactory): OpenCodeClient {
-    return new OpenCodeClient(
-      8080,
-      SILENT_LOGGER,
-      factory as unknown as import("./client").SdkClientFactory
-    );
+    return new OpenCodeClient(8080, SILENT_LOGGER, factory as unknown as RealSdkClientFactory);
   }
 
   /**

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -15,6 +15,7 @@ import type { DomainEvent } from "../intents/infrastructure/types";
 import type { Logger } from "../../services/logging/types";
 import type { AgentBinaryManager } from "../../services/binary-download";
 import type { AgentBinaryType } from "../../services/binary-download";
+import type { BinaryType } from "../../services/vscode-setup/types";
 import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
 
 import type { LoggingService } from "../../services/logging";
@@ -222,7 +223,7 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
             const { configuredAgent } = ctx as CheckDepsHookContext;
             if (configuredAgent !== "claude") return {};
 
-            const missingBinaries: import("../../services/vscode-setup/types").BinaryType[] = [];
+            const missingBinaries: BinaryType[] = [];
             const agentResult = await agentBinaryManager.preflight();
             if (agentResult.success && agentResult.needsDownload) {
               const binaryType = agentBinaryManager.getBinaryType() as AgentBinaryType;

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -25,6 +25,7 @@ import type { Logger } from "../../services/logging/types";
 import type { DomainEvent } from "../intents/infrastructure/types";
 import type { SupportedPlatform, SupportedArch } from "../../agents/types";
 import type { DownloadRequest } from "../../services/binary-download";
+import type { BinaryType } from "../../services/vscode-setup/types";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type {
   CheckDepsResult,
@@ -139,7 +140,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
         // -------------------------------------------------------------------
         "check-deps": {
           handler: async (): Promise<CheckDepsResult> => {
-            const missingBinaries: import("../../services/vscode-setup/types").BinaryType[] = [];
+            const missingBinaries: BinaryType[] = [];
 
             // Check code-server binary
             const codeServerResult = await codeServerManager.preflight();

--- a/src/main/modules/opencode-agent-module.ts
+++ b/src/main/modules/opencode-agent-module.ts
@@ -15,6 +15,7 @@ import type { DomainEvent } from "../intents/infrastructure/types";
 import type { Logger } from "../../services/logging/types";
 import type { AgentBinaryManager } from "../../services/binary-download";
 import type { AgentBinaryType } from "../../services/binary-download";
+import type { BinaryType } from "../../services/vscode-setup/types";
 import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
 
 import type { LoggingService } from "../../services/logging";
@@ -255,7 +256,7 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
             const { configuredAgent } = ctx as CheckDepsHookContext;
             if (configuredAgent !== "opencode") return {};
 
-            const missingBinaries: import("../../services/vscode-setup/types").BinaryType[] = [];
+            const missingBinaries: BinaryType[] = [];
             const agentResult = await agentBinaryManager.preflight();
             if (agentResult.success && agentResult.needsDownload) {
               const binaryType = agentBinaryManager.getBinaryType() as AgentBinaryType;

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -87,6 +87,7 @@ import { SILENT_LOGGER } from "../../services/logging";
 import { createViewModule, type ViewModuleDeps } from "./view-module";
 import type { ProjectId, WorkspaceName, Project } from "../../shared/api/types";
 import { ApiIpcChannels } from "../../shared/ipc";
+import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
 import {
   createBehavioralIpcLayer,
   type BehavioralIpcLayer,
@@ -861,10 +862,10 @@ describe("ViewModule Integration", () => {
           const event: AgentStatusUpdatedEvent = {
             type: EVENT_AGENT_STATUS_UPDATED,
             payload: {
-              workspacePath: "/workspaces/ws1" as import("../../shared/ipc").WorkspacePath,
+              workspacePath: "/workspaces/ws1" as WorkspacePath,
               projectId: "test-project" as ProjectId,
               workspaceName: "ws1" as WorkspaceName,
-              status: { status: "idle" } as import("../../shared/ipc").AggregatedAgentStatus,
+              status: { status: "idle" } as AggregatedAgentStatus,
             },
           };
           ctx.emit(event);

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -32,7 +32,7 @@ import type { Logger } from "../../services/logging";
 import type { ViewLayer } from "../../services/shell/view";
 import type { WindowLayerInternal } from "../../services/shell/window";
 import type { SessionLayer } from "../../services/shell/session";
-import type { IpcEventHandler } from "../../services/platform/ipc";
+import type { IpcEventHandler, IpcLayer } from "../../services/platform/ipc";
 import type { Unsubscribe } from "../../shared/api/interfaces";
 import type { WorkspaceRef } from "../../shared/api/types";
 import type { WorkspacePath, WorkspaceLoadingChangedPayload } from "../../shared/ipc";
@@ -109,10 +109,7 @@ export interface ViewModuleDeps {
   readonly windowLayer: WindowLayerInternal | null;
   readonly sessionLayer: SessionLayer | null;
   readonly dialogLayer?: Pick<DialogLayer, "showOpenDialog"> | null;
-  readonly ipcLayer?: Pick<
-    import("../../services/platform/ipc").IpcLayer,
-    "on" | "removeListener"
-  > | null;
+  readonly ipcLayer?: Pick<IpcLayer, "on" | "removeListener"> | null;
   readonly menuLayer?: { setApplicationMenu(menu: null): void } | null;
   readonly windowManager?: {
     create(): void;

--- a/src/main/operations/get-metadata.integration.test.ts
+++ b/src/main/operations/get-metadata.integration.test.ts
@@ -42,6 +42,8 @@ import type {
   ResolveHookResult as ResolveProjectHookResult,
 } from "./resolve-project";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
+import type { IpcEventBridgeDeps } from "../modules/ipc-event-bridge";
+import type { IApiRegistry } from "../api/registry-types";
 import { createMockGitClient } from "../../services/git/git-client.state-mock";
 import { createFileSystemMock, directory } from "../../services/platform/filesystem.state-mock";
 import { GitWorktreeProvider } from "../../services/git/git-worktree-provider";
@@ -204,18 +206,17 @@ function createTestSetup(): TestSetup {
   // Wire IpcEventBridge
   const mockApiRegistry = createMockApiRegistry();
   const ipcEventBridge = createIpcEventBridge({
-    apiRegistry: mockApiRegistry as unknown as import("../api/registry-types").IApiRegistry,
+    apiRegistry: mockApiRegistry as unknown as IApiRegistry,
     getApi: () => {
       throw new Error("not wired");
     },
     sendToUI: vi.fn(),
     pluginServer: null,
     logger: SILENT_LOGGER,
-    dispatcher:
-      dispatcher as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["dispatcher"],
+    dispatcher: dispatcher as unknown as IpcEventBridgeDeps["dispatcher"],
     agentStatusManager: {
       getStatus: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
+    } as unknown as IpcEventBridgeDeps["agentStatusManager"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/open-project.integration.test.ts
+++ b/src/main/operations/open-project.integration.test.ts
@@ -57,7 +57,7 @@ import type {
   WorkspaceCreatedEvent,
 } from "./open-workspace";
 import type { IViewManager } from "../managers/view-manager.interface";
-import type { Project, ProjectId } from "../../shared/api/types";
+import type { Project, ProjectId, WorkspaceName } from "../../shared/api/types";
 import { Path } from "../../services/platform/path";
 import { expandGitUrl } from "../../services/project/url-utils";
 import {
@@ -609,7 +609,7 @@ function createTestHarness(options?: {
                 const workspaceName = extractWorkspaceName(wsPath);
                 return {
                   projectPath: project.path,
-                  workspaceName: workspaceName as import("../../shared/api/types").WorkspaceName,
+                  workspaceName: workspaceName as WorkspaceName,
                 };
               }
             }

--- a/src/main/operations/open-workspace.integration.test.ts
+++ b/src/main/operations/open-workspace.integration.test.ts
@@ -59,10 +59,10 @@ import type {
 import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { DomainEvent, Intent } from "../intents/infrastructure/types";
-import type { ProjectId, Workspace } from "../../shared/api/types";
+import type { ProjectId, Workspace, WorkspaceName } from "../../shared/api/types";
 import { extractWorkspaceName } from "../../shared/api/id-utils";
 
-const PROJECT_ID = "project-ea0135bc" as import("../../shared/api/types").ProjectId;
+const PROJECT_ID = "project-ea0135bc" as ProjectId;
 import { Path } from "../../services/platform/path";
 import {
   SwitchWorkspaceOperation,
@@ -245,7 +245,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
             const workspaceName = extractWorkspaceName(wsPath);
             return {
               projectPath: PROJECT_ROOT,
-              workspaceName: workspaceName as import("../../shared/api/types").WorkspaceName,
+              workspaceName: workspaceName as WorkspaceName,
             };
           },
         },
@@ -639,7 +639,7 @@ describe("OpenWorkspace Operation", () => {
       const setup = createTestSetup({
         activeWorkspaceRef: {
           projectId: PROJECT_ID,
-          workspaceName: "other" as import("../../shared/api/types").WorkspaceName,
+          workspaceName: "other" as WorkspaceName,
           path: "/workspaces/other",
         },
       });
@@ -889,7 +889,7 @@ describe("OpenWorkspace Operation", () => {
                 const workspaceName = extractWorkspaceName(wsPath);
                 return {
                   projectPath: PROJECT_ROOT,
-                  workspaceName: workspaceName as import("../../shared/api/types").WorkspaceName,
+                  workspaceName: workspaceName as WorkspaceName,
                 };
               },
             },
@@ -1022,7 +1022,7 @@ describe("OpenWorkspace Operation", () => {
       const setup = createTestSetup({
         activeWorkspaceRef: {
           projectId: PROJECT_ID,
-          workspaceName: "other-ws" as import("../../shared/api/types").WorkspaceName,
+          workspaceName: "other-ws" as WorkspaceName,
           path: "/workspaces/other-ws",
         },
       });

--- a/src/main/operations/set-metadata.integration.test.ts
+++ b/src/main/operations/set-metadata.integration.test.ts
@@ -47,6 +47,7 @@ import type {
   ResolveHookResult as ResolveProjectHookResult,
 } from "./resolve-project";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
+import type { IpcEventBridgeDeps } from "../modules/ipc-event-bridge";
 import { createMockGitClient } from "../../services/git/git-client.state-mock";
 import { createFileSystemMock, directory } from "../../services/platform/filesystem.state-mock";
 import { GitWorktreeProvider } from "../../services/git/git-worktree-provider";
@@ -198,11 +199,10 @@ function createTestSetup(): TestSetup {
     sendToUI: vi.fn(),
     pluginServer: null,
     logger: SILENT_LOGGER,
-    dispatcher:
-      dispatcher as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["dispatcher"],
+    dispatcher: dispatcher as unknown as IpcEventBridgeDeps["dispatcher"],
     agentStatusManager: {
       getStatus: vi.fn(),
-    } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
+    } as unknown as IpcEventBridgeDeps["agentStatusManager"],
   });
   dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(resolveProjectModule);

--- a/src/main/operations/set-mode.integration.test.ts
+++ b/src/main/operations/set-mode.integration.test.ts
@@ -27,6 +27,7 @@ import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { DomainEvent, Intent } from "../intents/infrastructure/types";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
+import type { IpcEventBridgeDeps } from "../modules/ipc-event-bridge";
 import type { UIMode } from "../../shared/ipc";
 import { SILENT_LOGGER } from "../../services/logging";
 
@@ -101,11 +102,10 @@ function createTestSetup(opts?: { initialMode?: UIMode; withIpcEventBridge?: boo
       sendToUI: vi.fn(),
       pluginServer: null,
       logger: SILENT_LOGGER,
-      dispatcher:
-        dispatcher as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["dispatcher"],
+      dispatcher: dispatcher as unknown as IpcEventBridgeDeps["dispatcher"],
       agentStatusManager: {
         getStatus: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
+      } as unknown as IpcEventBridgeDeps["agentStatusManager"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/main/operations/switch-workspace.integration.test.ts
+++ b/src/main/operations/switch-workspace.integration.test.ts
@@ -56,6 +56,7 @@ import type { IntentModule } from "../intents/infrastructure/module";
 import type { HookContext } from "../intents/infrastructure/operation";
 import type { DomainEvent, Intent } from "../intents/infrastructure/types";
 import { createIpcEventBridge } from "../modules/ipc-event-bridge";
+import type { IpcEventBridgeDeps } from "../modules/ipc-event-bridge";
 import { createWindowTitleModule } from "../modules/window-title-module";
 import { SILENT_LOGGER } from "../../services/logging";
 import { UpdateAvailableOperation, INTENT_UPDATE_AVAILABLE } from "./update-available";
@@ -331,11 +332,10 @@ function createTestSetup(opts?: {
       sendToUI: vi.fn(),
       pluginServer: null,
       logger: SILENT_LOGGER,
-      dispatcher:
-        dispatcher as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["dispatcher"],
+      dispatcher: dispatcher as unknown as IpcEventBridgeDeps["dispatcher"],
       agentStatusManager: {
         getStatus: vi.fn(),
-      } as unknown as import("../modules/ipc-event-bridge").IpcEventBridgeDeps["agentStatusManager"],
+      } as unknown as IpcEventBridgeDeps["agentStatusManager"],
     });
     modules.push(ipcEventBridge);
   }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -17,6 +17,11 @@ export {
 } from "./errors";
 export type { SerializedError } from "./errors";
 
+// Types used by createGitWorktreeProvider
+import type { Path } from "./platform/path";
+import type { FileSystemLayer } from "./platform/filesystem";
+import type { Logger } from "./logging";
+
 // Git types
 export type { Workspace, BaseInfo } from "./git/types";
 
@@ -181,11 +186,11 @@ export type {
  * @throws WorkspaceError if path is invalid or not a git repository
  */
 export async function createGitWorktreeProvider(
-  projectRoot: import("./platform/path").Path,
-  workspacesDir: import("./platform/path").Path,
-  fileSystemLayer: import("./platform/filesystem").FileSystemLayer,
-  gitLogger: import("./logging").Logger,
-  worktreeLogger: import("./logging").Logger
+  projectRoot: Path,
+  workspacesDir: Path,
+  fileSystemLayer: FileSystemLayer,
+  gitLogger: Logger,
+  worktreeLogger: Logger
 ): Promise<GitWorktreeProvider> {
   const gitClient = new SimpleGitClient(gitLogger);
   const provider = new GitWorktreeProvider(gitClient, fileSystemLayer, worktreeLogger);


### PR DESCRIPTION
- Add ESLint `no-restricted-syntax` rule to ban `TSImportType` nodes, preventing future use of `import("...").Type` inline syntax
- Convert all 39 existing violations across 16 files to standard top-level `import type` declarations