### PR TITLE
fix: clean up git branch config when workspace gets deleted

### DIFF
--- a/src/services/git/git-worktree-provider.integration.test.ts
+++ b/src/services/git/git-worktree-provider.integration.test.ts
@@ -1435,6 +1435,44 @@ describe("GitWorktreeProvider", () => {
       expect(result2.workspaceRemoved).toBe(true);
       expect(result2.baseDeleted).toBe(true); // Branch already deleted, treat as success
     });
+
+    it("clears codehydra metadata from branch config on deletion", async () => {
+      const worktreePath = new Path("/data/workspaces/feature-x");
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            currentBranch: "main",
+            worktrees: [{ name: "feature-x", path: worktreePath.toString(), branch: "feature-x" }],
+            branchConfigs: {
+              "feature-x": {
+                "codehydra.base": "main",
+                "codehydra.note": "WIP feature",
+                "codehydra.model": "claude-4",
+              },
+            },
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      await provider.removeWorkspace(PROJECT_ROOT, worktreePath, false);
+
+      // Branch still exists but metadata should be cleared
+      expect(mockClient).toHaveBranch(PROJECT_ROOT, "feature-x");
+      const metadata = await mockClient.getBranchConfigsByPrefix(
+        PROJECT_ROOT,
+        "feature-x",
+        "codehydra"
+      );
+      expect(metadata).toEqual({});
+    });
   });
 
   describe("isDirty", () => {

--- a/src/services/git/git-worktree-provider.ts
+++ b/src/services/git/git-worktree-provider.ts
@@ -533,6 +533,26 @@ export class GitWorktreeProvider {
       }
     }
 
+    // Step 1.5: Clear codehydra metadata from branch config
+    if (branchName) {
+      try {
+        const metadata = await this.gitClient.getBranchConfigsByPrefix(
+          projectRoot,
+          branchName,
+          GitWorktreeProvider.METADATA_CONFIG_PREFIX
+        );
+        for (const key of Object.keys(metadata)) {
+          await this.gitClient.unsetBranchConfig(
+            projectRoot,
+            branchName,
+            `${GitWorktreeProvider.METADATA_CONFIG_PREFIX}.${key}`
+          );
+        }
+      } catch {
+        this.logger.warn("Failed to clear branch metadata", { branch: branchName });
+      }
+    }
+
     // Step 2: Delete the branch (always attempt if requested)
     // This ensures branch is deleted even if worktree removal failed
     // (e.g., due to Windows file locks - directory cleanup happens at startup)


### PR DESCRIPTION
- Clear all `codehydra.*` branch config entries during workspace removal
- Git does not remove `branch.<name>.*` config when a branch is deleted, causing stale metadata to accumulate and leak into recreated workspaces with the same name
- Added integration test verifying metadata is cleared even when branch is kept