### PR TITLE
feat: warn about unmerged commits when deleting workspace

### DIFF
--- a/src/main/modules/code-server-module.integration.test.ts
+++ b/src/main/modules/code-server-module.integration.test.ts
@@ -1080,7 +1080,7 @@ describe("CodeServerModule", () => {
     });
 
     it("getStatus dispatches correct intent", async () => {
-      const status = { isDirty: false, agent: { type: "none" as const } };
+      const status = { isDirty: false, unmergedCommits: 0, agent: { type: "none" as const } };
       const { handlers, mockDispatch } = await setupPluginHandlers(status);
 
       const result = await handlers.getStatus(testWorkspacePath);

--- a/src/main/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/main/modules/git-worktree-workspace-module.integration.test.ts
@@ -52,6 +52,7 @@ function createMockGitWorktreeProvider() {
     createWorkspace: vi.fn(),
     removeWorkspace: vi.fn().mockResolvedValue({ workspaceRemoved: true, baseDeleted: false }),
     isDirty: vi.fn().mockResolvedValue(false),
+    countUnmergedCommits: vi.fn().mockResolvedValue(0),
     listBases: vi.fn().mockResolvedValue([]),
     defaultBase: vi.fn().mockResolvedValue(undefined),
     updateBases: vi.fn().mockResolvedValue(undefined),
@@ -217,6 +218,7 @@ class MinimalGetProjectBasesOperation implements Operation<Intent, GetProjectBas
 /** Result from get-workspace-status: resolve-workspace + get. */
 interface GetStatusResult {
   readonly isDirty?: boolean;
+  readonly unmergedCommits?: number;
 }
 
 /**
@@ -247,10 +249,14 @@ class MinimalGetStatusOperation implements Operation<Intent, GetStatusResult> {
     if (errors.length > 0) throw errors[0]!;
 
     let isDirty = false;
+    let unmergedCommits = 0;
     for (const result of results) {
       if (result.isDirty) isDirty = true;
+      if (result.unmergedCommits !== undefined && result.unmergedCommits > unmergedCommits) {
+        unmergedCommits = result.unmergedCommits;
+      }
     }
-    return { isDirty };
+    return { isDirty, unmergedCommits };
   }
 }
 

--- a/src/main/modules/git-worktree-workspace-module.ts
+++ b/src/main/modules/git-worktree-workspace-module.ts
@@ -359,7 +359,8 @@ export function createGitWorktreeWorkspaceModule(
           handler: async (ctx: HookContext): Promise<GetStatusHookResult> => {
             const { workspacePath: wsPath } = ctx as GetStatusHookInput;
             const isDirty = await globalProvider.isDirty(new Path(wsPath));
-            return { isDirty };
+            const unmergedCommits = await globalProvider.countUnmergedCommits(new Path(wsPath));
+            return { isDirty, unmergedCommits };
           },
         },
       },

--- a/src/main/modules/ipc-event-bridge.integration.test.ts
+++ b/src/main/modules/ipc-event-bridge.integration.test.ts
@@ -216,6 +216,7 @@ describe("IpcEventBridge - agent:status-updated", () => {
         path: TEST_WORKSPACE_PATH,
         status: {
           isDirty: false,
+          unmergedCommits: 0,
           agent: { type: "idle", counts: { idle: 2, busy: 0, total: 2 } },
         },
       });
@@ -235,6 +236,7 @@ describe("IpcEventBridge - agent:status-updated", () => {
         path: TEST_WORKSPACE_PATH,
         status: {
           isDirty: false,
+          unmergedCommits: 0,
           agent: { type: "busy", counts: { idle: 0, busy: 3, total: 3 } },
         },
       });
@@ -254,6 +256,7 @@ describe("IpcEventBridge - agent:status-updated", () => {
         path: TEST_WORKSPACE_PATH,
         status: {
           isDirty: false,
+          unmergedCommits: 0,
           agent: { type: "mixed", counts: { idle: 1, busy: 2, total: 3 } },
         },
       });
@@ -273,6 +276,7 @@ describe("IpcEventBridge - agent:status-updated", () => {
         path: TEST_WORKSPACE_PATH,
         status: {
           isDirty: false,
+          unmergedCommits: 0,
           agent: { type: "none" },
         },
       });

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -237,9 +237,10 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
 
       const status: WorkspaceStatus =
         aggregatedStatus.status === "none"
-          ? { isDirty: false, agent: { type: "none" } }
+          ? { isDirty: false, unmergedCommits: 0, agent: { type: "none" } }
           : {
               isDirty: false,
+              unmergedCommits: 0,
               agent: {
                 type: aggregatedStatus.status,
                 counts: {

--- a/src/main/modules/mcp-handlers.integration.test.ts
+++ b/src/main/modules/mcp-handlers.integration.test.ts
@@ -74,6 +74,7 @@ function createTestSetup() {
     INTENT_GET_WORKSPACE_STATUS,
     createCapturingOperation(GET_WORKSPACE_STATUS_OPERATION_ID, capturedIntents, {
       isDirty: false,
+      unmergedCommits: 0,
       agent: { type: "none" as const },
     })
   );
@@ -151,7 +152,7 @@ describe("createMcpHandlers", () => {
       expect(capturedIntents).toHaveLength(1);
       expect(capturedIntents[0]!.type).toBe(INTENT_GET_WORKSPACE_STATUS);
       expect(capturedIntents[0]!.payload).toEqual({ workspacePath: "/workspace/path" });
-      expect(result).toEqual({ isDirty: false, agent: { type: "none" } });
+      expect(result).toEqual({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } });
     });
   });
 

--- a/src/main/operations/get-workspace-status.integration.test.ts
+++ b/src/main/operations/get-workspace-status.integration.test.ts
@@ -261,6 +261,67 @@ describe("GetWorkspaceStatus Operation", () => {
     });
   });
 
+  describe("unmerged commits (#3)", () => {
+    it("returns unmergedCommits from hook result", async () => {
+      const hookRegistry = new HookRegistry();
+      const dispatcher = new Dispatcher(hookRegistry);
+      const workspaceName = extractWorkspaceName(WORKSPACE_PATH) as WorkspaceName;
+
+      dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
+      dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+
+      const resolveModule: IntentModule = {
+        name: "test",
+        hooks: {
+          [RESOLVE_WORKSPACE_OPERATION_ID]: {
+            resolve: {
+              handler: async (): Promise<ResolveHookResult> => ({
+                projectPath: PROJECT_ROOT,
+                workspaceName,
+              }),
+            },
+          },
+        },
+      };
+
+      const unmergedModule: IntentModule = {
+        name: "test",
+        hooks: {
+          [GET_WORKSPACE_STATUS_OPERATION_ID]: {
+            get: {
+              handler: async (): Promise<GetStatusHookResult> => ({
+                isDirty: false,
+                unmergedCommits: 3,
+              }),
+            },
+          },
+        },
+      };
+
+      dispatcher.registerModule(resolveModule);
+      dispatcher.registerModule(unmergedModule);
+
+      const result = (await dispatcher.dispatch(statusIntent(WORKSPACE_PATH))) as WorkspaceStatus;
+
+      expect(result.unmergedCommits).toBe(3);
+    });
+
+    it("defaults unmergedCommits to 0 when not provided", async () => {
+      const setup = createTestSetup({
+        workspaceProvider: createMockWorkspaceProvider({
+          [WORKSPACE_PATH]: false,
+        }),
+        agentStatusManager: null,
+      });
+
+      const result = (await setup.dispatcher.dispatch(
+        statusIntent(WORKSPACE_PATH)
+      )) as WorkspaceStatus;
+
+      expect(result.unmergedCommits).toBe(0);
+    });
+  });
+
   describe("no workspace provider", () => {
     it("returns isDirty false when no provider", async () => {
       const setup = createTestSetup({

--- a/src/main/operations/get-workspace-status.ts
+++ b/src/main/operations/get-workspace-status.ts
@@ -49,6 +49,7 @@ export interface GetStatusHookInput extends HookContext {
  */
 export interface GetStatusHookResult {
   readonly isDirty?: boolean;
+  readonly unmergedCommits?: number;
   readonly agentStatus?: AggregatedAgentStatus;
 }
 
@@ -81,12 +82,16 @@ export class GetWorkspaceStatusOperation implements Operation<
       throw new AggregateError(errors, "get-workspace-status get hooks failed");
     }
 
-    // Merge results — isDirty uses OR (any hook says dirty = dirty)
+    // Merge results — isDirty uses OR, unmergedCommits uses max
     let isDirty = false;
+    let unmergedCommits = 0;
     let agentStatus: AggregatedAgentStatus | undefined;
 
     for (const result of results) {
       if (result.isDirty) isDirty = true;
+      if (result.unmergedCommits !== undefined && result.unmergedCommits > unmergedCommits) {
+        unmergedCommits = result.unmergedCommits;
+      }
       if (result.agentStatus !== undefined) agentStatus = result.agentStatus;
     }
 
@@ -97,6 +102,7 @@ export class GetWorkspaceStatusOperation implements Operation<
 
     return {
       isDirty,
+      unmergedCommits,
       agent:
         finalAgentStatus.status === "none"
           ? { type: "none" }

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -18,7 +18,9 @@ const { mockApi, eventCallbacks } = vi.hoisted(() => {
       workspaces: {
         create: vi.fn().mockResolvedValue({}),
         remove: vi.fn().mockResolvedValue({ branchDeleted: true }),
-        getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+        getStatus: vi
+          .fn()
+          .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
         get: vi.fn().mockResolvedValue(undefined),
       },
       projects: {

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -29,7 +29,9 @@ const mockApi = vi.hoisted(() => ({
   workspaces: {
     create: vi.fn().mockResolvedValue({}),
     remove: vi.fn().mockResolvedValue({ branchDeleted: true }),
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     get: vi.fn().mockResolvedValue(undefined),
   },
   // Flat API structure - ui namespace

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -35,7 +35,9 @@ const mockApi = vi.hoisted(() => ({
   workspaces: {
     create: vi.fn().mockResolvedValue({}),
     remove: vi.fn().mockResolvedValue({ started: true }),
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     get: vi.fn().mockResolvedValue(undefined),
   },
   // Flat API structure - ui namespace

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
@@ -3,6 +3,7 @@
   import Icon from "./Icon.svelte";
   import { workspaces, type WorkspaceRef } from "$lib/api";
   import { closeDialog } from "$lib/stores/dialogs.svelte.js";
+  import { getAllWorkspaces } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
 
   const logger = createLogger("ui");
@@ -17,29 +18,38 @@
   // Form state
   let keepBranch = $state(false);
   let isDirty = $state(false);
-  let isCheckingDirty = $state(true);
+  let unmergedCommits = $state(0);
+  let isCheckingStatus = $state(true);
 
   // Extract workspace name from ref
   const workspaceName = $derived(workspaceRef.workspaceName);
 
-  // Check dirty status on mount
+  // Get the base branch name from workspace metadata
+  const baseBranch = $derived(() => {
+    const ws = getAllWorkspaces().find((w) => w.path === workspaceRef.path);
+    return ws?.metadata?.base;
+  });
+
+  // Check workspace status on mount
   $effect(() => {
     if (!open) return;
 
-    isCheckingDirty = true;
+    isCheckingStatus = true;
     isDirty = false;
+    unmergedCommits = 0;
 
     workspaces
       .getStatus(workspaceRef.path)
       .then((status) => {
         isDirty = status.isDirty;
+        unmergedCommits = status.unmergedCommits;
       })
       .catch(() => {
-        // Assume clean on error
         isDirty = false;
+        unmergedCommits = 0;
       })
       .finally(() => {
-        isCheckingDirty = false;
+        isCheckingStatus = false;
       });
   });
 
@@ -86,15 +96,26 @@
       Remove workspace "{workspaceName}"?
     </p>
 
-    {#if isCheckingDirty}
-      <div class="ch-status-message" role="status">Checking for uncommitted changes...</div>
-    {:else if isDirty}
-      <div class="ch-alert-box" role="alert">
-        <span class="ch-alert-box-icon">
-          <Icon name="warning" />
-        </span>
-        This workspace has uncommitted changes that will be lost.
-      </div>
+    {#if isCheckingStatus}
+      <div class="ch-status-message" role="status">Checking workspace status...</div>
+    {:else}
+      {#if isDirty}
+        <div class="ch-alert-box" role="alert">
+          <span class="ch-alert-box-icon">
+            <Icon name="warning" />
+          </span>
+          This workspace has uncommitted changes that will be lost.
+        </div>
+      {/if}
+      {#if unmergedCommits > 0}
+        <div class="ch-alert-box" role="alert">
+          <span class="ch-alert-box-icon">
+            <Icon name="warning" />
+          </span>
+          This branch has {unmergedCommits} commit{unmergedCommits === 1 ? "" : "s"} not merged into {baseBranch() ??
+            "base"}.
+        </div>
+      {/if}
     {/if}
 
     <div class="ch-checkbox-row">

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
@@ -40,6 +40,19 @@ vi.mock("$lib/stores/dialogs.svelte.js", () => ({
   closeDialog: mockCloseDialog,
 }));
 
+// Mock $lib/stores/projects.svelte.js
+vi.mock("$lib/stores/projects.svelte.js", () => ({
+  getAllWorkspaces: () => [
+    {
+      name: "feature-branch",
+      path: "/test/project/.worktrees/feature-branch",
+      branch: "feature-branch",
+      metadata: { base: "main" },
+      projectId: "test-project-12345678",
+    },
+  ],
+}));
+
 // Import component after mocks
 import RemoveWorkspaceDialog from "./RemoveWorkspaceDialog.svelte";
 import { workspaces } from "$lib/api";
@@ -76,7 +89,11 @@ describe("RemoveWorkspaceDialog component", () => {
     // Fire-and-forget API returns { started: true }
     mockRemoveWorkspace.mockResolvedValue({ started: true });
     // v2 API returns WorkspaceStatus
-    mockGetStatus.mockResolvedValue({ isDirty: false, agent: { type: "none" } });
+    mockGetStatus.mockResolvedValue({
+      isDirty: false,
+      unmergedCommits: 0,
+      agent: { type: "none" },
+    });
   });
 
   afterEach(() => {
@@ -114,19 +131,22 @@ describe("RemoveWorkspaceDialog component", () => {
   });
 
   describe("dirty status", () => {
-    it("loads dirty status using workspaces.getStatus on mount", async () => {
+    it("loads status using workspaces.getStatus on mount", async () => {
       render(RemoveWorkspaceDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
       expect(workspaces.getStatus).toHaveBeenCalledWith(testWorkspaceRef.path);
     });
 
-    it("shows spinner while checking dirty status", async () => {
+    it("shows spinner while checking status", async () => {
       // Delay the API response - v2 returns WorkspaceStatus object
       mockGetStatus.mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ isDirty: false, agent: { type: "none" } }), 1000)
+            setTimeout(
+              () => resolve({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
+              1000
+            )
           )
       );
 
@@ -138,7 +158,11 @@ describe("RemoveWorkspaceDialog component", () => {
     });
 
     it("shows warning box when workspace is dirty", async () => {
-      mockGetStatus.mockResolvedValue({ isDirty: true, agent: { type: "none" } });
+      mockGetStatus.mockResolvedValue({
+        isDirty: true,
+        unmergedCommits: 0,
+        agent: { type: "none" },
+      });
 
       render(RemoveWorkspaceDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
@@ -147,7 +171,11 @@ describe("RemoveWorkspaceDialog component", () => {
     });
 
     it("hides warning box when workspace is clean", async () => {
-      mockGetStatus.mockResolvedValue({ isDirty: false, agent: { type: "none" } });
+      mockGetStatus.mockResolvedValue({
+        isDirty: false,
+        unmergedCommits: 0,
+        agent: { type: "none" },
+      });
 
       render(RemoveWorkspaceDialog, { props: defaultProps });
       await vi.runAllTimersAsync();

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -39,7 +39,9 @@ const mockApi = vi.hoisted(() => ({
   workspaces: {
     create: vi.fn().mockResolvedValue({}),
     remove: vi.fn().mockResolvedValue({ branchDeleted: true }),
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     get: vi.fn().mockResolvedValue(undefined),
   },
   projects: {

--- a/src/renderer/lib/utils/domain-events.test.ts
+++ b/src/renderer/lib/utils/domain-events.test.ts
@@ -165,6 +165,7 @@ describe("setupDomainEvents", () => {
 
       const status = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "idle" as const, counts: { idle: 1, busy: 0, total: 1 } },
       };
       const event = { ...TEST_WORKSPACE_REF, status };
@@ -286,6 +287,7 @@ describe("setupDomainEvents", () => {
 
       const status = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "idle" as const, counts: { idle: 1, busy: 0, total: 1 } },
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });
@@ -306,6 +308,7 @@ describe("setupDomainEvents", () => {
 
       const status = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "none" as const },
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });
@@ -342,6 +345,7 @@ describe("setupDomainEvents", () => {
 
       const status = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "busy" as const, counts: { idle: 0, busy: 2, total: 2 } },
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });

--- a/src/renderer/lib/utils/initialize-app.test.ts
+++ b/src/renderer/lib/utils/initialize-app.test.ts
@@ -49,6 +49,7 @@ const TEST_PROJECT: Project = {
 
 const TEST_STATUS: WorkspaceStatus = {
   isDirty: false,
+  unmergedCommits: 0,
   agent: { type: "idle", counts: { idle: 1, busy: 0, total: 1 } },
 };
 

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -275,6 +275,7 @@ describe("setupDomainEventBindings", () => {
 
       const status: WorkspaceStatus = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "idle", counts: { idle: 1, busy: 0, total: 1 } },
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });
@@ -288,6 +289,7 @@ describe("setupDomainEventBindings", () => {
 
       const status: WorkspaceStatus = {
         isDirty: false,
+        unmergedCommits: 0,
         agent: { type: "none" },
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });

--- a/src/services/git/git-client.state-mock.ts
+++ b/src/services/git/git-client.state-mock.ts
@@ -49,6 +49,7 @@ interface WorktreeState {
   readonly path: string;
   readonly branch: string | null;
   readonly isDirty: boolean;
+  readonly unmergedCommits: number;
 }
 
 /**
@@ -91,6 +92,8 @@ export interface WorktreeInit {
   readonly branch: string | null;
   /** Whether the worktree has uncommitted changes. Defaults to `false`. */
   readonly isDirty?: boolean;
+  /** Number of commits not merged into base. Defaults to `0`. */
+  readonly unmergedCommits?: number;
 }
 
 /**
@@ -283,6 +286,7 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
             path: wtPath,
             branch: wt.branch,
             isDirty: wt.isDirty ?? false,
+            unmergedCommits: wt.unmergedCommits ?? 0,
           });
         }
       }
@@ -393,6 +397,7 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
         path: normalizedWorktreePath,
         branch,
         isDirty: false,
+        unmergedCommits: 0,
       });
     },
 
@@ -632,6 +637,16 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
         isBare: true,
         remoteUrl: url,
       });
+    },
+
+    async countUnmergedCommits(repoPath: Path, branch: string, _base: string): Promise<number> {
+      const repo = getRepoOrThrow(repoPath);
+      for (const wt of repo.worktrees.values()) {
+        if (wt.branch === branch) {
+          return wt.unmergedCommits;
+        }
+      }
+      return 0;
     },
 
     async isBare(repoPath: Path): Promise<boolean> {

--- a/src/services/git/git-client.ts
+++ b/src/services/git/git-client.ts
@@ -194,4 +194,15 @@ export interface IGitClient {
    * @throws GitError if not a git repository
    */
   isBare(repoPath: Path): Promise<boolean>;
+
+  /**
+   * Count commits on a branch that are not reachable from a base ref.
+   * Equivalent to `git rev-list --count <base>..<branch>`.
+   * @param repoPath Absolute path to the git repository
+   * @param branch Branch to count commits on
+   * @param base Base ref to compare against
+   * @returns Promise resolving to the number of unmerged commits
+   * @throws GitError if refs don't exist or not a git repository
+   */
+  countUnmergedCommits(repoPath: Path, branch: string, base: string): Promise<number>;
 }

--- a/src/services/git/git-worktree-provider.integration.test.ts
+++ b/src/services/git/git-worktree-provider.integration.test.ts
@@ -1560,6 +1560,127 @@ describe("GitWorktreeProvider", () => {
     });
   });
 
+  describe("countUnmergedCommits", () => {
+    it("returns count when base is in metadata", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            currentBranch: "main",
+            worktrees: [
+              {
+                name: "feature-x",
+                path: "/data/workspaces/feature-x",
+                branch: "feature-x",
+                unmergedCommits: 5,
+              },
+            ],
+            branchConfigs: { "feature-x": { "codehydra.base": "main" } },
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+      const wsPath = new Path("/data/workspaces/feature-x");
+      provider.ensureWorkspaceRegistered(wsPath, PROJECT_ROOT);
+
+      const count = await provider.countUnmergedCommits(wsPath);
+
+      expect(count).toBe(5);
+    });
+
+    it("returns 0 for detached HEAD", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main"],
+            currentBranch: "main",
+            worktrees: [
+              {
+                name: "detached",
+                path: "/data/workspaces/detached",
+                branch: null,
+              },
+            ],
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+      const wsPath = new Path("/data/workspaces/detached");
+      provider.ensureWorkspaceRegistered(wsPath, PROJECT_ROOT);
+
+      const count = await provider.countUnmergedCommits(wsPath);
+
+      expect(count).toBe(0);
+    });
+
+    it("returns 0 when workspace is not registered", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main"],
+            currentBranch: "main",
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const count = await provider.countUnmergedCommits(new Path("/nonexistent"));
+
+      expect(count).toBe(0);
+    });
+
+    it("falls back to defaultBase when no base in metadata", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            remoteBranches: ["origin/main"],
+            currentBranch: "main",
+            worktrees: [
+              {
+                name: "feature-x",
+                path: "/data/workspaces/feature-x",
+                branch: "feature-x",
+                unmergedCommits: 2,
+              },
+            ],
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+      const wsPath = new Path("/data/workspaces/feature-x");
+      provider.ensureWorkspaceRegistered(wsPath, PROJECT_ROOT);
+
+      const count = await provider.countUnmergedCommits(wsPath);
+
+      expect(count).toBe(2);
+    });
+  });
+
   describe("isMainWorkspace", () => {
     it("returns true for project root path", async () => {
       const mockClient = createMockGitClient({

--- a/src/services/git/git-worktree-provider.ts
+++ b/src/services/git/git-worktree-provider.ts
@@ -603,6 +603,31 @@ export class GitWorktreeProvider {
     return status.isDirty;
   }
 
+  async countUnmergedCommits(workspacePath: Path): Promise<number> {
+    try {
+      const branch = await this.gitClient.getCurrentBranch(workspacePath);
+      if (!branch) return 0;
+
+      const projectRoot = this.workspaceRegistry.get(workspacePath.toString());
+      if (!projectRoot) return 0;
+
+      const metadata = await this.gitClient.getBranchConfigsByPrefix(
+        projectRoot,
+        branch,
+        GitWorktreeProvider.METADATA_CONFIG_PREFIX
+      );
+      let base = metadata.base;
+      if (!base) {
+        base = await this.defaultBase(projectRoot);
+      }
+      if (!base) return 0;
+
+      return await this.gitClient.countUnmergedCommits(projectRoot, branch, base);
+    } catch {
+      return 0;
+    }
+  }
+
   isMainWorkspace(projectRoot: Path, workspacePath: Path): boolean {
     // Use Path.equals() for proper normalized comparison
     return workspacePath.equals(projectRoot);

--- a/src/services/git/simple-git-client.ts
+++ b/src/services/git/simple-git-client.ts
@@ -559,4 +559,17 @@ export class SimpleGitClient implements IGitClient {
       "Failed to check if repository is bare"
     );
   }
+
+  async countUnmergedCommits(repoPath: Path, branch: string, base: string): Promise<number> {
+    return this.wrapGitOperation(
+      async () => {
+        const git = this.getGit(repoPath);
+        const result = await git.raw(["rev-list", "--count", `${base}..${branch}`]);
+        return parseInt(result.trim(), 10);
+      },
+      "countUnmergedCommits",
+      repoPath,
+      `Failed to count unmerged commits for ${branch} against ${base}`
+    );
+  }
 }

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -35,7 +35,9 @@ async function findFreePort(): Promise<number> {
  */
 function createMockMcpHandlers(): McpApiHandlers {
   return {
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(null),

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -38,7 +38,9 @@ async function findFreePort(): Promise<number> {
  */
 function createMockMcpHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers {
   return {
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(14001),

--- a/src/services/mcp-server/tools.test.ts
+++ b/src/services/mcp-server/tools.test.ts
@@ -60,7 +60,9 @@ interface SimulatedToolContext {
  */
 function createMockHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers {
   return {
-    getStatus: vi.fn().mockResolvedValue({ isDirty: false, agent: { type: "none" } }),
+    getStatus: vi
+      .fn()
+      .mockResolvedValue({ isDirty: false, unmergedCommits: 0, agent: { type: "none" } }),
     getMetadata: vi.fn().mockResolvedValue({ base: "main" }),
     setMetadata: vi.fn().mockResolvedValue(undefined),
     getAgentSession: vi.fn().mockResolvedValue(null),
@@ -278,6 +280,7 @@ describe("MCP Tools", () => {
     it("returns correct status format on success", async () => {
       const expectedStatus: WorkspaceStatus = {
         isDirty: true,
+        unmergedCommits: 0,
         agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
       };
 

--- a/src/services/plugin-server/plugin-server.boundary.test.ts
+++ b/src/services/plugin-server/plugin-server.boundary.test.ts
@@ -266,6 +266,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       const handlers = createMockApiHandlers({
         getStatus: {
           isDirty: true,
+          unmergedCommits: 0,
           agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
         },
       });
@@ -286,6 +287,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
         isDirty: true,
+        unmergedCommits: 0,
         agent: { type: "busy", counts: { idle: 0, busy: 1, total: 1 } },
       });
       expect(handlers.getStatus).toHaveBeenCalledWith("/test/workspace");
@@ -478,7 +480,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
           callCount++;
           return Promise.resolve({
             success: true,
-            data: { isDirty: false, agent: { type: "none" } },
+            data: { isDirty: false, unmergedCommits: 0, agent: { type: "none" } },
           });
         }),
       };
@@ -531,7 +533,10 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
             new Promise((resolve) => {
               // This will never resolve before disconnect
               setTimeout(() => {
-                resolve({ success: true, data: { isDirty: false, agent: { type: "none" } } });
+                resolve({
+                  success: true,
+                  data: { isDirty: false, unmergedCommits: 0, agent: { type: "none" } },
+                });
               }, 5000);
             })
         ),

--- a/src/services/plugin-server/plugin-server.test-utils.ts
+++ b/src/services/plugin-server/plugin-server.test-utils.ts
@@ -286,7 +286,11 @@ export interface MockApiHandlersOptions {
  * ```
  */
 export function createMockApiHandlers(options?: MockApiHandlersOptions): ApiCallHandlers {
-  const defaultStatus: WorkspaceStatus = { isDirty: false, agent: { type: "none" } };
+  const defaultStatus: WorkspaceStatus = {
+    isDirty: false,
+    unmergedCommits: 0,
+    agent: { type: "none" },
+  };
   const defaultMetadata: Record<string, string> = { base: "main" };
 
   // Helper to check if value is already a PluginResult

--- a/src/services/plugin-server/plugin-server.test.ts
+++ b/src/services/plugin-server/plugin-server.test.ts
@@ -187,9 +187,10 @@ describe("PluginServer", () => {
 
     it("accepts handler registration without throwing", () => {
       const handlers: ApiCallHandlers = {
-        getStatus: vi
-          .fn()
-          .mockResolvedValue({ success: true, data: { isDirty: false, agent: { type: "none" } } }),
+        getStatus: vi.fn().mockResolvedValue({
+          success: true,
+          data: { isDirty: false, unmergedCommits: 0, agent: { type: "none" } },
+        }),
         getAgentSession: vi.fn().mockResolvedValue({ success: true, data: null }),
         restartAgentServer: vi.fn().mockResolvedValue({ success: true, data: 14001 }),
         getMetadata: vi.fn().mockResolvedValue({ success: true, data: {} }),
@@ -205,9 +206,10 @@ describe("PluginServer", () => {
 
     it("allows handlers to be replaced", () => {
       const handlers1: ApiCallHandlers = {
-        getStatus: vi
-          .fn()
-          .mockResolvedValue({ success: true, data: { isDirty: false, agent: { type: "none" } } }),
+        getStatus: vi.fn().mockResolvedValue({
+          success: true,
+          data: { isDirty: false, unmergedCommits: 0, agent: { type: "none" } },
+        }),
         getAgentSession: vi.fn().mockResolvedValue({ success: true, data: null }),
         restartAgentServer: vi.fn().mockResolvedValue({ success: true, data: 14001 }),
         getMetadata: vi.fn().mockResolvedValue({ success: true, data: {} }),
@@ -244,9 +246,10 @@ describe("PluginServer", () => {
 
     it("should register getAgentSession handler on socket connection", () => {
       const handlers: ApiCallHandlers = {
-        getStatus: vi
-          .fn()
-          .mockResolvedValue({ success: true, data: { isDirty: false, agent: { type: "none" } } }),
+        getStatus: vi.fn().mockResolvedValue({
+          success: true,
+          data: { isDirty: false, unmergedCommits: 0, agent: { type: "none" } },
+        }),
         getAgentSession: vi
           .fn()
           .mockResolvedValue({ success: true, data: { port: 12345, sessionId: "session-abc" } }),

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -233,6 +233,7 @@ export interface WorkspaceRef {
  */
 export interface WorkspaceStatus {
   readonly isDirty: boolean;
+  readonly unmergedCommits: number;
   readonly agent: AgentStatus;
 }
 

--- a/src/shared/test-fixtures.ts
+++ b/src/shared/test-fixtures.ts
@@ -225,6 +225,7 @@ export const MOCK_WORKSPACE_API_DEFAULTS = {
 
   status: {
     isDirty: false,
+    unmergedCommits: 0,
     agent: { type: "none" },
   } as WorkspaceStatus,
 


### PR DESCRIPTION
- Add `countUnmergedCommits` to `IGitClient` and `SimpleGitClient` using `git rev-list --count <base>..<branch>`
- Add `countUnmergedCommits` method to `GitWorktreeProvider` that resolves branch/base and delegates to git client (fail-safe: returns 0 on error)
- Extend `WorkspaceStatus` with `unmergedCommits: number` field
- Extend `GetStatusHookResult` and merge logic to propagate unmerged count through the intent dispatcher
- Update `RemoveWorkspaceDialog` to show unmerged commits warning alongside existing dirty state warning
- Add integration tests for `countUnmergedCommits` in `GitWorktreeProvider` and `GetWorkspaceStatus` operation