### PR TITLE
fix: closing agent terminal did not put agent status to offline

### DIFF
--- a/src/agents/claude/wrapper.test.ts
+++ b/src/agents/claude/wrapper.test.ts
@@ -12,6 +12,7 @@ import {
   buildInitialPromptArgs,
   buildPermissionArgs,
   consumeNoSessionMarker,
+  installSignalHandlers,
   type InitialPromptConfig,
 } from "./wrapper";
 
@@ -124,5 +125,25 @@ describe("consumeNoSessionMarker", () => {
   it("returns false when env var is set but file does not exist", () => {
     process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH = join(tempDir, "nonexistent");
     expect(consumeNoSessionMarker()).toBe(false);
+  });
+});
+
+describe("installSignalHandlers", () => {
+  it("registers handlers for SIGHUP and SIGTERM", () => {
+    const handlers: Array<{ signal: string; handler: () => void }> = [];
+    const fakeProcess = {
+      on(signal: string, handler: () => void) {
+        handlers.push({ signal, handler });
+        return fakeProcess as unknown as NodeJS.Process;
+      },
+    };
+
+    installSignalHandlers(fakeProcess);
+
+    expect(handlers).toHaveLength(2);
+    expect(handlers.map((h) => h.signal)).toEqual(["SIGHUP", "SIGTERM"]);
+    for (const h of handlers) {
+      expect(() => h.handler()).not.toThrow();
+    }
   });
 });

--- a/src/agents/claude/wrapper.ts
+++ b/src/agents/claude/wrapper.ts
@@ -361,6 +361,35 @@ async function notifyHook(hookName: "WrapperStart" | "WrapperEnd"): Promise<void
 }
 
 /**
+ * Signals to catch so the wrapper survives long enough to send WrapperEnd.
+ *
+ * - SIGHUP: PTY hangup when the terminal tab is closed.
+ * - SIGTERM: Graceful termination from process managers (code-server may
+ *   send this after SIGHUP if the process hasn't exited yet).
+ *
+ * Without these handlers Node.js terminates immediately on these signals,
+ * preventing the async notifyHook("WrapperEnd") call from executing after
+ * spawnSync returns.
+ */
+const WRAPPER_SIGNALS: NodeJS.Signals[] = ["SIGHUP", "SIGTERM"];
+
+/**
+ * Install no-op signal handlers to prevent default process termination.
+ *
+ * Must be called before spawnSync so the wrapper survives terminal-close
+ * signals and can still send the WrapperEnd hook notification.
+ * The process exits via the explicit process.exit() in main().
+ *
+ * @param proc - Process-like object for testability (defaults to global process)
+ */
+function installSignalHandlers(proc: Pick<NodeJS.Process, "on"> = process): void {
+  const noop = (): void => {};
+  for (const signal of WRAPPER_SIGNALS) {
+    proc.on(signal, noop);
+  }
+}
+
+/**
  * Main entry point for the wrapper script.
  */
 async function main(): Promise<never> {
@@ -410,10 +439,14 @@ async function main(): Promise<never> {
   // 5. Clear CLAUDECODE to allow nested Claude Code sessions inside CodeHydra
   delete process.env.CLAUDECODE;
 
-  // 6. Notify wrapper start (clears loading screen before Claude shows dialogs)
+  // 6. Catch SIGHUP/SIGTERM so the wrapper survives terminal-close signals
+  //    and can still send WrapperEnd after Claude exits.
+  installSignalHandlers();
+
+  // 7. Notify wrapper start (clears loading screen before Claude shows dialogs)
   await notifyHook("WrapperStart");
 
-  // 7. Spawn Claude with automatic session resume
+  // 8. Spawn Claude with automatic session resume
   // Use shell on Windows to resolve binary name via PATH (handles .cmd shims)
   // Skip --continue attempt for new workspaces (no prior session to resume)
   const result = runClaude(claudeBinary, args, {
@@ -421,10 +454,10 @@ async function main(): Promise<never> {
     skipContinue: consumeNoSessionMarker(),
   });
 
-  // 8. Notify wrapper end (Claude has exited)
+  // 9. Notify wrapper end (Claude has exited)
   await notifyHook("WrapperEnd");
 
-  // 9. Handle result
+  // 10. Handle result
   if (result.error) {
     console.error(`Error: Failed to start Claude: ${result.error.message}`);
     process.exit(EXIT_SPAWN_FAILED);
@@ -450,4 +483,5 @@ export {
   buildInitialPromptArgs,
   buildPermissionArgs,
   consumeNoSessionMarker,
+  installSignalHandlers,
 };


### PR DESCRIPTION
- Install SIGHUP/SIGTERM signal handlers in the Claude wrapper script before spawning Claude via spawnSync
- Without these handlers, closing the terminal tab sends SIGHUP which terminates the wrapper before the WrapperEnd hook notification can be sent
- The agent status now correctly transitions to offline ("none") on terminal close, matching the behavior when typing "exit"