### PR TITLE
fix: Alt+X was not working right after app start

### DIFF
--- a/src/main/managers/window-manager.test-utils.ts
+++ b/src/main/managers/window-manager.test-utils.ts
@@ -19,6 +19,7 @@ export interface MockWindowManager {
   getBounds: Mock<WindowManager["getBounds"]>;
   onResize: Mock<WindowManager["onResize"]>;
   maximizeAsync: Mock<WindowManager["maximizeAsync"]>;
+  focus: Mock<WindowManager["focus"]>;
   setTitle: Mock<WindowManager["setTitle"]>;
   setOverlayIcon: Mock<WindowManager["setOverlayIcon"]>;
   close: Mock<WindowManager["close"]>;
@@ -68,6 +69,7 @@ export function createMockWindowManager(options?: MockWindowManagerOptions): Moc
     getBounds: vi.fn(() => bounds),
     onResize: vi.fn((): Unsubscribe => vi.fn()),
     maximizeAsync: vi.fn(async () => {}),
+    focus: vi.fn(),
     setTitle: vi.fn(),
     setOverlayIcon: vi.fn((image: ImageHandle | null, description: string) => {
       overlayIconCalls.push({ image, description });

--- a/src/main/managers/window-manager.ts
+++ b/src/main/managers/window-manager.ts
@@ -204,6 +204,13 @@ export class WindowManager {
   }
 
   /**
+   * Focuses the window (requests OS-level focus).
+   */
+  focus(): void {
+    this.windowLayer.focus(this.windowHandle);
+  }
+
+  /**
    * Closes the window.
    */
   close(): void {

--- a/src/main/modules/view-module.integration.test.ts
+++ b/src/main/modules/view-module.integration.test.ts
@@ -1115,6 +1115,7 @@ describe("ViewModule Integration", () => {
       const windowManager = {
         create: vi.fn(),
         maximizeAsync: vi.fn().mockResolvedValue(undefined),
+        focus: vi.fn(),
       };
       const { module } = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
@@ -1139,6 +1140,7 @@ describe("ViewModule Integration", () => {
       expect(windowManager.create).toHaveBeenCalled();
       expect(viewManager.create).toHaveBeenCalled();
       expect(windowManager.maximizeAsync).toHaveBeenCalled();
+      expect(windowManager.focus).toHaveBeenCalled();
       expect(layers.viewLayer.loadURL).toHaveBeenCalledWith(
         viewManager.getUIViewHandle(),
         "file:///app/ui.html"

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -114,6 +114,7 @@ export interface ViewModuleDeps {
   readonly windowManager?: {
     create(): void;
     maximizeAsync(): Promise<void>;
+    focus(): void;
   } | null;
   readonly buildInfo?: {
     isDevelopment: boolean;
@@ -187,9 +188,10 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
             }
             viewManager.create();
 
-            // Maximize window
+            // Maximize and focus window
             if (deps.windowManager) {
               await deps.windowManager.maximizeAsync();
+              deps.windowManager.focus();
             }
 
             // Load UI HTML

--- a/src/services/shell/window.state-mock.ts
+++ b/src/services/shell/window.state-mock.ts
@@ -453,6 +453,11 @@ export function createWindowLayerMock(): MockWindowLayer {
       window.title = title;
     },
 
+    focus(handle: WindowHandle): void {
+      getWindow(handle); // Validate handle exists
+      // No-op in mock - focus is an OS-level operation
+    },
+
     close(handle: WindowHandle): void {
       const window = getWindow(handle);
       // Trigger close callbacks before marking destroyed

--- a/src/services/shell/window.ts
+++ b/src/services/shell/window.ts
@@ -164,6 +164,14 @@ export interface WindowLayer {
   setTitle(handle: WindowHandle, title: string): void;
 
   /**
+   * Focus a window (request OS-level focus).
+   *
+   * @param handle - Handle to the window
+   * @throws ShellError with code WINDOW_NOT_FOUND if handle is invalid
+   */
+  focus(handle: WindowHandle): void;
+
+  /**
    * Close a window.
    *
    * @param handle - Handle to the window
@@ -433,6 +441,11 @@ export class DefaultWindowLayer implements WindowLayerInternal {
   setTitle(handle: WindowHandle, title: string): void {
     const state = this.getWindowState(handle);
     state.window.setTitle(title);
+  }
+
+  focus(handle: WindowHandle): void {
+    const state = this.getWindowState(handle);
+    state.window.focus();
   }
 
   close(handle: WindowHandle): void {


### PR DESCRIPTION
- Add `focus()` to `WindowLayer` interface and `DefaultWindowLayer` implementation (calls `BaseWindow.focus()`)
- Add `focus()` to `WindowManager` facade
- Call `windowManager.focus()` in `app-start/init` hook after `maximizeAsync()` to request OS-level focus
- On Linux AppImage launches, focus-stealing prevention doesn't grant the window OS focus automatically, so keyboard events never reach WebContentsViews and Alt+X doesn't work until the user clicks into the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)