### PR TITLE
fix(ci): add engines.node to package.json for setup-node resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "out/main/index.cjs",
   "packageManager": "pnpm@10.11.0",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "preinstall": "node scripts/check-path-length.js",
     "bootstrap": "pnpm install && pnpm build",


### PR DESCRIPTION
- Add `engines.node: ">=22"` to package.json so `actions/setup-node` can resolve the node version from `node-version-file: package.json`
- Fixes CI warning: "Could not determine node version from package.json. Falling back"