### PR TITLE
fix: code-server was not shutdown correctly after timeout

### DIFF
--- a/src/services/code-server/code-server-manager.integration.test.ts
+++ b/src/services/code-server/code-server-manager.integration.test.ts
@@ -530,6 +530,63 @@ describe("CodeServerManager Integration", () => {
     });
   });
 
+  describe("start failure cleanup", () => {
+    it("kills the spawned process when health check times out", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const processRunner = createMockProcessRunner({
+          onSpawn: () => ({ pid: 99999, running: true }),
+        });
+
+        // Health check always returns non-200, so it never becomes healthy
+        const httpClient = createMockHttpClient({ defaultResponse: { status: 503 } });
+        const portManager = createPortManagerMock([8080]);
+        const config = {
+          port: CODE_SERVER_PORT,
+          binaryPath: "/app/code-server",
+          runtimeDir: "/tmp/runtime",
+          extensionsDir: "/tmp/extensions",
+          userDataDir: "/tmp/user-data",
+          binDir: "/app/bin",
+          codeServerDir: "/app/code-server-dir",
+          opencodeDir: "/app/opencode-dir",
+        };
+
+        const manager = new CodeServerManager(
+          config,
+          processRunner,
+          httpClient,
+          portManager,
+          testLogger
+        );
+
+        // Start ensureRunning (will block on health check).
+        // Attach a catch handler immediately to prevent unhandled rejection warnings,
+        // since the rejection fires before the await in ensureRunning handles it.
+        let caughtError: unknown;
+        const startPromise = manager.ensureRunning().catch((err: unknown) => {
+          caughtError = err;
+        });
+
+        // Advance past the 10s health check timeout
+        await vi.advanceTimersByTimeAsync(11_000);
+
+        await startPromise;
+
+        // Verify the start failed with a timeout error
+        expect(caughtError).toBeDefined();
+        expect(String(caughtError)).toContain("Failed to start code-server");
+
+        // Verify the spawned process was killed to avoid orphaning
+        const spawned = processRunner.$.spawned(0);
+        expect(spawned).toHaveBeenKilled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("setCodeServerVersion", () => {
     it("updates binaryPath, codeServerDir, and download request", async () => {
       const processRunner = createMockProcessRunner({

--- a/src/services/code-server/code-server-manager.ts
+++ b/src/services/code-server/code-server-manager.ts
@@ -453,9 +453,20 @@ export class CodeServerManager {
       this.logger.info("Started", { port, pid: this.currentPid ?? 0 });
       return port;
     } catch (error: unknown) {
+      const proc = this.process;
       this.currentPort = null;
       this.currentPid = null;
       this.process = null;
+
+      // Kill the orphaned process to release the port
+      if (proc) {
+        try {
+          await proc.kill(PROCESS_KILL_GRACEFUL_TIMEOUT_MS, PROCESS_KILL_FORCE_TIMEOUT_MS);
+        } catch {
+          // Best-effort cleanup — log but don't mask the original error
+          this.logger.warn("Failed to kill code-server after start failure");
+        }
+      }
 
       const errorMsg = getErrorMessage(error);
       this.logger.error("Start failed", { error: errorMsg });


### PR DESCRIPTION
- Kill code-server process in `doStart()` catch block before dropping the reference
- Prevents orphaned processes holding the port after health check timeout
- Subsequent app restarts no longer fail with "port already in use"