### PR TITLE
feat: added json as logging format

### DIFF
--- a/src/main/modules/logging-module.integration.test.ts
+++ b/src/main/modules/logging-module.integration.test.ts
@@ -159,4 +159,53 @@ describe("LoggingModule Integration", () => {
       "telemetry.distinct-id": null,
     });
   });
+
+  it("reconfigures logging when log.format changes", () => {
+    const deps = createDeps();
+    const module = createLoggingModule(deps);
+
+    const handler = module.events![EVENT_CONFIG_UPDATED]!;
+    handler({
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: { "log.level": "debug", "log.output": "file", "log.format": "json" } },
+    } as ConfigUpdatedEvent);
+
+    expect(deps.loggingService.configure).toHaveBeenCalledWith({
+      logLevel: "debug",
+      logFile: true,
+      logConsole: false,
+      allowedLoggers: undefined,
+      logFormat: "json",
+    });
+  });
+
+  it("reconfigures with logFormat when only log.format changes", () => {
+    const deps = createDeps();
+    const module = createLoggingModule(deps);
+
+    const handler = module.events![EVENT_CONFIG_UPDATED]!;
+    handler({
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: { "log.format": "json" } },
+    } as ConfigUpdatedEvent);
+
+    expect(deps.loggingService.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ logFormat: "json" })
+    );
+  });
+
+  it("includes logFormat in reconfigure when log.level changes", () => {
+    const deps = createDeps();
+    const module = createLoggingModule(deps);
+
+    const handler = module.events![EVENT_CONFIG_UPDATED]!;
+    handler({
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: { "log.level": "info" } },
+    } as ConfigUpdatedEvent);
+
+    expect(deps.loggingService.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ logFormat: "text" })
+    );
+  });
 });

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -18,7 +18,9 @@ import type { BuildInfo } from "../../services/platform/build-info";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { RegisterConfigResult } from "../operations/app-start";
+import type { LogFormat } from "../../services/logging/types";
 import {
+  parseLogFormat,
   parseLogLevelSpec,
   parseLogOutput,
   splitLogLevelSpec,
@@ -69,6 +71,12 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
                 parse: parseLogOutput,
                 validate: (v: unknown) => (typeof v === "string" ? parseLogOutput(v) : undefined),
               },
+              {
+                name: "log.format",
+                default: "text",
+                parse: parseLogFormat,
+                validate: (v: unknown) => (typeof v === "string" ? parseLogFormat(v) : undefined),
+              },
             ],
           }),
         },
@@ -103,15 +111,21 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
         deps.logger.info("Config updated", context);
 
         // Reconfigure logging when any log-related value changes
-        if (values["log.level"] !== undefined || values["log.output"] !== undefined) {
+        if (
+          values["log.level"] !== undefined ||
+          values["log.output"] !== undefined ||
+          values["log.format"] !== undefined
+        ) {
           const levelSpec = (values["log.level"] as string | undefined) ?? "warn";
           const { level, filter } = splitLogLevelSpec(levelSpec);
           const output = (values["log.output"] as string | undefined) ?? "file";
+          const logFormat = ((values["log.format"] as string | undefined) ?? "text") as LogFormat;
           deps.loggingService.configure({
             logLevel: level,
             logFile: output.includes("file"),
             logConsole: output.includes("console"),
             allowedLoggers: filter,
+            logFormat,
           });
         }
       },

--- a/src/services/logging/electron-log-service.boundary.test.ts
+++ b/src/services/logging/electron-log-service.boundary.test.ts
@@ -21,6 +21,7 @@ const DEFAULT_OPTIONS: LoggingConfigureOptions = {
   logFile: true,
   logConsole: false,
   allowedLoggers: undefined,
+  logFormat: "text",
 };
 
 /**

--- a/src/services/logging/electron-log-service.test.ts
+++ b/src/services/logging/electron-log-service.test.ts
@@ -15,11 +15,11 @@ const mockInitialize = vi.fn();
 const mockTransports = {
   file: {
     level: undefined as string | false | undefined,
-    format: undefined as string | undefined,
+    format: undefined as string | ((...args: unknown[]) => string) | undefined,
   },
   console: {
     level: undefined as string | false | undefined,
-    format: undefined as string | undefined,
+    format: undefined as string | ((...args: unknown[]) => string) | undefined,
   },
 };
 
@@ -56,6 +56,7 @@ describe("ElectronLogService", () => {
     logFile: true,
     logConsole: false,
     allowedLoggers: undefined,
+    logFormat: "text",
   };
 
   async function createService(options?: {
@@ -449,6 +450,7 @@ describe("ElectronLogService", () => {
         logFile: true,
         logConsole: false,
         allowedLoggers: undefined,
+        logFormat: "text",
       });
       expect(mockTransports.file.level).toBe("debug");
 
@@ -457,6 +459,7 @@ describe("ElectronLogService", () => {
         logFile: true,
         logConsole: true,
         allowedLoggers: undefined,
+        logFormat: "text",
       });
       expect(mockTransports.file.level).toBe("warn");
       expect(mockTransports.console.level).toBe("warn");
@@ -643,6 +646,117 @@ describe("ElectronLogService", () => {
       const { parseLogOutput } = await import("./electron-log-service");
       expect(parseLogOutput(undefined)).toBeUndefined();
       expect(parseLogOutput("")).toBeUndefined();
+    });
+  });
+
+  describe("parseLogFormat", () => {
+    it("parses valid format values", async () => {
+      const { parseLogFormat } = await import("./electron-log-service");
+      expect(parseLogFormat("text")).toBe("text");
+      expect(parseLogFormat("json")).toBe("json");
+    });
+
+    it("handles case-insensitive input", async () => {
+      const { parseLogFormat } = await import("./electron-log-service");
+      expect(parseLogFormat("TEXT")).toBe("text");
+      expect(parseLogFormat("JSON")).toBe("json");
+      expect(parseLogFormat("Json")).toBe("json");
+    });
+
+    it("returns undefined for invalid input", async () => {
+      const { parseLogFormat } = await import("./electron-log-service");
+      expect(parseLogFormat("xml")).toBeUndefined();
+      expect(parseLogFormat("csv")).toBeUndefined();
+    });
+
+    it("returns undefined for empty or undefined input", async () => {
+      const { parseLogFormat } = await import("./electron-log-service");
+      expect(parseLogFormat(undefined)).toBeUndefined();
+      expect(parseLogFormat("")).toBeUndefined();
+    });
+  });
+
+  describe("JSON format mode", () => {
+    it("sets function format on transports", async () => {
+      await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFormat: "json" },
+      });
+
+      expect(typeof mockTransports.file.format).toBe("function");
+      expect(typeof mockTransports.console.format).toBe("function");
+    });
+
+    it("sets string format on transports in text mode", async () => {
+      await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFormat: "text" },
+      });
+
+      expect(typeof mockTransports.file.format).toBe("string");
+      expect(typeof mockTransports.console.format).toBe("string");
+    });
+
+    it("passes message and context separately to scope", async () => {
+      const scopeLogger = {
+        silly: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      mockScope.mockReturnValue(scopeLogger);
+
+      const service = await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFormat: "json" },
+      });
+      const logger = service.createLogger("git");
+
+      logger.info("Clone complete", { repo: "myrepo", branch: "main" });
+
+      expect(scopeLogger.info).toHaveBeenCalledWith("Clone complete", {
+        repo: "myrepo",
+        branch: "main",
+      });
+    });
+
+    it("passes only message to scope without context", async () => {
+      const scopeLogger = {
+        silly: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      mockScope.mockReturnValue(scopeLogger);
+
+      const service = await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFormat: "json" },
+      });
+      const logger = service.createLogger("app");
+
+      logger.info("Services started");
+
+      expect(scopeLogger.info).toHaveBeenCalledWith("Services started");
+    });
+
+    it("passes message, context, and error separately for error level", async () => {
+      const scopeLogger = {
+        silly: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      mockScope.mockReturnValue(scopeLogger);
+
+      const service = await createService({
+        configureOptions: { ...DEFAULT_OPTIONS, logFormat: "json" },
+      });
+      const logger = service.createLogger("app");
+
+      const testError = new Error("Test error");
+      logger.error("Failed", { op: "test" }, testError);
+
+      expect(scopeLogger.error).toHaveBeenCalledWith("Failed", { op: "test" }, testError);
     });
   });
 });

--- a/src/services/logging/electron-log-service.ts
+++ b/src/services/logging/electron-log-service.ts
@@ -16,6 +16,7 @@ import type { PathProvider } from "../platform/path-provider";
 import type {
   Logger,
   LoggerName,
+  LogFormat,
   LoggingConfigureOptions,
   LoggingService,
   LogContext,
@@ -133,6 +134,125 @@ export function parseLogOutput(raw: string | undefined): string | undefined {
   // Deduplicate and sort for canonical form
   const unique = [...new Set(tokens)].sort() as LogOutput[];
   return unique.join(",");
+}
+
+/**
+ * Validate and normalize a log format string.
+ *
+ * @param raw - Raw string value (e.g., "text", "json")
+ * @returns Normalized format string, or undefined if invalid
+ */
+export function parseLogFormat(raw: string | undefined): LogFormat | undefined {
+  if (!raw) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "text" || normalized === "json") {
+    return normalized;
+  }
+  return undefined;
+}
+
+/**
+ * Text format template for electron-log transports.
+ */
+const TEXT_FORMAT = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {scope} {text}";
+
+/**
+ * Create a format function for JSON log output.
+ *
+ * The returned function receives electron-log's FormatParams and produces
+ * a single JSONL line with structured fields:
+ * - timestamp, level, scope, message
+ * - context: first non-Error object in data[1:]
+ * - error: first Error instance in data[1:] (message + stack)
+ *
+ * electron-log Format signature: (params: FormatParams) => any[]
+ * FormatParams: { data, level, logger, message, transport }
+ * message: LogMessage { data, date, level, scope?, ... }
+ */
+function createJsonFormatFn(): (params: {
+  message: { date: Date; level: string; scope?: string; data: unknown[] };
+}) => string[] {
+  return ({ message }) => {
+    const entry: Record<string, unknown> = {
+      timestamp: message.date.toISOString(),
+      level: message.level,
+    };
+
+    if (message.scope) {
+      entry.scope = message.scope;
+    }
+
+    entry.message = typeof message.data[0] === "string" ? message.data[0] : String(message.data[0]);
+
+    // Find context and error in remaining data arguments
+    for (let i = 1; i < message.data.length; i++) {
+      const arg = message.data[i];
+      if (arg instanceof Error) {
+        entry.error = { message: arg.message, stack: arg.stack };
+      } else if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
+        entry.context = arg;
+      }
+    }
+
+    return [JSON.stringify(entry)];
+  };
+}
+
+/**
+ * JSON-mode logger that passes message and context as separate arguments
+ * to the electron-log scope, so the format function can include context
+ * as a structured JSON field.
+ */
+class JsonLogLogger implements Logger {
+  private readonly scope: ElectronLogScope;
+
+  constructor(scope: ElectronLogScope) {
+    this.scope = scope;
+  }
+
+  silly(message: string, context?: LogContext): void {
+    if (context) {
+      this.scope.silly(message, context);
+    } else {
+      this.scope.silly(message);
+    }
+  }
+
+  debug(message: string, context?: LogContext): void {
+    if (context) {
+      this.scope.debug(message, context);
+    } else {
+      this.scope.debug(message);
+    }
+  }
+
+  info(message: string, context?: LogContext): void {
+    if (context) {
+      this.scope.info(message, context);
+    } else {
+      this.scope.info(message);
+    }
+  }
+
+  warn(message: string, context?: LogContext): void {
+    if (context) {
+      this.scope.warn(message, context);
+    } else {
+      this.scope.warn(message);
+    }
+  }
+
+  error(message: string, context?: LogContext, error?: Error): void {
+    if (context && error) {
+      this.scope.error(message, context, error);
+    } else if (error) {
+      this.scope.error(message, error);
+    } else if (context) {
+      this.scope.error(message, context);
+    } else {
+      this.scope.error(message);
+    }
+  }
 }
 
 /**
@@ -348,6 +468,7 @@ export class ElectronLogService implements LoggingService {
   private readonly loggers = new Map<LoggerName, QueuedLogger>();
   private configured = false;
   private logLevel: LogLevel = "warn";
+  private logFormat: LogFormat = "text";
   private allowedLoggers: Set<LoggerName> | undefined;
 
   constructor(pathProvider: PathProvider) {
@@ -361,22 +482,29 @@ export class ElectronLogService implements LoggingService {
     log.transports.file.resolvePathFn = (): string => join(logsDir, filename);
 
     // Format: [timestamp] [level] [scope] message
-    log.transports.file.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {scope} {text}";
-    log.transports.console.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {scope} {text}";
+    log.transports.file.format = TEXT_FORMAT;
+    log.transports.console.format = TEXT_FORMAT;
   }
 
   configure(options: LoggingConfigureOptions): void {
     this.logLevel = options.logLevel;
+    this.logFormat = options.logFormat;
     this.allowedLoggers = options.allowedLoggers;
 
     // Enable transports with the configured level
     log.transports.file.level = options.logFile ? this.logLevel : false;
     log.transports.console.level = options.logConsole ? this.logLevel : false;
 
+    // Set transport format based on log format
+    const format = this.logFormat === "json" ? createJsonFormatFn() : TEXT_FORMAT;
+    log.transports.file.format = format;
+    log.transports.console.format = format;
+
     // Activate all existing queued loggers
     for (const [name, queued] of this.loggers) {
       const scope = log.scope(name);
-      const inner = new ElectronLogLogger(scope);
+      const inner =
+        this.logFormat === "json" ? new JsonLogLogger(scope) : new ElectronLogLogger(scope);
       const filtered = new FilteredLogger(inner, this.allowedLoggers, name);
       queued.activate(filtered);
     }
@@ -400,7 +528,8 @@ export class ElectronLogService implements LoggingService {
     // If already configured, activate immediately
     if (this.configured) {
       const scope = log.scope(name);
-      const inner = new ElectronLogLogger(scope);
+      const inner =
+        this.logFormat === "json" ? new JsonLogLogger(scope) : new ElectronLogLogger(scope);
       const filtered = new FilteredLogger(inner, this.allowedLoggers, name);
       queued.activate(filtered);
     }

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -7,6 +7,7 @@ export type {
   LoggingService,
   LoggingConfigureOptions,
   LogContext,
+  LogFormat,
   LoggerName,
   LogLevel,
   LogOutput,
@@ -14,6 +15,7 @@ export type {
 export { LogLevel as LogLevelValues, logAtLevel } from "./types";
 export {
   ElectronLogService,
+  parseLogFormat,
   parseLogLevel,
   parseLogLevelSpec,
   splitLogLevelSpec,

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -74,6 +74,13 @@ export type LogContext = Record<string, string | number | boolean | null>;
 export type LogOutput = "file" | "console";
 
 /**
+ * Log output format.
+ * - "text": Human-readable text lines (default)
+ * - "json": JSONL with structured context
+ */
+export type LogFormat = "text" | "json";
+
+/**
  * Configuration options for the logging service.
  * Passed to `configure()` to set transport levels and filters.
  */
@@ -82,6 +89,7 @@ export interface LoggingConfigureOptions {
   readonly logFile: boolean;
   readonly logConsole: boolean;
   readonly allowedLoggers: Set<LoggerName> | undefined;
+  readonly logFormat: LogFormat;
 }
 
 /**


### PR DESCRIPTION
- Add `log.format` config value (`"text"` default, `"json"` option)
- JSON mode emits JSONL with structured `context` and `error` fields
- New `JsonLogLogger` passes message and context as separate args to electron-log scope
- New `createJsonFormatFn()` produces JSONL from electron-log's FormatParams
- `parseLogFormat()` validates/normalizes the config value
- `log.format` changes trigger logging reconfiguration
- Tests for parseLogFormat, JSON mode transport format, JSON mode logger behavior, and integration