### PR TITLE
feat: MCP can control VS Code notifications, status bar items, and quick pick

### DIFF
--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -13,6 +13,14 @@ import type {
   InitialPrompt,
   AgentSession,
   AgentType,
+  ShowNotificationRequest,
+  ShowNotificationResponse,
+  StatusBarUpdateRequest,
+  StatusBarDisposeRequest,
+  ShowQuickPickRequest,
+  ShowQuickPickResponse,
+  ShowInputBoxRequest,
+  ShowInputBoxResponse,
 } from "./types";
 import {
   reconstructVscodeObjects,
@@ -173,6 +181,23 @@ function setupTerminalCloseListener(): void {
       codehydraApi.log.debug("Agent terminal closed");
     }
   });
+}
+
+// ============================================================================
+// MCP Status Bar Management
+// ============================================================================
+
+/** Status bar items created via MCP ui:statusBarUpdate, keyed by id */
+const mcpStatusBarItems = new Map<string, vscode.StatusBarItem>();
+
+/**
+ * Dispose all MCP-created status bar items.
+ */
+function disposeAllMcpStatusBarItems(): void {
+  for (const item of mcpStatusBarItems.values()) {
+    item.dispose();
+  }
+  mcpStatusBarItems.clear();
 }
 
 // ============================================================================
@@ -592,6 +617,7 @@ function connectToPluginServer(port: number, workspacePath: string): void {
   socket.on("disconnect", (reason) => {
     codehydraApi.log.info("Disconnected from PluginServer", { reason });
     isConnected = false;
+    disposeAllMcpStatusBarItems();
   });
 
   socket.on("connect_error", (err) => {
@@ -636,6 +662,108 @@ function connectToPluginServer(port: number, workspacePath: string): void {
     codehydraApi.log.info("Exiting extension host");
     setImmediate(() => process.exit(0));
   });
+
+  // ---- UI event handlers ----
+
+  socket.on(
+    "ui:showNotification",
+    (
+      request: ShowNotificationRequest,
+      ack: (result: PluginResult<ShowNotificationResponse>) => void
+    ) => {
+      const showFn =
+        request.severity === "error"
+          ? vscode.window.showErrorMessage
+          : request.severity === "warning"
+            ? vscode.window.showWarningMessage
+            : vscode.window.showInformationMessage;
+
+      if (!request.actions || request.actions.length === 0) {
+        // Fire-and-forget: ack immediately, then show modal notification
+        ack({ success: true, data: { action: null } });
+        void showFn(request.message, { modal: true });
+      } else {
+        // Interactive: show modal with actions, await user response, then ack
+        const actions = [...request.actions];
+        void showFn(request.message, { modal: true }, ...actions).then((selected) => {
+          ack({ success: true, data: { action: selected ?? null } });
+        });
+      }
+    }
+  );
+
+  socket.on(
+    "ui:statusBarUpdate",
+    (request: StatusBarUpdateRequest, ack: (result: PluginResult<void>) => void) => {
+      try {
+        let item = mcpStatusBarItems.get(request.id);
+        if (!item) {
+          item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+          mcpStatusBarItems.set(request.id, item);
+        }
+        item.text = request.text;
+        if (request.tooltip !== undefined) item.tooltip = request.tooltip;
+        if (request.command !== undefined) item.command = request.command;
+        if (request.color !== undefined) {
+          item.color = request.color;
+        }
+        item.show();
+        ack({ success: true, data: undefined });
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        ack({ success: false, error });
+      }
+    }
+  );
+
+  socket.on(
+    "ui:statusBarDispose",
+    (request: StatusBarDisposeRequest, ack: (result: PluginResult<void>) => void) => {
+      const item = mcpStatusBarItems.get(request.id);
+      if (item) {
+        item.dispose();
+        mcpStatusBarItems.delete(request.id);
+      }
+      ack({ success: true, data: undefined });
+    }
+  );
+
+  socket.on(
+    "ui:showQuickPick",
+    (request: ShowQuickPickRequest, ack: (result: PluginResult<ShowQuickPickResponse>) => void) => {
+      const items: vscode.QuickPickItem[] = request.items.map((i) => ({
+        label: i.label,
+        ...(i.description !== undefined && { description: i.description }),
+        ...(i.detail !== undefined && { detail: i.detail }),
+      }));
+
+      void vscode.window
+        .showQuickPick(items, {
+          ...(request.title !== undefined && { title: request.title }),
+          ...(request.placeholder !== undefined && { placeHolder: request.placeholder }),
+        })
+        .then((selected) => {
+          ack({ success: true, data: { selected: selected?.label ?? null } });
+        });
+    }
+  );
+
+  socket.on(
+    "ui:showInputBox",
+    (request: ShowInputBoxRequest, ack: (result: PluginResult<ShowInputBoxResponse>) => void) => {
+      void vscode.window
+        .showInputBox({
+          ...(request.title !== undefined && { title: request.title }),
+          ...(request.prompt !== undefined && { prompt: request.prompt }),
+          ...(request.placeholder !== undefined && { placeHolder: request.placeholder }),
+          ...(request.value !== undefined && { value: request.value }),
+          ...(request.password !== undefined && { password: request.password }),
+        })
+        .then((value) => {
+          ack({ success: true, data: { value: value ?? null } });
+        });
+    }
+  );
 
   socket.connect();
 }
@@ -822,6 +950,8 @@ export function activate(context: vscode.ExtensionContext): { codehydra: typeof 
 }
 
 export function deactivate(): void {
+  disposeAllMcpStatusBarItems();
+
   if (socket) {
     codehydraApi.log.info("Deactivating");
     socket.disconnect();

--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -57,11 +57,84 @@ export interface WorkspaceCreateRequest {
   readonly stealFocus?: boolean;
 }
 
+// UI request/response types
+export type NotificationSeverity = "info" | "warning" | "error";
+
+export interface ShowNotificationRequest {
+  readonly severity: NotificationSeverity;
+  readonly message: string;
+  readonly actions?: readonly string[];
+}
+
+export interface ShowNotificationResponse {
+  readonly action: string | null;
+}
+
+export interface StatusBarUpdateRequest {
+  readonly id: string;
+  readonly text: string;
+  readonly tooltip?: string;
+  readonly command?: string;
+  readonly color?: string;
+}
+
+export interface StatusBarDisposeRequest {
+  readonly id: string;
+}
+
+export interface QuickPickItem {
+  readonly label: string;
+  readonly description?: string;
+  readonly detail?: string;
+}
+
+export interface ShowQuickPickRequest {
+  readonly items: readonly QuickPickItem[];
+  readonly title?: string;
+  readonly placeholder?: string;
+}
+
+export interface ShowQuickPickResponse {
+  readonly selected: string | null;
+}
+
+export interface ShowInputBoxRequest {
+  readonly title?: string;
+  readonly prompt?: string;
+  readonly placeholder?: string;
+  readonly value?: string;
+  readonly password?: boolean;
+}
+
+export interface ShowInputBoxResponse {
+  readonly value: string | null;
+}
+
 // Socket.IO typed events
 export interface ServerToClientEvents {
   config: (config: PluginConfig) => void;
   command: (request: CommandRequest, ack: (result: PluginResult) => void) => void;
   shutdown: (ack: (result: PluginResult<undefined>) => void) => void;
+  "ui:showNotification": (
+    request: ShowNotificationRequest,
+    ack: (result: PluginResult<ShowNotificationResponse>) => void
+  ) => void;
+  "ui:statusBarUpdate": (
+    request: StatusBarUpdateRequest,
+    ack: (result: PluginResult<void>) => void
+  ) => void;
+  "ui:statusBarDispose": (
+    request: StatusBarDisposeRequest,
+    ack: (result: PluginResult<void>) => void
+  ) => void;
+  "ui:showQuickPick": (
+    request: ShowQuickPickRequest,
+    ack: (result: PluginResult<ShowQuickPickResponse>) => void
+  ) => void;
+  "ui:showInputBox": (
+    request: ShowInputBoxRequest,
+    ack: (result: PluginResult<ShowInputBoxResponse>) => void
+  ) => void;
 }
 
 export interface ClientToServerEvents {

--- a/src/main/modules/mcp-handlers.integration.test.ts
+++ b/src/main/modules/mcp-handlers.integration.test.ts
@@ -57,6 +57,11 @@ function createCapturingOperation<TIntent extends Intent = Intent, TResult = voi
 function createMockPluginServer() {
   return {
     sendCommand: vi.fn().mockResolvedValue({ success: true, data: "result" }),
+    showNotification: vi.fn().mockResolvedValue({ success: true, data: { action: null } }),
+    updateStatusBar: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+    disposeStatusBar: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+    showQuickPick: vi.fn().mockResolvedValue({ success: true, data: { selected: "Option A" } }),
+    showInputBox: vi.fn().mockResolvedValue({ success: true, data: { value: "hello" } }),
   };
 }
 
@@ -345,6 +350,217 @@ describe("createMcpHandlers", () => {
       await expect(handlers.executeCommand("/workspace/path", "test.command")).rejects.toThrow(
         "Plugin server not available"
       );
+    });
+  });
+
+  describe("showNotification", () => {
+    it("delegates to pluginServer.showNotification", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { severity: "info" as const, message: "Hello" };
+      const result = await handlers.showNotification("/workspace/path", request);
+
+      expect(pluginServer.showNotification).toHaveBeenCalledWith(
+        "/workspace/path",
+        request,
+        undefined
+      );
+      expect(result).toEqual({ action: null });
+    });
+
+    it("passes timeout to pluginServer", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { severity: "info" as const, message: "Hello", actions: ["OK"] };
+      await handlers.showNotification("/workspace/path", request, 5000);
+
+      expect(pluginServer.showNotification).toHaveBeenCalledWith("/workspace/path", request, 5000);
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.showNotification.mockResolvedValue({
+        success: false,
+        error: "Not connected",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(
+        handlers.showNotification("/workspace/path", { severity: "info", message: "Hi" })
+      ).rejects.toThrow("Not connected");
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(
+        handlers.showNotification("/workspace/path", { severity: "info", message: "Hi" })
+      ).rejects.toThrow("Plugin server not available");
+    });
+  });
+
+  describe("updateStatusBar", () => {
+    it("delegates to pluginServer.updateStatusBar", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { id: "my-status", text: "Building..." };
+      await handlers.updateStatusBar("/workspace/path", request);
+
+      expect(pluginServer.updateStatusBar).toHaveBeenCalledWith("/workspace/path", request);
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.updateStatusBar.mockResolvedValue({
+        success: false,
+        error: "Socket disconnected",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(
+        handlers.updateStatusBar("/workspace/path", { id: "my-status", text: "Building..." })
+      ).rejects.toThrow("Socket disconnected");
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(
+        handlers.updateStatusBar("/workspace/path", { id: "my-status", text: "Building..." })
+      ).rejects.toThrow("Plugin server not available");
+    });
+  });
+
+  describe("disposeStatusBar", () => {
+    it("delegates to pluginServer.disposeStatusBar", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { id: "my-status" };
+      await handlers.disposeStatusBar("/workspace/path", request);
+
+      expect(pluginServer.disposeStatusBar).toHaveBeenCalledWith("/workspace/path", request);
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.disposeStatusBar.mockResolvedValue({
+        success: false,
+        error: "Item not found",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(
+        handlers.disposeStatusBar("/workspace/path", { id: "my-status" })
+      ).rejects.toThrow("Item not found");
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(
+        handlers.disposeStatusBar("/workspace/path", { id: "my-status" })
+      ).rejects.toThrow("Plugin server not available");
+    });
+  });
+
+  describe("showQuickPick", () => {
+    it("delegates to pluginServer.showQuickPick", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { items: [{ label: "Option A" }, { label: "Option B" }] };
+      const result = await handlers.showQuickPick("/workspace/path", request);
+
+      expect(pluginServer.showQuickPick).toHaveBeenCalledWith(
+        "/workspace/path",
+        request,
+        undefined
+      );
+      expect(result).toEqual({ selected: "Option A" });
+    });
+
+    it("passes timeout to pluginServer", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { items: [{ label: "Option A" }], title: "Pick one" };
+      await handlers.showQuickPick("/workspace/path", request, 10000);
+
+      expect(pluginServer.showQuickPick).toHaveBeenCalledWith("/workspace/path", request, 10000);
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.showQuickPick.mockResolvedValue({
+        success: false,
+        error: "Timed out",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(
+        handlers.showQuickPick("/workspace/path", { items: [{ label: "A" }] })
+      ).rejects.toThrow("Timed out");
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(
+        handlers.showQuickPick("/workspace/path", { items: [{ label: "A" }] })
+      ).rejects.toThrow("Plugin server not available");
+    });
+  });
+
+  describe("showInputBox", () => {
+    it("delegates to pluginServer.showInputBox", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { prompt: "Enter your name", placeholder: "Name" };
+      const result = await handlers.showInputBox("/workspace/path", request);
+
+      expect(pluginServer.showInputBox).toHaveBeenCalledWith("/workspace/path", request, undefined);
+      expect(result).toEqual({ value: "hello" });
+    });
+
+    it("passes timeout to pluginServer", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      const request = { prompt: "Enter value", password: true };
+      await handlers.showInputBox("/workspace/path", request, 15000);
+
+      expect(pluginServer.showInputBox).toHaveBeenCalledWith("/workspace/path", request, 15000);
+    });
+
+    it("throws when pluginServer returns error", async () => {
+      const { dispatcher, pluginServer } = createTestSetup();
+      pluginServer.showInputBox.mockResolvedValue({
+        success: false,
+        error: "User cancelled",
+      });
+      const handlers = createMcpHandlers(dispatcher, pluginServer as never);
+
+      await expect(
+        handlers.showInputBox("/workspace/path", { prompt: "Enter value" })
+      ).rejects.toThrow("User cancelled");
+    });
+
+    it("throws when pluginServer is null", async () => {
+      const { dispatcher } = createTestSetup();
+      const handlers = createMcpHandlers(dispatcher, null);
+
+      await expect(
+        handlers.showInputBox("/workspace/path", { prompt: "Enter value" })
+      ).rejects.toThrow("Plugin server not available");
     });
   });
 });

--- a/src/main/modules/mcp-handlers.ts
+++ b/src/main/modules/mcp-handlers.ts
@@ -147,5 +147,58 @@ export function createMcpHandlers(
       }
       return result.data;
     },
+
+    async showNotification(workspacePath, request, timeoutMs) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.showNotification(workspacePath, request, timeoutMs);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+
+    async updateStatusBar(workspacePath, request) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.updateStatusBar(workspacePath, request);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+    },
+
+    async disposeStatusBar(workspacePath, request) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.disposeStatusBar(workspacePath, request);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+    },
+
+    async showQuickPick(workspacePath, request, timeoutMs) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.showQuickPick(workspacePath, request, timeoutMs);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+
+    async showInputBox(workspacePath, request, timeoutMs) {
+      if (!pluginServer) {
+        throw new Error("Plugin server not available");
+      }
+      const result = await pluginServer.showInputBox(workspacePath, request, timeoutMs);
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
   };
 }

--- a/src/services/mcp-server/mcp-server-manager.test.ts
+++ b/src/services/mcp-server/mcp-server-manager.test.ts
@@ -25,6 +25,11 @@ function createMockMcpHandlers(): McpApiHandlers {
     createWorkspace: vi.fn(),
     deleteWorkspace: vi.fn(),
     executeCommand: vi.fn(),
+    showNotification: vi.fn(),
+    updateStatusBar: vi.fn(),
+    disposeStatusBar: vi.fn(),
+    showQuickPick: vi.fn(),
+    showInputBox: vi.fn(),
   };
 }
 

--- a/src/services/mcp-server/mcp-server.boundary.test.ts
+++ b/src/services/mcp-server/mcp-server.boundary.test.ts
@@ -46,6 +46,11 @@ function createMockMcpHandlers(): McpApiHandlers {
     createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
     deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),
+    showNotification: vi.fn().mockResolvedValue({ action: null }),
+    updateStatusBar: vi.fn().mockResolvedValue(undefined),
+    disposeStatusBar: vi.fn().mockResolvedValue(undefined),
+    showQuickPick: vi.fn().mockResolvedValue({ selected: null }),
+    showInputBox: vi.fn().mockResolvedValue({ value: null }),
   };
 }
 

--- a/src/services/mcp-server/mcp-server.test.ts
+++ b/src/services/mcp-server/mcp-server.test.ts
@@ -55,6 +55,11 @@ function createMockMcpHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandl
     }),
     deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),
+    showNotification: vi.fn().mockResolvedValue({ action: null }),
+    updateStatusBar: vi.fn().mockResolvedValue(undefined),
+    disposeStatusBar: vi.fn().mockResolvedValue(undefined),
+    showQuickPick: vi.fn().mockResolvedValue({ selected: null }),
+    showInputBox: vi.fn().mockResolvedValue({ value: null }),
     ...overrides,
   };
 }
@@ -178,7 +183,7 @@ describe("McpServer", () => {
       expect(toolNames).toContain("project_list");
       expect(toolNames).toContain("workspace_create");
       expect(toolNames).toContain("log");
-      expect(tools.length).toBe(10);
+      expect(tools.length).toBe(15);
     });
 
     it("workspace_restart_agent_server tool calls handler and returns port", async () => {

--- a/src/services/mcp-server/mcp-server.ts
+++ b/src/services/mcp-server/mcp-server.ts
@@ -33,6 +33,7 @@ import {
   normalizeInitialPrompt,
   type PromptModel,
 } from "../../shared/api/types";
+import { COMMAND_TIMEOUT_MS } from "../../shared/plugin-protocol";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 
 /**
@@ -603,6 +604,270 @@ export class McpServer implements IMcpServer {
       )
     );
 
+    // ui_show_notification
+    mcpServer.registerTool(
+      "ui_show_notification",
+      {
+        description:
+          "Show a notification in the workspace's VS Code editor. " +
+          "Supports info, warning, and error severity levels.\n\n" +
+          "**Fire-and-forget mode** (no actions): The notification is shown and the tool returns immediately " +
+          'with { action: null }. Use this for status updates: ui_show_notification({ severity: "info", message: "Done!" })\n\n' +
+          "**Interactive mode** (with actions): The tool blocks until the user clicks a button or dismisses " +
+          "the notification. Returns the label of the clicked button, or null if dismissed.\n\n" +
+          "Example with actions:\n" +
+          '  ui_show_notification({ severity: "warning", message: "Overwrite file?", actions: ["Yes", "No"] })\n' +
+          '  → { action: "Yes" } or { action: null } if dismissed',
+        inputSchema: z.object({
+          severity: z
+            .enum(["info", "warning", "error"])
+            .describe("Notification severity: info (blue), warning (yellow), error (red)"),
+          message: z.string().min(1).max(1000).describe("Notification message text"),
+          actions: z
+            .array(z.string())
+            .max(3)
+            .optional()
+            .describe(
+              "Button labels to show on the notification. When present, the tool blocks until " +
+                "the user clicks a button or dismisses. When absent, fire-and-forget."
+            ),
+          timeout: z
+            .number()
+            .positive()
+            .optional()
+            .describe(
+              "Timeout in seconds (only applies when actions are present). " +
+                "Default: no timeout (waits indefinitely for user interaction)."
+            ),
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (
+          workspacePath,
+          args: {
+            severity: "info" | "warning" | "error";
+            message: string;
+            actions?: string[] | undefined;
+            timeout?: number | undefined;
+          }
+        ) => {
+          const timeoutMs = args.actions?.length
+            ? args.timeout
+              ? args.timeout * 1000
+              : 0
+            : COMMAND_TIMEOUT_MS;
+          return this.handlers.showNotification(
+            workspacePath,
+            {
+              severity: args.severity,
+              message: args.message,
+              ...(args.actions !== undefined && { actions: args.actions }),
+            },
+            timeoutMs
+          );
+        }
+      )
+    );
+
+    // ui_status_bar_update
+    mcpServer.registerTool(
+      "ui_status_bar_update",
+      {
+        description:
+          "Create or update a named status bar item in the workspace's VS Code editor. " +
+          "Uses upsert semantics: if an item with the same id exists, it is updated; otherwise a new item is created. " +
+          "Items persist until explicitly disposed via ui_status_bar_dispose or the workspace disconnects.\n\n" +
+          "The text field supports codicon syntax: $(icon-name) before text. " +
+          'Example: "$(sync~spin) Building..." shows a spinning sync icon.\n\n' +
+          "Common codicons: check, error, warning, info, sync~spin, gear, debug, rocket, beaker",
+        inputSchema: z.object({
+          id: z
+            .string()
+            .min(1)
+            .max(64)
+            .describe(
+              "Unique identifier for the status bar item. Reusing an id updates the existing item."
+            ),
+          text: z
+            .string()
+            .min(1)
+            .max(100)
+            .describe('Display text. Supports codicon syntax: "$(icon-name) text"'),
+          tooltip: z.string().max(200).optional().describe("Tooltip shown on hover"),
+          command: z
+            .string()
+            .optional()
+            .describe("VS Code command ID to execute when the item is clicked"),
+          color: z
+            .string()
+            .optional()
+            .describe('Text color as CSS value (e.g., "#ff0000") or ThemeColor name'),
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (
+          workspacePath,
+          args: {
+            id: string;
+            text: string;
+            tooltip?: string | undefined;
+            command?: string | undefined;
+            color?: string | undefined;
+          }
+        ) => {
+          await this.handlers.updateStatusBar(workspacePath, args);
+          return null;
+        }
+      )
+    );
+
+    // ui_status_bar_dispose
+    mcpServer.registerTool(
+      "ui_status_bar_dispose",
+      {
+        description:
+          "Remove a status bar item by id. Idempotent: disposing a non-existent id is a no-op.",
+        inputSchema: z.object({
+          id: z.string().min(1).max(64).describe("The id of the status bar item to remove"),
+        }),
+      },
+      this.createWorkspaceHandler(async (workspacePath, args: { id: string }) => {
+        await this.handlers.disposeStatusBar(workspacePath, { id: args.id });
+        return null;
+      })
+    );
+
+    // ui_show_quick_pick
+    mcpServer.registerTool(
+      "ui_show_quick_pick",
+      {
+        description:
+          "Show a quick pick list in the workspace's VS Code editor and wait for the user to select an item. " +
+          "Returns the label of the selected item, or null if the user cancels (Escape).\n\n" +
+          "This tool blocks until the user makes a selection or cancels. " +
+          "Use the timeout parameter to limit how long to wait.\n\n" +
+          "Example:\n" +
+          '  ui_show_quick_pick({ items: [{ label: "Option A" }, { label: "Option B", description: "The B option" }] })\n' +
+          '  → { selected: "Option A" } or { selected: null } if cancelled',
+        inputSchema: z.object({
+          items: z
+            .array(
+              z.object({
+                label: z.string().describe("Item label (returned on selection)"),
+                description: z
+                  .string()
+                  .optional()
+                  .describe("Short description shown next to the label"),
+                detail: z.string().optional().describe("Additional detail shown below the label"),
+              })
+            )
+            .min(1)
+            .max(100)
+            .describe("List of items to show in the quick pick"),
+          title: z.string().max(200).optional().describe("Title shown above the quick pick list"),
+          placeholder: z
+            .string()
+            .max(200)
+            .optional()
+            .describe("Placeholder text in the filter input"),
+          timeout: z
+            .number()
+            .positive()
+            .optional()
+            .describe(
+              "Timeout in seconds. Default: no timeout (waits indefinitely for user selection)."
+            ),
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (
+          workspacePath,
+          args: {
+            items: Array<{
+              label: string;
+              description?: string | undefined;
+              detail?: string | undefined;
+            }>;
+            title?: string | undefined;
+            placeholder?: string | undefined;
+            timeout?: number | undefined;
+          }
+        ) => {
+          const timeoutMs = args.timeout ? args.timeout * 1000 : 0;
+          return this.handlers.showQuickPick(
+            workspacePath,
+            {
+              items: args.items,
+              ...(args.title !== undefined && { title: args.title }),
+              ...(args.placeholder !== undefined && { placeholder: args.placeholder }),
+            },
+            timeoutMs
+          );
+        }
+      )
+    );
+
+    // ui_show_input_box
+    mcpServer.registerTool(
+      "ui_show_input_box",
+      {
+        description:
+          "Show an input box in the workspace's VS Code editor and wait for the user to enter text. " +
+          "Returns the entered text, or null if the user cancels (Escape).\n\n" +
+          "This tool blocks until the user submits (Enter) or cancels. " +
+          "Use the timeout parameter to limit how long to wait.\n\n" +
+          "Example:\n" +
+          '  ui_show_input_box({ prompt: "Enter your name", placeholder: "Name" })\n' +
+          '  → { value: "Alice" } or { value: null } if cancelled',
+        inputSchema: z.object({
+          title: z.string().max(200).optional().describe("Title shown above the input box"),
+          prompt: z.string().max(500).optional().describe("Hint text shown below the input"),
+          placeholder: z
+            .string()
+            .max(200)
+            .optional()
+            .describe("Placeholder text in the input field"),
+          value: z.string().optional().describe("Pre-filled default value"),
+          password: z.boolean().optional().describe("If true, mask input characters"),
+          timeout: z
+            .number()
+            .positive()
+            .optional()
+            .describe(
+              "Timeout in seconds. Default: no timeout (waits indefinitely for user input)."
+            ),
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (
+          workspacePath,
+          args: {
+            title?: string | undefined;
+            prompt?: string | undefined;
+            placeholder?: string | undefined;
+            value?: string | undefined;
+            password?: boolean | undefined;
+            timeout?: number | undefined;
+          }
+        ) => {
+          const timeoutMs = args.timeout ? args.timeout * 1000 : 0;
+          const request: {
+            title?: string;
+            prompt?: string;
+            placeholder?: string;
+            value?: string;
+            password?: boolean;
+          } = {};
+          if (args.title !== undefined) request.title = args.title;
+          if (args.prompt !== undefined) request.prompt = args.prompt;
+          if (args.placeholder !== undefined) request.placeholder = args.placeholder;
+          if (args.value !== undefined) request.value = args.value;
+          if (args.password !== undefined) request.password = args.password;
+          return this.handlers.showInputBox(workspacePath, request, timeoutMs);
+        }
+      )
+    );
+
     // log - different pattern, doesn't require workspace resolution
     mcpServer.registerTool(
       "log",
@@ -634,7 +899,7 @@ export class McpServer implements IMcpServer {
       }
     );
 
-    this.logger.debug("Registered tools", { count: 10 });
+    this.logger.debug("Registered tools", { count: 15 });
   }
 
   /**

--- a/src/services/mcp-server/tools.test.ts
+++ b/src/services/mcp-server/tools.test.ts
@@ -71,6 +71,11 @@ function createMockHandlers(overrides?: Partial<McpApiHandlers>): McpApiHandlers
     createWorkspace: vi.fn().mockResolvedValue({ name: "test", path: "/path" }),
     deleteWorkspace: vi.fn().mockResolvedValue({ started: true }),
     executeCommand: vi.fn().mockResolvedValue(undefined),
+    showNotification: vi.fn().mockResolvedValue({ action: null }),
+    updateStatusBar: vi.fn().mockResolvedValue(undefined),
+    disposeStatusBar: vi.fn().mockResolvedValue(undefined),
+    showQuickPick: vi.fn().mockResolvedValue({ selected: null }),
+    showInputBox: vi.fn().mockResolvedValue({ value: null }),
     ...overrides,
   };
 }

--- a/src/services/mcp-server/types.ts
+++ b/src/services/mcp-server/types.ts
@@ -10,6 +10,16 @@ import type {
   Project,
   InitialPrompt,
 } from "../../shared/api/types";
+import type {
+  ShowNotificationRequest,
+  ShowNotificationResponse,
+  StatusBarUpdateRequest,
+  StatusBarDisposeRequest,
+  ShowQuickPickRequest,
+  ShowQuickPickResponse,
+  ShowInputBoxRequest,
+  ShowInputBoxResponse,
+} from "../../shared/plugin-protocol";
 
 // =============================================================================
 // MCP Error Types
@@ -64,6 +74,23 @@ export interface McpApiHandlers {
     command: string,
     args?: readonly unknown[]
   ): Promise<unknown>;
+  showNotification(
+    workspacePath: string,
+    request: ShowNotificationRequest,
+    timeoutMs?: number
+  ): Promise<ShowNotificationResponse>;
+  updateStatusBar(workspacePath: string, request: StatusBarUpdateRequest): Promise<void>;
+  disposeStatusBar(workspacePath: string, request: StatusBarDisposeRequest): Promise<void>;
+  showQuickPick(
+    workspacePath: string,
+    request: ShowQuickPickRequest,
+    timeoutMs?: number
+  ): Promise<ShowQuickPickResponse>;
+  showInputBox(
+    workspacePath: string,
+    request: ShowInputBoxRequest,
+    timeoutMs?: number
+  ): Promise<ShowInputBoxResponse>;
 }
 
 // =============================================================================

--- a/src/services/plugin-server/plugin-server.boundary.test.ts
+++ b/src/services/plugin-server/plugin-server.boundary.test.ts
@@ -1033,4 +1033,214 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       expect(shutdownCount).toBe(2);
     });
   });
+
+  describe("UI events", () => {
+    it("showNotification round-trip with action", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showNotification", (request, ack) => {
+        expect(request.severity).toBe("info");
+        expect(request.message).toBe("Continue?");
+        expect(request.actions).toEqual(["Yes", "No"]);
+        ack({ success: true, data: { action: "Yes" } });
+      });
+
+      const result = await env.server.showNotification("/test/workspace", {
+        severity: "info",
+        message: "Continue?",
+        actions: ["Yes", "No"],
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.action).toBe("Yes");
+      }
+    });
+
+    it("showNotification fire-and-forget without actions", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showNotification", (request, ack) => {
+        expect(request.severity).toBe("warning");
+        expect(request.message).toBe("Something happened");
+        expect(request.actions).toBeUndefined();
+        ack({ success: true, data: { action: null } });
+      });
+
+      const result = await env.server.showNotification("/test/workspace", {
+        severity: "warning",
+        message: "Something happened",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.action).toBeNull();
+      }
+    });
+
+    it("showNotification returns error when workspace not connected", async () => {
+      const result = await env.server.showNotification("/nonexistent", {
+        severity: "info",
+        message: "test",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Workspace not connected");
+      }
+    });
+
+    it("updateStatusBar round-trip", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:statusBarUpdate", (request, ack) => {
+        expect(request.id).toBe("myStatusBar");
+        expect(request.text).toBe("$(sync~spin) Building...");
+        expect(request.tooltip).toBe("Build in progress");
+        ack({ success: true, data: undefined });
+      });
+
+      const result = await env.server.updateStatusBar("/test/workspace", {
+        id: "myStatusBar",
+        text: "$(sync~spin) Building...",
+        tooltip: "Build in progress",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("disposeStatusBar round-trip", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:statusBarDispose", (request, ack) => {
+        expect(request.id).toBe("myStatusBar");
+        ack({ success: true, data: undefined });
+      });
+
+      const result = await env.server.disposeStatusBar("/test/workspace", {
+        id: "myStatusBar",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("showQuickPick round-trip with selection", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showQuickPick", (request, ack) => {
+        expect(request.items).toEqual([
+          { label: "Option A", description: "First option" },
+          { label: "Option B", description: "Second option" },
+        ]);
+        expect(request.title).toBe("Pick one");
+        expect(request.placeholder).toBe("Select an option...");
+        ack({ success: true, data: { selected: "Option A" } });
+      });
+
+      const result = await env.server.showQuickPick("/test/workspace", {
+        items: [
+          { label: "Option A", description: "First option" },
+          { label: "Option B", description: "Second option" },
+        ],
+        title: "Pick one",
+        placeholder: "Select an option...",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.selected).toBe("Option A");
+      }
+    });
+
+    it("showQuickPick returns null on cancel", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showQuickPick", (_request, ack) => {
+        ack({ success: true, data: { selected: null } });
+      });
+
+      const result = await env.server.showQuickPick("/test/workspace", {
+        items: [{ label: "Option A" }],
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.selected).toBeNull();
+      }
+    });
+
+    it("showInputBox round-trip with value", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showInputBox", (request, ack) => {
+        expect(request.title).toBe("Enter name");
+        expect(request.prompt).toBe("Workspace name");
+        expect(request.placeholder).toBe("my-workspace");
+        expect(request.value).toBe("default-name");
+        ack({ success: true, data: { value: "user-input" } });
+      });
+
+      const result = await env.server.showInputBox("/test/workspace", {
+        title: "Enter name",
+        prompt: "Workspace name",
+        placeholder: "my-workspace",
+        value: "default-name",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.value).toBe("user-input");
+      }
+    });
+
+    it("showInputBox returns null on cancel", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.on("ui:showInputBox", (_request, ack) => {
+        ack({ success: true, data: { value: null } });
+      });
+
+      const result = await env.server.showInputBox("/test/workspace", {
+        prompt: "Enter something",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.value).toBeNull();
+      }
+    });
+
+    it("showNotification times out when client does not ack", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      // Handler that never acks
+      client.on("ui:showNotification", () => {
+        // Intentionally do not call ack
+      });
+
+      const start = Date.now();
+      const result = await env.server.showNotification(
+        "/test/workspace",
+        { severity: "info", message: "test", actions: ["OK"] },
+        500
+      );
+      const elapsed = Date.now() - start;
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("UI event timed out");
+      }
+      expect(elapsed).toBeGreaterThanOrEqual(500 - TIMING_TOLERANCE_MS);
+      expect(elapsed).toBeLessThan(2000);
+    });
+  });
 });

--- a/src/services/plugin-server/plugin-server.ts
+++ b/src/services/plugin-server/plugin-server.ts
@@ -29,6 +29,14 @@ import {
   type PluginConfig,
   type LogContext,
   type AgentType,
+  type ShowNotificationRequest,
+  type ShowNotificationResponse,
+  type StatusBarUpdateRequest,
+  type StatusBarDisposeRequest,
+  type ShowQuickPickRequest,
+  type ShowQuickPickResponse,
+  type ShowInputBoxRequest,
+  type ShowInputBoxResponse,
   COMMAND_TIMEOUT_MS,
   SHUTDOWN_DISCONNECT_TIMEOUT_MS,
   validateSetMetadataRequest,
@@ -323,6 +331,127 @@ export class PluginServer {
         resolve(result);
       });
     });
+  }
+
+  /**
+   * Send a UI event to a connected workspace and wait for acknowledgment.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param event - The UI event name
+   * @param request - The request payload
+   * @param timeoutMs - Timeout for acknowledgment (0 = no timeout)
+   * @returns Result from the extension
+   */
+  private async sendUiEvent<TReq, TRes>(
+    workspacePath: string,
+    event: keyof ServerToClientEvents,
+    request: TReq,
+    timeoutMs: number = COMMAND_TIMEOUT_MS
+  ): Promise<PluginResult<TRes>> {
+    const normalized = new Path(workspacePath).toString();
+    const socket = this.connections.get(normalized);
+
+    if (!socket) {
+      return { success: false, error: "Workspace not connected" };
+    }
+
+    if (!socket.connected) {
+      this.connections.delete(normalized);
+      return { success: false, error: "Workspace disconnected" };
+    }
+
+    return new Promise((resolve) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      if (timeoutMs > 0) {
+        timeoutId = setTimeout(() => {
+          this.logger.warn("UI event timeout", { workspace: normalized, event, timeoutMs });
+          resolve({ success: false, error: "UI event timed out" });
+        }, timeoutMs);
+      }
+
+      // @ts-expect-error Dynamic event name - TypedSocket strict typing cannot accommodate generic event dispatch
+      socket.emit(event, request, (result: PluginResult<TRes>) => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        this.logger.debug("UI event result", {
+          workspace: normalized,
+          event,
+          success: result.success,
+        });
+        resolve(result);
+      });
+    });
+  }
+
+  /**
+   * Show a notification in the workspace's VS Code instance.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param request - Notification request
+   * @param timeoutMs - Timeout (default: COMMAND_TIMEOUT_MS; 0 = no timeout)
+   */
+  async showNotification(
+    workspacePath: string,
+    request: ShowNotificationRequest,
+    timeoutMs: number = COMMAND_TIMEOUT_MS
+  ): Promise<PluginResult<ShowNotificationResponse>> {
+    return this.sendUiEvent(workspacePath, "ui:showNotification", request, timeoutMs);
+  }
+
+  /**
+   * Create or update a status bar item in the workspace's VS Code instance.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param request - Status bar update request
+   */
+  async updateStatusBar(
+    workspacePath: string,
+    request: StatusBarUpdateRequest
+  ): Promise<PluginResult<void>> {
+    return this.sendUiEvent(workspacePath, "ui:statusBarUpdate", request);
+  }
+
+  /**
+   * Dispose a status bar item in the workspace's VS Code instance.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param request - Status bar dispose request
+   */
+  async disposeStatusBar(
+    workspacePath: string,
+    request: StatusBarDisposeRequest
+  ): Promise<PluginResult<void>> {
+    return this.sendUiEvent(workspacePath, "ui:statusBarDispose", request);
+  }
+
+  /**
+   * Show a quick pick in the workspace's VS Code instance.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param request - Quick pick request
+   * @param timeoutMs - Timeout (default: 0 = no timeout, waits for user)
+   */
+  async showQuickPick(
+    workspacePath: string,
+    request: ShowQuickPickRequest,
+    timeoutMs: number = 0
+  ): Promise<PluginResult<ShowQuickPickResponse>> {
+    return this.sendUiEvent(workspacePath, "ui:showQuickPick", request, timeoutMs);
+  }
+
+  /**
+   * Show an input box in the workspace's VS Code instance.
+   *
+   * @param workspacePath - Path to the workspace
+   * @param request - Input box request
+   * @param timeoutMs - Timeout (default: 0 = no timeout, waits for user)
+   */
+  async showInputBox(
+    workspacePath: string,
+    request: ShowInputBoxRequest,
+    timeoutMs: number = 0
+  ): Promise<PluginResult<ShowInputBoxResponse>> {
+    return this.sendUiEvent(workspacePath, "ui:showInputBox", request, timeoutMs);
   }
 
   /**

--- a/src/shared/plugin-protocol.test.ts
+++ b/src/shared/plugin-protocol.test.ts
@@ -7,6 +7,11 @@ import {
   validateSetMetadataRequest,
   validateExecuteCommandRequest,
   validateLogRequest,
+  validateShowNotificationRequest,
+  validateStatusBarUpdateRequest,
+  validateStatusBarDisposeRequest,
+  validateShowQuickPickRequest,
+  validateShowInputBoxRequest,
   COMMAND_TIMEOUT_MS,
   SHUTDOWN_DISCONNECT_TIMEOUT_MS,
   type ServerToClientEvents,
@@ -464,6 +469,596 @@ describe("validateLogRequest", () => {
         error: "Request must be an object",
       });
     });
+  });
+});
+
+describe("validateShowNotificationRequest", () => {
+  describe("valid requests", () => {
+    it("accepts valid notification with info severity", () => {
+      const result = validateShowNotificationRequest({ severity: "info", message: "Hello" });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts valid notification with warning severity", () => {
+      const result = validateShowNotificationRequest({ severity: "warning", message: "Caution" });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts valid notification with error severity", () => {
+      const result = validateShowNotificationRequest({ severity: "error", message: "Failed" });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts notification with actions array", () => {
+      const result = validateShowNotificationRequest({
+        severity: "info",
+        message: "Proceed?",
+        actions: ["Yes", "No"],
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts notification with empty actions array", () => {
+      const result = validateShowNotificationRequest({
+        severity: "info",
+        message: "Hello",
+        actions: [],
+      });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests - structure", () => {
+    it("rejects null payload", () => {
+      const result = validateShowNotificationRequest(null);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects undefined payload", () => {
+      const result = validateShowNotificationRequest(undefined);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects primitive values", () => {
+      expect(validateShowNotificationRequest("string")).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateShowNotificationRequest(123)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateShowNotificationRequest(true)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+  });
+
+  describe("invalid requests - missing fields", () => {
+    it("rejects missing severity", () => {
+      const result = validateShowNotificationRequest({ message: "Hello" });
+      expect(result).toEqual({ valid: false, error: "Missing required field: severity" });
+    });
+
+    it("rejects missing message", () => {
+      const result = validateShowNotificationRequest({ severity: "info" });
+      expect(result).toEqual({ valid: false, error: "Missing required field: message" });
+    });
+
+    it("rejects empty object", () => {
+      const result = validateShowNotificationRequest({});
+      expect(result).toEqual({ valid: false, error: "Missing required field: severity" });
+    });
+  });
+
+  describe("invalid requests - wrong types", () => {
+    it("rejects non-string severity", () => {
+      expect(validateShowNotificationRequest({ severity: 123, message: "Hello" })).toEqual({
+        valid: false,
+        error: "Field 'severity' must be a string",
+      });
+      expect(validateShowNotificationRequest({ severity: null, message: "Hello" })).toEqual({
+        valid: false,
+        error: "Field 'severity' must be a string",
+      });
+    });
+
+    it("rejects invalid severity value", () => {
+      const result = validateShowNotificationRequest({ severity: "critical", message: "Hello" });
+      expect(result).toEqual({ valid: false, error: "Invalid severity: critical" });
+    });
+
+    it("rejects non-string message", () => {
+      expect(validateShowNotificationRequest({ severity: "info", message: 123 })).toEqual({
+        valid: false,
+        error: "Field 'message' must be a string",
+      });
+      expect(validateShowNotificationRequest({ severity: "info", message: null })).toEqual({
+        valid: false,
+        error: "Field 'message' must be a string",
+      });
+    });
+
+    it("rejects empty message", () => {
+      const result = validateShowNotificationRequest({ severity: "info", message: "" });
+      expect(result).toEqual({ valid: false, error: "Field 'message' cannot be empty" });
+    });
+
+    it("rejects non-array actions", () => {
+      expect(
+        validateShowNotificationRequest({
+          severity: "info",
+          message: "Hello",
+          actions: "not-array",
+        })
+      ).toEqual({
+        valid: false,
+        error: "Field 'actions' must be an array",
+      });
+      expect(
+        validateShowNotificationRequest({ severity: "info", message: "Hello", actions: 123 })
+      ).toEqual({
+        valid: false,
+        error: "Field 'actions' must be an array",
+      });
+    });
+
+    it("rejects non-string action items", () => {
+      const result = validateShowNotificationRequest({
+        severity: "info",
+        message: "Hello",
+        actions: [123],
+      });
+      expect(result).toEqual({ valid: false, error: "Each action must be a string" });
+    });
+  });
+});
+
+describe("validateStatusBarUpdateRequest", () => {
+  describe("valid requests", () => {
+    it("accepts valid request with required fields only", () => {
+      const result = validateStatusBarUpdateRequest({ id: "my-item", text: "Hello" });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with all optional fields", () => {
+      const result = validateStatusBarUpdateRequest({
+        id: "my-item",
+        text: "Hello",
+        tooltip: "A tooltip",
+        command: "workbench.action.test",
+        color: "#ff0000",
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with some optional fields", () => {
+      const result = validateStatusBarUpdateRequest({
+        id: "my-item",
+        text: "Hello",
+        tooltip: "A tooltip",
+      });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests - structure", () => {
+    it("rejects null payload", () => {
+      const result = validateStatusBarUpdateRequest(null);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects undefined payload", () => {
+      const result = validateStatusBarUpdateRequest(undefined);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects primitive values", () => {
+      expect(validateStatusBarUpdateRequest("string")).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateStatusBarUpdateRequest(123)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+  });
+
+  describe("invalid requests - missing fields", () => {
+    it("rejects missing id", () => {
+      const result = validateStatusBarUpdateRequest({ text: "Hello" });
+      expect(result).toEqual({ valid: false, error: "Missing required field: id" });
+    });
+
+    it("rejects missing text", () => {
+      const result = validateStatusBarUpdateRequest({ id: "my-item" });
+      expect(result).toEqual({ valid: false, error: "Missing required field: text" });
+    });
+
+    it("rejects empty object", () => {
+      const result = validateStatusBarUpdateRequest({});
+      expect(result).toEqual({ valid: false, error: "Missing required field: id" });
+    });
+  });
+
+  describe("invalid requests - wrong types", () => {
+    it("rejects non-string id", () => {
+      expect(validateStatusBarUpdateRequest({ id: 123, text: "Hello" })).toEqual({
+        valid: false,
+        error: "Field 'id' must be a string",
+      });
+      expect(validateStatusBarUpdateRequest({ id: null, text: "Hello" })).toEqual({
+        valid: false,
+        error: "Field 'id' must be a string",
+      });
+    });
+
+    it("rejects empty id", () => {
+      const result = validateStatusBarUpdateRequest({ id: "", text: "Hello" });
+      expect(result).toEqual({ valid: false, error: "Field 'id' cannot be empty" });
+    });
+
+    it("rejects non-string text", () => {
+      expect(validateStatusBarUpdateRequest({ id: "my-item", text: 123 })).toEqual({
+        valid: false,
+        error: "Field 'text' must be a string",
+      });
+      expect(validateStatusBarUpdateRequest({ id: "my-item", text: null })).toEqual({
+        valid: false,
+        error: "Field 'text' must be a string",
+      });
+    });
+
+    it("rejects empty text", () => {
+      const result = validateStatusBarUpdateRequest({ id: "my-item", text: "" });
+      expect(result).toEqual({ valid: false, error: "Field 'text' cannot be empty" });
+    });
+
+    it("rejects non-string tooltip", () => {
+      const result = validateStatusBarUpdateRequest({
+        id: "my-item",
+        text: "Hello",
+        tooltip: 123,
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'tooltip' must be a string" });
+    });
+
+    it("rejects non-string command", () => {
+      const result = validateStatusBarUpdateRequest({
+        id: "my-item",
+        text: "Hello",
+        command: 123,
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'command' must be a string" });
+    });
+
+    it("rejects non-string color", () => {
+      const result = validateStatusBarUpdateRequest({
+        id: "my-item",
+        text: "Hello",
+        color: 123,
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'color' must be a string" });
+    });
+  });
+});
+
+describe("validateStatusBarDisposeRequest", () => {
+  describe("valid requests", () => {
+    it("accepts valid request with id", () => {
+      const result = validateStatusBarDisposeRequest({ id: "my-item" });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests - structure", () => {
+    it("rejects null payload", () => {
+      const result = validateStatusBarDisposeRequest(null);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects undefined payload", () => {
+      const result = validateStatusBarDisposeRequest(undefined);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects primitive values", () => {
+      expect(validateStatusBarDisposeRequest("string")).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateStatusBarDisposeRequest(123)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+  });
+
+  describe("invalid requests - missing fields", () => {
+    it("rejects missing id", () => {
+      const result = validateStatusBarDisposeRequest({});
+      expect(result).toEqual({ valid: false, error: "Missing required field: id" });
+    });
+  });
+
+  describe("invalid requests - wrong types", () => {
+    it("rejects non-string id", () => {
+      expect(validateStatusBarDisposeRequest({ id: 123 })).toEqual({
+        valid: false,
+        error: "Field 'id' must be a string",
+      });
+      expect(validateStatusBarDisposeRequest({ id: null })).toEqual({
+        valid: false,
+        error: "Field 'id' must be a string",
+      });
+      expect(validateStatusBarDisposeRequest({ id: {} })).toEqual({
+        valid: false,
+        error: "Field 'id' must be a string",
+      });
+    });
+
+    it("rejects empty id", () => {
+      const result = validateStatusBarDisposeRequest({ id: "" });
+      expect(result).toEqual({ valid: false, error: "Field 'id' cannot be empty" });
+    });
+  });
+});
+
+describe("validateShowQuickPickRequest", () => {
+  describe("valid requests", () => {
+    it("accepts valid request with items", () => {
+      const result = validateShowQuickPickRequest({ items: [{ label: "Option 1" }] });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with multiple items", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Option 1" }, { label: "Option 2" }],
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with items having description and detail", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Option 1", description: "desc", detail: "detail" }],
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with title and placeholder", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Option 1" }],
+        title: "Pick one",
+        placeholder: "Search...",
+      });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests - structure", () => {
+    it("rejects null payload", () => {
+      const result = validateShowQuickPickRequest(null);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects undefined payload", () => {
+      const result = validateShowQuickPickRequest(undefined);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects primitive values", () => {
+      expect(validateShowQuickPickRequest("string")).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateShowQuickPickRequest(123)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+  });
+
+  describe("invalid requests - missing fields", () => {
+    it("rejects missing items", () => {
+      const result = validateShowQuickPickRequest({});
+      expect(result).toEqual({ valid: false, error: "Missing required field: items" });
+    });
+  });
+
+  describe("invalid requests - wrong types", () => {
+    it("rejects non-array items", () => {
+      expect(validateShowQuickPickRequest({ items: "not-array" })).toEqual({
+        valid: false,
+        error: "Field 'items' must be an array",
+      });
+      expect(validateShowQuickPickRequest({ items: 123 })).toEqual({
+        valid: false,
+        error: "Field 'items' must be an array",
+      });
+      expect(validateShowQuickPickRequest({ items: {} })).toEqual({
+        valid: false,
+        error: "Field 'items' must be an array",
+      });
+    });
+
+    it("rejects empty items array", () => {
+      const result = validateShowQuickPickRequest({ items: [] });
+      expect(result).toEqual({ valid: false, error: "Field 'items' cannot be empty" });
+    });
+
+    it("rejects non-object item", () => {
+      const result = validateShowQuickPickRequest({ items: ["not-object"] });
+      expect(result).toEqual({ valid: false, error: "Item at index 0 must be an object" });
+    });
+
+    it("rejects null item", () => {
+      const result = validateShowQuickPickRequest({ items: [null] });
+      expect(result).toEqual({ valid: false, error: "Item at index 0 must be an object" });
+    });
+
+    it("rejects item without label", () => {
+      const result = validateShowQuickPickRequest({ items: [{ description: "no label" }] });
+      expect(result).toEqual({ valid: false, error: "Item at index 0 must have a string 'label'" });
+    });
+
+    it("rejects item with non-string label", () => {
+      const result = validateShowQuickPickRequest({ items: [{ label: 123 }] });
+      expect(result).toEqual({ valid: false, error: "Item at index 0 must have a string 'label'" });
+    });
+
+    it("rejects invalid item at later index", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Valid" }, { label: 456 }],
+      });
+      expect(result).toEqual({ valid: false, error: "Item at index 1 must have a string 'label'" });
+    });
+
+    it("rejects non-string title", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Option 1" }],
+        title: 123,
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'title' must be a string" });
+    });
+
+    it("rejects non-string placeholder", () => {
+      const result = validateShowQuickPickRequest({
+        items: [{ label: "Option 1" }],
+        placeholder: 123,
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'placeholder' must be a string" });
+    });
+  });
+});
+
+describe("validateShowInputBoxRequest", () => {
+  describe("valid requests", () => {
+    it("accepts empty object (all fields optional)", () => {
+      const result = validateShowInputBoxRequest({});
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with all optional fields", () => {
+      const result = validateShowInputBoxRequest({
+        title: "Enter name",
+        prompt: "Please enter a name",
+        placeholder: "Name...",
+        value: "default",
+        password: false,
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with password true", () => {
+      const result = validateShowInputBoxRequest({
+        title: "Enter password",
+        password: true,
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts request with only title", () => {
+      const result = validateShowInputBoxRequest({ title: "My Title" });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests - structure", () => {
+    it("rejects null payload", () => {
+      const result = validateShowInputBoxRequest(null);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects undefined payload", () => {
+      const result = validateShowInputBoxRequest(undefined);
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
+    });
+
+    it("rejects primitive values", () => {
+      expect(validateShowInputBoxRequest("string")).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateShowInputBoxRequest(123)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+      expect(validateShowInputBoxRequest(true)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+  });
+
+  describe("invalid requests - wrong types", () => {
+    it("rejects non-string title", () => {
+      const result = validateShowInputBoxRequest({ title: 123 });
+      expect(result).toEqual({ valid: false, error: "Field 'title' must be a string" });
+    });
+
+    it("rejects non-string prompt", () => {
+      const result = validateShowInputBoxRequest({ prompt: 123 });
+      expect(result).toEqual({ valid: false, error: "Field 'prompt' must be a string" });
+    });
+
+    it("rejects non-string placeholder", () => {
+      const result = validateShowInputBoxRequest({ placeholder: 123 });
+      expect(result).toEqual({ valid: false, error: "Field 'placeholder' must be a string" });
+    });
+
+    it("rejects non-string value", () => {
+      const result = validateShowInputBoxRequest({ value: 123 });
+      expect(result).toEqual({ valid: false, error: "Field 'value' must be a string" });
+    });
+
+    it("rejects non-boolean password", () => {
+      const result = validateShowInputBoxRequest({ password: "yes" });
+      expect(result).toEqual({ valid: false, error: "Field 'password' must be a boolean" });
+    });
+  });
+});
+
+describe("UI event signatures", () => {
+  it("showNotification event accepts correct types", () => {
+    const mockHandler: ServerToClientEvents["ui:showNotification"] = (_request, ack) => {
+      ack({ success: true, data: { action: null } });
+      ack({ success: true, data: { action: "Yes" } });
+    };
+    expect(typeof mockHandler).toBe("function");
+  });
+
+  it("statusBarUpdate event accepts correct types", () => {
+    const mockHandler: ServerToClientEvents["ui:statusBarUpdate"] = (_request, ack) => {
+      ack({ success: true, data: undefined });
+      ack({ success: false, error: "test error" });
+    };
+    expect(typeof mockHandler).toBe("function");
+  });
+
+  it("statusBarDispose event accepts correct types", () => {
+    const mockHandler: ServerToClientEvents["ui:statusBarDispose"] = (_request, ack) => {
+      ack({ success: true, data: undefined });
+      ack({ success: false, error: "test error" });
+    };
+    expect(typeof mockHandler).toBe("function");
+  });
+
+  it("showQuickPick event accepts correct types", () => {
+    const mockHandler: ServerToClientEvents["ui:showQuickPick"] = (_request, ack) => {
+      ack({ success: true, data: { selected: null } });
+      ack({ success: true, data: { selected: "Option 1" } });
+    };
+    expect(typeof mockHandler).toBe("function");
+  });
+
+  it("showInputBox event accepts correct types", () => {
+    const mockHandler: ServerToClientEvents["ui:showInputBox"] = (_request, ack) => {
+      ack({ success: true, data: { value: null } });
+      ack({ success: true, data: { value: "user input" } });
+    };
+    expect(typeof mockHandler).toBe("function");
   });
 });
 

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -96,6 +96,46 @@ export interface ServerToClientEvents {
    * @param ack - Acknowledgment callback to confirm shutdown received
    */
   shutdown: (ack: (result: PluginResult<void>) => void) => void;
+
+  /**
+   * Show a notification in VS Code.
+   */
+  "ui:showNotification": (
+    request: ShowNotificationRequest,
+    ack: (result: PluginResult<ShowNotificationResponse>) => void
+  ) => void;
+
+  /**
+   * Create or update a status bar item.
+   */
+  "ui:statusBarUpdate": (
+    request: StatusBarUpdateRequest,
+    ack: (result: PluginResult<void>) => void
+  ) => void;
+
+  /**
+   * Dispose a status bar item.
+   */
+  "ui:statusBarDispose": (
+    request: StatusBarDisposeRequest,
+    ack: (result: PluginResult<void>) => void
+  ) => void;
+
+  /**
+   * Show a quick pick list.
+   */
+  "ui:showQuickPick": (
+    request: ShowQuickPickRequest,
+    ack: (result: PluginResult<ShowQuickPickResponse>) => void
+  ) => void;
+
+  /**
+   * Show an input box.
+   */
+  "ui:showInputBox": (
+    request: ShowInputBoxRequest,
+    ack: (result: PluginResult<ShowInputBoxResponse>) => void
+  ) => void;
 }
 
 // ============================================================================
@@ -335,6 +375,327 @@ export function validateDeleteWorkspaceRequest(
       keepBranch: request.keepBranch as boolean | undefined,
     },
   };
+}
+
+// ============================================================================
+// UI Request/Response Types
+// ============================================================================
+
+/**
+ * Notification severity level.
+ */
+export type NotificationSeverity = "info" | "warning" | "error";
+
+/**
+ * Request to show a notification in VS Code.
+ */
+export interface ShowNotificationRequest {
+  readonly severity: NotificationSeverity;
+  readonly message: string;
+  readonly actions?: readonly string[] | undefined;
+}
+
+/**
+ * Response from a notification interaction.
+ */
+export interface ShowNotificationResponse {
+  readonly action: string | null;
+}
+
+/**
+ * Request to create or update a status bar item.
+ */
+export interface StatusBarUpdateRequest {
+  readonly id: string;
+  readonly text: string;
+  readonly tooltip?: string | undefined;
+  readonly command?: string | undefined;
+  readonly color?: string | undefined;
+}
+
+/**
+ * Request to dispose a status bar item.
+ */
+export interface StatusBarDisposeRequest {
+  readonly id: string;
+}
+
+/**
+ * A single item in a quick pick list.
+ */
+export interface QuickPickItem {
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly detail?: string | undefined;
+}
+
+/**
+ * Request to show a quick pick list.
+ */
+export interface ShowQuickPickRequest {
+  readonly items: readonly QuickPickItem[];
+  readonly title?: string | undefined;
+  readonly placeholder?: string | undefined;
+}
+
+/**
+ * Response from a quick pick selection.
+ */
+export interface ShowQuickPickResponse {
+  readonly selected: string | null;
+}
+
+/**
+ * Request to show an input box.
+ */
+export interface ShowInputBoxRequest {
+  readonly title?: string | undefined;
+  readonly prompt?: string | undefined;
+  readonly placeholder?: string | undefined;
+  readonly value?: string | undefined;
+  readonly password?: boolean | undefined;
+}
+
+/**
+ * Response from an input box.
+ */
+export interface ShowInputBoxResponse {
+  readonly value: string | null;
+}
+
+// ============================================================================
+// UI Validation Functions
+// ============================================================================
+
+const VALID_SEVERITIES = ["info", "warning", "error"];
+
+/**
+ * Runtime validation for ShowNotificationRequest.
+ */
+export function validateShowNotificationRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if (!("severity" in request)) {
+    return { valid: false, error: "Missing required field: severity" };
+  }
+
+  if (typeof request.severity !== "string") {
+    return { valid: false, error: "Field 'severity' must be a string" };
+  }
+
+  if (!VALID_SEVERITIES.includes(request.severity)) {
+    return { valid: false, error: `Invalid severity: ${request.severity}` };
+  }
+
+  if (!("message" in request)) {
+    return { valid: false, error: "Missing required field: message" };
+  }
+
+  if (typeof request.message !== "string") {
+    return { valid: false, error: "Field 'message' must be a string" };
+  }
+
+  if (request.message.length === 0) {
+    return { valid: false, error: "Field 'message' cannot be empty" };
+  }
+
+  if ("actions" in request && request.actions !== undefined) {
+    if (!Array.isArray(request.actions)) {
+      return { valid: false, error: "Field 'actions' must be an array" };
+    }
+    for (const action of request.actions) {
+      if (typeof action !== "string") {
+        return { valid: false, error: "Each action must be a string" };
+      }
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Runtime validation for StatusBarUpdateRequest.
+ */
+export function validateStatusBarUpdateRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if (!("id" in request)) {
+    return { valid: false, error: "Missing required field: id" };
+  }
+
+  if (typeof request.id !== "string") {
+    return { valid: false, error: "Field 'id' must be a string" };
+  }
+
+  if (request.id.length === 0) {
+    return { valid: false, error: "Field 'id' cannot be empty" };
+  }
+
+  if (!("text" in request)) {
+    return { valid: false, error: "Missing required field: text" };
+  }
+
+  if (typeof request.text !== "string") {
+    return { valid: false, error: "Field 'text' must be a string" };
+  }
+
+  if (request.text.length === 0) {
+    return { valid: false, error: "Field 'text' cannot be empty" };
+  }
+
+  if (
+    "tooltip" in request &&
+    request.tooltip !== undefined &&
+    typeof request.tooltip !== "string"
+  ) {
+    return { valid: false, error: "Field 'tooltip' must be a string" };
+  }
+
+  if (
+    "command" in request &&
+    request.command !== undefined &&
+    typeof request.command !== "string"
+  ) {
+    return { valid: false, error: "Field 'command' must be a string" };
+  }
+
+  if ("color" in request && request.color !== undefined && typeof request.color !== "string") {
+    return { valid: false, error: "Field 'color' must be a string" };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Runtime validation for StatusBarDisposeRequest.
+ */
+export function validateStatusBarDisposeRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if (!("id" in request)) {
+    return { valid: false, error: "Missing required field: id" };
+  }
+
+  if (typeof request.id !== "string") {
+    return { valid: false, error: "Field 'id' must be a string" };
+  }
+
+  if (request.id.length === 0) {
+    return { valid: false, error: "Field 'id' cannot be empty" };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Runtime validation for ShowQuickPickRequest.
+ */
+export function validateShowQuickPickRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if (!("items" in request)) {
+    return { valid: false, error: "Missing required field: items" };
+  }
+
+  if (!Array.isArray(request.items)) {
+    return { valid: false, error: "Field 'items' must be an array" };
+  }
+
+  if (request.items.length === 0) {
+    return { valid: false, error: "Field 'items' cannot be empty" };
+  }
+
+  for (let i = 0; i < request.items.length; i++) {
+    const item = request.items[i] as unknown;
+    if (typeof item !== "object" || item === null) {
+      return { valid: false, error: `Item at index ${i} must be an object` };
+    }
+    const itemObj = item as Record<string, unknown>;
+    if (typeof itemObj.label !== "string") {
+      return { valid: false, error: `Item at index ${i} must have a string 'label'` };
+    }
+  }
+
+  if ("title" in request && request.title !== undefined && typeof request.title !== "string") {
+    return { valid: false, error: "Field 'title' must be a string" };
+  }
+
+  if (
+    "placeholder" in request &&
+    request.placeholder !== undefined &&
+    typeof request.placeholder !== "string"
+  ) {
+    return { valid: false, error: "Field 'placeholder' must be a string" };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Runtime validation for ShowInputBoxRequest.
+ */
+export function validateShowInputBoxRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if ("title" in request && request.title !== undefined && typeof request.title !== "string") {
+    return { valid: false, error: "Field 'title' must be a string" };
+  }
+
+  if ("prompt" in request && request.prompt !== undefined && typeof request.prompt !== "string") {
+    return { valid: false, error: "Field 'prompt' must be a string" };
+  }
+
+  if (
+    "placeholder" in request &&
+    request.placeholder !== undefined &&
+    typeof request.placeholder !== "string"
+  ) {
+    return { valid: false, error: "Field 'placeholder' must be a string" };
+  }
+
+  if ("value" in request && request.value !== undefined && typeof request.value !== "string") {
+    return { valid: false, error: "Field 'value' must be a string" };
+  }
+
+  if (
+    "password" in request &&
+    request.password !== undefined &&
+    typeof request.password !== "boolean"
+  ) {
+    return { valid: false, error: "Field 'password' must be a boolean" };
+  }
+
+  return { valid: true };
 }
 
 // ============================================================================


### PR DESCRIPTION
- Add 5 new MCP tools for AI agent → VS Code UI interaction
- `ui_show_notification`: modal notifications with optional action buttons (fire-and-forget or interactive)
- `ui_status_bar_update` / `ui_status_bar_dispose`: create, update, and remove named status bar items with upsert semantics
- `ui_show_quick_pick`: present a list of options and return the user's selection
- `ui_show_input_box`: prompt the user for text input with optional password mode
- Tools flow through PluginServer → Socket.IO → sidekick extension → VS Code API
- Interactive tools block until user responds, with configurable timeout (default: no timeout)
- Status bar items auto-cleanup on workspace disconnect