### PR TITLE
refactor(api): remove ICodeHydraApi facade, dispatch intents directly

### DIFF
--- a/src/main/operations/delete-workspace.integration.test.ts
+++ b/src/main/operations/delete-workspace.integration.test.ts
@@ -47,7 +47,6 @@ import type { IViewManager } from "../managers/view-manager.interface";
 
 import type { WorkspaceLockHandler } from "../../services/platform/workspace-lock-handler";
 import type { IWorkspaceFileService } from "../../services";
-import { ApiIpcChannels } from "../../shared/ipc";
 import type { WorkspacePath } from "../../shared/ipc";
 import type {
   BlockingProcess,
@@ -299,15 +298,13 @@ function createTestViewManager(activeWorkspacePath: string | null = WORKSPACE_PA
 }
 
 function createTestSendToUI(): {
-  sendToUI: ReturnType<typeof vi.fn<(channel: string, payload: unknown) => void>>;
-  emittedEvents: Array<{ channel: string; payload: unknown }>;
+  sendToUI: (channel: string, payload: unknown) => void;
+  emittedEvents: Array<{ event: string; payload: unknown }>;
 } {
-  const emittedEvents: Array<{ channel: string; payload: unknown }> = [];
-  const sendToUI = vi
-    .fn<(channel: string, payload: unknown) => void>()
-    .mockImplementation((channel: string, payload: unknown) => {
-      emittedEvents.push({ channel, payload });
-    });
+  const emittedEvents: Array<{ event: string; payload: unknown }> = [];
+  const sendToUI = vi.fn((channel: string, payload: unknown) => {
+    emittedEvents.push({ event: channel, payload });
+  });
   return { sendToUI, emittedEvents };
 }
 
@@ -329,7 +326,7 @@ interface TestHarness {
   viewManager: IViewManager;
   activeWorkspace: { path: string | null };
   destroyedViews: string[];
-  emittedEvents: Array<{ channel: string; payload: unknown }>;
+  emittedEvents: Array<{ event: string; payload: unknown }>;
   inProgressDeletions: Set<string>;
   globalProviderState: { removed: boolean };
   globalProviderMock: {
@@ -683,7 +680,7 @@ function createTestHarness(options?: {
     events: {
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const payload = (event as WorkspaceDeletedEvent).payload;
-        sendToUI(ApiIpcChannels.WORKSPACE_REMOVED, {
+        sendToUI("api:workspace:removed", {
           projectId: payload.projectId,
           workspaceName: payload.workspaceName,
           path: payload.workspacePath,
@@ -874,9 +871,7 @@ describe("DeleteWorkspaceOperation.normalDeletion", () => {
     });
 
     // Event subscriber: IPC event emitted
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeDefined();
     expect(ipcEvent!.payload).toEqual({
       projectId: PROJECT_ID,
@@ -913,9 +908,7 @@ describe("DeleteWorkspaceOperation.forceDeletion", () => {
     });
 
     // IPC event still emitted
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeDefined();
 
     // Final progress should report errors
@@ -1131,9 +1124,7 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     expect(harness.testState.removedWorkspaces).toHaveLength(0);
 
     // No IPC workspace:removed event
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeUndefined();
 
     // Idempotency was reset by delete-failed event (allows retry)
@@ -1467,9 +1458,7 @@ describe("DeleteWorkspaceOperation.ipcEvents", () => {
 
     await harness.dispatcher.dispatch(intent);
 
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeDefined();
     expect(ipcEvent!.payload).toEqual({
       projectId: PROJECT_ID,
@@ -1521,9 +1510,7 @@ describe("DeleteWorkspaceOperation.removeWorktree", () => {
     });
 
     // IPC event emitted
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeDefined();
   });
 
@@ -1558,9 +1545,7 @@ describe("DeleteWorkspaceOperation.resolveHooks", () => {
     expect(result).toEqual({ started: true });
 
     // Workspace deleted event should use the resolved project path
-    const ipcEvent = harness.emittedEvents.find(
-      (e) => e.channel === ApiIpcChannels.WORKSPACE_REMOVED
-    );
+    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
     expect(ipcEvent).toBeDefined();
     expect((ipcEvent!.payload as { projectId: string }).projectId).toBe(PROJECT_ID);
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,7 +33,7 @@ function createEventSubscription<T>(channel: string) {
 // Expose the API to the renderer process
 contextBridge.exposeInMainWorld("api", {
   // ============ API (api: prefixed channels) ============
-  // Primary API using ICodeHydraApi-based backend.
+  // Primary API backed by intent dispatcher.
   // Lifecycle handlers are registered in bootstrap(), others in startServices().
 
   projects: {

--- a/src/renderer/lib/utils/domain-events.ts
+++ b/src/renderer/lib/utils/domain-events.ts
@@ -24,7 +24,7 @@ export type ApiEvents = IApiEvents;
 
 /**
  * API interface for event subscriptions.
- * Supports all events from the ICodeHydraApi interface.
+ * Supports all events from the ApiEvents interface.
  */
 export interface DomainEventApi {
   on<E extends keyof ApiEvents>(event: E, handler: ApiEvents[E]): Unsubscribe;

--- a/src/services/test-utils.ts
+++ b/src/services/test-utils.ts
@@ -9,8 +9,6 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { simpleGit } from "simple-git";
 import { vi } from "vitest";
-import type { IWorkspaceApi } from "../shared/api/interfaces";
-import { MOCK_WORKSPACE_API_DEFAULTS } from "../shared/test-fixtures";
 
 /**
  * Create a temporary directory with automatic cleanup.
@@ -286,36 +284,5 @@ export function suppressConsole(
         spy.mockRestore();
       }
     },
-  };
-}
-
-// =============================================================================
-// API Mock Factories
-// =============================================================================
-
-/**
- * Creates a mock IWorkspaceApi with sensible defaults.
- * All methods return mock functions that can be configured in tests.
- *
- * @param overrides - Optional method overrides
- * @returns Mock IWorkspaceApi with all methods mocked
- *
- * @example
- * ```typescript
- * const mockApi = createMockWorkspaceApi();
- * mockApi.getStatus.mockResolvedValue({ isDirty: true, agent: { type: "busy" } });
- * ```
- */
-export function createMockWorkspaceApi(overrides?: Partial<IWorkspaceApi>): IWorkspaceApi {
-  return {
-    create: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.workspace),
-    remove: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.removeResult),
-    getStatus: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.status),
-    getAgentSession: vi.fn().mockResolvedValue(null),
-    restartAgentServer: vi.fn().mockResolvedValue(14001),
-    setMetadata: vi.fn().mockResolvedValue(undefined),
-    getMetadata: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.metadata),
-    executeCommand: vi.fn().mockResolvedValue(undefined),
-    ...overrides,
   };
 }

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -9,7 +9,7 @@
  * - `WorkspaceRef`: Reference to a workspace (includes path for efficiency)
  *
  * ## Key Interfaces
- * - `IProjectApi`, `IWorkspaceApi`, `IUiApi`, `ILifecycleApi`: Domain API contracts
+ * - `ApiEvents`: All events emitted by the API
  *
  * @module @shared/api
  */
@@ -35,4 +35,4 @@ export type {
 export { isProjectId, isWorkspaceName, validateWorkspaceName } from "./types";
 
 // API interfaces
-export type { IProjectApi, IWorkspaceApi, IUiApi, ILifecycleApi, Unsubscribe } from "./interfaces";
+export type { ApiEvents, Unsubscribe } from "./interfaces";

--- a/src/shared/api/interfaces.test.ts
+++ b/src/shared/api/interfaces.test.ts
@@ -1,153 +1,72 @@
 /**
- * Tests for API interface definitions.
- * Verifies interface structure through compile-time type checking.
+ * Tests for API event type definitions.
+ * Verifies event structure through compile-time type checking.
  */
 import { describe, it, expect } from "vitest";
-import type { IProjectApi, IWorkspaceApi, IUiApi, ILifecycleApi } from "./interfaces";
+import type { ApiEvents } from "./interfaces";
 import type {
   ProjectId,
+  WorkspaceName,
   Project,
   Workspace,
   WorkspaceRef,
   WorkspaceStatus,
   BaseInfo,
-  AgentSession,
+  SetupScreenProgress,
 } from "./types";
-import type { UIMode } from "../ipc";
+import type { UIModeChangedEvent, SetupErrorPayload } from "../ipc";
 
-describe("IProjectApi Interface", () => {
-  it("should have correct method signatures", () => {
-    // Type-level test: this compiles if interface is correct
-    const api: IProjectApi = {
-      async open(path?: string): Promise<Project | null> {
-        void path;
-        throw new Error("mock");
+describe("ApiEvents Interface", () => {
+  it("should define all required event handlers", () => {
+    // Type-level test: assign functions to event handler types
+    const handlers: ApiEvents = {
+      "project:opened": (event: { readonly project: Project }) => {
+        void event;
       },
-      async close(projectId: ProjectId): Promise<void> {
-        void projectId;
+      "project:closed": (event: { readonly projectId: ProjectId }) => {
+        void event;
       },
-      async clone(url: string): Promise<Project> {
-        void url;
-        throw new Error("mock");
+      "project:bases-updated": (event: {
+        readonly projectId: ProjectId;
+        readonly bases: readonly BaseInfo[];
+      }) => {
+        void event;
       },
-      async fetchBases(projectId: ProjectId): Promise<{ readonly bases: readonly BaseInfo[] }> {
-        void projectId;
-        return { bases: [] };
+      "workspace:created": (event: {
+        readonly projectId: ProjectId;
+        readonly workspace: Workspace;
+      }) => {
+        void event;
+      },
+      "workspace:removed": (event: WorkspaceRef) => {
+        void event;
+      },
+      "workspace:switched": (event: WorkspaceRef | null) => {
+        void event;
+      },
+      "workspace:status-changed": (event: WorkspaceRef & { readonly status: WorkspaceStatus }) => {
+        void event;
+      },
+      "workspace:metadata-changed": (event: {
+        readonly projectId: ProjectId;
+        readonly workspaceName: WorkspaceName;
+        readonly key: string;
+        readonly value: string | null;
+      }) => {
+        void event;
+      },
+      "ui:mode-changed": (event: UIModeChangedEvent) => {
+        void event;
+      },
+      "lifecycle:setup-progress": (event: SetupScreenProgress) => {
+        void event;
+      },
+      "lifecycle:setup-error": (event: SetupErrorPayload) => {
+        void event;
       },
     };
 
-    expect(api).toBeDefined();
-    expect(typeof api.open).toBe("function");
-    expect(typeof api.close).toBe("function");
-    expect(typeof api.fetchBases).toBe("function");
-  });
-});
-
-describe("IWorkspaceApi Interface", () => {
-  it("should have correct method signatures", () => {
-    const api: IWorkspaceApi = {
-      async create(
-        projectId: ProjectId | undefined,
-        name: string,
-        base: string
-      ): Promise<Workspace> {
-        void projectId;
-        void name;
-        void base;
-        throw new Error("mock");
-      },
-      async remove(
-        workspacePath: string,
-        options?: {
-          keepBranch?: boolean;
-          skipSwitch?: boolean;
-          force?: boolean;
-        }
-      ): Promise<{ started: boolean }> {
-        void workspacePath;
-        void options;
-        return { started: true };
-      },
-      async getStatus(workspacePath: string): Promise<WorkspaceStatus> {
-        void workspacePath;
-        return { isDirty: false, agent: { type: "none" } };
-      },
-      async setMetadata(workspacePath: string, key: string, value: string | null): Promise<void> {
-        void workspacePath;
-        void key;
-        void value;
-      },
-      async getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>> {
-        void workspacePath;
-        return { base: "main" };
-      },
-      async getAgentSession(workspacePath: string): Promise<AgentSession | null> {
-        void workspacePath;
-        return null;
-      },
-      async restartAgentServer(workspacePath: string): Promise<number> {
-        void workspacePath;
-        return 14001;
-      },
-      async executeCommand(
-        workspacePath: string,
-        command: string,
-        args?: readonly unknown[]
-      ): Promise<unknown> {
-        void workspacePath;
-        void command;
-        void args;
-        return undefined;
-      },
-    };
-
-    expect(api).toBeDefined();
-    expect(typeof api.create).toBe("function");
-    expect(typeof api.remove).toBe("function");
-    expect(typeof api.getStatus).toBe("function");
-    expect(typeof api.setMetadata).toBe("function");
-    expect(typeof api.getMetadata).toBe("function");
-    expect(typeof api.getAgentSession).toBe("function");
-    expect(typeof api.restartAgentServer).toBe("function");
-    expect(typeof api.executeCommand).toBe("function");
-  });
-});
-
-describe("IUiApi Interface", () => {
-  it("should have correct method signatures", () => {
-    const api: IUiApi = {
-      async getActiveWorkspace(): Promise<WorkspaceRef | null> {
-        return null;
-      },
-      async switchWorkspace(workspacePath: string, focus?: boolean): Promise<void> {
-        void workspacePath;
-        void focus;
-      },
-      async setMode(mode: UIMode): Promise<void> {
-        void mode;
-      },
-    };
-
-    expect(api).toBeDefined();
-    expect(typeof api.getActiveWorkspace).toBe("function");
-    expect(typeof api.switchWorkspace).toBe("function");
-    expect(typeof api.setMode).toBe("function");
-  });
-});
-
-describe("ILifecycleApi Interface", () => {
-  it("should have correct method signatures", () => {
-    const api: ILifecycleApi = {
-      async ready(): Promise<void> {
-        // no-op
-      },
-      async quit(): Promise<void> {
-        // no-op
-      },
-    };
-
-    expect(api).toBeDefined();
-    expect(typeof api.ready).toBe("function");
-    expect(typeof api.quit).toBe("function");
+    expect(handlers).toBeDefined();
+    expect(Object.keys(handlers)).toHaveLength(11);
   });
 });

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -1,8 +1,10 @@
 /**
- * API interface definitions for CodeHydra.
+ * API event type definitions for CodeHydra.
  *
- * These interfaces define the API contract for projects, workspaces, UI, and lifecycle.
- * IPC handlers in IpcEventBridge dispatch intents that implement these contracts.
+ * ApiEvents defines the IPC event contract between the main process and renderer.
+ * These event types are used by:
+ * - The IPC event bridge (domain events → sendToUI)
+ * - The renderer (event type definitions for IPC listeners)
  */
 
 import type {
@@ -13,178 +15,12 @@ import type {
   WorkspaceRef,
   WorkspaceStatus,
   BaseInfo,
-  InitialPrompt,
-  AgentSession,
   SetupScreenProgress,
 } from "./types";
-import type { UIMode, UIModeChangedEvent, SetupErrorPayload } from "../ipc";
+import type { UIModeChangedEvent, SetupErrorPayload } from "../ipc";
 
 // Re-export for consumers that import from this module
 export type { Unsubscribe } from "../types";
-
-// =============================================================================
-// Domain API Interfaces
-// =============================================================================
-
-/**
- * Options for closing a project.
- */
-export interface ProjectCloseOptions {
-  /** If true and project has remoteUrl, delete the entire project directory including cloned repo */
-  readonly removeLocalRepo?: boolean;
-}
-
-export interface IProjectApi {
-  open(path?: string): Promise<Project | null>;
-  close(projectPath: string, options?: ProjectCloseOptions): Promise<void>;
-  /**
-   * Clone a git repository and create a new project.
-   * If the URL has already been cloned, returns the existing project.
-   *
-   * @param url Git remote URL (HTTPS or SSH format)
-   * @returns The created or existing project
-   * @throws Error if clone fails (network, auth, invalid URL)
-   */
-  clone(url: string): Promise<Project>;
-  fetchBases(projectPath: string): Promise<{ readonly bases: readonly BaseInfo[] }>;
-}
-
-/**
- * Options for workspace creation.
- */
-export interface WorkspaceCreateOptions {
-  /** Optional initial prompt to send after workspace is created */
-  readonly initialPrompt?: InitialPrompt;
-  /** If true, steal focus from current workspace. If false, don't steal focus but still
-   *  switch when no workspace is active. Default: switch (undefined treated as true). */
-  readonly stealFocus?: boolean;
-  /**
-   * Workspace path of the calling workspace.
-   * Used by Plugin API / MCP server as an alternative to projectId.
-   * When provided, projectId is resolved from this workspace's project.
-   */
-  readonly callerWorkspacePath?: string;
-}
-
-export interface IWorkspaceApi {
-  /**
-   * Create a new workspace.
-   *
-   * @param projectPath Project path to create the workspace in
-   * @param name Name of the new workspace
-   * @param base Base branch to create the workspace from
-   * @param options Optional creation options (initialPrompt, stealFocus)
-   */
-  create(
-    projectPath: string | undefined,
-    name: string,
-    base: string,
-    options?: WorkspaceCreateOptions
-  ): Promise<Workspace>;
-  /**
-   * Start workspace removal (fire-and-forget).
-   * Progress is emitted via workspace:deletion-progress events.
-   * Returns { started: true } on success, { started: false } if blocked by idempotency.
-   *
-   * @param workspacePath Absolute path to the workspace to remove
-   * @param options Optional removal options (keepBranch, skipSwitch, force)
-   */
-  remove(
-    workspacePath: string,
-    options?: {
-      keepBranch?: boolean;
-      skipSwitch?: boolean;
-      force?: boolean;
-      blockingPids?: readonly number[];
-    }
-  ): Promise<{ started: boolean }>;
-  /**
-   * Get the status of a workspace.
-   * @param workspacePath Absolute path to the workspace
-   * @returns Workspace status including dirty flag and agent status
-   * @throws Error if workspace not found
-   */
-  getStatus(workspacePath: string): Promise<WorkspaceStatus>;
-  /**
-   * Get the agent session info for a workspace.
-   * @param workspacePath Absolute path to the workspace
-   * @returns Session info (port and sessionId) if available, null if not running or not initialized
-   * @throws Error if workspace not found
-   */
-  getAgentSession(workspacePath: string): Promise<AgentSession | null>;
-  /**
-   * Set a metadata value for a workspace.
-   * @param workspacePath Absolute path to the workspace
-   * @param key Metadata key (must match /^[A-Za-z][A-Za-z0-9-]*$/)
-   * @param value Value to set, or null to delete the key
-   * @throws Error if workspace not found, or key format invalid
-   */
-  setMetadata(workspacePath: string, key: string, value: string | null): Promise<void>;
-  /**
-   * Get all metadata for a workspace.
-   * Always includes `base` key (with fallback if not in config).
-   * @param workspacePath Absolute path to the workspace
-   * @returns Metadata record with at least `base` key
-   * @throws Error if workspace not found
-   */
-  getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>>;
-  /**
-   * Execute a VS Code command in a workspace.
-   *
-   * Note: Most VS Code commands return `undefined`. The return type is `unknown`
-   * because command return types are not statically typed.
-   *
-   * @param workspacePath Absolute path to the workspace
-   * @param command VS Code command identifier (e.g., "workbench.action.files.save")
-   * @param args Optional arguments to pass to the command
-   * @returns The command's return value, or undefined if command returns nothing
-   * @throws Error if workspace not found, workspace not connected, command not found, or execution fails
-   * @throws Error if command times out (10-second limit)
-   */
-  executeCommand(
-    workspacePath: string,
-    command: string,
-    args?: readonly unknown[]
-  ): Promise<unknown>;
-  /**
-   * Restart the agent server for a workspace, preserving the same port.
-   * Useful for reloading configuration changes without affecting other workspaces.
-   *
-   * @param workspacePath Absolute path to the workspace
-   * @returns The port number of the restarted server
-   * @throws Error if workspace not found, or server not running
-   */
-  restartAgentServer(workspacePath: string): Promise<number>;
-}
-
-export interface IUiApi {
-  getActiveWorkspace(): Promise<WorkspaceRef | null>;
-  switchWorkspace(workspacePath: string, focus?: boolean): Promise<void>;
-  /**
-   * Sets the UI mode.
-   * - "workspace": UI at z-index 0, focus active workspace
-   * - "shortcut": UI on top, focus UI layer
-   * - "dialog": UI on top, no focus change
-   *
-   * Mode transitions are idempotent - setting the same mode twice does not emit an event.
-   *
-   * @param mode - The new UI mode
-   */
-  setMode(mode: UIMode): Promise<void>;
-}
-
-export interface ILifecycleApi {
-  /**
-   * Signal that the renderer is ready to receive state.
-   * The main process emits domain events for all current state
-   * (project:opened, workspace:switched) before the promise resolves.
-   */
-  ready(): Promise<void>;
-  /**
-   * Quit the application.
-   */
-  quit(): Promise<void>;
-}
 
 // =============================================================================
 // Domain Event Types (shared with renderer)

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -29,7 +29,7 @@ export type Unsubscribe = () => void;
  */
 export interface Api {
   // ============ API (api: prefixed channels) ============
-  // Primary API using ICodeHydraApi-based backend.
+  // Primary API backed by intent dispatcher.
   // Lifecycle handlers are registered in bootstrap(), others in startServices().
 
   projects: {


### PR DESCRIPTION
- Remove `ICodeHydraApi`, `ICoreApi`, `IProjectApi`, `IWorkspaceApi`, `IUiApi`, `ILifecycleApi` facade interfaces
- Remove `createMockWorkspaceApi()` from test utilities
- Update `ApiEvents` and `Unsubscribe` as the only exports from `interfaces.ts`
- Clean up shared type re-exports in `index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)