### PR TITLE
fix: clone dialog cannot be closed anymore while in progress

### DIFF
--- a/src/renderer/lib/components/Dialog.svelte
+++ b/src/renderer/lib/components/Dialog.svelte
@@ -63,6 +63,7 @@
 
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key === "Escape") {
+        if (busy) return;
         onClose();
       }
     }
@@ -73,24 +74,10 @@
       document.removeEventListener("keydown", handleKeyDown);
     };
   });
-
-  function handleOverlayClick(): void {
-    onClose();
-  }
-
-  function handleDialogClick(event: MouseEvent): void {
-    event.stopPropagation();
-  }
 </script>
 
 {#if open}
-  <div
-    class="dialog-overlay"
-    data-testid="dialog-overlay"
-    role="presentation"
-    onclick={handleOverlayClick}
-    onkeydown={() => {}}
-  >
+  <div class="dialog-overlay" data-testid="dialog-overlay" role="presentation">
     <div
       bind:this={dialogElement}
       class="dialog"
@@ -100,8 +87,6 @@
       aria-describedby={descriptionId}
       aria-busy={busy || undefined}
       tabindex="-1"
-      onclick={handleDialogClick}
-      onkeydown={() => {}}
     >
       {#if title}
         <div class="dialog-title">

--- a/src/renderer/lib/components/Dialog.test.ts
+++ b/src/renderer/lib/components/Dialog.test.ts
@@ -97,22 +97,21 @@ describe("Dialog component", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it("click on overlay calls onClose", async () => {
+    it("click on overlay does not call onClose", async () => {
       const onClose = vi.fn();
       render(Dialog, { props: { ...defaultProps, onClose } });
 
       const overlay = screen.getByTestId("dialog-overlay");
       await fireEvent.click(overlay);
 
-      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onClose).not.toHaveBeenCalled();
     });
 
-    it("click inside dialog does not call onClose", async () => {
+    it("Escape key does not call onClose when busy", async () => {
       const onClose = vi.fn();
-      render(Dialog, { props: { ...defaultProps, onClose } });
+      render(Dialog, { props: { ...defaultProps, onClose, busy: true } });
 
-      const dialog = screen.getByRole("dialog");
-      await fireEvent.click(dialog);
+      await fireEvent.keyDown(document, { key: "Escape" });
 
       expect(onClose).not.toHaveBeenCalled();
     });

--- a/src/renderer/lib/components/GitCloneDialog.test.ts
+++ b/src/renderer/lib/components/GitCloneDialog.test.ts
@@ -329,6 +329,29 @@ describe("GitCloneDialog component", () => {
       expect(mockOpenCreateDialog).toHaveBeenCalledWith();
     });
 
+    it("Escape key does not close during clone", async () => {
+      mockCloneProject.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve(createProject(testProjectId)), 1000))
+      );
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: testUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      // Clone is in progress — Escape should not close
+      await fireEvent.keyDown(document.body, { key: "Escape" });
+
+      expect(mockOpenCreateDialog).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+    });
+
     it("cancel button disabled during clone", async () => {
       mockCloneProject.mockImplementation(
         () =>

--- a/src/renderer/lib/components/OpenProjectErrorDialog.integration.test.ts
+++ b/src/renderer/lib/components/OpenProjectErrorDialog.integration.test.ts
@@ -104,14 +104,14 @@ describe("OpenProjectErrorDialog component", () => {
       expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
-    it("calls onClose when clicking overlay", async () => {
+    it("does not call onClose when clicking overlay", async () => {
       render(OpenProjectErrorDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
       const overlay = screen.getByTestId("dialog-overlay");
       await fireEvent.click(overlay);
 
-      expect(defaultProps.onClose).toHaveBeenCalled();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
- Remove backdrop click-to-close from Dialog component (overlay remains for dimming only)
- Add busy guard to Escape key handler so dialogs cannot be dismissed while busy
- Update Dialog, GitCloneDialog, and OpenProjectErrorDialog tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)