### PR TITLE
refactor(auto-pr): replace state file with workspace listing + metadata

### DIFF
--- a/src/main/modules/auto-pr-module.integration.test.ts
+++ b/src/main/modules/auto-pr-module.integration.test.ts
@@ -18,7 +18,7 @@ import { HookRegistry } from "../intents/infrastructure/hook-registry";
 import { Dispatcher } from "../intents/infrastructure/dispatcher";
 
 import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
-import type { Project, WorkspaceName } from "../../shared/api/types";
+import type { Project, ProjectId, WorkspaceName } from "../../shared/api/types";
 import {
   APP_START_OPERATION_ID,
   INTENT_APP_START,
@@ -38,6 +38,7 @@ import {
   type DeleteWorkspaceIntent,
   type WorkspaceDeletedEvent,
 } from "../operations/delete-workspace";
+import { INTENT_LIST_PROJECTS, type ListProjectsIntent } from "../operations/list-projects";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "../operations/set-metadata";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
 import { createMockProcessRunner } from "../../services/platform/process.state-mock";
@@ -173,6 +174,44 @@ class TrackingSetMetadataOperation implements Operation<SetMetadataIntent, void>
   }
 }
 
+/**
+ * Tracking operation for project:list — returns configurable projects with workspace metadata.
+ */
+class TrackingListProjectsOperation implements Operation<ListProjectsIntent, Project[]> {
+  readonly id = "list-projects";
+  projects: Project[] = [];
+
+  async execute(): Promise<Project[]> {
+    return this.projects;
+  }
+}
+
+function autoPrWorkspace(
+  prUrl: string,
+  workspacePath: string,
+  extra?: Record<string, string>
+): Project {
+  return {
+    id: "project-1" as ProjectId,
+    name: "repo",
+    path: "/home/user/projects/repo",
+    workspaces: [
+      {
+        projectId: "project-1" as ProjectId,
+        name: "pr-workspace" as WorkspaceName,
+        branch: "feature",
+        path: workspacePath,
+        metadata: {
+          base: "origin/main",
+          source: "auto-pr",
+          "auto-pr.url": prUrl,
+          ...extra,
+        },
+      },
+    ],
+  };
+}
+
 // =============================================================================
 // GitHub API Response Helpers
 // =============================================================================
@@ -231,6 +270,7 @@ interface TestSetup {
   openWorkspaceOp: TrackingOpenWorkspaceOperation;
   deleteWorkspaceOp: TrackingDeleteWorkspaceOperation;
   setMetadataOp: TrackingSetMetadataOperation;
+  listProjectsOp: TrackingListProjectsOperation;
 }
 
 const DEFAULT_TEMPLATE_PATH = "/data/review.liquid";
@@ -239,7 +279,7 @@ const DEFAULT_TEMPLATE_CONTENT = "Review PR #{{ number }}: {{ title }}";
 function createTestSetup(options?: {
   ghAuthFails?: boolean;
   disabled?: boolean;
-  existingState?: string;
+  dismissedUrls?: string[];
   templatePath?: string | null;
   templateContent?: string;
 }): TestSetup {
@@ -273,8 +313,9 @@ function createTestSetup(options?: {
   const fsEntries: Record<string, ReturnType<typeof file> | ReturnType<typeof directory>> = {
     "/data": directory(),
   };
-  if (options?.existingState) {
-    fsEntries["/data/auto-pr-workspaces.json"] = file(options.existingState);
+  if (options?.dismissedUrls) {
+    const dismissedState = JSON.stringify({ dismissed: options.dismissedUrls });
+    fsEntries["/data/auto-pr-workspaces.json"] = file(dismissedState);
   }
   if (tplPath && tplContent !== undefined) {
     fsEntries[tplPath] = file(tplContent);
@@ -288,6 +329,7 @@ function createTestSetup(options?: {
   const openWorkspaceOp = new TrackingOpenWorkspaceOperation();
   const deleteWorkspaceOp = new TrackingDeleteWorkspaceOperation();
   const setMetadataOp = new TrackingSetMetadataOperation();
+  const listProjectsOp = new TrackingListProjectsOperation();
 
   const configValues: Record<string, unknown> = {};
   if (tplPath !== null) {
@@ -299,6 +341,7 @@ function createTestSetup(options?: {
   dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, openWorkspaceOp);
   dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteWorkspaceOp);
   dispatcher.registerOperation(INTENT_SET_METADATA, setMetadataOp);
+  dispatcher.registerOperation(INTENT_LIST_PROJECTS, listProjectsOp);
 
   const autoPrModule = createAutoPrModule({
     processRunner,
@@ -320,6 +363,7 @@ function createTestSetup(options?: {
     openWorkspaceOp,
     deleteWorkspaceOp,
     setMetadataOp,
+    listProjectsOp,
   };
 }
 
@@ -403,21 +447,14 @@ describe("AutoPrModule Integration", () => {
     });
 
     it("does not recreate workspace for already-tracked PR", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": {
-            workspaceName: "pr-42/feature-login",
-            workspacePath: "/data/workspaces/repo-abc/workspaces/pr-42/feature-login",
-            prNumber: 42,
-            repo: "org/repo",
-            projectPath: "/home/user/projects/repo",
-            createdAt: "2026-02-27T10:00:00Z",
-          },
-        },
-      });
+      const { dispatcher, httpClient, openProjectOp, listProjectsOp } = createTestSetup();
 
-      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+      listProjectsOp.projects = [
+        autoPrWorkspace(
+          "https://github.com/org/repo/pull/42",
+          "/data/workspaces/repo-abc/workspaces/pr-42/feature-login"
+        ),
+      ];
 
       httpClient.setResponse(SEARCH_URL, {
         body: searchResponse([
@@ -439,29 +476,44 @@ describe("AutoPrModule Integration", () => {
 
   describe("PR disappearance", () => {
     it("deletes workspace when tracked PR disappears from search results", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": {
-            workspaceName: "pr-42/feature-login",
-            workspacePath: "/data/workspaces/repo-abc/workspaces/pr-42/feature-login",
-            prNumber: 42,
-            repo: "org/repo",
-            projectPath: "/home/user/projects/repo",
-            createdAt: "2026-02-27T10:00:00Z",
-          },
-        },
-      });
+      const { dispatcher, httpClient, deleteWorkspaceOp, listProjectsOp } = createTestSetup();
 
-      const { dispatcher, httpClient, deleteWorkspaceOp } = createTestSetup({ existingState });
+      listProjectsOp.projects = [
+        autoPrWorkspace(
+          "https://github.com/org/repo/pull/42",
+          "/data/workspaces/repo-abc/workspaces/pr-42/feature-login"
+        ),
+      ];
 
       httpClient.setResponse(SEARCH_URL, { body: searchResponse([]) });
 
       await dispatcher.dispatch(startIntent());
 
       expect(deleteWorkspaceOp.dispatched).toHaveLength(1);
+      expect(deleteWorkspaceOp.dispatched[0]!.payload.workspacePath).toBe(
+        "/data/workspaces/repo-abc/workspaces/pr-42/feature-login"
+      );
       expect(deleteWorkspaceOp.dispatched[0]!.payload.removeWorktree).toBe(true);
       expect(deleteWorkspaceOp.dispatched[0]!.payload.force).toBe(true);
+    });
+
+    it("does not add auto-deleted workspace to dismissed set", async () => {
+      const { dispatcher, httpClient, deleteWorkspaceOp, listProjectsOp, fs } = createTestSetup();
+
+      listProjectsOp.projects = [
+        autoPrWorkspace(
+          "https://github.com/org/repo/pull/42",
+          "/data/workspaces/repo-abc/workspaces/pr-42/feature-login"
+        ),
+      ];
+
+      httpClient.setResponse(SEARCH_URL, { body: searchResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(deleteWorkspaceOp.dispatched).toHaveLength(1);
+      // No dismissed URLs → file should not be written
+      expect(fs).not.toHaveFile("/data/auto-pr-workspaces.json");
     });
   });
 
@@ -478,7 +530,7 @@ describe("AutoPrModule Integration", () => {
   });
 
   describe("state persistence", () => {
-    it("persists state after creating a PR workspace", async () => {
+    it("does not persist dismissed set when workspace is successfully created", async () => {
       const { dispatcher, httpClient, fs } = createTestSetup();
 
       httpClient.setResponse(SEARCH_URL, {
@@ -499,25 +551,16 @@ describe("AutoPrModule Integration", () => {
 
       await dispatcher.dispatch(startIntent());
 
-      expect(fs).toHaveFile("/data/auto-pr-workspaces.json");
+      // No dismissed URLs → file should not be written
+      expect(fs).not.toHaveFile("/data/auto-pr-workspaces.json");
     });
 
-    it("loads existing state on startup", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": {
-            workspaceName: "pr-42/feature-login",
-            workspacePath: "/data/workspaces/repo-abc/workspaces/pr-42/feature-login",
-            prNumber: 42,
-            repo: "org/repo",
-            projectPath: "/home/user/projects/repo",
-            createdAt: "2026-02-27T10:00:00Z",
-          },
-        },
+    it("loads dismissed URLs from persisted state and skips PR", async () => {
+      const { dispatcher, httpClient, openProjectOp, listProjectsOp } = createTestSetup({
+        dismissedUrls: ["https://github.com/org/repo/pull/42"],
       });
 
-      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+      listProjectsOp.projects = [];
 
       httpClient.setResponse(SEARCH_URL, {
         body: searchResponse([
@@ -613,10 +656,10 @@ describe("AutoPrModule Integration", () => {
       // No workspace created — template read failure means empty prompt → skip
       expect(openProjectOp.dispatched).toHaveLength(0);
       expect(openWorkspaceOp.dispatched).toHaveLength(0);
-      // Null entry recorded in state
+      // PR URL recorded in dismissed set
       expect(fs).toHaveFileContaining(
         "/data/auto-pr-workspaces.json",
-        '"https://github.com/org/repo/pull/42": null'
+        "https://github.com/org/repo/pull/42"
       );
     });
 
@@ -633,7 +676,7 @@ describe("AutoPrModule Integration", () => {
       expect(openWorkspaceOp.dispatched).toHaveLength(0);
       expect(fs).toHaveFileContaining(
         "/data/auto-pr-workspaces.json",
-        '"https://github.com/org/repo/pull/42": null'
+        "https://github.com/org/repo/pull/42"
       );
     });
 
@@ -649,20 +692,13 @@ describe("AutoPrModule Integration", () => {
       expect(openWorkspaceOp.dispatched).toHaveLength(0);
       expect(fs).toHaveFileContaining(
         "/data/auto-pr-workspaces.json",
-        '"https://github.com/org/repo/pull/42": null'
+        "https://github.com/org/repo/pull/42"
       );
     });
 
     it("does not re-evaluate template for previously skipped PR", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": null,
-        },
-      });
-
       const { dispatcher, httpClient, openProjectOp } = createTestSetup({
-        existingState,
+        dismissedUrls: ["https://github.com/org/repo/pull/42"],
         templatePath: TEMPLATE_PATH,
         templateContent: "Review PR #{{ number }}",
       });
@@ -772,7 +808,7 @@ describe("AutoPrModule Integration", () => {
       expect(openWorkspaceOp.dispatched).toHaveLength(0);
       expect(fs).toHaveFileContaining(
         "/data/auto-pr-workspaces.json",
-        '"https://github.com/org/repo/pull/42": null'
+        "https://github.com/org/repo/pull/42"
       );
     });
 
@@ -794,12 +830,18 @@ describe("AutoPrModule Integration", () => {
       await dispatcher.dispatch(startIntent());
 
       expect(openWorkspaceOp.dispatched).toHaveLength(1);
-      expect(setMetadataOp.dispatched).toHaveLength(2);
+      // 2 marker keys (source, auto-pr.url) + 2 template metadata keys
+      expect(setMetadataOp.dispatched).toHaveLength(4);
 
       const metaPayloads = setMetadataOp.dispatched.map((i) => ({
         key: i.payload.key,
         value: i.payload.value,
       }));
+      expect(metaPayloads).toContainEqual({ key: "source", value: "auto-pr" });
+      expect(metaPayloads).toContainEqual({
+        key: "auto-pr.url",
+        value: "https://github.com/org/repo/pull/42",
+      });
       expect(metaPayloads).toContainEqual({
         key: "pr-url",
         value: "https://github.com/org/repo/pull/42",
@@ -815,7 +857,7 @@ describe("AutoPrModule Integration", () => {
       }
     });
 
-    it("does not dispatch set-metadata when no metadata keys in template", async () => {
+    it("always sets marker metadata even without template metadata keys", async () => {
       const { dispatcher, openWorkspaceOp, setMetadataOp } = setupWithPr({
         templatePath: TEMPLATE_PATH,
         templateContent: "---\nname: review/{{ number }}\n---\nReview PR #{{ number }}",
@@ -824,7 +866,18 @@ describe("AutoPrModule Integration", () => {
       await dispatcher.dispatch(startIntent());
 
       expect(openWorkspaceOp.dispatched).toHaveLength(1);
-      expect(setMetadataOp.dispatched).toHaveLength(0);
+      // 2 marker keys (source, auto-pr.url) only
+      expect(setMetadataOp.dispatched).toHaveLength(2);
+
+      const metaPayloads = setMetadataOp.dispatched.map((i) => ({
+        key: i.payload.key,
+        value: i.payload.value,
+      }));
+      expect(metaPayloads).toContainEqual({ key: "source", value: "auto-pr" });
+      expect(metaPayloads).toContainEqual({
+        key: "auto-pr.url",
+        value: "https://github.com/org/repo/pull/42",
+      });
     });
 
     it("creates workspace despite unknown front-matter keys (non-fatal warning)", async () => {
@@ -875,28 +928,24 @@ describe("AutoPrModule Integration", () => {
   });
 
   describe("template-skipped PR cleanup", () => {
-    it("cleans up template-skipped null entry when PR disappears", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": null,
-        },
+    it("cleans up dismissed entry when PR disappears", async () => {
+      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({
+        dismissedUrls: ["https://github.com/org/repo/pull/42"],
       });
-
-      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({ existingState });
 
       httpClient.setResponse(SEARCH_URL, { body: searchResponse([]) });
 
       await dispatcher.dispatch(startIntent());
 
       expect(deleteWorkspaceOp.dispatched).toHaveLength(0);
-      expect(fs).toHaveFileContaining("/data/auto-pr-workspaces.json", '"workspaces": {}');
+      expect(fs).toHaveFileContaining("/data/auto-pr-workspaces.json", '"dismissed": []');
     });
   });
 
   describe("manual workspace deletion", () => {
     it("does not recreate workspace after manual deletion", async () => {
-      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp } = createTestSetup();
+      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp, listProjectsOp } =
+        createTestSetup();
 
       // First poll: workspace gets created
       httpClient.setResponse(SEARCH_URL, {
@@ -932,6 +981,8 @@ describe("AutoPrModule Integration", () => {
       // Reset tracking and set up second poll with same PR
       openProjectOp.dispatched.length = 0;
       openWorkspaceOp.dispatched.length = 0;
+      // Workspace no longer appears in listing (it was deleted)
+      listProjectsOp.projects = [];
       httpClient.setResponse(SEARCH_URL, {
         body: searchResponse([
           {
@@ -951,15 +1002,10 @@ describe("AutoPrModule Integration", () => {
       expect(openWorkspaceOp.dispatched).toHaveLength(0);
     });
 
-    it("cleans up null entry when PR disappears from GitHub", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": null,
-        },
+    it("cleans up dismissed entry when PR disappears from GitHub", async () => {
+      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({
+        dismissedUrls: ["https://github.com/org/repo/pull/42"],
       });
-
-      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({ existingState });
 
       // Poll returns empty — PR no longer requesting review
       httpClient.setResponse(SEARCH_URL, { body: searchResponse([]) });
@@ -969,19 +1015,14 @@ describe("AutoPrModule Integration", () => {
       // Should NOT dispatch a delete (workspace already gone)
       expect(deleteWorkspaceOp.dispatched).toHaveLength(0);
 
-      // State file should have empty workspaces (entry cleaned up)
-      expect(fs).toHaveFileContaining("/data/auto-pr-workspaces.json", '"workspaces": {}');
+      // Dismissed set should be empty (entry cleaned up)
+      expect(fs).toHaveFileContaining("/data/auto-pr-workspaces.json", '"dismissed": []');
     });
 
-    it("loads null entry from persisted state and skips PR", async () => {
-      const existingState = JSON.stringify({
-        version: 1,
-        workspaces: {
-          "https://github.com/org/repo/pull/42": null,
-        },
+    it("loads dismissed URL from persisted state and skips PR", async () => {
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({
+        dismissedUrls: ["https://github.com/org/repo/pull/42"],
       });
-
-      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
 
       // Poll returns the same PR
       httpClient.setResponse(SEARCH_URL, {

--- a/src/main/modules/auto-pr-module.ts
+++ b/src/main/modules/auto-pr-module.ts
@@ -32,6 +32,7 @@ import {
   type WorkspaceDeletedEvent,
 } from "../operations/delete-workspace";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "../operations/open-project";
+import { INTENT_LIST_PROJECTS, type ListProjectsIntent } from "../operations/list-projects";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
 import type { ProcessRunner } from "../../services/platform/process";
 import type { HttpClient } from "../../services/platform/network";
@@ -48,19 +49,17 @@ import type { ConfigKeyDefinition } from "../../services/config/config-definitio
 // Persistence Types
 // =============================================================================
 
-interface AutoPrWorkspaceEntry {
-  readonly workspaceName: string;
-  readonly workspacePath: string;
-  readonly prNumber: number;
-  readonly repo: string;
-  readonly projectPath: string;
-  readonly createdAt: string;
+interface AutoPrDismissedState {
+  readonly dismissed: readonly string[]; // PR URLs
 }
 
-interface AutoPrState {
-  readonly version: 1;
-  readonly workspaces: Record<string, AutoPrWorkspaceEntry | null>;
-}
+// =============================================================================
+// Metadata Constants
+// =============================================================================
+
+const METADATA_SOURCE_KEY = "source";
+const METADATA_SOURCE_VALUE = "auto-pr";
+const METADATA_PR_URL_KEY = "auto-pr.url";
 
 // =============================================================================
 // GitHub API Types (minimal)
@@ -95,7 +94,7 @@ interface GitHubRepoDetail {
 export interface AutoPrModuleDeps {
   readonly processRunner: ProcessRunner;
   readonly httpClient: HttpClient;
-  readonly fs: Pick<FileSystemLayer, "readFile" | "writeFile" | "mkdir">;
+  readonly fs: Pick<FileSystemLayer, "readFile" | "writeFile">;
   readonly logger: Logger;
   readonly stateFilePath: string;
   readonly dispatcher: Dispatcher;
@@ -111,10 +110,6 @@ const GITHUB_API_BASE = "https://api.github.com";
 // =============================================================================
 // Helpers
 // =============================================================================
-
-function emptyState(): AutoPrState {
-  return { version: 1, workspaces: {} };
-}
 
 /**
  * Extract "owner/repo" from a GitHub repository API URL.
@@ -247,7 +242,9 @@ export function parseTemplateOutput(rendered: string): ParseResult {
 
 export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
   let token: string | null = null;
-  let state: AutoPrState = emptyState();
+  let dismissedSet = new Set<string>(); // PR URLs to never recreate
+  const deletingPrUrls = new Set<string>(); // sentinel for auto-deletions (in-memory only)
+  let workspaceMap = new Map<string, string>(); // prUrl → workspacePath (refreshed each poll)
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let enabled = false;
   // Tracked from config:updated events (fires during app:start init phase, before activate)
@@ -281,26 +278,48 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
   // ------ State Persistence ------
 
-  async function loadState(): Promise<AutoPrState> {
+  async function loadDismissedSet(): Promise<Set<string>> {
     try {
       const raw = await deps.fs.readFile(stateFilePath);
-      const parsed = JSON.parse(raw) as AutoPrState;
-      if (parsed.version === 1 && typeof parsed.workspaces === "object") {
-        return parsed;
+      const parsed = JSON.parse(raw) as AutoPrDismissedState;
+      if (Array.isArray(parsed.dismissed)) {
+        return new Set(parsed.dismissed);
       }
-      deps.logger.warn("Invalid auto-pr state file, starting fresh");
-      return emptyState();
+      return new Set();
     } catch {
-      return emptyState();
+      return new Set();
     }
   }
 
-  async function saveState(): Promise<void> {
+  async function saveDismissedSet(): Promise<void> {
     try {
-      await deps.fs.writeFile(stateFilePath, JSON.stringify(state, null, 2));
+      const data: AutoPrDismissedState = { dismissed: [...dismissedSet] };
+      await deps.fs.writeFile(stateFilePath, JSON.stringify(data, null, 2));
     } catch (error) {
-      deps.logger.warn("Failed to save auto-pr state", { error: getErrorMessage(error) });
+      deps.logger.warn("Failed to save auto-pr dismissed set", { error: getErrorMessage(error) });
     }
+  }
+
+  // ------ Workspace Listing ------
+
+  async function buildWorkspaceMap(): Promise<Map<string, string>> {
+    const projects = await deps.dispatcher.dispatch({
+      type: INTENT_LIST_PROJECTS,
+      payload: {},
+    } as ListProjectsIntent);
+
+    const map = new Map<string, string>();
+    for (const project of projects) {
+      for (const workspace of project.workspaces) {
+        if (
+          workspace.metadata[METADATA_SOURCE_KEY] === METADATA_SOURCE_VALUE &&
+          workspace.metadata[METADATA_PR_URL_KEY]
+        ) {
+          map.set(workspace.metadata[METADATA_PR_URL_KEY], workspace.path);
+        }
+      }
+    }
+    return map;
   }
 
   // ------ GitHub API ------
@@ -424,7 +443,6 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
   async function createPrWorkspace(
     prUrl: string,
-    repo: string,
     prNumber: number,
     headRef: string,
     cloneUrl: string,
@@ -438,10 +456,7 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       const config = await buildWorkspaceConfig(prNumber, headRef, baseRef, prDetail);
       if (!config) {
         deps.logger.info("Skipping PR workspace (template resolved to empty)", { prUrl });
-        state = {
-          ...state,
-          workspaces: { ...state.workspaces, [prUrl]: null },
-        };
+        dismissedSet.add(prUrl);
         return;
       }
 
@@ -474,39 +489,32 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
           ? (wsResult as { path: string }).path
           : "";
 
-      // Set metadata keys if any
-      if (config.metadata && workspacePath) {
-        for (const [key, value] of Object.entries(config.metadata)) {
-          try {
-            await deps.dispatcher.dispatch({
-              type: INTENT_SET_METADATA,
-              payload: { workspacePath, key, value },
-            } as SetMetadataIntent);
-          } catch (error) {
-            deps.logger.warn("Failed to set workspace metadata", {
-              key,
-              prUrl,
-              error: getErrorMessage(error),
-            });
-          }
+      if (!workspacePath) return;
+
+      // Always set marker metadata for discovery
+      const metadataEntries: Array<[string, string]> = [
+        [METADATA_SOURCE_KEY, METADATA_SOURCE_VALUE],
+        [METADATA_PR_URL_KEY, prUrl],
+        ...(config.metadata ? Object.entries(config.metadata) : []),
+      ];
+
+      for (const [key, value] of metadataEntries) {
+        try {
+          await deps.dispatcher.dispatch({
+            type: INTENT_SET_METADATA,
+            payload: { workspacePath, key, value },
+          } as SetMetadataIntent);
+        } catch (error) {
+          deps.logger.warn("Failed to set workspace metadata", {
+            key,
+            prUrl,
+            error: getErrorMessage(error),
+          });
         }
       }
 
-      // Record in state
-      state = {
-        ...state,
-        workspaces: {
-          ...state.workspaces,
-          [prUrl]: {
-            workspaceName: config.workspaceName,
-            workspacePath,
-            prNumber,
-            repo,
-            projectPath: project.path,
-            createdAt: new Date().toISOString(),
-          },
-        },
-      };
+      // Update in-memory workspace map
+      workspaceMap.set(prUrl, workspacePath);
 
       deps.logger.info("PR workspace created", {
         prUrl,
@@ -520,36 +528,29 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     }
   }
 
-  async function deletePrWorkspace(prUrl: string, entry: AutoPrWorkspaceEntry): Promise<void> {
-    deps.logger.info("Deleting PR workspace (PR disappeared)", {
-      prUrl,
-      workspaceName: entry.workspaceName,
-    });
+  async function deletePrWorkspace(prUrl: string, wsPath: string): Promise<void> {
+    deps.logger.info("Deleting PR workspace (PR disappeared)", { prUrl });
 
+    deletingPrUrls.add(prUrl);
     try {
       await deps.dispatcher.dispatch({
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: entry.workspacePath,
+          workspacePath: wsPath,
           keepBranch: false,
           force: true,
           removeWorktree: true,
         },
       } as DeleteWorkspaceIntent);
 
-      deps.logger.info("PR workspace deleted", { prUrl, workspaceName: entry.workspaceName });
+      deps.logger.info("PR workspace deleted", { prUrl });
     } catch (error) {
       deps.logger.warn("Failed to delete PR workspace", {
         prUrl,
         error: getErrorMessage(error),
       });
     }
-
-    // Remove from state regardless of success (don't retry forever)
-    const remaining = Object.fromEntries(
-      Object.entries(state.workspaces).filter(([key]) => key !== prUrl)
-    );
-    state = { ...state, workspaces: remaining };
+    deletingPrUrls.delete(prUrl);
   }
 
   // ------ Poll Cycle ------
@@ -559,8 +560,12 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
     deps.logger.debug("Polling GitHub for review-requested PRs");
 
-    const stateBefore = state;
+    let dismissedChanged = false;
 
+    // 1. Discover existing auto-PR workspaces via project:list
+    workspaceMap = await buildWorkspaceMap();
+
+    // 2. Fetch GitHub search results
     let items: GitHubSearchItem[];
     try {
       items = await fetchReviewRequestedPrs();
@@ -576,25 +581,27 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       openPrUrls.add(prUrl);
     }
 
-    // Detect disappeared PRs → delete workspaces or clean up dismissed entries
-    const disappearedUrls = Object.keys(state.workspaces).filter((url) => !openPrUrls.has(url));
-    for (const prUrl of disappearedUrls) {
-      const entry = state.workspaces[prUrl];
-      if (entry) {
-        await deletePrWorkspace(prUrl, entry);
-      } else {
-        // null entry (dismissed by user or template-skipped) — just remove the key
-        const remaining = Object.fromEntries(
-          Object.entries(state.workspaces).filter(([key]) => key !== prUrl)
-        );
-        state = { ...state, workspaces: remaining };
+    // 3. Delete workspaces for PRs that disappeared
+    for (const [prUrl, wsPath] of workspaceMap) {
+      if (!openPrUrls.has(prUrl)) {
+        await deletePrWorkspace(prUrl, wsPath);
       }
     }
 
-    // Detect new PRs → create workspaces
+    // 4. Clean up dismissed entries for PRs that disappeared
+    for (const prUrl of dismissedSet) {
+      if (!openPrUrls.has(prUrl)) {
+        dismissedSet.delete(prUrl);
+        dismissedChanged = true;
+      }
+    }
+
+    // 5. Create workspaces for new PRs
+    const allTracked = new Set([...workspaceMap.keys(), ...dismissedSet]);
+    const dismissedBeforeCreation = dismissedSet.size;
     for (const item of items) {
       const prUrl = item.pull_request?.html_url ?? item.html_url;
-      if (prUrl in state.workspaces) continue; // tracked (active or dismissed)
+      if (allTracked.has(prUrl)) continue;
 
       const repo = repoFromApiUrl(item.repository_url);
       const prDetail = await fetchPrDetail(repo, item.number);
@@ -609,7 +616,6 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
 
       await createPrWorkspace(
         prUrl,
-        repo,
         item.number,
         head.ref,
         repoDetail.clone_url,
@@ -618,9 +624,9 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       );
     }
 
-    // Persist if state changed (new workspaces, deletions, or template-skipped null entries)
-    if (state !== stateBefore) {
-      await saveState();
+    // 6. Persist dismissed set if changed
+    if (dismissedChanged || dismissedSet.size !== dismissedBeforeCreation) {
+      await saveDismissedSet();
     }
   }
 
@@ -654,7 +660,7 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
     token = await acquireToken();
     if (!token) return;
 
-    state = await loadState();
+    dismissedSet = await loadDismissedSet();
     enabled = true;
 
     // Run initial poll (reconcile stale state)
@@ -721,18 +727,19 @@ export function createAutoPrModule(deps: AutoPrModuleDeps): IntentModule {
       },
       [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
         const { workspacePath } = (event as WorkspaceDeletedEvent).payload;
-        // If a tracked PR workspace is deleted, set to null to prevent re-creation
-        for (const [prUrl, entry] of Object.entries(state.workspaces)) {
-          if (entry?.workspacePath === workspacePath) {
-            state = {
-              ...state,
-              workspaces: { ...state.workspaces, [prUrl]: null },
-            };
-            void saveState();
-            deps.logger.info("Marked PR workspace as dismissed", {
-              prUrl,
-              workspaceName: entry.workspaceName,
-            });
+        // Find the PR URL for this workspace path
+        for (const [prUrl, wsPath] of workspaceMap) {
+          if (wsPath === workspacePath) {
+            // Auto-deletion (PR disappeared) — do NOT dismiss, just clean up the map
+            if (deletingPrUrls.has(prUrl)) {
+              workspaceMap.delete(prUrl);
+              break;
+            }
+            // Manual deletion — add to dismissed set to prevent re-creation
+            workspaceMap.delete(prUrl);
+            dismissedSet.add(prUrl);
+            void saveDismissedSet();
+            deps.logger.info("Marked PR workspace as dismissed", { prUrl });
             break;
           }
         }


### PR DESCRIPTION
- Discover auto-PR workspaces via `project:list` metadata instead of maintaining a parallel JSON state file
- Set `source=auto-pr` and `auto-pr.url` marker metadata on every created workspace for discovery
- Only persist a dismissed set (template-skipped or manually deleted PR URLs)
- Use `deletingPrUrls` sentinel to distinguish auto vs manual deletions in event handler
- Remove `AutoPrState`/`AutoPrWorkspaceEntry` types and unused `repo` param
- Update tests with `TrackingListProjectsOperation` and `dismissedUrls` option