### PR TITLE
feat: pr workspaces can be configured via template

### DIFF
--- a/src/main/modules/auto-pr-module.integration.test.ts
+++ b/src/main/modules/auto-pr-module.integration.test.ts
@@ -46,7 +46,7 @@ import {
   file,
   directory,
 } from "../../services/platform/filesystem.state-mock";
-import { createAutoPrModule } from "./auto-pr-module";
+import { createAutoPrModule, parseTemplateOutput } from "./auto-pr-module";
 
 // =============================================================================
 // Minimal Test Operations
@@ -680,6 +680,130 @@ describe("AutoPrModule Integration", () => {
         agent: "plan",
       });
     });
+
+    it("uses front-matter name to override workspace name", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nname: review/{{ number }}\n---\nReview PR #{{ number }}",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.workspaceName).toBe("review/42");
+    });
+
+    it("uses front-matter agent to override agent mode", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nagent: build\n---\nDo the thing",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Do the thing",
+        agent: "build",
+      });
+    });
+
+    it("uses front-matter base to override base branch", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nbase: origin/develop\n---\nReview",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.base).toBe("origin/develop");
+    });
+
+    it("uses front-matter focus to override stealFocus", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nfocus: true\n---\nReview",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.stealFocus).toBe(true);
+    });
+
+    it("uses front-matter model to set model in initial prompt", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nmodel.provider: anthropic\nmodel.id: claude-sonnet-4-6\n---\nReview",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Review",
+        agent: "plan",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      });
+    });
+
+    it("skips workspace when front-matter prompt body is empty", async () => {
+      const { dispatcher, openProjectOp, openWorkspaceOp, fs } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nname: review/{{ number }}\n---\n   ",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining(
+        "/data/auto-pr-workspaces.json",
+        '"https://github.com/org/repo/pull/42": null'
+      );
+    });
+
+    it("creates workspace despite unknown front-matter keys (non-fatal warning)", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: "---\nunknown: value\n---\nReview",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched).toHaveLength(1);
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Review",
+        agent: "plan",
+      });
+    });
+
+    it("applies all front-matter overrides together", async () => {
+      const template = [
+        "---",
+        "name: review/{{ number }}",
+        "agent: build",
+        "base: origin/{{ base.ref }}",
+        "focus: true",
+        "model.provider: anthropic",
+        "model.id: claude-sonnet-4-6",
+        "---",
+        "Review PR #{{ number }}: {{ title }}",
+      ].join("\n");
+
+      const { dispatcher, openWorkspaceOp } = setupWithPr({
+        templatePath: TEMPLATE_PATH,
+        templateContent: template,
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      const payload = openWorkspaceOp.dispatched[0]!.payload;
+      expect(payload.workspaceName).toBe("review/42");
+      expect(payload.base).toBe("origin/main");
+      expect(payload.stealFocus).toBe(true);
+      expect(payload.initialPrompt).toEqual({
+        prompt: "Review PR #42: Add login feature",
+        agent: "build",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      });
+    });
   });
 
   describe("template-skipped PR cleanup", () => {
@@ -807,5 +931,124 @@ describe("AutoPrModule Integration", () => {
       // Should NOT create a workspace
       expect(openProjectOp.dispatched).toHaveLength(0);
     });
+  });
+});
+
+// =============================================================================
+// parseTemplateOutput
+// =============================================================================
+
+describe("parseTemplateOutput", () => {
+  it("treats entire string as prompt when no front matter", () => {
+    const result = parseTemplateOutput("Review PR #42");
+    expect(result.config).toEqual({ prompt: "Review PR #42" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("parses all supported front-matter fields", () => {
+    const input = [
+      "---",
+      "name: review/42",
+      "agent: plan",
+      "base: origin/main",
+      "focus: true",
+      "model.provider: anthropic",
+      "model.id: claude-sonnet-4-6",
+      "---",
+      "Review this PR",
+    ].join("\n");
+
+    const result = parseTemplateOutput(input);
+    expect(result.config).toEqual({
+      prompt: "Review this PR",
+      name: "review/42",
+      agent: "plan",
+      base: "origin/main",
+      focus: true,
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("returns only specified fields (rest remain undefined)", () => {
+    const input = "---\nagent: build\n---\nDo the thing";
+    const result = parseTemplateOutput(input);
+    expect(result.config.agent).toBe("build");
+    expect(result.config.name).toBeUndefined();
+    expect(result.config.base).toBeUndefined();
+    expect(result.config.focus).toBeUndefined();
+    expect(result.config.model).toBeUndefined();
+    expect(result.config.prompt).toBe("Do the thing");
+  });
+
+  it("handles empty front matter (prompt only)", () => {
+    const input = "---\n---\nJust the prompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config).toEqual({ prompt: "Just the prompt" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns on unknown front-matter keys", () => {
+    const input = "---\nunknown: value\nname: ws\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.name).toBe("ws");
+    expect(result.warnings).toEqual(['Unknown front-matter key: "unknown"']);
+  });
+
+  it("warns on invalid boolean value for focus", () => {
+    const input = "---\nfocus: banana\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.focus).toBeUndefined();
+    expect(result.warnings).toEqual(['Invalid focus value "banana", expected "true" or "false"']);
+  });
+
+  it("treats opening --- without closing as no front matter", () => {
+    const input = "---\nname: ws\nno closing delimiter";
+    const result = parseTemplateOutput(input);
+    expect(result.config).toEqual({ prompt: input });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns when only model.provider is specified", () => {
+    const input = "---\nmodel.provider: anthropic\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.model).toBeUndefined();
+    expect(result.warnings).toEqual([
+      "Both model.provider and model.id must be specified together",
+    ]);
+  });
+
+  it("warns when only model.id is specified", () => {
+    const input = "---\nmodel.id: claude-sonnet-4-6\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.model).toBeUndefined();
+    expect(result.warnings).toEqual([
+      "Both model.provider and model.id must be specified together",
+    ]);
+  });
+
+  it("ignores comments and blank lines in front matter", () => {
+    const input = "---\n# this is a comment\n\nname: ws\n\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.name).toBe("ws");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("splits on first colon only (values can contain colons)", () => {
+    const input = "---\nbase: origin/main:feature\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.base).toBe("origin/main:feature");
+  });
+
+  it("parses focus: false correctly", () => {
+    const input = "---\nfocus: false\n---\nprompt";
+    const result = parseTemplateOutput(input);
+    expect(result.config.focus).toBe(false);
+  });
+
+  it("strips single leading newline after closing delimiter", () => {
+    const input = "---\nname: ws\n---\n\nTwo newlines before this";
+    const result = parseTemplateOutput(input);
+    expect(result.config.prompt).toBe("\nTwo newlines before this");
   });
 });

--- a/src/main/modules/auto-pr-module.ts
+++ b/src/main/modules/auto-pr-module.ts
@@ -133,6 +133,101 @@ function buildWorkspaceName(prNumber: number, headRef: string): string {
 }
 
 // =============================================================================
+// Front-matter parser
+// =============================================================================
+
+export interface TemplateConfig {
+  readonly name?: string;
+  readonly agent?: string;
+  readonly base?: string;
+  readonly focus?: boolean;
+  readonly model?: { readonly providerID: string; readonly modelID: string };
+  readonly prompt: string;
+}
+
+export interface ParseResult {
+  readonly config: TemplateConfig;
+  readonly warnings: readonly string[];
+}
+
+const FRONT_MATTER_OPEN = "---\n";
+const KNOWN_KEYS = new Set(["name", "agent", "base", "focus", "model.provider", "model.id"]);
+
+export function parseTemplateOutput(rendered: string): ParseResult {
+  const warnings: string[] = [];
+
+  if (!rendered.startsWith(FRONT_MATTER_OPEN)) {
+    return { config: { prompt: rendered }, warnings };
+  }
+
+  // Find closing delimiter after the opening "---\n"
+  const rest = rendered.slice(FRONT_MATTER_OPEN.length);
+  const closeMatch = /^---[ \t]*$/m.exec(rest);
+  if (!closeMatch || closeMatch.index === undefined) {
+    // No closing delimiter → treat entire string as prompt
+    return { config: { prompt: rendered }, warnings };
+  }
+
+  const frontMatterBlock = rest.slice(0, closeMatch.index);
+  const prompt = rest.slice(closeMatch.index + closeMatch[0].length).replace(/^\n/, "");
+
+  // Parse key-value lines
+  const fields: Record<string, string> = {};
+  for (const line of frontMatterBlock.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex === -1) {
+      warnings.push(`Ignoring front-matter line (no colon): "${trimmed}"`);
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+
+    if (!KNOWN_KEYS.has(key)) {
+      warnings.push(`Unknown front-matter key: "${key}"`);
+      continue;
+    }
+
+    fields[key] = value;
+  }
+
+  // Build config
+  let focus: boolean | undefined;
+  if (fields["focus"] !== undefined) {
+    if (fields["focus"] === "true") {
+      focus = true;
+    } else if (fields["focus"] === "false") {
+      focus = false;
+    } else {
+      warnings.push(`Invalid focus value "${fields["focus"]}", expected "true" or "false"`);
+    }
+  }
+
+  let model: { readonly providerID: string; readonly modelID: string } | undefined;
+  if (fields["model.provider"] !== undefined || fields["model.id"] !== undefined) {
+    if (fields["model.provider"] && fields["model.id"]) {
+      model = { providerID: fields["model.provider"], modelID: fields["model.id"] };
+    } else {
+      warnings.push("Both model.provider and model.id must be specified together");
+    }
+  }
+
+  const config: TemplateConfig = {
+    prompt,
+    ...(fields["name"] !== undefined && { name: fields["name"] }),
+    ...(fields["agent"] !== undefined && { agent: fields["agent"] }),
+    ...(fields["base"] !== undefined && { base: fields["base"] }),
+    ...(focus !== undefined && { focus }),
+    ...(model !== undefined && { model }),
+  };
+
+  return { config, warnings };
+}
+
+// =============================================================================
 // Module Factory
 // =============================================================================
 
@@ -266,19 +361,48 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
   // ------ Workspace Lifecycle ------
 
-  async function buildInitialPrompt(
+  interface WorkspaceConfig {
+    readonly workspaceName: string;
+    readonly base: string;
+    readonly stealFocus: boolean;
+    readonly initialPrompt: NormalizedInitialPrompt;
+  }
+
+  async function buildWorkspaceConfig(
+    prNumber: number,
+    headRef: string,
+    baseRef: string,
     prDetail: Record<string, unknown>
-  ): Promise<NormalizedInitialPrompt> {
+  ): Promise<WorkspaceConfig | null> {
     try {
       const templateContent = await deps.fs.readFile(templatePath!);
       const rendered = renderTemplate(templateContent, prDetail);
-      return { prompt: rendered, agent: "plan" };
+      const { config, warnings } = parseTemplateOutput(rendered);
+
+      for (const warning of warnings) {
+        deps.logger.warn("Template front-matter warning", { warning, templatePath });
+      }
+
+      if (!config.prompt.trim()) return null;
+
+      const initialPrompt: NormalizedInitialPrompt = {
+        prompt: config.prompt,
+        agent: config.agent ?? "plan",
+        ...(config.model !== undefined && { model: config.model }),
+      };
+
+      return {
+        workspaceName: config.name ?? buildWorkspaceName(prNumber, headRef),
+        base: config.base ?? `origin/${baseRef}`,
+        stealFocus: config.focus ?? false,
+        initialPrompt,
+      };
     } catch (error) {
-      deps.logger.warn("Failed to read/render PR template, falling back to empty prompt", {
+      deps.logger.warn("Failed to read/render PR template", {
         templatePath,
         error: getErrorMessage(error),
       });
-      return { prompt: "", agent: "plan" };
+      return null;
     }
   }
 
@@ -291,14 +415,12 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     baseRef: string,
     prDetail: Record<string, unknown>
   ): Promise<void> {
-    const workspaceName = buildWorkspaceName(prNumber, headRef);
-
-    deps.logger.info("Creating PR workspace", { prUrl, workspaceName });
+    deps.logger.info("Creating PR workspace", { prUrl });
 
     try {
-      // Build prompt first — skip workspace entirely if template resolves to empty
-      const initialPrompt = await buildInitialPrompt(prDetail);
-      if (!initialPrompt.prompt.trim()) {
+      // Build config first — skip workspace entirely if template resolves to empty
+      const config = await buildWorkspaceConfig(prNumber, headRef, baseRef, prDetail);
+      if (!config) {
         deps.logger.info("Skipping PR workspace (template resolved to empty)", { prUrl });
         state = {
           ...state,
@@ -322,11 +444,11 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       const wsResult = await deps.dispatcher.dispatch({
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          workspaceName,
-          base: `origin/${baseRef}`,
-          stealFocus: false,
+          workspaceName: config.workspaceName,
+          base: config.base,
+          stealFocus: config.stealFocus,
           projectPath: project.path,
-          initialPrompt,
+          initialPrompt: config.initialPrompt,
         },
       } as OpenWorkspaceIntent);
 
@@ -342,7 +464,7 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
         workspaces: {
           ...state.workspaces,
           [prUrl]: {
-            workspaceName,
+            workspaceName: config.workspaceName,
             workspacePath,
             prNumber,
             repo,
@@ -352,7 +474,10 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
         },
       };
 
-      deps.logger.info("PR workspace created", { prUrl, workspaceName });
+      deps.logger.info("PR workspace created", {
+        prUrl,
+        workspaceName: config.workspaceName,
+      });
     } catch (error) {
       deps.logger.warn("Failed to create PR workspace", {
         prUrl,


### PR DESCRIPTION
- Auto-PR Liquid templates now support front-matter to control all workspace creation options
- Supported front-matter fields: `name`, `agent`, `base`, `focus`, `model.provider`, `model.id`
- Templates without front-matter remain backwards-compatible (entire output = prompt, existing defaults)
- Front-matter parser lives in `auto-pr-module.ts` alongside the module logic
- 21 new tests covering parser behavior and integration with workspace creation