### PR TITLE
feat: workspaces can be created across projects

### DIFF
--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -56,6 +56,7 @@ import { INTENT_GET_AGENT_SESSION } from "../operations/get-agent-session";
 import { INTENT_RESTART_AGENT } from "../operations/restart-agent";
 import { INTENT_GET_METADATA } from "../operations/get-metadata";
 import { INTENT_SET_METADATA } from "../operations/set-metadata";
+import { INTENT_RESOLVE_WORKSPACE } from "../operations/resolve-workspace";
 
 // =============================================================================
 // Minimal Test Operations
@@ -696,7 +697,7 @@ describe("CodeServerModule", () => {
       const result = (await dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678" as ProjectId,
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
         },
@@ -745,7 +746,7 @@ describe("CodeServerModule", () => {
       const result = (await dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678" as ProjectId,
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
         },
@@ -780,7 +781,7 @@ describe("CodeServerModule", () => {
       await dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678" as ProjectId,
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
         },
@@ -819,7 +820,7 @@ describe("CodeServerModule", () => {
       await dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678" as ProjectId,
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
           existingWorkspace: {
@@ -1228,7 +1229,20 @@ describe("CodeServerModule", () => {
         metadata: {},
         path: "/workspaces/my-ws",
       };
+      const resolvedProject = { projectPath: "/project/path", workspaceName: "caller-ws" };
       const { handlers, mockDispatch } = await setupPluginHandlers(workspace);
+      // Mock: first dispatch (workspace:resolve) returns resolvedProject,
+      // second dispatch (workspace:open) returns workspace
+      mockDispatch.mockImplementation((intent: Intent) => {
+        const handle = new IntentHandle();
+        handle.signalAccepted(true);
+        if (intent.type === INTENT_RESOLVE_WORKSPACE) {
+          handle.resolve(resolvedProject);
+        } else {
+          handle.resolve(workspace);
+        }
+        return handle;
+      });
 
       const result = await handlers.create(testWorkspacePath, {
         name: "my-ws",
@@ -1245,7 +1259,7 @@ describe("CodeServerModule", () => {
         expect.objectContaining({
           type: INTENT_OPEN_WORKSPACE,
           payload: expect.objectContaining({
-            callerWorkspacePath: testWorkspacePath,
+            projectPath: "/project/path",
             workspaceName: "my-ws",
             base: "main",
             initialPrompt: "Do something",
@@ -1256,17 +1270,30 @@ describe("CodeServerModule", () => {
     });
 
     it("create does not include optional fields when undefined", async () => {
-      const { handlers, mockDispatch } = await setupPluginHandlers({
+      const workspace = {
         projectId: "p",
         name: "ws",
         branch: "ws",
         metadata: {},
         path: "/ws",
+      };
+      const resolvedProject = { projectPath: "/project/path", workspaceName: "caller-ws" };
+      const { handlers, mockDispatch } = await setupPluginHandlers(workspace);
+      mockDispatch.mockImplementation((intent: Intent) => {
+        const handle = new IntentHandle();
+        handle.signalAccepted(true);
+        if (intent.type === INTENT_RESOLVE_WORKSPACE) {
+          handle.resolve(resolvedProject);
+        } else {
+          handle.resolve(workspace);
+        }
+        return handle;
       });
 
       await handlers.create(testWorkspacePath, { name: "my-ws", base: "main" });
 
-      const dispatchedIntent = mockDispatch.mock.calls[0]![0];
+      // Second call is workspace:open (first is workspace:resolve)
+      const dispatchedIntent = mockDispatch.mock.calls[1]![0];
       expect(dispatchedIntent.payload).not.toHaveProperty("initialPrompt");
       expect(dispatchedIntent.payload).not.toHaveProperty("stealFocus");
     });

--- a/src/main/modules/code-server-module.ts
+++ b/src/main/modules/code-server-module.ts
@@ -69,6 +69,8 @@ import { INTENT_GET_METADATA } from "../operations/get-metadata";
 import type { GetMetadataIntent } from "../operations/get-metadata";
 import { INTENT_SET_METADATA } from "../operations/set-metadata";
 import type { SetMetadataIntent } from "../operations/set-metadata";
+import { INTENT_RESOLVE_WORKSPACE } from "../operations/resolve-workspace";
+import type { ResolveWorkspaceIntent } from "../operations/resolve-workspace";
 import { urlForWorkspace, urlForFolder } from "../../services/code-server/code-server-manager";
 import {
   CODE_SERVER_VERSION,
@@ -628,10 +630,16 @@ function createPluginApiHandlers(
         workspacePath,
         "create",
         async () => {
+          // Resolve workspacePath → projectPath before dispatching workspace:open
+          const resolved = await dispatcher.dispatch({
+            type: INTENT_RESOLVE_WORKSPACE,
+            payload: { workspacePath },
+          } as ResolveWorkspaceIntent);
+
           const intent: OpenWorkspaceIntent = {
             type: INTENT_OPEN_WORKSPACE,
             payload: {
-              callerWorkspacePath: workspacePath,
+              projectPath: resolved.projectPath,
               workspaceName: request.name,
               base: request.base,
               ...(request.initialPrompt !== undefined && {

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -27,8 +27,6 @@ import type {
   OpenWorkspaceIntent,
   CreateHookInput,
   CreateHookResult,
-  ResolveCallerHookInput,
-  ResolveCallerHookResult,
 } from "../operations/open-workspace";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../operations/open-workspace";
 import type {
@@ -206,16 +204,8 @@ export function createGitWorktreeWorkspaceModule(
         },
       },
 
-      // open-workspace -> resolve-caller + create
+      // open-workspace -> create
       [OPEN_WORKSPACE_OPERATION_ID]: {
-        "resolve-caller": {
-          handler: async (ctx: HookContext): Promise<ResolveCallerHookResult> => {
-            const { callerWorkspacePath } = ctx as ResolveCallerHookInput;
-            const result = resolveFromWorkspacePath(callerWorkspacePath);
-            if (!result) return {};
-            return { projectPath: result.projectPath, workspaceName: result.workspaceName };
-          },
-        },
         create: {
           handler: async (ctx: HookContext): Promise<CreateHookResult> => {
             const intent = ctx.intent as OpenWorkspaceIntent;

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -265,17 +265,17 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
 
   registerIpc(ApiIpcChannels.WORKSPACE_CREATE, async (payload) => {
     const p = payload as WorkspaceCreatePayload;
+    if (!p.projectPath) {
+      throw new Error("projectPath is required");
+    }
     const intent: OpenWorkspaceIntent = {
       type: INTENT_OPEN_WORKSPACE,
       payload: {
-        ...(p.projectPath !== undefined && { projectPath: p.projectPath }),
+        projectPath: p.projectPath,
         workspaceName: p.name,
         base: p.base,
         ...(p.initialPrompt !== undefined && { initialPrompt: p.initialPrompt }),
         ...(p.stealFocus !== undefined && { stealFocus: p.stealFocus }),
-        ...(p.callerWorkspacePath !== undefined && {
-          callerWorkspacePath: p.callerWorkspacePath,
-        }),
       },
     };
     const result = await dispatcher.dispatch(intent);

--- a/src/main/modules/mcp-handlers.integration.test.ts
+++ b/src/main/modules/mcp-handlers.integration.test.ts
@@ -28,7 +28,8 @@ import {
   INTENT_DELETE_WORKSPACE,
   DELETE_WORKSPACE_OPERATION_ID,
 } from "../operations/delete-workspace";
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../operations/list-projects";
+import type { ProjectId, WorkspaceName, Project } from "../../shared/api/types";
 
 import { createMcpHandlers } from "./mcp-handlers";
 
@@ -118,7 +119,21 @@ function createTestSetup() {
     createCapturingOperation(DELETE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
   );
 
-  return { dispatcher, hookRegistry, pluginServer, capturedIntents };
+  const mockProjects: Project[] = [
+    {
+      id: "proj-12345678" as ProjectId,
+      name: "my-project",
+      path: "/projects/my-project",
+      workspaces: [],
+    },
+  ];
+
+  dispatcher.registerOperation(
+    INTENT_LIST_PROJECTS,
+    createCapturingOperation(LIST_PROJECTS_OPERATION_ID, capturedIntents, mockProjects)
+  );
+
+  return { dispatcher, hookRegistry, pluginServer, capturedIntents, mockProjects };
 }
 
 // =============================================================================
@@ -199,13 +214,26 @@ describe("createMcpHandlers", () => {
     });
   });
 
+  describe("listProjects", () => {
+    it("dispatches ListProjectsIntent and returns projects", async () => {
+      const { dispatcher, pluginServer, capturedIntents, mockProjects } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const result = await handlers.listProjects();
+
+      expect(capturedIntents).toHaveLength(1);
+      expect(capturedIntents[0]!.type).toBe(INTENT_LIST_PROJECTS);
+      expect(result).toEqual(mockProjects);
+    });
+  });
+
   describe("createWorkspace", () => {
     it("dispatches OpenWorkspaceIntent with mapped payload", async () => {
       const { dispatcher, pluginServer, capturedIntents } = createTestSetup();
       const handlers = createMcpHandlers(dispatcher, pluginServer as never);
 
       const result = await handlers.createWorkspace({
-        callerWorkspacePath: "/caller/workspace",
+        projectPath: "/projects/my-project",
         name: "feature",
         base: "main",
         stealFocus: false,
@@ -214,7 +242,7 @@ describe("createMcpHandlers", () => {
       expect(capturedIntents).toHaveLength(1);
       expect(capturedIntents[0]!.type).toBe(INTENT_OPEN_WORKSPACE);
       expect(capturedIntents[0]!.payload).toEqual({
-        callerWorkspacePath: "/caller/workspace",
+        projectPath: "/projects/my-project",
         workspaceName: "feature",
         base: "main",
         stealFocus: false,
@@ -227,7 +255,7 @@ describe("createMcpHandlers", () => {
       const handlers = createMcpHandlers(dispatcher, pluginServer as never);
 
       await handlers.createWorkspace({
-        callerWorkspacePath: "/caller/workspace",
+        projectPath: "/projects/my-project",
         name: "feature",
         base: "main",
         initialPrompt: "Implement the feature",

--- a/src/main/modules/mcp-handlers.ts
+++ b/src/main/modules/mcp-handlers.ts
@@ -23,6 +23,8 @@ import { INTENT_OPEN_WORKSPACE } from "../operations/open-workspace";
 import type { OpenWorkspaceIntent } from "../operations/open-workspace";
 import { INTENT_DELETE_WORKSPACE } from "../operations/delete-workspace";
 import type { DeleteWorkspaceIntent } from "../operations/delete-workspace";
+import { INTENT_LIST_PROJECTS } from "../operations/list-projects";
+import type { ListProjectsIntent } from "../operations/list-projects";
 
 /**
  * Create McpApiHandlers that dispatch intents via the Dispatcher.
@@ -87,11 +89,23 @@ export function createMcpHandlers(
       return result;
     },
 
+    async listProjects() {
+      const intent: ListProjectsIntent = {
+        type: INTENT_LIST_PROJECTS,
+        payload: {} as Record<string, never>,
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (!result) {
+        throw new Error("List projects dispatch returned no result");
+      }
+      return result;
+    },
+
     async createWorkspace(options) {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          callerWorkspacePath: options.callerWorkspacePath,
+          projectPath: options.projectPath,
           workspaceName: options.name,
           base: options.base,
           ...(options.initialPrompt !== undefined && { initialPrompt: options.initialPrompt }),

--- a/src/main/modules/opencode-agent-module.integration.test.ts
+++ b/src/main/modules/opencode-agent-module.integration.test.ts
@@ -689,7 +689,7 @@ describe("OpenCodeAgentModule Integration", () => {
       const result = (await setup.dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678",
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
         },
@@ -711,7 +711,7 @@ describe("OpenCodeAgentModule Integration", () => {
       await setup.dispatcher.dispatch({
         type: "workspace:open",
         payload: {
-          projectId: "test-12345678",
+          projectPath: "/test/project",
           workspaceName: "feature-1",
           base: "main",
           initialPrompt: "Fix the bug",

--- a/src/main/operations/open-workspace.ts
+++ b/src/main/operations/open-workspace.ts
@@ -5,8 +5,6 @@
  * results that are merged field-by-field with conflict detection.
  *
  * Steps:
- * 0. If callerWorkspacePath:
- *    Dispatch workspace:resolve to get projectPath
  * 1. Dispatch project:resolve to get projectId from projectPath
  * 2. "create" → CreateHookResult — worktree creation (fatal)
  *    "setup" → SetupHookResult — keepfiles (best-effort, internal try/catch),
@@ -32,7 +30,6 @@ import type { AgentType } from "../../shared/plugin-protocol";
 import { normalizeInitialPrompt } from "../../shared/api/types";
 import { extractWorkspaceName } from "../../shared/api/id-utils";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
 
@@ -49,12 +46,6 @@ export interface ExistingWorkspaceData {
 }
 
 export interface OpenWorkspacePayload {
-  /**
-   * Workspace path of the calling workspace.
-   * Used by Plugin API / MCP server as an alternative to projectPath.
-   * When present, resolved via dispatch to determine projectPath.
-   */
-  readonly callerWorkspacePath?: string;
   readonly workspaceName: string;
   readonly base: string;
   readonly initialPrompt?: InitialPrompt;
@@ -64,7 +55,7 @@ export interface OpenWorkspacePayload {
   /** When set, skip worktree creation and populate context from existing workspace data. */
   readonly existingWorkspace?: ExistingWorkspaceData;
   /** Authoritative project path. */
-  readonly projectPath?: string;
+  readonly projectPath: string;
 }
 
 export type OpenWorkspaceResult = Workspace;
@@ -109,17 +100,6 @@ export const OPEN_WORKSPACE_OPERATION_ID = "open-workspace";
 // =============================================================================
 // Per-hook-point types
 // =============================================================================
-
-/** Input context for the "resolve-caller" hook point (callerWorkspacePath resolution). */
-export interface ResolveCallerHookInput extends HookContext {
-  readonly callerWorkspacePath: string;
-}
-
-/** Result from the "resolve-caller" hook point. */
-export interface ResolveCallerHookResult {
-  readonly projectPath?: string;
-  readonly workspaceName?: WorkspaceName;
-}
 
 /** Input context for the "create" hook point (enriched with resolved project path). */
 export interface CreateHookInput extends HookContext {
@@ -177,20 +157,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
 
   async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<OpenWorkspaceResult> {
-    let projectPath: string | undefined = ctx.intent.payload.projectPath;
-
-    // If callerWorkspacePath provided (Plugin API / MCP), resolve via dispatch
-    if (ctx.intent.payload.callerWorkspacePath && !projectPath) {
-      const wsResolved = await ctx.dispatch({
-        type: INTENT_RESOLVE_WORKSPACE,
-        payload: { workspacePath: ctx.intent.payload.callerWorkspacePath },
-      } as ResolveWorkspaceIntent);
-      projectPath = wsResolved.projectPath;
-    }
-
-    if (!projectPath) {
-      throw new Error("projectPath is required");
-    }
+    const { projectPath } = ctx.intent.payload;
 
     // Dispatch project:resolve to get projectId from projectPath
     const projResolved = await ctx.dispatch({

--- a/src/services/mcp-server/mcp-server-manager.test.ts
+++ b/src/services/mcp-server/mcp-server-manager.test.ts
@@ -21,6 +21,7 @@ function createMockMcpHandlers(): McpApiHandlers {
     setMetadata: vi.fn(),
     getAgentSession: vi.fn(),
     restartAgentServer: vi.fn(),
+    listProjects: vi.fn(),
     createWorkspace: vi.fn(),
     deleteWorkspace: vi.fn(),
     executeCommand: vi.fn(),

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -40,6 +40,7 @@ function createMockMcpHandlers(): McpApiHandlers {
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(null),
     restartAgentServer: vi.fn().mockResolvedValue(14001),
+    listProjects: vi.fn().mockResolvedValue([]),
     createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
     deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -43,6 +43,7 @@ function createMockMcpHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandl
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(14001),
     restartAgentServer: vi.fn().mockResolvedValue(14001),
+    listProjects: vi.fn().mockResolvedValue([]),
     createWorkspace: vi.fn().mockResolvedValue({
       name: "test",
       path: "/path",
@@ -172,9 +173,10 @@ describe("McpServer", () => {
       expect(toolNames).toContain("workspace_restart_agent_server");
       expect(toolNames).toContain("workspace_delete");
       expect(toolNames).toContain("workspace_execute_command");
+      expect(toolNames).toContain("project_list");
       expect(toolNames).toContain("workspace_create");
       expect(toolNames).toContain("log");
-      expect(tools.length).toBe(9);
+      expect(tools.length).toBe(10);
     });
 
     it("workspace_restart_agent_server tool calls handler and returns port", async () => {

--- a/src/services/mcp-server/mcp-server.ts
+++ b/src/services/mcp-server/mcp-server.ts
@@ -9,8 +9,8 @@
  * initialize request, and cleaned up when the client disconnects or the server stops.
  *
  * Workspace resolution is handled by the intent system — the MCP server passes
- * workspacePath directly to API methods. For `create`, it uses `callerWorkspacePath`
- * so the intent hooks resolve the project from the calling workspace.
+ * workspacePath directly to API methods. For `create`, the agent provides
+ * projectPath directly (discovered via `project_list` tool).
  */
 
 import {
@@ -64,6 +64,9 @@ export const SERVER_INSTRUCTIONS = [
   "- No agent field — the agent starts with full permissions. Use this when the task should proceed directly to implementation.",
   "",
   "The model is automatically propagated from your current session — you do not need to specify it.",
+  "",
+  "When working with tool results, write down any important information you might need later in your response,",
+  "as the original tool result may be cleared later.",
 ].join("\n");
 
 export function createDefaultMcpServer(): McpServerSdk {
@@ -442,13 +445,40 @@ export class McpServer implements IMcpServer {
       )
     );
 
+    // project_list
+    mcpServer.registerTool(
+      "project_list",
+      {
+        description:
+          "List all open projects with their workspaces. " +
+          "Call this before workspace_create to discover available projects and their projectPath values.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        try {
+          const projects = await this.handlers.listProjects();
+          return this.successResult(projects);
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
     // workspace_create
     mcpServer.registerTool(
       "workspace_create",
       {
         description:
-          "Create a new workspace in the same project as the caller. Returns the created workspace.",
+          "Create a new workspace in the specified project. " +
+          "Requires projectPath — use project_list to discover available projects. " +
+          "Returns the created workspace.",
         inputSchema: z.object({
+          projectPath: z
+            .string()
+            .min(1)
+            .describe(
+              "Project path to create the workspace in. Use project_list to discover available projects."
+            ),
           name: z.string().min(1).describe("Name for the new workspace (becomes branch name)"),
           base: z.string().min(1).describe("Base branch to create the workspace from"),
           initialPrompt: initialPromptSchema
@@ -469,11 +499,9 @@ export class McpServer implements IMcpServer {
       },
       async (args, extra) => {
         const workspacePath = this.getWorkspacePathFromExtra(extra);
-        if (!workspacePath) {
-          return this.errorResult("workspace-not-found", "Missing workspace path");
-        }
 
         try {
+          const projectPath = args.projectPath as string;
           const name = args.name as string;
           const base = args.base as string;
           const rawInitialPrompt = args.initialPrompt as
@@ -490,7 +518,7 @@ export class McpServer implements IMcpServer {
 
             // If no model specified, try to get caller's current model
             let model = normalized.model;
-            if (!model) {
+            if (!model && workspacePath) {
               model = await this.getCallerModel(workspacePath);
             }
 
@@ -504,9 +532,8 @@ export class McpServer implements IMcpServer {
             }
           }
 
-          // Create workspace with callerWorkspacePath (intent resolves project)
           const result = await this.handlers.createWorkspace({
-            callerWorkspacePath: workspacePath,
+            projectPath,
             name,
             base,
             ...(finalPrompt !== undefined && { initialPrompt: finalPrompt }),
@@ -603,7 +630,7 @@ export class McpServer implements IMcpServer {
       }
     );
 
-    this.logger.debug("Registered tools", { count: 9 });
+    this.logger.debug("Registered tools", { count: 10 });
   }
 
   /**

--- a/src/services/mcp-server/tools.test.ts
+++ b/src/services/mcp-server/tools.test.ts
@@ -65,6 +65,7 @@ function createMockHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(null),
     restartAgentServer: vi.fn().mockResolvedValue(14001),
+    listProjects: vi.fn().mockResolvedValue([]),
     createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
     deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),
@@ -175,6 +176,32 @@ function createToolHandlers(handlers: McpApiHandlers) {
           args.command,
           args.args
         );
+        return successResult(result);
+      } catch (error) {
+        return handleError(error);
+      }
+    },
+
+    project_list: async (): Promise<ToolResult> => {
+      try {
+        const projects = await handlers.listProjects();
+        return successResult(projects);
+      } catch (error) {
+        return handleError(error);
+      }
+    },
+
+    workspace_create: async (
+      _context: SimulatedToolContext,
+      args: { projectPath: string; name: string; base: string; stealFocus?: boolean }
+    ): Promise<ToolResult> => {
+      try {
+        const result = await handlers.createWorkspace({
+          projectPath: args.projectPath,
+          name: args.name,
+          base: args.base,
+          stealFocus: args.stealFocus ?? false,
+        });
         return successResult(result);
       } catch (error) {
         return handleError(error);
@@ -619,6 +646,119 @@ describe("MCP Tools", () => {
       if (!parsed.success) {
         expect(parsed.error.code).toBe("internal-error");
         expect(parsed.error.message).toBe("Command timed out");
+      }
+    });
+  });
+
+  describe("project_list", () => {
+    it("returns projects from handler", async () => {
+      const mockProjects = [
+        { id: "proj-1", name: "my-project", path: "/projects/my-project", workspaces: [] },
+      ];
+      const mockHandlers = createMockHandlers({
+        listProjects: vi.fn().mockResolvedValue(mockProjects),
+      });
+
+      const toolHandlers = createToolHandlers(mockHandlers);
+
+      const result = await toolHandlers.project_list();
+      const parsed = parseToolResult<typeof mockProjects>(result);
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data).toEqual(mockProjects);
+      }
+    });
+
+    it("returns empty array when no projects open", async () => {
+      const mockHandlers = createMockHandlers();
+      const toolHandlers = createToolHandlers(mockHandlers);
+
+      const result = await toolHandlers.project_list();
+      const parsed = parseToolResult<unknown[]>(result);
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data).toEqual([]);
+      }
+    });
+
+    it("propagates errors", async () => {
+      const mockHandlers = createMockHandlers({
+        listProjects: vi.fn().mockRejectedValue(new Error("List failed")),
+      });
+      const toolHandlers = createToolHandlers(mockHandlers);
+
+      const result = await toolHandlers.project_list();
+      const parsed = parseToolResult<unknown>(result);
+
+      expect(parsed.success).toBe(false);
+      if (!parsed.success) {
+        expect(parsed.error.code).toBe("internal-error");
+      }
+    });
+  });
+
+  describe("workspace_create", () => {
+    it("calls handler with projectPath", async () => {
+      const mockWorkspace = { name: "feature", path: "/workspaces/feature" };
+      const createMock = vi.fn().mockResolvedValue(mockWorkspace);
+      const mockHandlers = createMockHandlers({ createWorkspace: createMock });
+      const toolHandlers = createToolHandlers(mockHandlers);
+      const context = createContext();
+
+      const result = await toolHandlers.workspace_create(context, {
+        projectPath: "/projects/my-project",
+        name: "feature",
+        base: "main",
+      });
+      const parsed = parseToolResult<typeof mockWorkspace>(result);
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data).toEqual(mockWorkspace);
+      }
+      expect(createMock).toHaveBeenCalledWith({
+        projectPath: "/projects/my-project",
+        name: "feature",
+        base: "main",
+        stealFocus: false,
+      });
+    });
+
+    it("passes stealFocus when provided", async () => {
+      const createMock = vi.fn().mockResolvedValue({ name: "ws", path: "/ws" });
+      const mockHandlers = createMockHandlers({ createWorkspace: createMock });
+      const toolHandlers = createToolHandlers(mockHandlers);
+      const context = createContext();
+
+      await toolHandlers.workspace_create(context, {
+        projectPath: "/projects/my-project",
+        name: "ws",
+        base: "main",
+        stealFocus: true,
+      });
+
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ stealFocus: true }));
+    });
+
+    it("propagates errors", async () => {
+      const mockHandlers = createMockHandlers({
+        createWorkspace: vi.fn().mockRejectedValue(new Error("Create failed")),
+      });
+      const toolHandlers = createToolHandlers(mockHandlers);
+      const context = createContext();
+
+      const result = await toolHandlers.workspace_create(context, {
+        projectPath: "/projects/my-project",
+        name: "ws",
+        base: "main",
+      });
+      const parsed = parseToolResult<unknown>(result);
+
+      expect(parsed.success).toBe(false);
+      if (!parsed.success) {
+        expect(parsed.error.code).toBe("internal-error");
       }
     });
   });

--- a/src/services/mcp-server/types.ts
+++ b/src/services/mcp-server/types.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceStatus,
   AgentSession,
   Workspace,
+  Project,
   InitialPrompt,
 } from "../../shared/api/types";
 
@@ -46,8 +47,9 @@ export interface McpApiHandlers {
   setMetadata(workspacePath: string, key: string, value: string | null): Promise<void>;
   getAgentSession(workspacePath: string): Promise<AgentSession | null>;
   restartAgentServer(workspacePath: string): Promise<number>;
+  listProjects(): Promise<readonly Project[]>;
   createWorkspace(options: {
-    callerWorkspacePath: string;
+    projectPath: string;
     name: string;
     base: string;
     initialPrompt?: InitialPrompt;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -99,7 +99,7 @@ export interface ProjectPathPayload {
 
 /** workspaces.create */
 export interface WorkspaceCreatePayload {
-  readonly projectPath?: string;
+  readonly projectPath: string;
   readonly name: string;
   readonly base: string;
   /** Optional initial prompt to send after workspace is created */
@@ -107,8 +107,6 @@ export interface WorkspaceCreatePayload {
   /** If true, steal focus from current workspace. If false, don't steal focus but still
    *  switch when no workspace is active. Default: switch (undefined treated as true). */
   readonly stealFocus?: boolean;
-  /** Workspace path of the calling workspace (Plugin API / MCP alternative to projectId) */
-  readonly callerWorkspacePath?: string;
 }
 
 /** workspaces.remove */


### PR DESCRIPTION
- Add `project_list` MCP tool that returns all open projects, enabling agents to discover available projects before creating workspaces
- Update `workspace_create` MCP tool to accept `projectPath` directly instead of resolving from caller workspace
- Remove `callerWorkspacePath` indirection from `OpenWorkspacePayload` — `projectPath` is now required
- Remove `resolve-caller` hook from git-worktree-workspace-module
- Plugin API `create()` now resolves project via `workspace:resolve` dispatch before opening workspace