### PR TITLE
feat(intents): add project:list operation to query all open projects

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -138,6 +138,7 @@ import {
   GetActiveWorkspaceOperation,
   INTENT_GET_ACTIVE_WORKSPACE,
 } from "./operations/get-active-workspace";
+import { ListProjectsOperation, INTENT_LIST_PROJECTS } from "./operations/list-projects";
 import { OpenWorkspaceOperation, INTENT_OPEN_WORKSPACE } from "./operations/open-workspace";
 import { GetProjectBasesOperation, INTENT_GET_PROJECT_BASES } from "./operations/get-project-bases";
 import {
@@ -599,6 +600,7 @@ dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatus
 dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
 dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
 dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
+dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
 dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
 

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -10,6 +10,7 @@
  * - delete-workspace: remove worktree
  * - switch-workspace: find candidates
  * - get-workspace-status: check dirty status
+ * - list-projects: list workspaces per project
  *
  * Uses GitWorktreeProvider directly (no ProjectScopedWorkspaceProvider adapter).
  * Maintains its own workspace state in closure-scoped maps.
@@ -55,6 +56,11 @@ import {
   type GetStatusHookInput,
   type GetStatusHookResult,
 } from "../operations/get-workspace-status";
+import {
+  LIST_PROJECTS_OPERATION_ID,
+  type ListWorkspacesHookResult,
+  type ListWorkspacesHookEntry,
+} from "../operations/list-projects";
 import { extractWorkspaceName } from "../../shared/api/id-utils";
 import { Path } from "../../services/platform/path";
 import { getErrorMessage } from "../../services/errors";
@@ -364,6 +370,22 @@ export function createGitWorktreeWorkspaceModule(
             const { workspacePath: wsPath } = ctx as GetStatusHookInput;
             const isDirty = await globalProvider.isDirty(new Path(wsPath));
             return { isDirty };
+          },
+        },
+      },
+
+      // list-projects -> list-workspaces
+      [LIST_PROJECTS_OPERATION_ID]: {
+        "list-workspaces": {
+          handler: async (): Promise<ListWorkspacesHookResult> => {
+            const entries: ListWorkspacesHookEntry[] = [];
+            for (const [key, wsList] of workspaces) {
+              entries.push({
+                projectPath: key,
+                workspaces: wsList,
+              });
+            }
+            return { entries };
           },
         },
       },

--- a/src/main/modules/local-project-module.ts
+++ b/src/main/modules/local-project-module.ts
@@ -45,6 +45,11 @@ import {
   type ResolveHookInput as ResolveProjectHookInput,
   type ResolveHookResult as ResolveProjectHookResult,
 } from "../operations/resolve-project";
+import {
+  LIST_PROJECTS_OPERATION_ID,
+  type ListProjectsHookResult,
+  type ListProjectsHookEntry,
+} from "../operations/list-projects";
 
 // =============================================================================
 // Types
@@ -425,6 +430,23 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
           handler: async (): Promise<ActivateHookResult> => {
             const configs = await loadAllProjectConfigs(fs, projectsDir);
             return { projectPaths: configs.map((c) => c.path) };
+          },
+        },
+      },
+
+      // list-projects -> list-projects
+      [LIST_PROJECTS_OPERATION_ID]: {
+        "list-projects": {
+          handler: async (): Promise<ListProjectsHookResult> => {
+            const entries: ListProjectsHookEntry[] = [];
+            for (const [key, project] of projects) {
+              entries.push({
+                projectId: project.id,
+                name: project.name,
+                path: key,
+              });
+            }
+            return { projects: entries };
           },
         },
       },

--- a/src/main/operations/list-projects.integration.test.ts
+++ b/src/main/operations/list-projects.integration.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment node
+/**
+ * Integration tests for list-projects operation through the Dispatcher.
+ *
+ * Tests verify the full dispatch pipeline: intent -> operation -> hooks -> result,
+ * using mock hook modules for "list-projects" and "list-workspaces" hook points.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+
+import {
+  ListProjectsOperation,
+  LIST_PROJECTS_OPERATION_ID,
+  INTENT_LIST_PROJECTS,
+} from "./list-projects";
+import type {
+  ListProjectsIntent,
+  ListProjectsHookResult,
+  ListWorkspacesHookResult,
+} from "./list-projects";
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { Project, ProjectId } from "../../shared/api/types";
+import type { Workspace as InternalWorkspace } from "../../services/git/types";
+import { Path } from "../../services/platform/path";
+
+// =============================================================================
+// Test Constants
+// =============================================================================
+
+const PROJECT_A_ID = "project-a-ea0135bc" as ProjectId;
+const PROJECT_A_PATH = "/repos/project-a";
+const PROJECT_B_ID = "project-b-fb1246cd" as ProjectId;
+const PROJECT_B_PATH = "/repos/project-b";
+
+function makeWorkspace(name: string, projectPath: string, branch: string): InternalWorkspace {
+  return {
+    name,
+    path: new Path(`${projectPath}/.codehydra/workspaces/${name}`),
+    branch,
+    metadata: { base: "main" },
+  };
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+interface TestSetup {
+  dispatcher: Dispatcher;
+}
+
+function createTestSetup(
+  projectsHandler: () => Promise<ListProjectsHookResult>,
+  workspacesHandler: () => Promise<ListWorkspacesHookResult>
+): TestSetup {
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
+
+  const projectModule: IntentModule = {
+    name: "test-projects",
+    hooks: {
+      [LIST_PROJECTS_OPERATION_ID]: {
+        "list-projects": {
+          handler: projectsHandler,
+        },
+      },
+    },
+  };
+
+  const workspaceModule: IntentModule = {
+    name: "test-workspaces",
+    hooks: {
+      [LIST_PROJECTS_OPERATION_ID]: {
+        "list-workspaces": {
+          handler: workspacesHandler,
+        },
+      },
+    },
+  };
+
+  dispatcher.registerModule(projectModule);
+  dispatcher.registerModule(workspaceModule);
+
+  return { dispatcher };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function listProjectsIntent(): ListProjectsIntent {
+  return {
+    type: INTENT_LIST_PROJECTS,
+    payload: {},
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ListProjects Operation", () => {
+  describe("empty state", () => {
+    let setup: TestSetup;
+
+    beforeEach(() => {
+      setup = createTestSetup(
+        async () => ({ projects: [] }),
+        async () => ({ entries: [] })
+      );
+    });
+
+    it("returns empty array when no projects exist", async () => {
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("single project with workspaces", () => {
+    let setup: TestSetup;
+    const ws1 = makeWorkspace("feature-x", PROJECT_A_PATH, "feature-x");
+    const ws2 = makeWorkspace("bugfix-y", PROJECT_A_PATH, "bugfix-y");
+
+    beforeEach(() => {
+      setup = createTestSetup(
+        async () => ({
+          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+        }),
+        async () => ({
+          entries: [{ projectPath: PROJECT_A_PATH, workspaces: [ws1, ws2] }],
+        })
+      );
+    });
+
+    it("returns project with workspaces converted to IPC format", async () => {
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(PROJECT_A_ID);
+      expect(result[0]!.name).toBe("project-a");
+      expect(result[0]!.path).toBe(PROJECT_A_PATH);
+      expect(result[0]!.workspaces).toHaveLength(2);
+      expect(result[0]!.workspaces[0]!.projectId).toBe(PROJECT_A_ID);
+      expect(result[0]!.workspaces[0]!.name).toBe("feature-x");
+      expect(result[0]!.workspaces[0]!.path).toBe(ws1.path.toString());
+      expect(result[0]!.workspaces[1]!.name).toBe("bugfix-y");
+    });
+  });
+
+  describe("multiple projects with correct workspace grouping", () => {
+    let setup: TestSetup;
+    const wsA = makeWorkspace("ws-a", PROJECT_A_PATH, "ws-a");
+    const wsB = makeWorkspace("ws-b", PROJECT_B_PATH, "ws-b");
+
+    beforeEach(() => {
+      setup = createTestSetup(
+        async () => ({
+          projects: [
+            { projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH },
+            { projectId: PROJECT_B_ID, name: "project-b", path: PROJECT_B_PATH },
+          ],
+        }),
+        async () => ({
+          entries: [
+            { projectPath: PROJECT_A_PATH, workspaces: [wsA] },
+            { projectPath: PROJECT_B_PATH, workspaces: [wsB] },
+          ],
+        })
+      );
+    });
+
+    it("groups workspaces under the correct project", async () => {
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result).toHaveLength(2);
+
+      const projectA = result.find((p) => p.id === PROJECT_A_ID)!;
+      expect(projectA.workspaces).toHaveLength(1);
+      expect(projectA.workspaces[0]!.name).toBe("ws-a");
+      expect(projectA.workspaces[0]!.projectId).toBe(PROJECT_A_ID);
+
+      const projectB = result.find((p) => p.id === PROJECT_B_ID)!;
+      expect(projectB.workspaces).toHaveLength(1);
+      expect(projectB.workspaces[0]!.name).toBe("ws-b");
+      expect(projectB.workspaces[0]!.projectId).toBe(PROJECT_B_ID);
+    });
+  });
+
+  describe("project with no matching workspaces", () => {
+    let setup: TestSetup;
+
+    beforeEach(() => {
+      setup = createTestSetup(
+        async () => ({
+          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+        }),
+        async () => ({ entries: [] })
+      );
+    });
+
+    it("returns project with empty workspaces array", async () => {
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.workspaces).toEqual([]);
+    });
+  });
+
+  describe("workspace data for unknown project", () => {
+    let setup: TestSetup;
+    const ws = makeWorkspace("orphan", "/repos/unknown", "orphan");
+
+    beforeEach(() => {
+      setup = createTestSetup(
+        async () => ({
+          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+        }),
+        async () => ({
+          entries: [{ projectPath: "/repos/unknown", workspaces: [ws] }],
+        })
+      );
+    });
+
+    it("skips workspaces with no matching project entry", async () => {
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.workspaces).toEqual([]);
+    });
+  });
+
+  describe("error propagation", () => {
+    it("propagates list-projects hook errors", async () => {
+      const setup = createTestSetup(
+        async () => {
+          throw new Error("project hook failed");
+        },
+        async () => ({ entries: [] })
+      );
+
+      await expect(setup.dispatcher.dispatch(listProjectsIntent())).rejects.toThrow(
+        "project hook failed"
+      );
+    });
+
+    it("propagates list-workspaces hook errors", async () => {
+      const setup = createTestSetup(
+        async () => ({ projects: [] }),
+        async () => {
+          throw new Error("workspace hook failed");
+        }
+      );
+
+      await expect(setup.dispatcher.dispatch(listProjectsIntent())).rejects.toThrow(
+        "workspace hook failed"
+      );
+    });
+  });
+});

--- a/src/main/operations/list-projects.ts
+++ b/src/main/operations/list-projects.ts
@@ -1,0 +1,120 @@
+/**
+ * ListProjectsOperation - Returns all open projects with their workspaces.
+ *
+ * Read-only query with two hook points:
+ * - "list-projects": project modules contribute project identity (id, name, path)
+ * - "list-workspaces": workspace modules contribute workspaces per project
+ *
+ * Joins results by projectPath and converts internal types to IPC types
+ * using existing toIpcWorkspaces().
+ */
+
+import type { Intent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Project, ProjectId } from "../../shared/api/types";
+import type { Workspace as InternalWorkspace } from "../../services/git/types";
+import { toIpcWorkspaces } from "../api/workspace-conversion";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface ListProjectsIntent extends Intent<Project[]> {
+  readonly type: "project:list";
+  readonly payload: Record<string, never>;
+}
+
+export const INTENT_LIST_PROJECTS = "project:list" as const;
+
+// =============================================================================
+// Hook Result Types
+// =============================================================================
+
+export interface ListProjectsHookEntry {
+  readonly projectId: ProjectId;
+  readonly name: string;
+  readonly path: string;
+}
+
+export interface ListProjectsHookResult {
+  readonly projects?: readonly ListProjectsHookEntry[];
+}
+
+export interface ListWorkspacesHookEntry {
+  readonly projectPath: string;
+  readonly workspaces: readonly InternalWorkspace[];
+}
+
+export interface ListWorkspacesHookResult {
+  readonly entries?: readonly ListWorkspacesHookEntry[];
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export const LIST_PROJECTS_OPERATION_ID = "list-projects";
+
+export class ListProjectsOperation implements Operation<ListProjectsIntent, Project[]> {
+  readonly id = LIST_PROJECTS_OPERATION_ID;
+
+  async execute(ctx: OperationContext<ListProjectsIntent>): Promise<Project[]> {
+    const hookCtx: HookContext = {
+      intent: ctx.intent,
+    };
+
+    // Collect project identity from "list-projects" hook
+    const projectsResult = await ctx.hooks.collect<ListProjectsHookResult>(
+      "list-projects",
+      hookCtx
+    );
+    if (projectsResult.errors.length > 0) {
+      if (projectsResult.errors.length === 1) {
+        throw projectsResult.errors[0]!;
+      }
+      throw new AggregateError(projectsResult.errors, "Multiple errors listing projects");
+    }
+
+    // Collect workspace data from "list-workspaces" hook
+    const workspacesResult = await ctx.hooks.collect<ListWorkspacesHookResult>(
+      "list-workspaces",
+      hookCtx
+    );
+    if (workspacesResult.errors.length > 0) {
+      if (workspacesResult.errors.length === 1) {
+        throw workspacesResult.errors[0]!;
+      }
+      throw new AggregateError(workspacesResult.errors, "Multiple errors listing workspaces");
+    }
+
+    // Build workspace lookup by projectPath
+    const workspaceMap = new Map<string, InternalWorkspace[]>();
+    for (const result of workspacesResult.results) {
+      if (result.entries) {
+        for (const entry of result.entries) {
+          const existing = workspaceMap.get(entry.projectPath) ?? [];
+          existing.push(...entry.workspaces);
+          workspaceMap.set(entry.projectPath, existing);
+        }
+      }
+    }
+
+    // Join projects with their workspaces
+    const projects: Project[] = [];
+    for (const result of projectsResult.results) {
+      if (result.projects) {
+        for (const entry of result.projects) {
+          const internalWorkspaces = workspaceMap.get(entry.path) ?? [];
+          projects.push({
+            id: entry.projectId,
+            name: entry.name,
+            path: entry.path,
+            workspaces: toIpcWorkspaces(internalWorkspaces, entry.projectId),
+          });
+        }
+      }
+    }
+
+    return projects;
+  }
+}


### PR DESCRIPTION
- Add `project:list` read-only query operation with two hook points (`list-projects`, `list-workspaces`)
- Add `list-projects` hook to `local-project-module` reading from existing projects Map
- Add `list-workspaces` hook to `git-worktree-workspace-module` reading from existing workspaces Map
- Register `ListProjectsOperation` in bootstrap
- Add 7 integration tests covering empty state, grouping, error propagation