### PR TITLE
feat: better error messages on invalid configurations

### DIFF
--- a/src/main/modules/auto-pr-module.ts
+++ b/src/main/modules/auto-pr-module.ts
@@ -40,6 +40,7 @@ import type { Logger } from "../../services/logging/types";
 import type { NormalizedInitialPrompt } from "../../shared/api/types";
 import { getErrorMessage } from "../../shared/error-utils";
 import { renderTemplate } from "../../services/template/liquid-renderer";
+import { configPath } from "../../services/config/config-definition";
 import type { ConfigKeyDefinition } from "../../services/config/config-definition";
 
 // =============================================================================
@@ -521,8 +522,8 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
               {
                 name: "experimental.auto-pr-template-path",
                 default: null,
-                parse: (s: string) => (s === "" ? null : s),
-                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+                description: "Path to Liquid template for auto-PR workspaces",
+                ...configPath({ nullable: true }),
               },
             ] satisfies ConfigKeyDefinition<unknown>[],
           }),

--- a/src/main/modules/auto-updater-module.ts
+++ b/src/main/modules/auto-updater-module.ts
@@ -23,6 +23,7 @@ import {
   type UpdateAvailableIntent,
 } from "../operations/update-available";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedPayload } from "../operations/config-set-values";
+import { configEnum } from "../../services/config/config-definition";
 import type { AutoUpdatePreference } from "../../services/config/config-values";
 import type { AutoUpdater } from "../../services/auto-updater";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
@@ -45,10 +46,8 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
               {
                 name: "auto-update",
                 default: "always" as AutoUpdatePreference,
-                parse: (s: string) =>
-                  s === "always" || s === "never" ? (s as AutoUpdatePreference) : undefined,
-                validate: (v: unknown) =>
-                  v === "always" || v === "never" ? (v as AutoUpdatePreference) : undefined,
+                description: "Auto-update preference",
+                ...configEnum(["always", "never"]),
               },
             ],
           }),

--- a/src/main/modules/claude-agent-module.ts
+++ b/src/main/modules/claude-agent-module.ts
@@ -62,6 +62,7 @@ import { INTENT_UPDATE_AGENT_STATUS } from "../operations/update-agent-status";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { ConfigSetValuesIntent } from "../operations/config-set-values";
 import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
+import { configString } from "../../services/config/config-definition";
 import { SetupError, getErrorMessage } from "../../services/errors";
 import { normalizeInitialPrompt } from "../../shared/api/types";
 import { ClaudeCodeProvider } from "../../agents/claude/provider";
@@ -198,8 +199,8 @@ export function createClaudeAgentModule(deps: ClaudeAgentModuleDeps): IntentModu
               {
                 name: "version.claude",
                 default: null,
-                parse: (s: string) => (s === "" ? null : s),
-                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+                description: "Claude agent version override",
+                ...configString({ nullable: true }),
               },
             ],
           }),

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -76,6 +76,7 @@ import {
   getCodeServerExecutablePath,
 } from "../../services/code-server/setup-info";
 import { Path } from "../../services/platform/path";
+import { configString } from "../../services/config/config-definition";
 import { SetupError, getErrorMessage } from "../../services/errors";
 
 // =============================================================================
@@ -143,8 +144,8 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
               {
                 name: "version.code-server",
                 default: null,
-                parse: (s: string) => (s === "" ? null : s),
-                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+                description: "Code-server version override (null = built-in)",
+                ...configString({ nullable: true }),
               },
             ],
           }),

--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -51,7 +51,7 @@ import {
 } from "../../services/platform/filesystem.state-mock";
 import { createConfigModule, parseEnvVars, parseCliArgs } from "./config-module";
 import { generateHelpText } from "../../services/config/config-values";
-import { parseBool } from "../../services/config/config-definition";
+import { parseBool, ConfigValidationError } from "../../services/config/config-definition";
 import type { ConfigKeyDefinition } from "../../services/config/config-definition";
 
 // =============================================================================
@@ -113,9 +113,9 @@ function testDefinitions(): ConfigKeyDefinition<unknown>[] {
     },
     {
       name: "test.optional",
-      default: undefined,
-      parse: (s: string) => (s === "" ? undefined : s),
-      validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+      default: null,
+      parse: (s: string) => (s === "" ? null : s),
+      validate: (v: unknown) => (v === null ? null : typeof v === "string" ? v : undefined),
     },
   ];
 }
@@ -399,13 +399,14 @@ describe("ConfigModule Integration", () => {
 
     it("throws on unknown CH_ env var", () => {
       expect(() => parseEnvVars({ CH_UNKNOWN_VAR: "value" }, definitions)).toThrow(
-        /Unknown config env var/
+        ConfigValidationError
       );
     });
 
-    it("skips invalid values without throwing", () => {
-      const result = parseEnvVars({ CH_TEST__LEVEL: "not-a-level" }, definitions);
-      expect(result["test.level"]).toBeUndefined();
+    it("throws on invalid env var value", () => {
+      expect(() => parseEnvVars({ CH_TEST__LEVEL: "not-a-level" }, definitions)).toThrow(
+        ConfigValidationError
+      );
     });
   });
 
@@ -430,9 +431,10 @@ describe("ConfigModule Integration", () => {
       expect(result["test.enum"]).toBe("never");
     });
 
-    it("ignores unknown flags silently", () => {
-      const result = parseCliArgs(["--unknown-flag=value"], definitions);
-      expect(Object.keys(result)).toHaveLength(0);
+    it("throws on unknown CLI flag", () => {
+      expect(() => parseCliArgs(["--unknown-flag=value"], definitions)).toThrow(
+        ConfigValidationError
+      );
     });
 
     it("parses multiple flags", () => {
@@ -1096,7 +1098,7 @@ describe("ConfigModule Integration", () => {
       const output = stdout.write.mock.calls[0]![0] as string;
       // isDevelopment=true computes test.level=debug (not static default "warn")
       expect(output).toContain("test.level");
-      expect(output).toMatch(/test\.level\s+default: debug/);
+      expect(output).toMatch(/test\.level\s+default:\s+debug/);
     });
 
     it("CH_HELP=1 env var prints help and dispatches shutdown", async () => {
@@ -1156,6 +1158,7 @@ describe("ConfigModule Integration", () => {
       const text = generateHelpText("/some/config.json", definitions, defaultValues);
       expect(text).toContain("default: warn");
       expect(text).toContain("default: false");
+      // test.dev-flag has default true (static)
       expect(text).toContain("default: true");
     });
 
@@ -1166,8 +1169,8 @@ describe("ConfigModule Integration", () => {
         "test.dev-flag": false,
       };
       const text = generateHelpText("/some/config.json", definitions, computedDefaults);
-      expect(text).toMatch(/test\.level\s+default: debug/);
-      expect(text).toMatch(/test\.dev-flag\s+default: false/);
+      expect(text).toMatch(/test\.level\s+default:\s+debug/);
+      expect(text).toMatch(/test\.dev-flag\s+default:\s+false/);
     });
   });
 });

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -25,7 +25,11 @@ import type {
   ConfigKeyDefinition,
   ComputedDefaultContext,
 } from "../../services/config/config-definition";
-import { parseBool } from "../../services/config/config-definition";
+import {
+  configBoolean,
+  configEnum,
+  ConfigValidationError,
+} from "../../services/config/config-definition";
 import type { ConfigAgentType } from "../../services/config/config-values";
 import { envVarToConfigKey, generateHelpText } from "../../services/config/config-values";
 import type {
@@ -64,18 +68,96 @@ export interface ConfigModuleDeps {
 }
 
 // =============================================================================
+// Centralized Validation
+// =============================================================================
+
+/**
+ * Validate and parse raw string values (from env vars or CLI flags).
+ * Throws ConfigValidationError on unknown keys or invalid values.
+ */
+export function validateAndParse(
+  rawValues: Record<string, string>,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
+  source: string
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, rawValue] of Object.entries(rawValues)) {
+    const def = definitions.get(key);
+    if (!def) {
+      throw new ConfigValidationError({
+        key,
+        value: rawValue,
+        reason: "unknown",
+        source,
+      });
+    }
+
+    const parsed = def.parse(rawValue);
+    if (parsed === undefined) {
+      throw new ConfigValidationError({
+        key,
+        value: rawValue,
+        reason: "invalid",
+        source,
+      });
+    }
+    result[key] = parsed;
+  }
+
+  return result;
+}
+
+/**
+ * Validate already-typed values (from config.json or config:set-values).
+ * Throws ConfigValidationError on unknown keys or invalid values.
+ */
+export function validateTyped(
+  values: Record<string, unknown>,
+  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
+  source: string
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    const def = definitions.get(key);
+    if (!def) {
+      throw new ConfigValidationError({
+        key,
+        value,
+        reason: "unknown",
+        source,
+      });
+    }
+
+    const validated = def.validate(value);
+    if (validated === undefined) {
+      throw new ConfigValidationError({
+        key,
+        value,
+        reason: "invalid",
+        source,
+      });
+    }
+    result[key] = validated;
+  }
+
+  return result;
+}
+
+// =============================================================================
 // Env Var + CLI Parsing
 // =============================================================================
 
 /**
  * Scan an env object for CH_* keys (not _CH_*), convert to config keys,
- * validate against definition map, parse values.
+ * collect as raw string values for validation.
  */
 export function parseEnvVars(
   env: Record<string, string | undefined>,
   definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
 ): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+  const rawValues: Record<string, string> = {};
 
   for (const [envKey, rawValue] of Object.entries(env)) {
     if (!envKey.startsWith("CH_") || envKey.startsWith("_CH_")) continue;
@@ -84,22 +166,10 @@ export function parseEnvVars(
     const configKey = envVarToConfigKey(envKey);
     if (configKey === undefined) continue;
 
-    const def = definitions.get(configKey);
-    if (!def) {
-      throw new Error(`Unknown config env var: ${envKey} (maps to "${configKey}")`);
-    }
-
-    const parsed = def.parse(rawValue);
-    if (parsed === undefined && rawValue !== "") {
-      // Invalid value — skip (don't throw, env vars may come from external sources)
-      continue;
-    }
-    if (parsed !== undefined) {
-      result[configKey] = parsed;
-    }
+    rawValues[configKey] = rawValue;
   }
 
-  return result;
+  return validateAndParse(rawValues, definitions, "env var");
 }
 
 /**
@@ -110,14 +180,14 @@ export function parseCliArgs(
   argv: readonly string[],
   definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
 ): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+  const rawValues: Record<string, string> = {};
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (!arg.startsWith("--")) continue;
 
     let key: string;
-    let value: string | undefined;
+    let value: string;
 
     const eqIndex = arg.indexOf("=");
     if (eqIndex !== -1) {
@@ -136,19 +206,10 @@ export function parseCliArgs(
       }
     }
 
-    const def = definitions.get(key);
-    if (!def) {
-      // Unknown flag — skip silently (may be an Electron/Node flag)
-      continue;
-    }
-
-    const parsed = def.parse(value);
-    if (parsed !== undefined) {
-      result[key] = parsed;
-    }
+    rawValues[key] = value;
   }
 
-  return result;
+  return validateAndParse(rawValues, definitions, "CLI flag");
 }
 
 // =============================================================================
@@ -157,7 +218,7 @@ export function parseCliArgs(
 
 /**
  * Parse a config.json object (flat kebab-case format) into file-layer config values.
- * Unknown keys are ignored.
+ * Throws on unknown keys or invalid values.
  */
 function parseConfigFile(
   data: unknown,
@@ -166,34 +227,13 @@ function parseConfigFile(
   if (typeof data !== "object" || data === null) return {};
 
   const obj = data as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
+  const values: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {
-    if (definitions.has(key)) {
-      result[key] = value;
-    }
+    values[key] = value;
   }
 
-  return validateFileValues(result, definitions);
-}
-
-/**
- * Validate file-layer values using the definition map's validators. Returns only valid entries.
- */
-function validateFileValues(
-  values: Record<string, unknown>,
-  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(values)) {
-    const def = definitions.get(key);
-    if (!def || value === undefined) continue;
-    const validated = def.validate(value);
-    if (validated !== undefined) {
-      result[key] = validated;
-    }
-  }
-  return result;
+  return validateTyped(values, definitions, "config.json");
 }
 
 // =============================================================================
@@ -249,6 +289,9 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
     return defaults;
   }
 
+  const agentBuilder = configEnum(["claude", "opencode"], { nullable: true });
+  const helpBuilder = configBoolean();
+
   return {
     name: "config",
     hooks: {
@@ -259,18 +302,14 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
               {
                 name: "agent",
                 default: null,
-                parse: (s: string) =>
-                  s === "claude" || s === "opencode" ? s : s === "" ? null : undefined,
-                validate: (v: unknown) =>
-                  v === null || v === "claude" || v === "opencode"
-                    ? (v as ConfigAgentType)
-                    : undefined,
+                description: "Agent selection",
+                ...agentBuilder,
               },
               {
                 name: "help",
                 default: false,
-                parse: parseBool,
-                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+                description: "Print config help and exit",
+                ...helpBuilder,
               },
             ],
           }),
@@ -351,6 +390,9 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
               fileValues = parseConfigFile(parsed, definitionMap);
               logger.debug("Config loaded from disk", { path: configPath.toString() });
             } catch (error) {
+              if (error instanceof ConfigValidationError) {
+                throw error;
+              }
               if (error instanceof Error && "fsCode" in error && error.fsCode === "ENOENT") {
                 logger.debug("Config not found, using defaults", {
                   path: configPath.toString(),
@@ -396,6 +438,11 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
           handler: async (ctx: HookContext): Promise<ConfigSetHookResult> => {
             const { values, persist } = ctx as ConfigSetHookInput;
 
+            // Validate incoming values if definition map is populated
+            if (definitionMap.size > 0) {
+              validateTyped(values, definitionMap, "config:set-values");
+            }
+
             // Snapshot before merge
             const oldEffective = { ...effective };
 
@@ -417,7 +464,11 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
               }
 
               for (const [key, value] of Object.entries(values)) {
-                fileContent[key] = value;
+                if (value === null) {
+                  delete fileContent[key];
+                } else {
+                  fileContent[key] = value;
+                }
               }
               await fileSystem.mkdir(configPath.dirname);
               await fileSystem.writeFile(configPath, JSON.stringify(fileContent, null, 2));

--- a/src/main/modules/electron-lifecycle-module.ts
+++ b/src/main/modules/electron-lifecycle-module.ts
@@ -17,6 +17,7 @@ import type { IntentModule } from "../intents/infrastructure/module";
 import type { DomainEvent } from "../intents/infrastructure/types";
 import type { ConfigureResult, RegisterConfigResult } from "../operations/app-start";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
+import { configString } from "../../services/config/config-definition";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
@@ -93,9 +94,9 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
             definitions: [
               {
                 name: "electron.flags",
-                default: undefined,
-                parse: (s: string) => (s === "" ? undefined : s),
-                validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+                default: null,
+                description: "Electron switches (e.g., --disable-gpu)",
+                ...configString({ nullable: true }),
               },
             ],
           }),

--- a/src/main/modules/logging-module.ts
+++ b/src/main/modules/logging-module.ts
@@ -19,12 +19,8 @@ import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { RegisterConfigResult } from "../operations/app-start";
 import type { LogFormat } from "../../services/logging/types";
-import {
-  parseLogFormat,
-  parseLogLevelSpec,
-  parseLogOutput,
-  splitLogLevelSpec,
-} from "../../services/logging/electron-log-service";
+import { parseLogLevelSpec, splitLogLevelSpec } from "../../services/logging/electron-log-service";
+import { configCustom, configEnum, configEnumList } from "../../services/config/config-definition";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
 
@@ -60,22 +56,26 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
               {
                 name: "log.level",
                 default: "warn",
-                parse: parseLogLevelSpec,
-                validate: (v: unknown) =>
-                  typeof v === "string" ? parseLogLevelSpec(v) : undefined,
+                description: "Level spec: <level> or <level>:<filter>",
+                ...configCustom({
+                  parse: parseLogLevelSpec,
+                  validate: (v: unknown) =>
+                    typeof v === "string" ? parseLogLevelSpec(v) : undefined,
+                  validValues: "silly|debug|info|warn|error[:filter]",
+                }),
                 computedDefault: (ctx) => (ctx.isDevelopment ? "debug" : undefined),
               },
               {
                 name: "log.output",
                 default: "file",
-                parse: parseLogOutput,
-                validate: (v: unknown) => (typeof v === "string" ? parseLogOutput(v) : undefined),
+                description: "Output destinations (comma-separated)",
+                ...configEnumList(["file", "console"]),
               },
               {
                 name: "log.format",
                 default: "text",
-                parse: parseLogFormat,
-                validate: (v: unknown) => (typeof v === "string" ? parseLogFormat(v) : undefined),
+                description: "Log output format",
+                ...configEnum(["text", "json"]),
               },
             ],
           }),

--- a/src/main/modules/opencode-agent-module.ts
+++ b/src/main/modules/opencode-agent-module.ts
@@ -62,6 +62,7 @@ import { INTENT_UPDATE_AGENT_STATUS } from "../operations/update-agent-status";
 import type { ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { ConfigSetValuesIntent } from "../operations/config-set-values";
 import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
+import { configString } from "../../services/config/config-definition";
 import { SetupError, getErrorMessage } from "../../services/errors";
 import { normalizeInitialPrompt } from "../../shared/api/types";
 import { OpenCodeProvider } from "../../agents/opencode/provider";
@@ -236,8 +237,8 @@ export function createOpenCodeAgentModule(deps: OpenCodeAgentModuleDeps): Intent
               {
                 name: "version.opencode",
                 default: null,
-                parse: (s: string) => (s === "" ? null : s),
-                validate: (v: unknown) => (v === null || typeof v === "string" ? v : undefined),
+                description: "OpenCode agent version override",
+                ...configString({ nullable: true }),
               },
             ],
           }),

--- a/src/main/modules/telemetry-module.ts
+++ b/src/main/modules/telemetry-module.ts
@@ -19,7 +19,7 @@ import type { ConfigSetValuesIntent } from "../operations/config-set-values";
 import { APP_START_OPERATION_ID } from "../operations/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { INTENT_CONFIG_SET_VALUES, EVENT_CONFIG_UPDATED } from "../operations/config-set-values";
-import { parseBool } from "../../services/config/config-definition";
+import { configBoolean, configString } from "../../services/config/config-definition";
 import type { TelemetryService } from "../../services/telemetry/types";
 import type { PlatformInfo } from "../../services/platform/platform-info";
 import type { BuildInfo } from "../../services/platform/build-info";
@@ -65,16 +65,16 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
               {
                 name: "telemetry.enabled",
                 default: true,
-                parse: parseBool,
-                validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+                description: "Enable telemetry (false in dev/unpackaged)",
+                ...configBoolean(),
                 computedDefault: (ctx) =>
                   ctx.isDevelopment || !ctx.isPackaged ? false : undefined,
               },
               {
                 name: "telemetry.distinct-id",
-                default: undefined,
-                parse: (s: string) => (s === "" ? undefined : s),
-                validate: (v: unknown) => (typeof v === "string" ? v : undefined),
+                default: null,
+                description: "Telemetry user ID (auto-generated)",
+                ...configString({ nullable: true }),
               },
             ],
           }),

--- a/src/services/config/config-definition.ts
+++ b/src/services/config/config-definition.ts
@@ -6,6 +6,8 @@
  * for parsing, validation, and help text generation.
  */
 
+import { Path } from "../platform/path";
+
 /**
  * Context available to computedDefault callbacks for build-dependent defaults.
  */
@@ -31,7 +33,201 @@ export interface ConfigKeyDefinition<T> {
   readonly validate: (value: unknown) => T | undefined;
   /** Optional computed default that overrides the static default based on build context. */
   readonly computedDefault?: (ctx: ComputedDefaultContext) => T | undefined;
+  /** Human-readable description for help text. */
+  readonly description?: string;
+  /** Valid values hint for help text (e.g. "true|false", "claude|opencode"). */
+  readonly validValues?: string;
 }
+
+/**
+ * Subset of ConfigKeyDefinition produced by type builders.
+ */
+type ConfigTypeBuilder<T> = Pick<ConfigKeyDefinition<T>, "parse" | "validate"> & {
+  readonly validValues?: string;
+};
+
+// =============================================================================
+// Type Builders
+// =============================================================================
+
+/**
+ * Builder for boolean config values.
+ * Parses "true"/"1" → true, "false"/"0" → false.
+ */
+export function configBoolean(): ConfigTypeBuilder<boolean> {
+  return {
+    parse: parseBool,
+    validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
+    validValues: "true|false",
+  };
+}
+
+/**
+ * Builder for enum config values.
+ * Parses/validates against a fixed set of allowed string values.
+ */
+export function configEnum<T extends string>(values: readonly T[]): ConfigTypeBuilder<T>;
+export function configEnum<T extends string>(
+  values: readonly T[],
+  options: { nullable: true }
+): ConfigTypeBuilder<T | null>;
+export function configEnum<T extends string>(
+  values: readonly T[],
+  options?: { nullable: true }
+): ConfigTypeBuilder<T | null> {
+  const set = new Set<string>(values);
+  const validValues = options?.nullable ? [...values, "null"].join("|") : values.join("|");
+
+  if (options?.nullable) {
+    return {
+      parse: (s: string): T | null | undefined =>
+        set.has(s) ? (s as T) : s === "" ? null : undefined,
+      validate: (v: unknown): T | null | undefined =>
+        v === null ? null : typeof v === "string" && set.has(v) ? (v as T) : undefined,
+      validValues,
+    };
+  }
+
+  return {
+    parse: (s: string): T | null | undefined => (set.has(s) ? (s as T) : undefined),
+    validate: (v: unknown): T | null | undefined =>
+      typeof v === "string" && set.has(v) ? (v as T) : undefined,
+    validValues,
+  };
+}
+
+/**
+ * Builder for comma-separated enum list config values.
+ * Parses comma-separated tokens, deduplicates, sorts, validates each token.
+ */
+export function configEnumList(values: readonly string[]): ConfigTypeBuilder<string> {
+  const set = new Set(values);
+  const validValues = values.join(",");
+
+  function parseList(raw: string): string | undefined {
+    if (!raw) return undefined;
+    const tokens = raw
+      .split(",")
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0);
+    if (tokens.length === 0) return undefined;
+
+    for (const token of tokens) {
+      if (!set.has(token)) return undefined;
+    }
+
+    const unique = [...new Set(tokens)].sort();
+    return unique.join(",");
+  }
+
+  return {
+    parse: parseList,
+    validate: (v: unknown) => (typeof v === "string" ? parseList(v) : undefined),
+    validValues,
+  };
+}
+
+/**
+ * Builder for non-empty string config values.
+ */
+export function configString(): ConfigTypeBuilder<string>;
+export function configString(options: { nullable: true }): ConfigTypeBuilder<string | null>;
+export function configString(options?: { nullable: true }): ConfigTypeBuilder<string | null> {
+  if (options?.nullable) {
+    return {
+      parse: (s: string): string | null | undefined => (s === "" ? null : s),
+      validate: (v: unknown): string | null | undefined =>
+        v === null ? null : typeof v === "string" ? v : undefined,
+      validValues: "<string>",
+    };
+  }
+
+  return {
+    parse: (s: string): string | null | undefined => (s === "" ? undefined : s),
+    validate: (v: unknown): string | null | undefined => (typeof v === "string" ? v : undefined),
+    validValues: "<string>",
+  };
+}
+
+/**
+ * Builder for nullable path config values.
+ * Validates that the string has no null bytes and is a valid path.
+ */
+export function configPath(options: { nullable: true }): ConfigTypeBuilder<string | null> {
+  void options;
+  return {
+    parse: (s: string) => {
+      if (s === "") return null;
+      if (s.includes("\0")) return undefined;
+      try {
+        new Path(s);
+        return s;
+      } catch {
+        return undefined;
+      }
+    },
+    validate: (v: unknown) => {
+      if (v === null) return null;
+      if (typeof v !== "string") return undefined;
+      if (v.includes("\0")) return undefined;
+      try {
+        new Path(v);
+        return v;
+      } catch {
+        return undefined;
+      }
+    },
+    validValues: "<path>",
+  };
+}
+
+/**
+ * Builder for custom config values with explicit parse/validate functions.
+ */
+export function configCustom<T>(fns: {
+  parse: (raw: string) => T | undefined;
+  validate: (value: unknown) => T | undefined;
+  validValues?: string;
+}): ConfigTypeBuilder<T> {
+  return {
+    parse: fns.parse,
+    validate: fns.validate,
+    ...(fns.validValues !== undefined && { validValues: fns.validValues }),
+  };
+}
+
+// =============================================================================
+// Validation Error
+// =============================================================================
+
+export interface ValidationErrorDetail {
+  readonly key: string;
+  readonly value: unknown;
+  readonly reason: "unknown" | "invalid";
+  readonly source: string;
+}
+
+/**
+ * Error thrown when config validation fails.
+ * Contains structured details about what went wrong.
+ */
+export class ConfigValidationError extends Error {
+  readonly detail: ValidationErrorDetail;
+
+  constructor(detail: ValidationErrorDetail) {
+    const msg =
+      detail.reason === "unknown"
+        ? `Unknown config key "${detail.key}"`
+        : `Invalid value ${JSON.stringify(detail.value)} for config key "${detail.key}"`;
+    super(`${msg}\n  Source: ${detail.source}`);
+    this.name = "ConfigValidationError";
+    this.detail = detail;
+  }
+}
+
+// =============================================================================
+// Legacy helper (still used by test definitions)
+// =============================================================================
 
 /**
  * Parse a string as a boolean config value.

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -72,10 +72,18 @@ export function generateHelpText(
     "",
   ];
 
-  for (const key of definitions.keys()) {
+  for (const [key, def] of definitions) {
     const value = defaults[key];
-    const valueStr = value === undefined ? "—" : String(value);
-    lines.push(`  ${key.padEnd(24)} default: ${valueStr}`);
+    const valueStr = value === null || value === undefined ? "—" : String(value);
+
+    let line = `  ${key.padEnd(38)} default: ${valueStr}`;
+    if (def.validValues) {
+      line += `  [${def.validValues}]`;
+    }
+    if (def.description) {
+      line += `  — ${def.description}`;
+    }
+    lines.push(line);
   }
 
   lines.push("");


### PR DESCRIPTION
- Add centralized config validation pipeline (`validateAndParse`, `validateTyped`) that fails on unknown keys or invalid values across all three sources (env vars, CLI flags, config.json) and `config:set-values`
- Replace duplicated inline parse/validate logic in each module with shared type builders (`configBoolean`, `configEnum`, `configEnumList`, `configString`, `configPath`, `configCustom`)
- Add `ConfigValidationError` with structured detail (key, value, reason, source) for clear error messages
- Unify null/undefined: all "not set" defaults use `null`; null values delete keys from config.json
- Enhanced help text shows valid values and descriptions per key