### PR TITLE
fix: increase code-server timeout

### DIFF
--- a/src/services/code-server/code-server-manager.integration.test.ts
+++ b/src/services/code-server/code-server-manager.integration.test.ts
@@ -569,8 +569,8 @@ describe("CodeServerManager Integration", () => {
           caughtError = err;
         });
 
-        // Advance past the 10s health check timeout
-        await vi.advanceTimersByTimeAsync(11_000);
+        // Advance past the 30s health check timeout
+        await vi.advanceTimersByTimeAsync(31_000);
 
         await startPromise;
 

--- a/src/services/code-server/code-server-manager.ts
+++ b/src/services/code-server/code-server-manager.ts
@@ -476,7 +476,7 @@ export class CodeServerManager {
 
   /**
    * Wait for the server to become healthy.
-   * Uses shared health check utility with 10s timeout.
+   * Uses shared health check utility with 30s timeout.
    *
    * Port availability is checked BEFORE spawning code-server (in doStart),
    * so we don't need a delay here. The health check verifies both that
@@ -485,9 +485,9 @@ export class CodeServerManager {
   private async waitForServerHealthy(port: number): Promise<void> {
     await waitForHealthy({
       checkFn: () => this.checkHealth(port),
-      timeoutMs: 10000,
+      timeoutMs: 30000,
       intervalMs: 100,
-      errorMessage: "Health check timed out after 10 seconds",
+      errorMessage: "Health check timed out after 30 seconds",
     });
   }
 


### PR DESCRIPTION
- Increase code-server health check timeout from 10s to 30s
- Windows Defender can delay code-server startup after updates, causing timeouts