### PR TITLE
fix(telemetry): restore telemetry in production by removing config seed loop

### DIFF
--- a/src/main/modules/config-module.integration.test.ts
+++ b/src/main/modules/config-module.integration.test.ts
@@ -600,8 +600,8 @@ describe("ConfigModule Integration", () => {
       expect(result).not.toHaveProperty("scripts");
     });
 
-    it("no config:updated when merged config matches defaults (production)", async () => {
-      // isPackaged=true + isDevelopment=false → no computed defaults differ from static defaults
+    it("emits all keys including static defaults on first dispatch (production)", async () => {
+      // isPackaged=true + isDevelopment=false → all values emitted (no seed to suppress them)
       const { dispatcher } = createTestSetup({ isDevelopment: false, isPackaged: true });
 
       const events: ConfigUpdatedEvent[] = [];
@@ -614,8 +614,11 @@ describe("ConfigModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      // Dispatch happens but no values changed → no config:updated event
-      expect(events).toHaveLength(0);
+      // All keys are emitted on first dispatch — subscribers need full initial config
+      expect(events).toHaveLength(1);
+      const values = events[0]!.payload.values;
+      expect(values).toHaveProperty("test.string");
+      expect(values).toHaveProperty("test.level");
     });
   });
 
@@ -648,12 +651,13 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
 
       expect(result.configuredAgent).toBe("claude");
-      // Only init should produce changes (agent, test.nullable, test.enum from file)
-      const initEvents = events.filter((e) => e.payload.values.agent !== undefined);
-      expect(initEvents).toHaveLength(1);
-      expect(initEvents[0]!.payload.values.agent).toBe("claude");
-      expect(initEvents[0]!.payload.values["test.nullable"]).toBe("custom-val");
-      expect(initEvents[0]!.payload.values["test.enum"]).toBe("never");
+      // First event: before-ready emits all defaults; second: init emits file delta
+      expect(events).toHaveLength(2);
+      // Init delta contains file values that differ from defaults
+      const initEvent = events[1]!;
+      expect(initEvent.payload.values.agent).toBe("claude");
+      expect(initEvent.payload.values["test.nullable"]).toBe("custom-val");
+      expect(initEvent.payload.values["test.enum"]).toBe("never");
     });
 
     it("enum value from config.json round-trips through init", async () => {
@@ -674,9 +678,10 @@ describe("ConfigModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      const enumEvents = events.filter((e) => e.payload.values["test.enum"] !== undefined);
-      expect(enumEvents).toHaveLength(1);
-      expect(enumEvents[0]!.payload.values["test.enum"]).toBe("never");
+      // before-ready emits default "always", init emits file override "never"
+      expect(events).toHaveLength(2);
+      expect(events[0]!.payload.values["test.enum"]).toBe("always");
+      expect(events[1]!.payload.values["test.enum"]).toBe("never");
     });
 
     it("returns configuredAgent from effective config", async () => {
@@ -709,7 +714,8 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
 
       expect(result.configuredAgent).toBeNull();
-      expect(events).toHaveLength(0);
+      // before-ready emits all defaults; init has no delta (no file)
+      expect(events).toHaveLength(1);
     });
 
     it("uses defaults when config.json is corrupt JSON", async () => {
@@ -730,7 +736,8 @@ describe("ConfigModule Integration", () => {
       } as AppStartIntent)) as unknown as { configuredAgent?: string | null };
 
       expect(result.configuredAgent).toBeNull();
-      expect(events).toHaveLength(0);
+      // before-ready emits all defaults; init has no delta (corrupt file ignored)
+      expect(events).toHaveLength(1);
     });
   });
 
@@ -998,7 +1005,7 @@ describe("ConfigModule Integration", () => {
       expect(devFlagEvent!.payload.values["test.dev-flag"]).toBe(false);
     });
 
-    it("isPackaged=true and isDevelopment=false leaves static defaults unchanged", async () => {
+    it("isPackaged=true and isDevelopment=false emits all defaults then no init delta", async () => {
       const { dispatcher } = createTestSetup({ isDevelopment: false, isPackaged: true });
 
       dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation());
@@ -1011,9 +1018,9 @@ describe("ConfigModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      // No computed defaults override static defaults, and file defaults match static defaults.
-      // No changes should be emitted.
-      expect(events).toHaveLength(0);
+      // before-ready emits all keys (including static defaults); init has no delta
+      expect(events).toHaveLength(1);
+      expect(events[0]!.payload.values).toHaveProperty("test.string");
     });
 
     it("config file overrides computed defaults", async () => {

--- a/src/main/modules/config-module.ts
+++ b/src/main/modules/config-module.ts
@@ -338,11 +338,6 @@ export function createConfigModule(deps: ConfigModuleDeps): IntentModule {
               definitionMap.set(def.name, def);
             }
 
-            // Seed effective with static defaults so first dispatch only reports actual changes
-            for (const [key, def] of definitionMap) {
-              effective[key] = def.default;
-            }
-
             // Build defaults (static + computed)
             const computedDefaultCtx: ComputedDefaultContext = {
               isDevelopment: deps.isDevelopment,

--- a/src/main/modules/telemetry-module.integration.test.ts
+++ b/src/main/modules/telemetry-module.integration.test.ts
@@ -328,24 +328,17 @@ describe("TelemetryModule Integration", () => {
       }
     });
 
-    it("generates distinctId and dispatches config:set-values when no id yet", async () => {
-      const { dispatcher, tracking, configureCalls } = createTestSetup();
+    it("does not generate distinctId during config:updated (deferred to start hook)", async () => {
+      const { dispatcher, configureCalls } = createTestSetup();
 
-      // Telemetry enabled but no distinctId
+      // Telemetry enabled but no distinctId — ID generation is deferred to start hook
       await dispatcher.dispatch(configSetValuesIntent({ "telemetry.enabled": true }));
 
-      // First configure call from the initial event
-      expect(configureCalls).toHaveLength(2);
-      // First: from the initial config:updated
+      // Only one configure call from config:updated (no nested dispatch for ID generation)
+      expect(configureCalls).toHaveLength(1);
       expect(configureCalls[0]).toEqual({
         enabled: true,
         distinctId: undefined,
-        agent: undefined,
-      });
-      // Second: from the nested config:set-values dispatch that set the generated id
-      expect(configureCalls[1]).toEqual({
-        enabled: true,
-        distinctId: tracking.generateDistinctIdResult,
         agent: undefined,
       });
     });
@@ -420,6 +413,50 @@ describe("TelemetryModule Integration", () => {
 
       await dispatcher.dispatch(configSetValuesIntent({ agent: "opencode" }));
       await dispatcher.dispatch(startIntent());
+    });
+
+    it("generates distinctId during start hook when telemetry enabled and no id", async () => {
+      const { dispatcher, tracking, configureCalls } = createTestSetup();
+
+      // Simulate config:updated with telemetry enabled but no distinctId
+      await dispatcher.dispatch(
+        configSetValuesIntent({ "telemetry.enabled": true, agent: "claude" })
+      );
+
+      // Only the initial configure call — no ID generation yet
+      expect(configureCalls).toHaveLength(1);
+      expect(configureCalls[0]!.distinctId).toBeUndefined();
+
+      // Start hook triggers ID generation
+      await dispatcher.dispatch(startIntent());
+
+      // Start hook calls configure directly (2nd), then dispatches config:set-values
+      // which triggers config:updated → configure again (3rd)
+      expect(configureCalls).toHaveLength(3);
+      expect(configureCalls[1]).toEqual({
+        enabled: true,
+        distinctId: tracking.generateDistinctIdResult,
+        agent: "claude",
+      });
+    });
+
+    it("stored distinct-id from init takes precedence over generation", async () => {
+      const { dispatcher, configureCalls } = createTestSetup();
+
+      // Simulate init loading stored ID via config:updated
+      await dispatcher.dispatch(
+        configSetValuesIntent({
+          "telemetry.enabled": true,
+          "telemetry.distinct-id": "stored-id-from-config",
+          agent: "opencode",
+        })
+      );
+
+      await dispatcher.dispatch(startIntent());
+
+      // No additional configure call from start hook — ID already exists
+      expect(configureCalls).toHaveLength(1);
+      expect(configureCalls[0]!.distinctId).toBe("stored-id-from-config");
     });
   });
 

--- a/src/main/modules/telemetry-module.ts
+++ b/src/main/modules/telemetry-module.ts
@@ -3,7 +3,7 @@
  *
  * Hooks:
  * - app:start → "before-ready": registers global error handlers (only if telemetry.enabled)
- * - app:start → "start": captures "app_launched" event with platform/agent info
+ * - app:start → "start": generates distinct ID if needed, captures "app_launched" event
  * - app:shutdown → "stop": flushes and shuts down telemetry service (best-effort)
  *
  * Events:
@@ -81,6 +81,23 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
         },
         start: {
           handler: async (): Promise<StartHookResult> => {
+            // Generate distinctId if needed (after init has loaded stored config)
+            if (telemetryEnabled && !distinctId && deps.telemetryService) {
+              const newId = deps.telemetryService.generateDistinctId();
+              if (newId) {
+                distinctId = newId;
+                deps.telemetryService.configure({
+                  enabled: telemetryEnabled,
+                  distinctId: newId,
+                  agent: configuredAgent ?? undefined,
+                });
+                await deps.dispatcher.dispatch({
+                  type: INTENT_CONFIG_SET_VALUES,
+                  payload: { values: { "telemetry.distinct-id": newId } },
+                } as ConfigSetValuesIntent);
+              }
+            }
+
             if (configuredAgent !== undefined) {
               deps.telemetryService?.capture("app_launched", {
                 platform: deps.platformInfo.platform,
@@ -115,8 +132,9 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
           telemetryEnabled = values["telemetry.enabled"] as boolean;
         }
 
-        if (values["telemetry.distinct-id"] !== undefined) {
-          distinctId = values["telemetry.distinct-id"] as string;
+        const rawDistinctId = values["telemetry.distinct-id"];
+        if (typeof rawDistinctId === "string") {
+          distinctId = rawDistinctId;
         }
 
         // Configure telemetry service when relevant values arrive
@@ -130,18 +148,6 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
           // Register error handlers when telemetry is enabled
           if (telemetryEnabled) {
             registerErrorHandlers();
-          }
-
-          // Generate distinctId if telemetry is enabled but no id yet
-          if (telemetryEnabled && !distinctId) {
-            const newId = deps.telemetryService.generateDistinctId();
-            if (newId) {
-              distinctId = newId;
-              void deps.dispatcher.dispatch({
-                type: INTENT_CONFIG_SET_VALUES,
-                payload: { values: { "telemetry.distinct-id": newId } },
-              } as ConfigSetValuesIntent);
-            }
           }
         }
       },


### PR DESCRIPTION
- Remove config module's seed loop that pre-populated `effective` with static defaults, suppressing keys matching their default from `config:updated`
- Move distinct-id generation from `config:updated` event handler to `start` hook to avoid racing with `init`'s config.json read
- Fix null handling for `telemetry.distinct-id` (use `typeof` check instead of `!== undefined`)
- Update config-module and telemetry-module integration tests