### PR TITLE
feat: auto create workspaces based on youtrack query

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -119,6 +119,7 @@ import { createShortcutModule } from "./modules/shortcut-module";
 import { createIpcEventBridge } from "./modules/ipc-event-bridge";
 import { createWorkspaceSelectionModule } from "./modules/workspace-selection-module";
 import { createAutoPrModule } from "./modules/auto-pr-module";
+import { createYouTrackModule } from "./modules/youtrack-module";
 import { AppStartOperation, INTENT_APP_START } from "./operations/app-start";
 import type { AppStartIntent } from "./operations/app-start";
 import { ConfigSetValuesOperation, INTENT_CONFIG_SET_VALUES } from "./operations/config-set-values";
@@ -534,6 +535,13 @@ const autoPrModule = createAutoPrModule({
   stateFilePath: pathProvider.dataPath("auto-pr-workspaces.json").toString(),
   dispatcher,
 });
+const youtrackModule = createYouTrackModule({
+  httpClient: networkLayer,
+  fs: fileSystemLayer,
+  logger: loggingService.createLogger("youtrack"),
+  stateFilePath: pathProvider.dataPath("youtrack-workspaces.json").toString(),
+  dispatcher,
+});
 
 // 8. New modules
 
@@ -652,6 +660,7 @@ dispatcher.registerModule(scriptModule);
 dispatcher.registerModule(tempDirModule);
 dispatcher.registerModule(shortcutModule);
 dispatcher.registerModule(autoPrModule);
+dispatcher.registerModule(youtrackModule);
 dispatcher.registerModule(ipcEventBridge);
 
 // 11. Dispatch app:start

--- a/src/main/modules/youtrack-module.integration.test.ts
+++ b/src/main/modules/youtrack-module.integration.test.ts
@@ -1,0 +1,989 @@
+// @vitest-environment node
+/**
+ * Integration tests for YouTrackModule through the Dispatcher.
+ *
+ * Tests verify the full pipeline:
+ * dispatcher -> Operation -> hook point -> YouTrackModule handler
+ *
+ * Uses minimal operations to avoid full AppStartOperation pipeline.
+ * HttpClient is a behavioral mock.
+ *
+ * The real config module fires config:updated during init (before activate).
+ * Tests simulate this by having the MinimalActivateOperation emit the event first.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { SILENT_LOGGER } from "../../services/logging";
+import { HookRegistry } from "../intents/infrastructure/hook-registry";
+import { Dispatcher } from "../intents/infrastructure/dispatcher";
+
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { Project, WorkspaceName } from "../../shared/api/types";
+import {
+  APP_START_OPERATION_ID,
+  INTENT_APP_START,
+  type AppStartIntent,
+  type ActivateHookResult,
+} from "../operations/app-start";
+import {
+  AppShutdownOperation,
+  INTENT_APP_SHUTDOWN,
+  type AppShutdownIntent,
+} from "../operations/app-shutdown";
+import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "../operations/open-project";
+import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "../operations/open-workspace";
+import {
+  INTENT_DELETE_WORKSPACE,
+  EVENT_WORKSPACE_DELETED,
+  type DeleteWorkspaceIntent,
+  type WorkspaceDeletedEvent,
+} from "../operations/delete-workspace";
+import { INTENT_SET_METADATA, type SetMetadataIntent } from "../operations/set-metadata";
+import {
+  EVENT_CONFIG_UPDATED,
+  INTENT_CONFIG_SET_VALUES,
+  type ConfigUpdatedEvent,
+  type ConfigSetValuesIntent,
+} from "../operations/config-set-values";
+import { createMockHttpClient } from "../../services/platform/http-client.state-mock";
+import {
+  createFileSystemMock,
+  file,
+  directory,
+} from "../../services/platform/filesystem.state-mock";
+import { createYouTrackModule, parseYouTrackTemplateOutput } from "./youtrack-module";
+
+// =============================================================================
+// Minimal Test Operations
+// =============================================================================
+
+/**
+ * Minimal operation that emits config:updated (simulating the real config module)
+ * then runs the "activate" hook point.
+ */
+class MinimalActivateOperation implements Operation<AppStartIntent, void> {
+  readonly id = APP_START_OPERATION_ID;
+  configValues: Record<string, unknown>;
+
+  constructor(configValues?: Record<string, unknown>) {
+    this.configValues = configValues ?? {};
+  }
+
+  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
+    // Simulate config module emitting config:updated during init phase
+    if (Object.keys(this.configValues).length > 0) {
+      const configEvent: ConfigUpdatedEvent = {
+        type: EVENT_CONFIG_UPDATED,
+        payload: { values: this.configValues },
+      };
+      ctx.emit(configEvent);
+    }
+
+    const hookCtx: HookContext = { intent: ctx.intent };
+    const { errors } = await ctx.hooks.collect<ActivateHookResult>("activate", hookCtx);
+    if (errors.length > 0) throw errors[0]!;
+  }
+}
+
+/**
+ * Tracking operation for project:open — records dispatches and returns a fake project.
+ */
+class TrackingOpenProjectOperation implements Operation<OpenProjectIntent, Project> {
+  readonly id = "open-project";
+  readonly dispatched: OpenProjectIntent[] = [];
+
+  async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project> {
+    this.dispatched.push(ctx.intent);
+    const gitUrl = ctx.intent.payload.git ?? "";
+    const pathStr = ctx.intent.payload.path?.toString() ?? "";
+    const repoName =
+      gitUrl.replace(/.*\//, "").replace(/\.git$/, "") || pathStr.replace(/.*\//, "") || "repo";
+    return {
+      id: "project-1" as Project["id"],
+      name: repoName,
+      path: pathStr || `/home/user/projects/${repoName}`,
+      workspaces: [],
+    };
+  }
+}
+
+/**
+ * Tracking operation for workspace:open — records dispatches.
+ */
+class TrackingOpenWorkspaceOperation implements Operation<
+  OpenWorkspaceIntent,
+  {
+    projectId: string;
+    name: string;
+    path: string;
+    branch: string;
+    metadata: Record<string, string>;
+  }
+> {
+  readonly id = "open-workspace";
+  readonly dispatched: OpenWorkspaceIntent[] = [];
+
+  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<{
+    projectId: string;
+    name: string;
+    path: string;
+    branch: string;
+    metadata: Record<string, string>;
+  }> {
+    this.dispatched.push(ctx.intent);
+    return {
+      projectId: "project-1",
+      name: ctx.intent.payload.workspaceName ?? "ws",
+      path: `/home/user/projects/repo/${ctx.intent.payload.workspaceName ?? "ws"}`,
+      branch: "feature",
+      metadata: {},
+    };
+  }
+}
+
+/**
+ * Tracking operation for workspace:delete — records dispatches and emits event.
+ */
+class TrackingDeleteWorkspaceOperation implements Operation<
+  DeleteWorkspaceIntent,
+  { started: true }
+> {
+  readonly id = "delete-workspace";
+  readonly dispatched: DeleteWorkspaceIntent[] = [];
+
+  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+    this.dispatched.push(ctx.intent);
+    const event: WorkspaceDeletedEvent = {
+      type: EVENT_WORKSPACE_DELETED,
+      payload: {
+        projectId: "project-1" as Project["id"],
+        workspaceName: "PROJ-123" as WorkspaceName,
+        workspacePath: ctx.intent.payload.workspacePath,
+        projectPath: "/home/user/projects/repo",
+      },
+    };
+    ctx.emit(event);
+    return { started: true };
+  }
+}
+
+/**
+ * Minimal config-set operation that emits config:updated with the provided values.
+ */
+class MinimalConfigSetOperation implements Operation<ConfigSetValuesIntent, void> {
+  readonly id = "config-set-values";
+
+  async execute(ctx: OperationContext<ConfigSetValuesIntent>): Promise<void> {
+    const event: ConfigUpdatedEvent = {
+      type: EVENT_CONFIG_UPDATED,
+      payload: { values: ctx.intent.payload.values },
+    };
+    ctx.emit(event);
+  }
+}
+
+/**
+ * Tracking operation for workspace:set-metadata — records dispatches.
+ */
+class TrackingSetMetadataOperation implements Operation<SetMetadataIntent, void> {
+  readonly id = "set-metadata";
+  readonly dispatched: SetMetadataIntent[] = [];
+
+  async execute(ctx: OperationContext<SetMetadataIntent>): Promise<void> {
+    this.dispatched.push(ctx.intent);
+  }
+}
+
+// =============================================================================
+// YouTrack API Response Helpers
+// =============================================================================
+
+const BASE_URL = "https://youtrack.example.com";
+const DEFAULT_QUERY = "for:me State: {In Progress}";
+
+function issuesResponse(
+  issues: Array<{
+    id: string;
+    idReadable: string;
+    summary: string;
+    description?: string;
+  }>
+): string {
+  return JSON.stringify(
+    issues.map((issue) => ({
+      id: issue.id,
+      idReadable: issue.idReadable,
+      summary: issue.summary,
+      description: issue.description ?? "",
+      reporter: { login: "johndoe", fullName: "John Doe" },
+      created: 1709000000000,
+      updated: 1709100000000,
+      resolved: null,
+      project: { id: "0-1", name: "My Project", shortName: "PROJ" },
+      customFields: [],
+    }))
+  );
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+const YOUTRACK_FIELDS =
+  "id,idReadable,summary,description,reporter(login,fullName),created,updated,resolved,project(id,name,shortName),customFields(name,value(name))";
+const ISSUES_URL = `${BASE_URL}/api/issues?query=${encodeURIComponent(DEFAULT_QUERY)}&fields=${encodeURIComponent(YOUTRACK_FIELDS)}`;
+
+interface TestSetup {
+  dispatcher: Dispatcher;
+  httpClient: ReturnType<typeof createMockHttpClient>;
+  fs: ReturnType<typeof createFileSystemMock>;
+  openProjectOp: TrackingOpenProjectOperation;
+  openWorkspaceOp: TrackingOpenWorkspaceOperation;
+  deleteWorkspaceOp: TrackingDeleteWorkspaceOperation;
+  setMetadataOp: TrackingSetMetadataOperation;
+}
+
+const DEFAULT_TEMPLATE_PATH = "/data/youtrack.liquid";
+const DEFAULT_TEMPLATE_CONTENT =
+  "---\ngit: https://github.com/org/repo.git\nname: {{ idReadable }}\n---\nFix {{ idReadable }}: {{ summary }}";
+
+function createTestSetup(options?: {
+  disabled?: boolean;
+  partialConfig?: {
+    baseUrl?: string | null;
+    token?: string | null;
+    templatePath?: string | null;
+    query?: string | null;
+  };
+  existingState?: string;
+  templatePath?: string | null;
+  templateContent?: string;
+}): TestSetup {
+  // Build config values
+  const isDisabled = options?.disabled;
+  const partial = options?.partialConfig;
+
+  const baseUrl = partial ? (partial.baseUrl ?? null) : isDisabled ? null : BASE_URL;
+  const token = partial ? (partial.token ?? null) : isDisabled ? null : "perm:test-token";
+  const tplPath = partial
+    ? (partial.templatePath ?? null)
+    : isDisabled
+      ? null
+      : options?.templatePath !== undefined
+        ? options.templatePath
+        : DEFAULT_TEMPLATE_PATH;
+  const query = partial ? (partial.query ?? null) : isDisabled ? null : DEFAULT_QUERY;
+
+  const tplContent =
+    options?.templateContent !== undefined
+      ? options.templateContent
+      : options?.templatePath !== undefined
+        ? undefined
+        : DEFAULT_TEMPLATE_CONTENT;
+
+  const httpClient = createMockHttpClient();
+
+  const fsEntries: Record<string, ReturnType<typeof file> | ReturnType<typeof directory>> = {
+    "/data": directory(),
+  };
+  if (options?.existingState) {
+    fsEntries["/data/youtrack-workspaces.json"] = file(options.existingState);
+  }
+  if (tplPath && tplContent !== undefined) {
+    fsEntries[tplPath] = file(tplContent);
+  }
+  const fs = createFileSystemMock({ entries: fsEntries });
+
+  const hookRegistry = new HookRegistry();
+  const dispatcher = new Dispatcher(hookRegistry);
+
+  const openProjectOp = new TrackingOpenProjectOperation();
+  const openWorkspaceOp = new TrackingOpenWorkspaceOperation();
+  const deleteWorkspaceOp = new TrackingDeleteWorkspaceOperation();
+  const setMetadataOp = new TrackingSetMetadataOperation();
+
+  const configValues: Record<string, unknown> = {};
+  if (baseUrl !== null) configValues["experimental.youtrack.base-url"] = baseUrl;
+  if (token !== null) configValues["experimental.youtrack.token"] = token;
+  if (tplPath !== null) configValues["experimental.youtrack.template-path"] = tplPath;
+  if (query !== null) configValues["experimental.youtrack.query"] = query;
+
+  dispatcher.registerOperation(INTENT_APP_START, new MinimalActivateOperation(configValues));
+  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+  dispatcher.registerOperation(INTENT_CONFIG_SET_VALUES, new MinimalConfigSetOperation());
+  dispatcher.registerOperation(INTENT_OPEN_PROJECT, openProjectOp);
+  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, openWorkspaceOp);
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteWorkspaceOp);
+  dispatcher.registerOperation(INTENT_SET_METADATA, setMetadataOp);
+
+  const youtrackModule = createYouTrackModule({
+    httpClient,
+    fs,
+    logger: SILENT_LOGGER,
+    stateFilePath: "/data/youtrack-workspaces.json",
+    dispatcher,
+  });
+
+  dispatcher.registerModule(youtrackModule);
+
+  return {
+    dispatcher,
+    httpClient,
+    fs,
+    openProjectOp,
+    openWorkspaceOp,
+    deleteWorkspaceOp,
+    setMetadataOp,
+  };
+}
+
+function startIntent(): AppStartIntent {
+  return { type: INTENT_APP_START, payload: {} as AppStartIntent["payload"] };
+}
+
+function shutdownIntent(): AppShutdownIntent {
+  return { type: INTENT_APP_SHUTDOWN, payload: {} as AppShutdownIntent["payload"] };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("YouTrackModule Integration", () => {
+  describe("activation", () => {
+    it("does nothing when no config keys are set", async () => {
+      const { dispatcher, httpClient } = createTestSetup({ disabled: true });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(httpClient).toHaveNoRequests();
+    });
+
+    it("does nothing when only some config keys are set", async () => {
+      const { dispatcher, httpClient } = createTestSetup({
+        partialConfig: {
+          baseUrl: BASE_URL,
+          token: "perm:test-token",
+          templatePath: null,
+          query: DEFAULT_QUERY,
+        },
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(httpClient).toHaveNoRequests();
+    });
+
+    it("polls YouTrack on activation when fully configured", async () => {
+      const { dispatcher, httpClient } = createTestSetup();
+
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(httpClient).toHaveRequested(ISSUES_URL);
+    });
+  });
+
+  describe("new issue detection", () => {
+    it("creates workspace when new issue is detected", async () => {
+      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp } = createTestSetup();
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(1);
+      expect(openProjectOp.dispatched[0]!.payload.git).toBe("https://github.com/org/repo.git");
+
+      expect(openWorkspaceOp.dispatched).toHaveLength(1);
+      expect(openWorkspaceOp.dispatched[0]!.payload.workspaceName).toBe("PROJ-123");
+      expect(openWorkspaceOp.dispatched[0]!.payload.stealFocus).toBe(false);
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Fix PROJ-123: Fix the bug",
+        agent: "plan",
+      });
+    });
+
+    it("uses project front-matter key for local path projects", async () => {
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({
+        templateContent:
+          "---\nproject: /home/user/my-repo\nname: {{ idReadable }}\n---\nFix {{ summary }}",
+      });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(1);
+      expect(openProjectOp.dispatched[0]!.payload.path?.toString()).toBe("/home/user/my-repo");
+      expect(openProjectOp.dispatched[0]!.payload.git).toBeUndefined();
+    });
+
+    it("project key takes precedence over git key", async () => {
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({
+        templateContent:
+          "---\nproject: /home/user/my-repo\ngit: https://github.com/org/repo.git\nname: {{ idReadable }}\n---\nFix {{ summary }}",
+      });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched[0]!.payload.path?.toString()).toBe("/home/user/my-repo");
+      expect(openProjectOp.dispatched[0]!.payload.git).toBeUndefined();
+    });
+
+    it("skips issue when neither project nor git key is present", async () => {
+      const { dispatcher, httpClient, openProjectOp, fs } = createTestSetup({
+        templateContent: "---\nname: {{ idReadable }}\n---\nFix {{ summary }}",
+      });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      // Should be dismissed as null
+      expect(fs).toHaveFileContaining(
+        "/data/youtrack-workspaces.json",
+        `"${BASE_URL}/api/issues/2-123": null`
+      );
+    });
+
+    it("does not recreate workspace for already-tracked issue", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: {
+          [stateKey]: {
+            workspaceName: "PROJ-123",
+            workspacePath: "/home/user/projects/repo/PROJ-123",
+            issueId: "2-123",
+            idReadable: "PROJ-123",
+            projectPath: "/home/user/projects/repo",
+            createdAt: "2026-02-27T10:00:00Z",
+          },
+        },
+      });
+
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+    });
+
+    it("auto-sets source and url metadata on created workspaces", async () => {
+      const { dispatcher, httpClient, setMetadataOp } = createTestSetup();
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      const metaPayloads = setMetadataOp.dispatched.map((i) => ({
+        key: i.payload.key,
+        value: i.payload.value,
+      }));
+      expect(metaPayloads).toContainEqual({ key: "source", value: "youtrack" });
+      expect(metaPayloads).toContainEqual({
+        key: "url",
+        value: `${BASE_URL}/issue/PROJ-123`,
+      });
+    });
+  });
+
+  describe("issue disappearance", () => {
+    it("deletes workspace when tracked issue disappears from query results", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: {
+          [stateKey]: {
+            workspaceName: "PROJ-123",
+            workspacePath: "/home/user/projects/repo/PROJ-123",
+            issueId: "2-123",
+            idReadable: "PROJ-123",
+            projectPath: "/home/user/projects/repo",
+            createdAt: "2026-02-27T10:00:00Z",
+          },
+        },
+      });
+
+      const { dispatcher, httpClient, deleteWorkspaceOp } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(deleteWorkspaceOp.dispatched).toHaveLength(1);
+      expect(deleteWorkspaceOp.dispatched[0]!.payload.removeWorktree).toBe(true);
+      expect(deleteWorkspaceOp.dispatched[0]!.payload.force).toBe(true);
+    });
+
+    it("cleans up null entry when issue disappears", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: { [stateKey]: null },
+      });
+
+      const { dispatcher, httpClient, deleteWorkspaceOp, fs } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(deleteWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining("/data/youtrack-workspaces.json", '"workspaces": {}');
+    });
+  });
+
+  describe("shutdown", () => {
+    it("clears poll timer on shutdown", async () => {
+      const { dispatcher, httpClient } = createTestSetup();
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+      await dispatcher.dispatch(shutdownIntent());
+
+      // Verified by no timer leak — shutdown is best-effort
+    });
+  });
+
+  describe("state persistence", () => {
+    it("persists state after creating a workspace", async () => {
+      const { dispatcher, httpClient, fs } = createTestSetup();
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(fs).toHaveFile("/data/youtrack-workspaces.json");
+    });
+
+    it("loads existing state on startup", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: {
+          [stateKey]: {
+            workspaceName: "PROJ-123",
+            workspacePath: "/home/user/projects/repo/PROJ-123",
+            issueId: "2-123",
+            idReadable: "PROJ-123",
+            projectPath: "/home/user/projects/repo",
+            createdAt: "2026-02-27T10:00:00Z",
+          },
+        },
+      });
+
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+    });
+  });
+
+  describe("error handling", () => {
+    it("continues when YouTrack API returns non-OK", async () => {
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup();
+
+      httpClient.setResponse(ISSUES_URL, { status: 403, body: "Forbidden" });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+    });
+
+    it("skips workspace when template file not found", async () => {
+      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp, fs } = createTestSetup({
+        templatePath: "/data/nonexistent.liquid",
+      });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining(
+        "/data/youtrack-workspaces.json",
+        `"${BASE_URL}/api/issues/2-123": null`
+      );
+    });
+
+    it("skips workspace when template renders to whitespace-only", async () => {
+      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp, fs } = createTestSetup({
+        templateContent: "   \n  ",
+      });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+      expect(fs).toHaveFileContaining(
+        "/data/youtrack-workspaces.json",
+        `"${BASE_URL}/api/issues/2-123": null`
+      );
+    });
+  });
+
+  describe("template and front-matter", () => {
+    function setupWithIssue(options?: { templateContent?: string }) {
+      const setup = createTestSetup(options);
+      setup.httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+      return setup;
+    }
+
+    it("uses front-matter agent to override agent mode", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithIssue({
+        templateContent:
+          "---\ngit: https://github.com/org/repo.git\nagent: build\n---\nFix {{ summary }}",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Fix Fix the bug",
+        agent: "build",
+      });
+    });
+
+    it("uses front-matter base to override base branch", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithIssue({
+        templateContent:
+          "---\ngit: https://github.com/org/repo.git\nbase: origin/develop\n---\nFix it",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.base).toBe("origin/develop");
+    });
+
+    it("uses front-matter focus to override stealFocus", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithIssue({
+        templateContent: "---\ngit: https://github.com/org/repo.git\nfocus: true\n---\nFix it",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.stealFocus).toBe(true);
+    });
+
+    it("uses front-matter model to set model in initial prompt", async () => {
+      const { dispatcher, openWorkspaceOp } = setupWithIssue({
+        templateContent:
+          "---\ngit: https://github.com/org/repo.git\nmodel.provider: anthropic\nmodel.id: claude-sonnet-4-6\n---\nFix it",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+        prompt: "Fix it",
+        agent: "plan",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      });
+    });
+
+    it("dispatches template metadata along with auto metadata", async () => {
+      const template = [
+        "---",
+        "git: https://github.com/org/repo.git",
+        "name: {{ idReadable }}",
+        "metadata.custom-key: custom-value",
+        "---",
+        "Fix {{ summary }}",
+      ].join("\n");
+
+      const { dispatcher, setMetadataOp } = setupWithIssue({ templateContent: template });
+
+      await dispatcher.dispatch(startIntent());
+
+      const metaPayloads = setMetadataOp.dispatched.map((i) => ({
+        key: i.payload.key,
+        value: i.payload.value,
+      }));
+      // Auto metadata
+      expect(metaPayloads).toContainEqual({ key: "source", value: "youtrack" });
+      expect(metaPayloads).toContainEqual({
+        key: "url",
+        value: `${BASE_URL}/issue/PROJ-123`,
+      });
+      // Template metadata
+      expect(metaPayloads).toContainEqual({ key: "custom-key", value: "custom-value" });
+    });
+
+    it("does not re-evaluate template for previously skipped issue", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: { [stateKey]: null },
+      });
+
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+    });
+
+    it("applies all front-matter overrides together", async () => {
+      const template = [
+        "---",
+        "git: https://github.com/org/repo.git",
+        "name: yt/{{ idReadable }}",
+        "agent: build",
+        "base: origin/develop",
+        "focus: true",
+        "model.provider: anthropic",
+        "model.id: claude-sonnet-4-6",
+        "---",
+        "Fix {{ idReadable }}: {{ summary }}",
+      ].join("\n");
+
+      const { dispatcher, openWorkspaceOp } = setupWithIssue({ templateContent: template });
+
+      await dispatcher.dispatch(startIntent());
+
+      const payload = openWorkspaceOp.dispatched[0]!.payload;
+      expect(payload.workspaceName).toBe("yt/PROJ-123");
+      expect(payload.base).toBe("origin/develop");
+      expect(payload.stealFocus).toBe(true);
+      expect(payload.initialPrompt).toEqual({
+        prompt: "Fix PROJ-123: Fix the bug",
+        agent: "build",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      });
+    });
+  });
+
+  describe("manual workspace deletion", () => {
+    it("does not recreate workspace after manual deletion", async () => {
+      const { dispatcher, httpClient, openProjectOp, openWorkspaceOp } = createTestSetup();
+
+      // First poll: workspace gets created
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+      expect(openWorkspaceOp.dispatched).toHaveLength(1);
+
+      // User manually deletes the workspace (dispatch triggers workspace:deleted event)
+      await dispatcher.dispatch({
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath: "/home/user/projects/repo/PROJ-123",
+          keepBranch: false,
+          force: true,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent);
+
+      // Reset tracking and set up second poll with same issue
+      openProjectOp.dispatched.length = 0;
+      openWorkspaceOp.dispatched.length = 0;
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      // Trigger manual poll via shutdown + restart
+      await dispatcher.dispatch(shutdownIntent());
+      await dispatcher.dispatch(startIntent());
+
+      // Workspace should NOT be recreated
+      expect(openProjectOp.dispatched).toHaveLength(0);
+      expect(openWorkspaceOp.dispatched).toHaveLength(0);
+    });
+
+    it("loads null entry from persisted state and skips issue", async () => {
+      const stateKey = `${BASE_URL}/api/issues/2-123`;
+      const existingState = JSON.stringify({
+        version: 1,
+        workspaces: { [stateKey]: null },
+      });
+
+      const { dispatcher, httpClient, openProjectOp } = createTestSetup({ existingState });
+
+      httpClient.setResponse(ISSUES_URL, {
+        body: issuesResponse([{ id: "2-123", idReadable: "PROJ-123", summary: "Fix the bug" }]),
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      expect(openProjectOp.dispatched).toHaveLength(0);
+    });
+  });
+
+  describe("config toggling", () => {
+    it("activates when all four keys become non-null at runtime", async () => {
+      // Start with only 3 keys set
+      const { dispatcher, httpClient, fs } = createTestSetup({
+        partialConfig: {
+          baseUrl: BASE_URL,
+          token: "perm:test-token",
+          templatePath: null,
+          query: DEFAULT_QUERY,
+        },
+      });
+
+      // Ensure template file exists for when module tries to read it
+      fs.$.setEntry(DEFAULT_TEMPLATE_PATH, file(DEFAULT_TEMPLATE_CONTENT));
+
+      await dispatcher.dispatch(startIntent());
+      expect(httpClient).toHaveNoRequests();
+
+      // Now set the 4th key at runtime via config:set-values dispatch
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch({
+        type: INTENT_CONFIG_SET_VALUES,
+        payload: { values: { "experimental.youtrack.template-path": DEFAULT_TEMPLATE_PATH } },
+      } as ConfigSetValuesIntent);
+
+      // Allow async activate to complete
+      await vi.waitFor(() => {
+        expect(httpClient).toHaveRequested(ISSUES_URL);
+      });
+    });
+
+    it("deactivates when a config key becomes null at runtime", async () => {
+      const { dispatcher, httpClient } = createTestSetup();
+      httpClient.setResponse(ISSUES_URL, { body: issuesResponse([]) });
+
+      await dispatcher.dispatch(startIntent());
+      expect(httpClient).toHaveRequested(ISSUES_URL);
+
+      // Set one key to null → deactivates
+      await dispatcher.dispatch({
+        type: INTENT_CONFIG_SET_VALUES,
+        payload: { values: { "experimental.youtrack.token": null } },
+      } as ConfigSetValuesIntent);
+
+      // Module should be deactivated (no further polls)
+    });
+  });
+});
+
+// =============================================================================
+// parseYouTrackTemplateOutput
+// =============================================================================
+
+describe("parseYouTrackTemplateOutput", () => {
+  it("treats entire string as prompt when no front matter", () => {
+    const result = parseYouTrackTemplateOutput("Fix the bug");
+    expect(result.config).toEqual({ prompt: "Fix the bug" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("parses project key", () => {
+    const input = "---\nproject: /home/user/repo\n---\nFix it";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config.project).toBe("/home/user/repo");
+  });
+
+  it("parses git key", () => {
+    const input = "---\ngit: https://github.com/org/repo.git\n---\nFix it";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config.git).toBe("https://github.com/org/repo.git");
+  });
+
+  it("parses all supported front-matter fields", () => {
+    const input = [
+      "---",
+      "name: PROJ-123",
+      "agent: plan",
+      "base: origin/main",
+      "focus: true",
+      "model.provider: anthropic",
+      "model.id: claude-sonnet-4-6",
+      "project: /home/user/repo",
+      "git: https://github.com/org/repo.git",
+      "---",
+      "Fix this issue",
+    ].join("\n");
+
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config).toEqual({
+      prompt: "Fix this issue",
+      name: "PROJ-123",
+      agent: "plan",
+      base: "origin/main",
+      focus: true,
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      project: "/home/user/repo",
+      git: "https://github.com/org/repo.git",
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns on unknown front-matter keys", () => {
+    const input = "---\nunknown: value\nname: ws\n---\nprompt";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config.name).toBe("ws");
+    expect(result.warnings).toEqual(['Unknown front-matter key: "unknown"']);
+  });
+
+  it("parses metadata.* keys into metadata record", () => {
+    const input =
+      "---\nmetadata.issue-url: https://example.com\nmetadata.priority: high\n---\nprompt";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config.metadata).toEqual({
+      "issue-url": "https://example.com",
+      priority: "high",
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("handles empty front matter (prompt only)", () => {
+    const input = "---\n---\nJust the prompt";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config).toEqual({ prompt: "Just the prompt" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("treats opening --- without closing as no front matter", () => {
+    const input = "---\nname: ws\nno closing delimiter";
+    const result = parseYouTrackTemplateOutput(input);
+    expect(result.config).toEqual({ prompt: input });
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/main/modules/youtrack-module.ts
+++ b/src/main/modules/youtrack-module.ts
@@ -1,0 +1,716 @@
+/**
+ * YouTrackModule - Polls YouTrack for issues matching a configured query
+ * and automatically creates/deletes workspaces to match.
+ *
+ * Enabled when ALL FOUR config keys are non-null:
+ * - experimental.youtrack.base-url
+ * - experimental.youtrack.token
+ * - experimental.youtrack.template-path
+ * - experimental.youtrack.query
+ *
+ * Hooks:
+ * - app:start -> "register-config": register 4 config keys
+ * - app:start -> "activate": load state, run initial poll, start timer
+ * - app:shutdown -> "stop": clear poll timer
+ *
+ * Events:
+ * - config:updated: react to youtrack config key changes
+ * - workspace:deleted: clean up mapping if a youtrack workspace is manually deleted
+ */
+
+import type { IntentModule } from "../intents/infrastructure/module";
+import type { Dispatcher } from "../intents/infrastructure/dispatcher";
+import type { DomainEvent } from "../intents/infrastructure/types";
+import {
+  APP_START_OPERATION_ID,
+  type ActivateHookResult,
+  type RegisterConfigResult,
+} from "../operations/app-start";
+import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "../operations/open-workspace";
+import {
+  INTENT_DELETE_WORKSPACE,
+  EVENT_WORKSPACE_DELETED,
+  type DeleteWorkspaceIntent,
+  type WorkspaceDeletedEvent,
+} from "../operations/delete-workspace";
+import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "../operations/open-project";
+import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
+import type { HttpClient } from "../../services/platform/network";
+import type { FileSystemLayer } from "../../services/platform/filesystem";
+import type { Logger } from "../../services/logging/types";
+import { isValidMetadataKey, type NormalizedInitialPrompt } from "../../shared/api/types";
+import { getErrorMessage } from "../../shared/error-utils";
+import { renderTemplate } from "../../services/template/liquid-renderer";
+import { INTENT_SET_METADATA, type SetMetadataIntent } from "../operations/set-metadata";
+import { configString, configPath } from "../../services/config/config-definition";
+import type { ConfigKeyDefinition } from "../../services/config/config-definition";
+import { Path } from "../../services/platform/path";
+
+// =============================================================================
+// Persistence Types
+// =============================================================================
+
+interface YouTrackWorkspaceEntry {
+  readonly workspaceName: string;
+  readonly workspacePath: string;
+  readonly issueId: string;
+  readonly idReadable: string;
+  readonly projectPath: string;
+  readonly createdAt: string;
+}
+
+interface YouTrackState {
+  readonly version: 1;
+  readonly workspaces: Record<string, YouTrackWorkspaceEntry | null>;
+}
+
+// =============================================================================
+// Module Dependencies
+// =============================================================================
+
+export interface YouTrackModuleDeps {
+  readonly httpClient: HttpClient;
+  readonly fs: Pick<FileSystemLayer, "readFile" | "writeFile" | "mkdir">;
+  readonly logger: Logger;
+  readonly stateFilePath: string;
+  readonly dispatcher: Dispatcher;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const POLL_INTERVAL_MS = 3 * 60 * 1000; // 3 minutes
+
+const CONFIG_KEYS = {
+  baseUrl: "experimental.youtrack.base-url",
+  token: "experimental.youtrack.token",
+  templatePath: "experimental.youtrack.template-path",
+  query: "experimental.youtrack.query",
+} as const;
+
+const YOUTRACK_FIELDS =
+  "id,idReadable,summary,description,reporter(login,fullName),created,updated,resolved,project(id,name,shortName),customFields(name,value(name))";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function emptyState(): YouTrackState {
+  return { version: 1, workspaces: {} };
+}
+
+/**
+ * Build the state key for a YouTrack issue.
+ * e.g. "https://youtrack.example.com/api/issues/2-123"
+ */
+function issueStateKey(baseUrl: string, issueId: string): string {
+  return `${baseUrl}/api/issues/${issueId}`;
+}
+
+// =============================================================================
+// Front-matter parser
+// =============================================================================
+
+export interface YouTrackTemplateConfig {
+  readonly name?: string;
+  readonly agent?: string;
+  readonly base?: string;
+  readonly focus?: boolean;
+  readonly model?: { readonly providerID: string; readonly modelID: string };
+  readonly metadata?: Readonly<Record<string, string>>;
+  readonly project?: string;
+  readonly git?: string;
+  readonly prompt: string;
+}
+
+export interface YouTrackParseResult {
+  readonly config: YouTrackTemplateConfig;
+  readonly warnings: readonly string[];
+}
+
+const FRONT_MATTER_OPEN = "---\n";
+const KNOWN_KEYS = new Set([
+  "name",
+  "agent",
+  "base",
+  "focus",
+  "model.provider",
+  "model.id",
+  "project",
+  "git",
+]);
+
+export function parseYouTrackTemplateOutput(rendered: string): YouTrackParseResult {
+  const warnings: string[] = [];
+
+  if (!rendered.startsWith(FRONT_MATTER_OPEN)) {
+    return { config: { prompt: rendered }, warnings };
+  }
+
+  // Find closing delimiter after the opening "---\n"
+  const rest = rendered.slice(FRONT_MATTER_OPEN.length);
+  const closeMatch = /^---[ \t]*$/m.exec(rest);
+  if (!closeMatch || closeMatch.index === undefined) {
+    // No closing delimiter -> treat entire string as prompt
+    return { config: { prompt: rendered }, warnings };
+  }
+
+  const frontMatterBlock = rest.slice(0, closeMatch.index);
+  const prompt = rest.slice(closeMatch.index + closeMatch[0].length).replace(/^\n/, "");
+
+  // Parse key-value lines
+  const fields: Record<string, string> = {};
+  const metadataFields: Record<string, string> = {};
+  for (const line of frontMatterBlock.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex === -1) {
+      warnings.push(`Ignoring front-matter line (no colon): "${trimmed}"`);
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+
+    if (key.startsWith("metadata.")) {
+      const metaKey = key.slice("metadata.".length);
+      if (isValidMetadataKey(metaKey)) {
+        metadataFields[metaKey] = value;
+      } else {
+        warnings.push(`Invalid metadata key: "${metaKey}"`);
+      }
+      continue;
+    }
+
+    if (!KNOWN_KEYS.has(key)) {
+      warnings.push(`Unknown front-matter key: "${key}"`);
+      continue;
+    }
+
+    fields[key] = value;
+  }
+
+  // Build config
+  let focus: boolean | undefined;
+  if (fields["focus"] !== undefined) {
+    if (fields["focus"] === "true") {
+      focus = true;
+    } else if (fields["focus"] === "false") {
+      focus = false;
+    } else {
+      warnings.push(`Invalid focus value "${fields["focus"]}", expected "true" or "false"`);
+    }
+  }
+
+  let model: { readonly providerID: string; readonly modelID: string } | undefined;
+  if (fields["model.provider"] !== undefined || fields["model.id"] !== undefined) {
+    if (fields["model.provider"] && fields["model.id"]) {
+      model = { providerID: fields["model.provider"], modelID: fields["model.id"] };
+    } else {
+      warnings.push("Both model.provider and model.id must be specified together");
+    }
+  }
+
+  const config: YouTrackTemplateConfig = {
+    prompt,
+    ...(fields["name"] !== undefined && { name: fields["name"] }),
+    ...(fields["agent"] !== undefined && { agent: fields["agent"] }),
+    ...(fields["base"] !== undefined && { base: fields["base"] }),
+    ...(focus !== undefined && { focus }),
+    ...(model !== undefined && { model }),
+    ...(Object.keys(metadataFields).length > 0 && { metadata: metadataFields }),
+    ...(fields["project"] !== undefined && { project: fields["project"] }),
+    ...(fields["git"] !== undefined && { git: fields["git"] }),
+  };
+
+  return { config, warnings };
+}
+
+// =============================================================================
+// Module Factory
+// =============================================================================
+
+export function createYouTrackModule(deps: YouTrackModuleDeps): IntentModule {
+  let state: YouTrackState = emptyState();
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let enabled = false;
+  // Tracked from config:updated events (fires during app:start init phase, before activate)
+  let configBaseUrl: string | null = null;
+  let configToken: string | null = null;
+  let configTemplatePath: string | null = null;
+  let configQuery: string | null = null;
+  // Prevents the event handler from triggering activation during initial startup
+  let initialActivationDone = false;
+
+  const stateFilePath = deps.stateFilePath;
+
+  function isFullyConfigured(): boolean {
+    return (
+      configBaseUrl !== null &&
+      configToken !== null &&
+      configTemplatePath !== null &&
+      configQuery !== null
+    );
+  }
+
+  // ------ State Persistence ------
+
+  async function loadState(): Promise<YouTrackState> {
+    try {
+      const raw = await deps.fs.readFile(stateFilePath);
+      const parsed = JSON.parse(raw) as YouTrackState;
+      if (parsed.version === 1 && typeof parsed.workspaces === "object") {
+        return parsed;
+      }
+      deps.logger.warn("Invalid youtrack state file, starting fresh");
+      return emptyState();
+    } catch {
+      return emptyState();
+    }
+  }
+
+  async function saveState(): Promise<void> {
+    try {
+      await deps.fs.writeFile(stateFilePath, JSON.stringify(state, null, 2));
+    } catch (error) {
+      deps.logger.warn("Failed to save youtrack state", { error: getErrorMessage(error) });
+    }
+  }
+
+  // ------ YouTrack API ------
+
+  function youtrackHeaders(): Readonly<Record<string, string>> {
+    return {
+      Authorization: `Bearer ${configToken}`,
+      Accept: "application/json",
+    };
+  }
+
+  async function fetchIssues(): Promise<Record<string, unknown>[]> {
+    const query = encodeURIComponent(configQuery!);
+    const fields = encodeURIComponent(YOUTRACK_FIELDS);
+    const url = `${configBaseUrl}/api/issues?query=${query}&fields=${fields}`;
+
+    const response = await deps.httpClient.fetch(url, {
+      timeout: 15000,
+      headers: youtrackHeaders(),
+    });
+
+    if (!response.ok) {
+      deps.logger.warn("YouTrack API returned non-OK", { status: response.status });
+      return [];
+    }
+
+    return (await response.json()) as Record<string, unknown>[];
+  }
+
+  // ------ Workspace Lifecycle ------
+
+  interface WorkspaceConfig {
+    readonly workspaceName: string;
+    readonly base?: string;
+    readonly stealFocus: boolean;
+    readonly initialPrompt: NormalizedInitialPrompt;
+    readonly metadata?: Readonly<Record<string, string>>;
+    readonly projectSource: { type: "path"; path: string } | { type: "git"; url: string } | null;
+  }
+
+  async function buildWorkspaceConfig(
+    issue: Record<string, unknown>
+  ): Promise<WorkspaceConfig | null> {
+    try {
+      const templateContent = await deps.fs.readFile(configTemplatePath!);
+      const rendered = renderTemplate(templateContent, issue);
+      const { config, warnings } = parseYouTrackTemplateOutput(rendered);
+
+      for (const warning of warnings) {
+        deps.logger.warn("Template front-matter warning", {
+          warning,
+          templatePath: configTemplatePath,
+        });
+      }
+
+      if (!config.prompt.trim()) return null;
+
+      // Determine project source: "project" wins over "git"
+      let projectSource: WorkspaceConfig["projectSource"] = null;
+      if (config.project) {
+        projectSource = { type: "path", path: config.project };
+      } else if (config.git) {
+        projectSource = { type: "git", url: config.git };
+      }
+
+      // Skip if no project source
+      if (!projectSource) return null;
+
+      const initialPrompt: NormalizedInitialPrompt = {
+        prompt: config.prompt,
+        agent: config.agent ?? "plan",
+        ...(config.model !== undefined && { model: config.model }),
+      };
+
+      const idReadable = issue.idReadable as string;
+
+      return {
+        workspaceName: config.name ?? idReadable,
+        ...(config.base !== undefined && { base: config.base }),
+        stealFocus: config.focus ?? false,
+        initialPrompt,
+        ...(config.metadata !== undefined && { metadata: config.metadata }),
+        projectSource,
+      };
+    } catch (error) {
+      deps.logger.warn("Failed to read/render YouTrack template", {
+        templatePath: configTemplatePath,
+        error: getErrorMessage(error),
+      });
+      return null;
+    }
+  }
+
+  async function createIssueWorkspace(
+    stateKey: string,
+    issue: Record<string, unknown>
+  ): Promise<void> {
+    const issueId = issue.id as string;
+    const idReadable = issue.idReadable as string;
+    deps.logger.info("Creating YouTrack workspace", { stateKey, idReadable });
+
+    try {
+      const config = await buildWorkspaceConfig(issue);
+      if (!config) {
+        deps.logger.info("Skipping YouTrack workspace (template resolved to empty or no project)", {
+          stateKey,
+        });
+        state = {
+          ...state,
+          workspaces: { ...state.workspaces, [stateKey]: null },
+        };
+        return;
+      }
+
+      // Open the project (local path or git clone)
+      const projectPayload: OpenProjectIntent["payload"] =
+        config.projectSource!.type === "path"
+          ? { path: new Path(config.projectSource!.path) }
+          : { git: config.projectSource!.url };
+
+      const project = await deps.dispatcher.dispatch({
+        type: INTENT_OPEN_PROJECT,
+        payload: projectPayload,
+      } as OpenProjectIntent);
+
+      if (!project) {
+        deps.logger.warn("project:open returned null for YouTrack workspace", { stateKey });
+        return;
+      }
+
+      // Create the workspace
+      const wsResult = await deps.dispatcher.dispatch({
+        type: INTENT_OPEN_WORKSPACE,
+        payload: {
+          workspaceName: config.workspaceName,
+          ...(config.base !== undefined && { base: config.base }),
+          stealFocus: config.stealFocus,
+          projectPath: project.path,
+          initialPrompt: config.initialPrompt,
+        },
+      } as OpenWorkspaceIntent);
+
+      const workspacePath =
+        wsResult && typeof wsResult === "object" && "path" in wsResult
+          ? (wsResult as { path: string }).path
+          : "";
+
+      // Auto-set source and url metadata
+      if (workspacePath) {
+        const issueUrl = `${configBaseUrl}/issue/${idReadable}`;
+        const autoMetadata: Record<string, string> = {
+          source: "youtrack",
+          url: issueUrl,
+        };
+
+        // Merge auto metadata with template metadata (template wins on conflict)
+        const allMetadata = { ...autoMetadata, ...(config.metadata ?? {}) };
+
+        for (const [key, value] of Object.entries(allMetadata)) {
+          try {
+            await deps.dispatcher.dispatch({
+              type: INTENT_SET_METADATA,
+              payload: { workspacePath, key, value },
+            } as SetMetadataIntent);
+          } catch (error) {
+            deps.logger.warn("Failed to set workspace metadata", {
+              key,
+              stateKey,
+              error: getErrorMessage(error),
+            });
+          }
+        }
+      }
+
+      // Record in state
+      state = {
+        ...state,
+        workspaces: {
+          ...state.workspaces,
+          [stateKey]: {
+            workspaceName: config.workspaceName,
+            workspacePath,
+            issueId,
+            idReadable,
+            projectPath: project.path,
+            createdAt: new Date().toISOString(),
+          },
+        },
+      };
+
+      deps.logger.info("YouTrack workspace created", {
+        stateKey,
+        workspaceName: config.workspaceName,
+      });
+    } catch (error) {
+      deps.logger.warn("Failed to create YouTrack workspace", {
+        stateKey,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  async function deleteIssueWorkspace(
+    stateKey: string,
+    entry: YouTrackWorkspaceEntry
+  ): Promise<void> {
+    deps.logger.info("Deleting YouTrack workspace (issue disappeared)", {
+      stateKey,
+      workspaceName: entry.workspaceName,
+    });
+
+    try {
+      await deps.dispatcher.dispatch({
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath: entry.workspacePath,
+          keepBranch: false,
+          force: true,
+          removeWorktree: true,
+        },
+      } as DeleteWorkspaceIntent);
+
+      deps.logger.info("YouTrack workspace deleted", {
+        stateKey,
+        workspaceName: entry.workspaceName,
+      });
+    } catch (error) {
+      deps.logger.warn("Failed to delete YouTrack workspace", {
+        stateKey,
+        error: getErrorMessage(error),
+      });
+    }
+
+    // Remove from state regardless of success (don't retry forever)
+    const remaining = Object.fromEntries(
+      Object.entries(state.workspaces).filter(([key]) => key !== stateKey)
+    );
+    state = { ...state, workspaces: remaining };
+  }
+
+  // ------ Poll Cycle ------
+
+  async function poll(): Promise<void> {
+    deps.logger.debug("Polling YouTrack for issues");
+
+    const stateBefore = state;
+
+    let issues: Record<string, unknown>[];
+    try {
+      issues = await fetchIssues();
+    } catch (error) {
+      deps.logger.warn("Failed to poll YouTrack", { error: getErrorMessage(error) });
+      return;
+    }
+
+    // Build set of currently open issue state keys
+    const openIssueKeys = new Set<string>();
+    for (const issue of issues) {
+      const issueId = issue.id as string;
+      const key = issueStateKey(configBaseUrl!, issueId);
+      openIssueKeys.add(key);
+    }
+
+    // Detect disappeared issues -> delete workspaces or clean up null entries
+    const disappearedKeys = Object.keys(state.workspaces).filter((key) => !openIssueKeys.has(key));
+    for (const stateKey of disappearedKeys) {
+      const entry = state.workspaces[stateKey];
+      if (entry) {
+        await deleteIssueWorkspace(stateKey, entry);
+      } else {
+        // null entry (dismissed) — just remove the key
+        const remaining = Object.fromEntries(
+          Object.entries(state.workspaces).filter(([key]) => key !== stateKey)
+        );
+        state = { ...state, workspaces: remaining };
+      }
+    }
+
+    // Detect new issues -> create workspaces
+    for (const issue of issues) {
+      const issueId = issue.id as string;
+      const key = issueStateKey(configBaseUrl!, issueId);
+      if (key in state.workspaces) continue; // tracked (active or dismissed)
+
+      await createIssueWorkspace(key, issue);
+    }
+
+    // Persist if state changed
+    if (state !== stateBefore) {
+      await saveState();
+    }
+  }
+
+  // ------ Timer Management ------
+
+  function startPolling(): void {
+    if (pollTimer) return;
+    pollTimer = setInterval(() => {
+      void poll();
+    }, POLL_INTERVAL_MS);
+    deps.logger.info("YouTrack polling started", { intervalMs: POLL_INTERVAL_MS });
+  }
+
+  function stopPolling(): void {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+      deps.logger.info("YouTrack polling stopped");
+    }
+  }
+
+  // ------ Activation / Deactivation ------
+
+  async function activate(): Promise<void> {
+    if (!isFullyConfigured()) {
+      return;
+    }
+
+    deps.logger.info("YouTrack integration fully configured, enabling");
+
+    state = await loadState();
+    enabled = true;
+
+    // Run initial poll (reconcile stale state)
+    await poll();
+
+    startPolling();
+  }
+
+  function deactivate(): void {
+    stopPolling();
+    enabled = false;
+  }
+
+  // ------ Module Definition ------
+
+  return {
+    name: "youtrack",
+    hooks: {
+      [APP_START_OPERATION_ID]: {
+        "register-config": {
+          handler: async (): Promise<RegisterConfigResult> => ({
+            definitions: [
+              {
+                name: CONFIG_KEYS.baseUrl,
+                default: null,
+                description: "YouTrack instance URL (e.g. https://youtrack.example.com)",
+                ...configString({ nullable: true }),
+              },
+              {
+                name: CONFIG_KEYS.token,
+                default: null,
+                description: "YouTrack API permanent token",
+                ...configString({ nullable: true }),
+              },
+              {
+                name: CONFIG_KEYS.templatePath,
+                default: null,
+                description: "Path to Liquid template for YouTrack workspaces",
+                ...configPath({ nullable: true }),
+              },
+              {
+                name: CONFIG_KEYS.query,
+                default: null,
+                description: "YouTrack search query (e.g. for:me State: {In Progress})",
+                ...configString({ nullable: true }),
+              },
+            ] satisfies ConfigKeyDefinition<unknown>[],
+          }),
+        },
+        activate: {
+          handler: async (): Promise<ActivateHookResult> => {
+            await activate();
+            initialActivationDone = true;
+            return {};
+          },
+        },
+      },
+      [APP_SHUTDOWN_OPERATION_ID]: {
+        stop: {
+          handler: async () => {
+            deactivate();
+          },
+        },
+      },
+    },
+    events: {
+      [EVENT_CONFIG_UPDATED]: (event: DomainEvent) => {
+        const { values } = (event as ConfigUpdatedEvent).payload;
+        const prevConfigured = isFullyConfigured();
+
+        if (CONFIG_KEYS.baseUrl in values) {
+          configBaseUrl = (values[CONFIG_KEYS.baseUrl] as string | null) ?? null;
+        }
+        if (CONFIG_KEYS.token in values) {
+          configToken = (values[CONFIG_KEYS.token] as string | null) ?? null;
+        }
+        if (CONFIG_KEYS.templatePath in values) {
+          configTemplatePath = (values[CONFIG_KEYS.templatePath] as string | null) ?? null;
+        }
+        if (CONFIG_KEYS.query in values) {
+          configQuery = (values[CONFIG_KEYS.query] as string | null) ?? null;
+        }
+
+        // Only react to runtime toggles (after initial activate hook has run).
+        if (!initialActivationDone) return;
+
+        const nowConfigured = isFullyConfigured();
+        if (!prevConfigured && nowConfigured && !enabled) {
+          void activate();
+        } else if (prevConfigured && !nowConfigured && enabled) {
+          deactivate();
+        }
+      },
+      [EVENT_WORKSPACE_DELETED]: (event: DomainEvent) => {
+        const { workspacePath } = (event as WorkspaceDeletedEvent).payload;
+        // If a tracked YouTrack workspace is deleted, set to null to prevent re-creation
+        for (const [stateKey, entry] of Object.entries(state.workspaces)) {
+          if (entry?.workspacePath === workspacePath) {
+            state = {
+              ...state,
+              workspaces: { ...state.workspaces, [stateKey]: null },
+            };
+            void saveState();
+            deps.logger.info("Marked YouTrack workspace as dismissed", {
+              stateKey,
+              workspaceName: entry.workspaceName,
+            });
+            break;
+          }
+        }
+      },
+    },
+  };
+}

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -57,7 +57,8 @@ export type LoggerName =
   | "agent" // AgentServerManager / AgentStatusManager - agent lifecycle
   | "shortcut" // ShortcutController - keyboard shortcut detection
   | "dispatcher" // Dispatcher - intent dispatch pipeline
-  | "auto-pr"; // AutoPrModule - GitHub PR workspace automation
+  | "auto-pr" // AutoPrModule - GitHub PR workspace automation
+  | "youtrack"; // YouTrackModule - YouTrack issue workspace automation
 
 /**
  * Context data for log entries.


### PR DESCRIPTION
- Add YouTrack integration module that polls for issues matching a configured query
- Auto-create workspaces for new issues, auto-delete when issues disappear from query
- Track manually-deleted workspaces to prevent re-creation (null entry dismissal)
- Support `project` and `git` front-matter keys for repo association
- Auto-set `source=youtrack` and `url` metadata on created workspaces
- Four config keys required for activation: `experimental.youtrack.base-url`, `.token`, `.template-path`, `.query`
- Integration tests covering activation, detection, deletion, template rendering, config toggling, and error handling