### PR TITLE
fix: workspace deletion failed the first time on windows

### DIFF
--- a/src/services/git/git-worktree-provider.test.ts
+++ b/src/services/git/git-worktree-provider.test.ts
@@ -300,7 +300,12 @@ describe("GitWorktreeProvider error injection", () => {
 
       expect(result.workspaceRemoved).toBe(true);
       expect(result.baseDeleted).toBe(true);
-      expect(spyFs.rm).toHaveBeenCalledWith(worktreePath, { recursive: true, force: true });
+      expect(spyFs.rm).toHaveBeenCalledWith(worktreePath, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 200,
+      });
       expect(mockClient.pruneWorktrees).toHaveBeenCalledWith(PROJECT_ROOT);
     });
 

--- a/src/services/git/git-worktree-provider.ts
+++ b/src/services/git/git-worktree-provider.ts
@@ -519,7 +519,12 @@ export class GitWorktreeProvider {
         // git worktree remove can fail for various reasons (stale .git,
         // Windows long paths, locked files, etc.) — fall back to rm + prune
         try {
-          await this.fileSystemLayer.rm(workspacePath, { recursive: true, force: true });
+          await this.fileSystemLayer.rm(workspacePath, {
+            recursive: true,
+            force: true,
+            maxRetries: 3,
+            retryDelay: 200,
+          });
           await this.gitClient.pruneWorktrees(projectRoot);
           this.logger.info("Removed workspace via fallback", { path: workspacePath.toString() });
         } catch {

--- a/src/services/platform/filesystem.ts
+++ b/src/services/platform/filesystem.ts
@@ -59,6 +59,10 @@ export interface RmOptions {
   readonly recursive?: boolean;
   /** Ignore errors if path doesn't exist (default: false) */
   readonly force?: boolean;
+  /** Max retry count for EBUSY/ENOTEMPTY on Windows (default: 0). Only applies when recursive is true. */
+  readonly maxRetries?: number;
+  /** Delay in ms between retries (default: 100). Only applies when maxRetries > 0. */
+  readonly retryDelay?: number;
 }
 
 /**
@@ -447,7 +451,13 @@ export class DefaultFileSystemLayer implements FileSystemLayer {
     try {
       if (recursive) {
         // Use fs.rm for recursive deletion
-        await fs.rm(nativePath, { recursive, force });
+        // maxRetries/retryDelay handle EBUSY/ENOTEMPTY on Windows (lingering file handles)
+        await fs.rm(nativePath, {
+          recursive,
+          force,
+          ...(options?.maxRetries !== undefined && { maxRetries: options.maxRetries }),
+          ...(options?.retryDelay !== undefined && { retryDelay: options.retryDelay }),
+        });
       } else {
         // For non-recursive: check if directory or file
         const stat = await fs.stat(nativePath);


### PR DESCRIPTION
- Add `maxRetries` and `retryDelay` options to `RmOptions` interface in `FileSystemLayer`
- Use `maxRetries: 3, retryDelay: 200` in the worktree removal fallback path to handle lingering Windows file handles after process termination