### PR TITLE
feat: auto-update runs on startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -164,6 +164,7 @@ import {
   INTENT_UPDATE_AGENT_STATUS,
 } from "./operations/update-agent-status";
 import { UpdateAvailableOperation, INTENT_UPDATE_AVAILABLE } from "./operations/update-available";
+import { UpdateApplyOperation, INTENT_UPDATE_APPLY } from "./operations/update-apply";
 import {
   ResolveWorkspaceOperation,
   INTENT_RESOLVE_WORKSPACE,
@@ -505,6 +506,7 @@ const telemetryLifecycleModule = createTelemetryModule({
 const autoUpdaterLifecycleModule = createAutoUpdaterModule({
   autoUpdater,
   dispatcher,
+  ipcLayer,
 });
 const localProjectModule = createLocalProjectModule({
   projectsDir: pathProvider.dataPath("projects").toString(),
@@ -620,6 +622,7 @@ dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
 dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
 dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
 dispatcher.registerOperation(INTENT_UPDATE_AVAILABLE, new UpdateAvailableOperation());
+dispatcher.registerOperation(INTENT_UPDATE_APPLY, new UpdateApplyOperation());
 
 // Create IPC event bridge (registers all IPC handlers directly on ipcLayer)
 const ipcEventBridge = createIpcEventBridge({

--- a/src/main/modules/auto-updater-module.integration.test.ts
+++ b/src/main/modules/auto-updater-module.integration.test.ts
@@ -5,9 +5,7 @@
  * Tests verify the full pipeline:
  * dispatcher -> Operation -> hook point -> AutoUpdaterModule handler
  *
- * Uses a MinimalStartOperation (only runs "start" hook point) to avoid
- * the full AppStartOperation pipeline. AppShutdownOperation is simple
- * enough to use directly.
+ * Uses minimal operations to test individual hook behaviors.
  */
 
 import { describe, it, expect } from "vitest";
@@ -30,24 +28,42 @@ import {
   INTENT_UPDATE_AVAILABLE,
   type UpdateAvailableIntent,
 } from "../operations/update-available";
+import {
+  UpdateApplyOperation,
+  INTENT_UPDATE_APPLY,
+  type UpdateApplyIntent,
+} from "../operations/update-apply";
+import { INTENT_CONFIG_SET_VALUES } from "../operations/config-set-values";
 import { createAutoUpdaterModule } from "./auto-updater-module";
 import type { IntentModule } from "../intents/infrastructure/module";
-import type { DomainEvent } from "../intents/infrastructure/types";
+import type { DomainEvent, Intent } from "../intents/infrastructure/types";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedEvent } from "../operations/config-set-values";
-import type { AutoUpdater, UpdateAvailableCallback } from "../../services/auto-updater";
+import type {
+  AutoUpdater,
+  UpdateDetectedCallback,
+  UpdateDownloadedCallback,
+  DownloadProgressCallback,
+} from "../../services/auto-updater";
+import type { IpcEventHandler, IpcLayer } from "../../services/platform/ipc";
 
 // =============================================================================
-// Tracking Update Operation
+// Tracking Operations
 // =============================================================================
 
-/**
- * Minimal operation for update:available that records dispatched intents.
- */
 class TrackingUpdateOperation implements Operation<UpdateAvailableIntent, void> {
   readonly id = "update-available";
   readonly dispatched: UpdateAvailableIntent[] = [];
 
   async execute(ctx: OperationContext<UpdateAvailableIntent>): Promise<void> {
+    this.dispatched.push(ctx.intent);
+  }
+}
+
+class TrackingConfigOperation implements Operation<Intent<void>, void> {
+  readonly id = "config-set-values";
+  readonly dispatched: Intent[] = [];
+
+  async execute(ctx: OperationContext<Intent<void>>): Promise<void> {
     this.dispatched.push(ctx.intent);
   }
 }
@@ -60,22 +76,76 @@ interface MockAutoUpdater {
   mock: AutoUpdater;
   startCalled: boolean;
   disposeCalled: boolean;
-  capturedCallback: UpdateAvailableCallback | null;
+  checkForUpdatesCalled: boolean;
+  downloadCalled: boolean;
+  cancelCalled: boolean;
+  quitAndInstallCalled: boolean;
+  capturedDetectedCb: UpdateDetectedCallback | null;
+  capturedDownloadedCb: UpdateDownloadedCallback | null;
+  capturedProgressCb: DownloadProgressCallback | null;
+  resolveDownload: (() => void) | null;
+  rejectDownload: ((error: Error) => void) | null;
+  setCheckResult: (found: boolean) => void;
 }
 
-function createMockAutoUpdater(overrides?: { disposeThrows?: Error }): MockAutoUpdater {
+function createMockAutoUpdater(overrides?: {
+  disposeThrows?: Error;
+  checkReturns?: boolean;
+}): MockAutoUpdater {
   let startCalled = false;
   let disposeCalled = false;
-  let capturedCallback: UpdateAvailableCallback | null = null;
+  let checkForUpdatesCalled = false;
+  let downloadCalled = false;
+  let cancelCalled = false;
+  let quitAndInstallCalled = false;
+  let capturedDetectedCb: UpdateDetectedCallback | null = null;
+  let capturedDownloadedCb: UpdateDownloadedCallback | null = null;
+  let capturedProgressCb: DownloadProgressCallback | null = null;
+  let resolveDownload: (() => void) | null = null;
+  let rejectDownload: ((error: Error) => void) | null = null;
+  let checkResult = overrides?.checkReturns ?? false;
 
   const mock: AutoUpdater = {
     start() {
       startCalled = true;
     },
-    onUpdateAvailable(callback: UpdateAvailableCallback) {
-      capturedCallback = callback;
+    async checkForUpdates() {
+      checkForUpdatesCalled = true;
+      // Simulate the update-available event firing synchronously
+      if (checkResult && capturedDetectedCb) {
+        capturedDetectedCb("2.0.0");
+      }
+      return checkResult;
+    },
+    async downloadUpdate() {
+      downloadCalled = true;
+      return new Promise<void>((resolve, reject) => {
+        resolveDownload = resolve;
+        rejectDownload = reject;
+      });
+    },
+    cancelDownload() {
+      cancelCalled = true;
+    },
+    quitAndInstall() {
+      quitAndInstallCalled = true;
+    },
+    onUpdateDetected(callback: UpdateDetectedCallback) {
+      capturedDetectedCb = callback;
       return () => {
-        capturedCallback = null;
+        capturedDetectedCb = null;
+      };
+    },
+    onUpdateDownloaded(callback: UpdateDownloadedCallback) {
+      capturedDownloadedCb = callback;
+      return () => {
+        capturedDownloadedCb = null;
+      };
+    },
+    onDownloadProgress(callback: DownloadProgressCallback) {
+      capturedProgressCb = callback;
+      return () => {
+        capturedProgressCb = null;
       };
     },
     dispose() {
@@ -94,8 +164,72 @@ function createMockAutoUpdater(overrides?: { disposeThrows?: Error }): MockAutoU
     get disposeCalled() {
       return disposeCalled;
     },
-    get capturedCallback() {
-      return capturedCallback;
+    get checkForUpdatesCalled() {
+      return checkForUpdatesCalled;
+    },
+    get downloadCalled() {
+      return downloadCalled;
+    },
+    get cancelCalled() {
+      return cancelCalled;
+    },
+    get quitAndInstallCalled() {
+      return quitAndInstallCalled;
+    },
+    get capturedDetectedCb() {
+      return capturedDetectedCb;
+    },
+    get capturedDownloadedCb() {
+      return capturedDownloadedCb;
+    },
+    get capturedProgressCb() {
+      return capturedProgressCb;
+    },
+    get resolveDownload() {
+      return resolveDownload;
+    },
+    get rejectDownload() {
+      return rejectDownload;
+    },
+    setCheckResult(found: boolean) {
+      checkResult = found;
+    },
+  };
+}
+
+interface MockIpcLayer {
+  layer: Pick<IpcLayer, "on" | "removeListener">;
+  handlers: Map<string, IpcEventHandler[]>;
+  emit: (channel: string, ...args: unknown[]) => void;
+}
+
+function createMockIpcLayer(): MockIpcLayer {
+  const handlers = new Map<string, IpcEventHandler[]>();
+
+  const layer: Pick<IpcLayer, "on" | "removeListener"> = {
+    on(channel: string, handler: IpcEventHandler) {
+      if (!handlers.has(channel)) handlers.set(channel, []);
+      handlers.get(channel)!.push(handler);
+    },
+    removeListener(channel: string, handler: IpcEventHandler) {
+      const list = handlers.get(channel);
+      if (list) {
+        const idx = list.indexOf(handler);
+        if (idx !== -1) list.splice(idx, 1);
+      }
+    },
+  };
+
+  return {
+    layer,
+    handlers,
+    emit(channel: string, ...args: unknown[]) {
+      const list = handlers.get(channel);
+      if (list) {
+        for (const handler of [...list]) {
+          handler({} as Electron.IpcMainEvent, ...args);
+        }
+      }
     },
   };
 }
@@ -103,15 +237,19 @@ function createMockAutoUpdater(overrides?: { disposeThrows?: Error }): MockAutoU
 interface TestSetup {
   dispatcher: Dispatcher;
   autoUpdater: MockAutoUpdater;
+  ipcLayer: MockIpcLayer;
   updateOperation: TrackingUpdateOperation;
+  configOperation: TrackingConfigOperation;
   module: IntentModule;
+  emittedEvents: DomainEvent[];
 }
 
-function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
-  const autoUpdater = createMockAutoUpdater(
-    overrides?.disposeThrows ? { disposeThrows: overrides.disposeThrows } : undefined
-  );
+function createTestSetup(overrides?: { disposeThrows?: Error; checkReturns?: boolean }): TestSetup {
+  const autoUpdater = createMockAutoUpdater(overrides);
+  const ipcLayer = createMockIpcLayer();
   const updateOperation = new TrackingUpdateOperation();
+  const configOperation = new TrackingConfigOperation();
+  const emittedEvents: DomainEvent[] = [];
 
   const hookRegistry = new HookRegistry();
   const dispatcher = new Dispatcher(hookRegistry);
@@ -119,23 +257,35 @@ function createTestSetup(overrides?: { disposeThrows?: Error }): TestSetup {
   const autoUpdaterModule = createAutoUpdaterModule({
     autoUpdater: autoUpdater.mock,
     dispatcher,
+    ipcLayer: ipcLayer.layer,
   });
 
+  // Register minimal operations for the hooks we test
   dispatcher.registerOperation(
     INTENT_APP_START,
     createMinimalOperation(APP_START_OPERATION_ID, "start")
   );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
   dispatcher.registerOperation(INTENT_UPDATE_AVAILABLE, updateOperation);
+  dispatcher.registerOperation(INTENT_UPDATE_APPLY, new UpdateApplyOperation());
+  dispatcher.registerOperation(INTENT_CONFIG_SET_VALUES, configOperation);
 
   dispatcher.registerModule(autoUpdaterModule);
 
-  return { dispatcher, autoUpdater, updateOperation, module: autoUpdaterModule };
+  // Subscribe to all events for verification
+  dispatcher.subscribe("app:update:progress", (e) => emittedEvents.push(e));
+
+  return {
+    dispatcher,
+    autoUpdater,
+    ipcLayer,
+    updateOperation,
+    configOperation,
+    module: autoUpdaterModule,
+    emittedEvents,
+  };
 }
 
-/**
- * Simulate a config:updated event by calling the module's event handler directly.
- */
 function simulateConfigUpdated(
   module: IntentModule,
   values: Readonly<Record<string, unknown>>
@@ -151,8 +301,11 @@ function startIntent(): AppStartIntent {
   return { type: INTENT_APP_START, payload: {} as AppStartIntent["payload"] };
 }
 
-function shutdownIntent(): AppShutdownIntent {
-  return { type: INTENT_APP_SHUTDOWN, payload: {} as AppShutdownIntent["payload"] };
+function shutdownIntent(installUpdate?: boolean): AppShutdownIntent {
+  return {
+    type: INTENT_APP_SHUTDOWN,
+    payload: { ...(installUpdate !== undefined && { installUpdate }) },
+  };
 }
 
 // =============================================================================
@@ -168,13 +321,13 @@ describe("AutoUpdaterModule Integration", () => {
     expect(autoUpdater.startCalled).toBe(true);
   });
 
-  it("dispatch app:start wires onUpdateAvailable to dispatch update:available", async () => {
+  it("dispatch app:start wires onUpdateDownloaded to dispatch update:available", async () => {
     const { dispatcher, autoUpdater, updateOperation } = createTestSetup();
 
     await dispatcher.dispatch(startIntent());
 
-    // Simulate an update becoming available
-    autoUpdater.capturedCallback!("2.0.0");
+    // Simulate an update being downloaded
+    autoUpdater.capturedDownloadedCb!("2.0.0");
 
     // Allow the void dispatch to settle
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -196,28 +349,35 @@ describe("AutoUpdaterModule Integration", () => {
       disposeThrows: new Error("dispose failed"),
     });
 
-    // Handler throws, but collect() catches it and shutdown is best-effort
     await expect(dispatcher.dispatch(shutdownIntent())).resolves.toBeUndefined();
   });
 
-  it("auto-update=always (default) starts autoUpdater", async () => {
-    const { dispatcher, autoUpdater, module } = createTestSetup();
-
-    simulateConfigUpdated(module, { "auto-update": "always" });
-
-    await dispatcher.dispatch(startIntent());
-
-    expect(autoUpdater.startCalled).toBe(true);
-  });
-
-  it("auto-update=never skips autoUpdater.start()", async () => {
-    const { dispatcher, autoUpdater, module } = createTestSetup();
+  it("auto-update=never skips autoUpdater via interceptor", async () => {
+    const { dispatcher, module } = createTestSetup();
 
     simulateConfigUpdated(module, { "auto-update": "never" });
 
-    await dispatcher.dispatch(startIntent());
+    // The interceptor should reject the app:update intent
+    const handle = dispatcher.dispatch({
+      type: INTENT_UPDATE_APPLY,
+      payload: { needsChoice: false },
+    } as UpdateApplyIntent);
 
-    expect(autoUpdater.startCalled).toBe(false);
+    const accepted = await handle.accepted;
+    expect(accepted).toBe(false);
+  });
+
+  it("interceptor rejects when no update detected", async () => {
+    const { dispatcher } = createTestSetup();
+
+    // detectedVersion is null by default
+    const handle = dispatcher.dispatch({
+      type: INTENT_UPDATE_APPLY,
+      payload: { needsChoice: false },
+    } as UpdateApplyIntent);
+
+    const accepted = await handle.accepted;
+    expect(accepted).toBe(false);
   });
 
   it("auto-update=never still calls dispose() on shutdown", async () => {
@@ -228,7 +388,31 @@ describe("AutoUpdaterModule Integration", () => {
     await dispatcher.dispatch(startIntent());
     await dispatcher.dispatch(shutdownIntent());
 
-    expect(autoUpdater.startCalled).toBe(false);
     expect(autoUpdater.disposeCalled).toBe(true);
+  });
+
+  it("quit hook calls quitAndInstall when installUpdate is set", async () => {
+    const { dispatcher, autoUpdater } = createTestSetup();
+
+    await dispatcher.dispatch(shutdownIntent(true));
+
+    expect(autoUpdater.quitAndInstallCalled).toBe(true);
+  });
+
+  it("quit hook does NOT call quitAndInstall when installUpdate is not set", async () => {
+    const { dispatcher, autoUpdater } = createTestSetup();
+
+    await dispatcher.dispatch(shutdownIntent());
+
+    expect(autoUpdater.quitAndInstallCalled).toBe(false);
+  });
+
+  it("register-config registers auto-update with default 'ask'", async () => {
+    const { module } = createTestSetup();
+
+    // Verify the module has register-config hook
+    const hooks = module.hooks![APP_START_OPERATION_ID];
+    expect(hooks).toBeDefined();
+    expect(hooks!["register-config"]).toBeDefined();
   });
 });

--- a/src/main/modules/auto-updater-module.ts
+++ b/src/main/modules/auto-updater-module.ts
@@ -1,43 +1,79 @@
 /**
- * AutoUpdaterModule - Lifecycle module for auto-update checking and cleanup.
+ * AutoUpdaterModule - Lifecycle module for auto-update checking, download, and install.
  *
  * Hooks:
- * - app:start -> "start": starts auto-updater (unless auto-update=never),
- *   wires onUpdateAvailable to dispatch update:available
- * - app:shutdown -> "stop": disposes auto-updater (best-effort)
+ * - app:start -> "register-config": register auto-update config with default "ask"
+ * - app:start -> "check-deps": check for updates, store detectedVersion, return updateNeedsChoice
+ * - app:start -> "start": start auto-updater
+ * - update-apply -> "show-choice": emit show-choice UI event
+ * - update-apply -> "download": download update, report progress, handle cancel
+ * - update-apply -> "install": dispatch app:shutdown with installUpdate
+ * - app:shutdown -> "stop": dispose auto-updater
+ * - app:shutdown -> "quit": quitAndInstall if installUpdate flag is set
+ *
+ * Interceptor:
+ * - Rejects app:update if config="never" or no update detected
  *
  * Events:
  * - config:updated: tracks auto-update preference
  */
 
 import type { IntentModule } from "../intents/infrastructure/module";
-import type { DomainEvent } from "../intents/infrastructure/types";
+import type { IntentInterceptor } from "../intents/infrastructure/dispatcher";
+import type { Intent, DomainEvent } from "../intents/infrastructure/types";
+import type { HookContext } from "../intents/infrastructure/operation";
+import type { IpcEventHandler, IpcLayer } from "../../services/platform/ipc";
 import {
   APP_START_OPERATION_ID,
   type StartHookResult,
   type RegisterConfigResult,
+  type CheckDepsResult,
 } from "../operations/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
+import { APP_SHUTDOWN_OPERATION_ID, type AppShutdownIntent } from "../operations/app-shutdown";
 import {
   INTENT_UPDATE_AVAILABLE,
   type UpdateAvailableIntent,
 } from "../operations/update-available";
+import {
+  UPDATE_APPLY_OPERATION_ID,
+  INTENT_UPDATE_APPLY,
+  type UpdateApplyHookContext,
+  type UpdateDownloadResult,
+} from "../operations/update-apply";
+import { INTENT_APP_SHUTDOWN } from "../operations/app-shutdown";
 import { EVENT_CONFIG_UPDATED, type ConfigUpdatedPayload } from "../operations/config-set-values";
 import { configEnum } from "../../services/config/config-definition";
 import type { AutoUpdatePreference } from "../../services/config/config-values";
 import type { AutoUpdater } from "../../services/auto-updater";
 import type { Dispatcher } from "../intents/infrastructure/dispatcher";
+import { ApiIpcChannels } from "../../shared/ipc";
+
+/** Timeout for update check during startup (ms). */
+const UPDATE_CHECK_TIMEOUT_MS = 15_000;
 
 interface AutoUpdaterModuleDeps {
   readonly autoUpdater: AutoUpdater;
   readonly dispatcher: Dispatcher;
+  readonly ipcLayer: Pick<IpcLayer, "on" | "removeListener">;
 }
 
 export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModule {
-  let autoUpdate: AutoUpdatePreference = "always";
+  let autoUpdate: AutoUpdatePreference = "ask";
+  let detectedVersion: string | null = null;
+
+  // Interceptor: reject app:update if config="never" or no update detected
+  const interceptor: IntentInterceptor = {
+    id: "auto-updater-gate",
+    async before(intent: Intent): Promise<Intent | null> {
+      if (intent.type !== INTENT_UPDATE_APPLY) return intent;
+      if (autoUpdate === "never" || detectedVersion === null) return null;
+      return intent;
+    },
+  };
 
   return {
     name: "auto-updater",
+    interceptors: [interceptor],
     hooks: {
       [APP_START_OPERATION_ID]: {
         "register-config": {
@@ -45,29 +81,126 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
             definitions: [
               {
                 name: "auto-update",
-                default: "always" as AutoUpdatePreference,
+                default: "ask" as AutoUpdatePreference,
                 description: "Auto-update preference",
-                ...configEnum(["always", "never"]),
+                ...configEnum(["always", "ask", "never"]),
               },
             ],
           }),
         },
+        "check-deps": {
+          handler: async (): Promise<CheckDepsResult> => {
+            // Register detected callback BEFORE checking, to avoid race condition
+            // (update-available event fires during checkForUpdates)
+            const versionPromise = new Promise<string | null>((resolve) => {
+              const timeout = setTimeout(() => resolve(null), UPDATE_CHECK_TIMEOUT_MS);
+              const unsub = deps.autoUpdater.onUpdateDetected((version) => {
+                clearTimeout(timeout);
+                unsub();
+                resolve(version);
+              });
+
+              // Start the check — fires onUpdateDetected if update found
+              deps.autoUpdater.checkForUpdates().then(
+                (found) => {
+                  if (!found) {
+                    clearTimeout(timeout);
+                    unsub();
+                    resolve(null);
+                  }
+                },
+                () => {
+                  clearTimeout(timeout);
+                  unsub();
+                  resolve(null);
+                }
+              );
+            });
+
+            detectedVersion = await versionPromise;
+
+            return {
+              updateNeedsChoice: autoUpdate === "ask" && detectedVersion !== null,
+            };
+          },
+        },
         start: {
           handler: async (): Promise<StartHookResult> => {
-            if (autoUpdate === "never") {
-              return {};
-            }
-
             deps.autoUpdater.start();
 
-            // Wire auto-updater to dispatch update:available intent
-            deps.autoUpdater.onUpdateAvailable((version: string) => {
+            // Wire auto-updater to dispatch update:available intent (for window title backup)
+            deps.autoUpdater.onUpdateDownloaded((version: string) => {
               void deps.dispatcher.dispatch({
                 type: INTENT_UPDATE_AVAILABLE,
                 payload: { version },
               } as UpdateAvailableIntent);
             });
+
+            // Capture detected version from update-available events (for late detection)
+            deps.autoUpdater.onUpdateDetected((version: string) => {
+              detectedVersion = version;
+            });
+
             return {};
+          },
+        },
+      },
+      [UPDATE_APPLY_OPERATION_ID]: {
+        "show-choice": {
+          handler: async (ctx: HookContext): Promise<void> => {
+            const { report } = ctx as UpdateApplyHookContext;
+            report("show-choice", 0, detectedVersion ?? "");
+          },
+        },
+        download: {
+          handler: async (ctx: HookContext): Promise<UpdateDownloadResult> => {
+            const { report } = ctx as UpdateApplyHookContext;
+            const version = detectedVersion ?? "";
+            report("downloading", 0, version);
+
+            // Wire progress reporting
+            const unsubProgress = deps.autoUpdater.onDownloadProgress((info) => {
+              report("progress", info.percent, version);
+            });
+
+            // Listen for cancel IPC
+            let cancelled = false;
+            const cancelHandler: IpcEventHandler = () => {
+              cancelled = true;
+              deps.autoUpdater.cancelDownload();
+            };
+            deps.ipcLayer.on(ApiIpcChannels.UPDATE_CANCEL, cancelHandler);
+
+            try {
+              await deps.autoUpdater.downloadUpdate();
+            } catch {
+              // Download failed or was cancelled
+              if (cancelled) {
+                report("downloading", 0, version, true);
+                return { cancelled: true };
+              }
+              // Non-cancel failure — hide UI and continue startup
+              report("downloading", 0, version, true);
+              return { cancelled: true };
+            } finally {
+              unsubProgress();
+              deps.ipcLayer.removeListener(ApiIpcChannels.UPDATE_CANCEL, cancelHandler);
+            }
+
+            if (cancelled) {
+              report("downloading", 0, version, true);
+              return { cancelled: true };
+            }
+
+            return {};
+          },
+        },
+        install: {
+          handler: async (): Promise<void> => {
+            await deps.dispatcher.dispatch({
+              type: INTENT_APP_SHUTDOWN,
+              payload: { installUpdate: true },
+            });
           },
         },
       },
@@ -75,6 +208,14 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
         stop: {
           handler: async () => {
             deps.autoUpdater.dispose();
+          },
+        },
+        quit: {
+          handler: async (ctx: HookContext) => {
+            const intent = ctx.intent as AppShutdownIntent;
+            if (intent.payload.installUpdate) {
+              deps.autoUpdater.quitAndInstall();
+            }
           },
         },
       },

--- a/src/main/modules/ipc-event-bridge.ts
+++ b/src/main/modules/ipc-event-bridge.ts
@@ -73,6 +73,8 @@ import { EVENT_BASES_UPDATED, INTENT_GET_PROJECT_BASES } from "../operations/get
 import type { GetProjectBasesIntent } from "../operations/get-project-bases";
 import { EVENT_SETUP_ERROR, EVENT_SETUP_PROGRESS } from "../operations/setup";
 import type { SetupErrorEvent, SetupProgressEvent } from "../operations/setup";
+import { EVENT_UPDATE_PROGRESS } from "../operations/update-apply";
+import type { UpdateProgressEvent } from "../operations/update-apply";
 import type { WorkspaceStatus, Workspace } from "../../shared/api/types";
 import { INTENT_GET_METADATA } from "../operations/get-metadata";
 import type { GetMetadataIntent } from "../operations/get-metadata";
@@ -218,6 +220,10 @@ export function createIpcEventBridge(deps: IpcEventBridgeDeps): IntentModule {
         ...(code !== undefined && { code }),
       };
       deps.sendToUI(ApiIpcChannels.LIFECYCLE_SETUP_ERROR, errorPayload);
+    },
+    [EVENT_UPDATE_PROGRESS]: (event: DomainEvent) => {
+      const payload = (event as UpdateProgressEvent).payload;
+      deps.sendToUI(ApiIpcChannels.UPDATE_PROGRESS, payload);
     },
     [EVENT_BASES_UPDATED]: (event: DomainEvent) => {
       const p = (event as BasesUpdatedEvent).payload;

--- a/src/main/modules/view-module.ts
+++ b/src/main/modules/view-module.ts
@@ -64,6 +64,7 @@ import { SET_MODE_OPERATION_ID } from "../operations/set-mode";
 import { OPEN_PROJECT_OPERATION_ID } from "../operations/open-project";
 import { APP_SHUTDOWN_OPERATION_ID } from "../operations/app-shutdown";
 import { SETUP_OPERATION_ID } from "../operations/setup";
+import { UPDATE_APPLY_OPERATION_ID, type UpdateChoiceResult } from "../operations/update-apply";
 import { GET_ACTIVE_WORKSPACE_OPERATION_ID } from "../operations/get-active-workspace";
 import { SWITCH_WORKSPACE_OPERATION_ID } from "../operations/switch-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../operations/delete-workspace";
@@ -76,6 +77,8 @@ import {
   type LifecycleAgentType,
   type ShowAgentSelectionPayload,
   type AgentSelectedPayload,
+  type UpdateChoice,
+  type UpdateChoicePayload,
 } from "../../shared/ipc";
 import { ApiIpcChannels as SetupIpcChannels } from "../../shared/ipc";
 import { SetupError } from "../../services/errors";
@@ -310,6 +313,30 @@ export function createViewModule(deps: ViewModuleDeps): ViewModuleResult {
         "hide-ui": {
           handler: async () => {
             viewManager.sendToUI(SetupIpcChannels.LIFECYCLE_SHOW_STARTING);
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // update-apply → await-choice: listen for user's update choice via IPC
+      // -------------------------------------------------------------------
+      [UPDATE_APPLY_OPERATION_ID]: {
+        "await-choice": {
+          handler: async (): Promise<UpdateChoiceResult> => {
+            if (!deps.ipcLayer) {
+              return {};
+            }
+
+            const ipcLayer = deps.ipcLayer;
+            const choice = await new Promise<UpdateChoice>((resolve) => {
+              const handler: IpcEventHandler = (_event, ...args) => {
+                ipcLayer.removeListener(ApiIpcChannels.UPDATE_CHOICE, handler);
+                resolve((args[0] as UpdateChoicePayload).choice);
+              };
+              ipcLayer.on(ApiIpcChannels.UPDATE_CHOICE, handler);
+            });
+
+            return { choice };
           },
         },
       },

--- a/src/main/operations/app-shutdown.ts
+++ b/src/main/operations/app-shutdown.ts
@@ -23,8 +23,8 @@ import type { Operation, OperationContext, HookContext } from "../intents/infras
 // =============================================================================
 
 export interface AppShutdownPayload {
-  /** No payload needed - shutdown has no parameters. */
-  readonly [key: string]: never;
+  /** If true, install a downloaded update after shutdown cleanup. */
+  readonly installUpdate?: boolean;
 }
 
 export interface AppShutdownIntent extends Intent<void> {

--- a/src/main/operations/app-start.ts
+++ b/src/main/operations/app-start.ts
@@ -42,6 +42,7 @@ import type { ConfigAgentType } from "../../shared/api/types";
 import type { BinaryType } from "../../services/vscode-setup/types";
 import type { ConfigKeyDefinition } from "../../services/config/config-definition";
 import { INTENT_SETUP } from "./setup";
+import { INTENT_UPDATE_APPLY } from "./update-apply";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
 import { Path } from "../../services/platform/path";
 
@@ -89,6 +90,8 @@ export interface CheckDepsResult {
   readonly missingBinaries?: readonly BinaryType[];
   readonly missingExtensions?: readonly string[];
   readonly outdatedExtensions?: readonly string[];
+  /** True when auto-update config is "ask" and an update was detected. */
+  readonly updateNeedsChoice?: boolean;
 }
 
 /**
@@ -169,6 +172,7 @@ interface CheckResult {
   readonly needsExtensions: boolean;
   readonly missingExtensions: readonly string[];
   readonly outdatedExtensions: readonly string[];
+  readonly updateNeedsChoice: boolean;
 }
 
 // =============================================================================
@@ -231,6 +235,16 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
 
     // Hook 5: "check-deps" (collect, isolated contexts)
     let checkResult = await this.runChecks(ctx, configuredAgent);
+
+    // Dispatch app:update before setup (interceptor rejects if config="never" or no update)
+    try {
+      await ctx.dispatch({
+        type: INTENT_UPDATE_APPLY,
+        payload: { needsChoice: checkResult.updateNeedsChoice ?? false },
+      });
+    } catch {
+      // Update rejected by interceptor or failed — non-fatal, continue startup
+    }
 
     // Dispatch app:setup if needed (blocking sub-operation)
     // Setup manages its own UI (shows/hides setup screen)
@@ -339,11 +353,13 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     const missingBinaries: BinaryType[] = [];
     const missingExtensions: string[] = [];
     const outdatedExtensions: string[] = [];
+    let updateNeedsChoice = false;
 
     for (const result of depsResults) {
       if (result.missingBinaries) missingBinaries.push(...result.missingBinaries);
       if (result.missingExtensions) missingExtensions.push(...result.missingExtensions);
       if (result.outdatedExtensions) outdatedExtensions.push(...result.outdatedExtensions);
+      if (result.updateNeedsChoice) updateNeedsChoice = true;
     }
 
     // Derive booleans (dissolved from needsSetupModule)
@@ -361,6 +377,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       needsExtensions,
       missingExtensions,
       outdatedExtensions,
+      updateNeedsChoice,
     };
   }
 }

--- a/src/main/operations/update-apply.ts
+++ b/src/main/operations/update-apply.ts
@@ -1,0 +1,160 @@
+/**
+ * UpdateApplyOperation - Orchestrates update choice, download, and install.
+ *
+ * Dispatched from AppStartOperation after check-deps detects an update.
+ * Uses an interceptor (in auto-updater module) to reject when config="never"
+ * or no update was detected.
+ *
+ * Runs four hook points:
+ * 1. "show-choice" - (if needsChoice) Emit show-choice UI event
+ * 2. "await-choice" - (if needsChoice) Await user response via IPC
+ * 3. "download" - Download update, report progress, handle cancel
+ * 4. "install" - Dispatch app:shutdown with installUpdate flag
+ *
+ * Version is NOT in the payload — it lives in auto-updater module state.
+ * Hook handlers supply the version when calling report().
+ */
+
+import type { Intent, DomainEvent } from "../intents/infrastructure/types";
+import type { Operation, OperationContext, HookContext } from "../intents/infrastructure/operation";
+import type { UpdateProgressAction, UpdateChoice } from "../../shared/ipc";
+import { INTENT_CONFIG_SET_VALUES } from "./config-set-values";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface UpdateApplyPayload {
+  readonly needsChoice: boolean;
+}
+
+export interface UpdateApplyIntent extends Intent<void> {
+  readonly type: "app:update";
+  readonly payload: UpdateApplyPayload;
+}
+
+export const INTENT_UPDATE_APPLY = "app:update" as const;
+
+// =============================================================================
+// Domain Events
+// =============================================================================
+
+export interface UpdateProgressPayload {
+  readonly action: UpdateProgressAction;
+  readonly version: string;
+  readonly percent: number;
+  readonly finished?: boolean;
+}
+
+export interface UpdateProgressEvent extends DomainEvent {
+  readonly type: typeof EVENT_UPDATE_PROGRESS;
+  readonly payload: UpdateProgressPayload;
+}
+
+export const EVENT_UPDATE_PROGRESS = "app:update:progress" as const;
+
+// =============================================================================
+// Hook Context & Result Types
+// =============================================================================
+
+export const UPDATE_APPLY_OPERATION_ID = "update-apply";
+
+/**
+ * Progress reporter callback for update UI.
+ * Wraps ctx.emit() to emit UPDATE_PROGRESS domain events.
+ */
+export type UpdateProgressReporter = (
+  action: UpdateProgressAction,
+  percent: number,
+  version: string,
+  finished?: boolean
+) => void;
+
+/**
+ * Input context for update-apply hooks — carries the report callback.
+ */
+export interface UpdateApplyHookContext extends HookContext {
+  readonly report: UpdateProgressReporter;
+}
+
+/**
+ * Result from the "choice" hook — returns the user's choice.
+ */
+export interface UpdateChoiceResult {
+  readonly choice?: UpdateChoice;
+}
+
+/**
+ * Result from the "download" hook — indicates if download was cancelled.
+ */
+export interface UpdateDownloadResult {
+  readonly cancelled?: boolean;
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class UpdateApplyOperation implements Operation<UpdateApplyIntent, void> {
+  readonly id = UPDATE_APPLY_OPERATION_ID;
+
+  async execute(ctx: OperationContext<UpdateApplyIntent>): Promise<void> {
+    const { needsChoice } = ctx.intent.payload;
+
+    const report: UpdateProgressReporter = (action, percent, version, finished?) => {
+      ctx.emit({
+        type: EVENT_UPDATE_PROGRESS,
+        payload: {
+          action,
+          version,
+          percent,
+          ...(finished !== undefined && { finished }),
+        },
+      });
+    };
+
+    const hookCtx: UpdateApplyHookContext = {
+      intent: ctx.intent,
+      report,
+    };
+
+    // 1. Choice (conditional)
+    if (needsChoice) {
+      // show-choice: emit UI event (auto-updater module)
+      await ctx.hooks.collect("show-choice", hookCtx);
+      // await-choice: block until user responds via IPC (view module)
+      const { results } = await ctx.hooks.collect<UpdateChoiceResult>("await-choice", hookCtx);
+      const choice = results.find((r) => r.choice)?.choice;
+
+      switch (choice) {
+        case "always":
+          await ctx.dispatch({
+            type: INTENT_CONFIG_SET_VALUES,
+            payload: { values: { "auto-update": "always" } },
+          });
+          break;
+        case "never":
+          await ctx.dispatch({
+            type: INTENT_CONFIG_SET_VALUES,
+            payload: { values: { "auto-update": "never" } },
+          });
+          report("show-choice", 0, "", true);
+          return;
+        case "skip":
+          report("show-choice", 0, "", true);
+          return;
+      }
+    }
+
+    // 2. Download (cancel handled by download hook — emits finished:true before returning)
+    const { results: dlResults } = await ctx.hooks.collect<UpdateDownloadResult>(
+      "download",
+      hookCtx
+    );
+    const cancelled = dlResults.some((r) => r.cancelled);
+    if (cancelled) return; // download hook already emitted finished:true
+
+    // 3. Install (dispatches app:shutdown with installUpdate flag)
+    await ctx.hooks.collect("install", hookCtx);
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import type {
   LogContext,
   LifecycleAgentType,
   AgentSelectedPayload,
+  UpdateChoice,
+  UpdateChoicePayload,
 } from "../shared/ipc";
 import type { ShortcutKey } from "../shared/shortcuts";
 import type { InitialPrompt } from "../shared/api/types";
@@ -111,6 +113,21 @@ contextBridge.exposeInMainWorld("api", {
    */
   sendRetry: () => {
     ipcRenderer.send(ApiIpcChannels.LIFECYCLE_RETRY);
+  },
+  /**
+   * Send update choice event to main process.
+   * Used when user responds to the update choice dialog.
+   */
+  sendUpdateChoice: (choice: UpdateChoice) => {
+    const payload: UpdateChoicePayload = { choice };
+    ipcRenderer.send(ApiIpcChannels.UPDATE_CHOICE, payload);
+  },
+  /**
+   * Send cancel update event to main process.
+   * Used when user clicks Cancel during update download.
+   */
+  sendCancelUpdate: () => {
+    ipcRenderer.send(ApiIpcChannels.UPDATE_CANCEL);
   },
   // Log API (renderer → main, fire-and-forget)
   log: {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -27,6 +27,8 @@
     ShowAgentSelectionPayload,
     SetupErrorPayload,
     LifecycleAgentType,
+    UpdateProgressPayload,
+    UpdateChoice,
   } from "@shared/ipc";
   import {
     handleModeChange,
@@ -41,6 +43,7 @@
   import SetupScreen from "$lib/components/SetupScreen.svelte";
   import SetupError from "$lib/components/SetupError.svelte";
   import AgentSelectionDialog from "$lib/components/AgentSelectionDialog.svelte";
+  import UpdateOverlay from "$lib/components/UpdateOverlay.svelte";
 
   const logger = createLogger("ui");
 
@@ -78,6 +81,14 @@
 
   // Announcement message for screen readers (cleared after announcement)
   let announceMessage = $state<string>("");
+
+  // Update overlay state
+  type UpdateState =
+    | { type: "none" }
+    | { type: "choice"; version: string }
+    | { type: "downloading"; version: string; percent: number };
+
+  let updateState = $state<UpdateState>({ type: "none" });
 
   // Subscribe to ui:mode-changed events from main process (unified mode system)
   $effect(() => {
@@ -204,6 +215,45 @@
     };
   });
 
+  // Subscribe to update:progress events from main process
+  $effect(() => {
+    const unsub = api.on<UpdateProgressPayload>("update:progress", (payload) => {
+      if (payload.finished) {
+        updateState = { type: "none" };
+        return;
+      }
+
+      switch (payload.action) {
+        case "show-choice":
+          updateState = { type: "choice", version: payload.version };
+          break;
+        case "downloading":
+        case "progress":
+          updateState = {
+            type: "downloading",
+            version: payload.version,
+            percent: payload.percent,
+          };
+          break;
+      }
+    });
+    return () => {
+      unsub();
+    };
+  });
+
+  // Handle update choice
+  function handleUpdateChoice(choice: UpdateChoice): void {
+    logger.info("Update choice", { choice });
+    api.sendUpdateChoice(choice);
+  }
+
+  // Handle update cancel
+  function handleUpdateCancel(): void {
+    logger.info("Update cancelled");
+    api.sendCancelUpdate();
+  }
+
   // No onMount needed - main process drives the flow via IPC events
   // The renderer starts in "initializing" mode and waits for IPC instructions
 
@@ -312,6 +362,18 @@
       </div>
     {/if}
   {/if}
+
+  {#if updateState.type !== "none"}
+    <div class="update-overlay-container">
+      <UpdateOverlay
+        mode={updateState.type === "choice" ? "choice" : "downloading"}
+        version={updateState.version}
+        percent={updateState.type === "downloading" ? updateState.percent : 0}
+        onchoice={handleUpdateChoice}
+        oncancel={handleUpdateCancel}
+      />
+    </div>
+  {/if}
 </main>
 
 <style>
@@ -356,6 +418,22 @@
     color: var(--ch-foreground);
     background-color: var(--ch-background);
     z-index: 1000;
+  }
+
+  .update-overlay-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    color: var(--ch-foreground);
+    background-color: var(--ch-background);
+    z-index: 1100;
   }
 
   @keyframes fadeIn {

--- a/src/renderer/lib/api/index.ts
+++ b/src/renderer/lib/api/index.ts
@@ -29,6 +29,9 @@ export const {
   sendAgentSelected,
   // Retry event (renderer → main process)
   sendRetry,
+  // Update events (renderer → main process)
+  sendUpdateChoice,
+  sendCancelUpdate,
 } = window.api;
 
 // Re-export branded path types from IPC (still used for type safety)

--- a/src/renderer/lib/components/UpdateOverlay.svelte
+++ b/src/renderer/lib/components/UpdateOverlay.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  /**
+   * UpdateOverlay - Shows update choice or download progress.
+   *
+   * Two states:
+   * - "choice": Shows version info and 4 buttons (Always, Yes, Skip, Never)
+   * - "downloading": Shows progress bar and Cancel button
+   */
+  import type { UpdateChoice } from "@shared/ipc";
+  import Logo from "./Logo.svelte";
+
+  interface Props {
+    /** Current overlay mode */
+    mode: "choice" | "downloading";
+    /** Version being updated to */
+    version: string;
+    /** Download progress (0-100) */
+    percent: number;
+    /** Callback when user makes a choice */
+    onchoice: (choice: UpdateChoice) => void;
+    /** Callback when user cancels download */
+    oncancel: () => void;
+  }
+
+  const { mode, version, percent, onchoice, oncancel }: Props = $props();
+</script>
+
+<div class="update-overlay" role="dialog" aria-label="Update available">
+  <Logo size={64} />
+
+  {#if mode === "choice"}
+    <h1>Update Available</h1>
+    <p class="subtitle">Version {version} is available.</p>
+    <p class="info">The app will restart to update.</p>
+
+    <div class="buttons">
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button appearance="secondary" onclick={() => onchoice("always")}>
+        Always
+      </vscode-button>
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button onclick={() => onchoice("yes")}>Yes</vscode-button>
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button appearance="secondary" onclick={() => onchoice("skip")}> Skip </vscode-button>
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button appearance="secondary" onclick={() => onchoice("never")}>
+        Never
+      </vscode-button>
+    </div>
+  {:else}
+    <h1>Updating CodeHydra</h1>
+    <p class="subtitle">Downloading version {version}...</p>
+
+    <div class="progress-container">
+      <vscode-progress-ring class:hidden={percent > 0}></vscode-progress-ring>
+      {#if percent > 0}
+        <div
+          class="progress-bar-wrapper"
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div class="progress-bar-fill" style="width: {percent}%"></div>
+        </div>
+        <span class="progress-text">{Math.round(percent)}%</span>
+      {/if}
+    </div>
+
+    <p class="info">The app will restart automatically.</p>
+
+    <div class="buttons">
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button appearance="secondary" onclick={oncancel}>Cancel</vscode-button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .update-overlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: center;
+    max-width: 400px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+
+  .subtitle {
+    margin: 0;
+    font-size: 0.875rem;
+    opacity: 0.8;
+  }
+
+  .info {
+    margin: 0;
+    font-size: 0.8rem;
+    opacity: 0.6;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .progress-container {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    margin: 0.5rem 0;
+  }
+
+  .progress-bar-wrapper {
+    flex: 1;
+    height: 4px;
+    background: var(--ch-border);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--ch-focus-border);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .progress-text {
+    font-size: 0.875rem;
+    min-width: 3ch;
+    text-align: right;
+    opacity: 0.8;
+  }
+
+  .hidden {
+    display: none;
+  }
+</style>

--- a/src/renderer/lib/components/UpdateOverlay.test.ts
+++ b/src/renderer/lib/components/UpdateOverlay.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the UpdateOverlay component.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import UpdateOverlay from "./UpdateOverlay.svelte";
+
+describe("UpdateOverlay component", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("choice mode", () => {
+    const defaultProps = {
+      mode: "choice" as const,
+      version: "2.1.0",
+      percent: 0,
+      onchoice: vi.fn(),
+      oncancel: vi.fn(),
+    };
+
+    it("renders heading and version", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByRole("heading", { name: /update available/i })).toBeInTheDocument();
+      expect(screen.getByText(/Version 2\.1\.0/)).toBeInTheDocument();
+    });
+
+    it("renders all four choice buttons", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByText("Always")).toBeInTheDocument();
+      expect(screen.getByText("Yes")).toBeInTheDocument();
+      expect(screen.getByText("Skip")).toBeInTheDocument();
+      expect(screen.getByText("Never")).toBeInTheDocument();
+    });
+
+    it("clicking Always fires onchoice with 'always'", async () => {
+      const onchoice = vi.fn();
+      render(UpdateOverlay, { props: { ...defaultProps, onchoice } });
+
+      await fireEvent.click(screen.getByText("Always"));
+      expect(onchoice).toHaveBeenCalledWith("always");
+    });
+
+    it("clicking Yes fires onchoice with 'yes'", async () => {
+      const onchoice = vi.fn();
+      render(UpdateOverlay, { props: { ...defaultProps, onchoice } });
+
+      await fireEvent.click(screen.getByText("Yes"));
+      expect(onchoice).toHaveBeenCalledWith("yes");
+    });
+
+    it("clicking Skip fires onchoice with 'skip'", async () => {
+      const onchoice = vi.fn();
+      render(UpdateOverlay, { props: { ...defaultProps, onchoice } });
+
+      await fireEvent.click(screen.getByText("Skip"));
+      expect(onchoice).toHaveBeenCalledWith("skip");
+    });
+
+    it("clicking Never fires onchoice with 'never'", async () => {
+      const onchoice = vi.fn();
+      render(UpdateOverlay, { props: { ...defaultProps, onchoice } });
+
+      await fireEvent.click(screen.getByText("Never"));
+      expect(onchoice).toHaveBeenCalledWith("never");
+    });
+
+    it("has dialog role", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  describe("downloading mode", () => {
+    const defaultProps = {
+      mode: "downloading" as const,
+      version: "2.1.0",
+      percent: 52,
+      onchoice: vi.fn(),
+      oncancel: vi.fn(),
+    };
+
+    it("renders downloading heading and version", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByRole("heading", { name: /updating codehydra/i })).toBeInTheDocument();
+      expect(screen.getByText(/Downloading version 2\.1\.0\.\.\./)).toBeInTheDocument();
+    });
+
+    it("renders progress bar with correct percentage", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      const progressBar = screen.getByRole("progressbar");
+      expect(progressBar).toHaveAttribute("aria-valuenow", "52");
+      expect(screen.getByText("52%")).toBeInTheDocument();
+    });
+
+    it("renders Cancel button", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+    });
+
+    it("clicking Cancel fires oncancel", async () => {
+      const oncancel = vi.fn();
+      render(UpdateOverlay, { props: { ...defaultProps, oncancel } });
+
+      await fireEvent.click(screen.getByText("Cancel"));
+      expect(oncancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows restart message", () => {
+      render(UpdateOverlay, { props: defaultProps });
+
+      expect(screen.getByText(/restart automatically/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -65,5 +65,7 @@ export function createMockApi(): Api {
     onShortcut: vi.fn(() => vi.fn()),
     sendAgentSelected: vi.fn(),
     sendRetry: vi.fn(),
+    sendUpdateChoice: vi.fn(),
+    sendCancelUpdate: vi.fn(),
   };
 }

--- a/src/services/auto-updater.ts
+++ b/src/services/auto-updater.ts
@@ -2,7 +2,8 @@
  * Auto-update service for the application.
  *
  * Uses electron-updater directly (singleton with Electron lifecycle integration).
- * Checks once per app session at startup, downloads in background, applies on next app quit.
+ * Separates detection from download: checkForUpdates() detects, downloadUpdate()
+ * downloads on demand, quitAndInstall() restarts the app.
  *
  * Platform support:
  * - Windows (NSIS): Full auto-update
@@ -14,14 +15,22 @@
 import { autoUpdater } from "electron-updater";
 import type { Logger } from "./logging";
 
-/** Delay before update check (avoid startup I/O contention) */
-const STARTUP_DELAY_MS = 10 * 1000;
+/**
+ * Callback type for update detected events (update-available, before download).
+ * @param version - The version string of the detected update
+ */
+export type UpdateDetectedCallback = (version: string) => void;
 
 /**
- * Callback type for update available events.
- * @param version - The version string of the available update
+ * Callback type for update downloaded events (download complete).
+ * @param version - The version string of the downloaded update
  */
-export type UpdateAvailableCallback = (version: string) => void;
+export type UpdateDownloadedCallback = (version: string) => void;
+
+/**
+ * Callback type for download progress events.
+ */
+export type DownloadProgressCallback = (info: { percent: number }) => void;
 
 /**
  * Auto-updater service dependencies.
@@ -35,16 +44,19 @@ export interface AutoUpdaterDeps {
  * Auto-updater service.
  *
  * Wraps electron-updater to provide:
- * - Single check per app session (after startup delay)
+ * - Detection via checkForUpdates() (fires onUpdateDetected)
+ * - Manual download via downloadUpdate() (fires onDownloadProgress, onUpdateDownloaded)
+ * - Install via quitAndInstall()
  * - Error handling (log but don't crash)
- * - Callback for update-downloaded events
  */
 export class AutoUpdater {
   private readonly logger: Logger;
   private readonly isDevelopment: boolean;
-  private readonly callbacks: Set<UpdateAvailableCallback> = new Set();
-  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly detectedCallbacks: Set<UpdateDetectedCallback> = new Set();
+  private readonly downloadedCallbacks: Set<UpdateDownloadedCallback> = new Set();
+  private readonly progressCallbacks: Set<DownloadProgressCallback> = new Set();
   private disposed = false;
+  private downloadCancelled = false;
 
   constructor(deps: AutoUpdaterDeps) {
     this.logger = deps.logger;
@@ -52,9 +64,8 @@ export class AutoUpdater {
 
     if (!this.isDevelopment) {
       // Configure electron-updater
-      // autoInstallOnAppQuit is true by default
       autoUpdater.autoDownload = false;
-      autoUpdater.autoInstallOnAppQuit = true;
+      autoUpdater.autoInstallOnAppQuit = false;
 
       // Route electron-updater logs through app logger
       autoUpdater.logger = {
@@ -68,67 +79,126 @@ export class AutoUpdater {
       this.handleError = this.handleError.bind(this);
       this.handleUpdateAvailable = this.handleUpdateAvailable.bind(this);
       this.handleUpdateDownloaded = this.handleUpdateDownloaded.bind(this);
+      this.handleDownloadProgress = this.handleDownloadProgress.bind(this);
 
       autoUpdater.on("error", this.handleError);
       autoUpdater.on("update-available", this.handleUpdateAvailable);
       autoUpdater.on("update-downloaded", this.handleUpdateDownloaded);
+      autoUpdater.on("download-progress", this.handleDownloadProgress);
     }
   }
 
   /**
-   * Start the auto-updater.
+   * Check for updates. Returns true if an update is available.
+   * Does NOT start download — use downloadUpdate() for that.
    *
-   * No-op if:
+   * No-op returning false if:
    * - Running in development mode
    * - Platform doesn't support auto-updates (portable, deb, rpm)
+   * - Already disposed
    */
-  start(): void {
-    // Skip in development mode
+  async checkForUpdates(): Promise<boolean> {
     if (this.isDevelopment) {
       this.logger.debug("Skipping update check (development mode)");
-      return;
+      return false;
     }
 
-    // Skip on unsupported platforms
-    // electron-updater handles this internally, but we log it for clarity
-    const platform = process.platform;
-    const isAppImage = process.env.APPIMAGE !== undefined;
-    const isNsis = platform === "win32"; // NSIS is the only Windows target
-    const isMac = platform === "darwin";
+    if (this.disposed) return false;
 
-    if (platform === "linux" && !isAppImage) {
-      this.logger.debug("Skipping update check (Linux non-AppImage)");
-      return;
-    }
+    if (!this.isPlatformSupported()) return false;
 
-    if (!isNsis && !isMac && !isAppImage) {
-      this.logger.debug("Skipping update check (unsupported platform)", {
-        platform,
+    try {
+      this.logger.info("Checking for updates");
+      const result = await autoUpdater.checkForUpdates();
+      return result?.updateInfo?.version !== undefined;
+    } catch (error) {
+      this.logger.warn("Update check failed", {
+        error: error instanceof Error ? error.message : String(error),
       });
-      return;
+      return false;
     }
-
-    // Wait before first check to avoid competing with startup I/O
-    this.logger.debug("Scheduling update check", {
-      delayMs: STARTUP_DELAY_MS,
-    });
-
-    this.startupTimer = setTimeout(() => {
-      this.startupTimer = null;
-      void this.checkForUpdates();
-    }, STARTUP_DELAY_MS);
   }
 
   /**
-   * Register a callback for when an update is downloaded and ready.
-   *
-   * @param callback - Called with version string when update is ready
-   * @returns Unsubscribe function
+   * Start downloading the update.
+   * Fires onDownloadProgress callbacks during download and onUpdateDownloaded on completion.
+   * Throws if cancelled via cancelDownload().
    */
-  onUpdateAvailable(callback: UpdateAvailableCallback): () => void {
-    this.callbacks.add(callback);
+  async downloadUpdate(): Promise<void> {
+    if (this.isDevelopment || this.disposed) return;
+
+    this.downloadCancelled = false;
+
+    try {
+      await autoUpdater.downloadUpdate();
+      if (this.downloadCancelled) {
+        throw new Error("Download cancelled");
+      }
+    } catch (error) {
+      this.logger.warn("Update download failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Cancel an in-progress download.
+   * Sets a flag that causes downloadUpdate() to throw on next check.
+   */
+  cancelDownload(): void {
+    this.downloadCancelled = true;
+  }
+
+  /**
+   * Quit the application and install the downloaded update.
+   */
+  quitAndInstall(): void {
+    if (this.isDevelopment) return;
+
+    this.logger.info("Quitting and installing update");
+    autoUpdater.quitAndInstall();
+  }
+
+  /**
+   * Start the auto-updater (legacy — just logs).
+   * The check-deps hook now calls checkForUpdates() directly.
+   */
+  start(): void {
+    if (this.isDevelopment) {
+      this.logger.debug("Skipping auto-updater start (development mode)");
+      return;
+    }
+    this.logger.debug("Auto-updater started");
+  }
+
+  /**
+   * Register a callback for when an update is detected (before download).
+   */
+  onUpdateDetected(callback: UpdateDetectedCallback): () => void {
+    this.detectedCallbacks.add(callback);
     return () => {
-      this.callbacks.delete(callback);
+      this.detectedCallbacks.delete(callback);
+    };
+  }
+
+  /**
+   * Register a callback for when an update has been downloaded.
+   */
+  onUpdateDownloaded(callback: UpdateDownloadedCallback): () => void {
+    this.downloadedCallbacks.add(callback);
+    return () => {
+      this.downloadedCallbacks.delete(callback);
+    };
+  }
+
+  /**
+   * Register a callback for download progress updates.
+   */
+  onDownloadProgress(callback: DownloadProgressCallback): () => void {
+    this.progressCallbacks.add(callback);
+    return () => {
+      this.progressCallbacks.delete(callback);
     };
   }
 
@@ -139,61 +209,80 @@ export class AutoUpdater {
     if (this.disposed) return;
     this.disposed = true;
 
-    // Clear startup timer if pending
-    if (this.startupTimer) {
-      clearTimeout(this.startupTimer);
-      this.startupTimer = null;
-    }
-
     // Remove event listeners (only registered when not in dev mode)
     if (!this.isDevelopment) {
       autoUpdater.off("error", this.handleError);
       autoUpdater.off("update-available", this.handleUpdateAvailable);
       autoUpdater.off("update-downloaded", this.handleUpdateDownloaded);
+      autoUpdater.off("download-progress", this.handleDownloadProgress);
     }
 
-    this.callbacks.clear();
+    this.detectedCallbacks.clear();
+    this.downloadedCallbacks.clear();
+    this.progressCallbacks.clear();
     this.logger.debug("Auto-updater disposed");
   }
 
-  /**
-   * Check for updates.
-   */
-  private async checkForUpdates(): Promise<void> {
-    if (this.disposed) return;
+  private isPlatformSupported(): boolean {
+    const platform = process.platform;
+    const isAppImage = process.env.APPIMAGE !== undefined;
+    const isNsis = platform === "win32";
+    const isMac = platform === "darwin";
 
-    try {
-      this.logger.info("Checking for updates");
-      await autoUpdater.checkForUpdates();
-    } catch (error) {
-      // Log but don't throw - updates are non-critical
-      this.logger.warn("Update check failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+    if (platform === "linux" && !isAppImage) {
+      this.logger.debug("Skipping update check (Linux non-AppImage)");
+      return false;
     }
+
+    if (!isNsis && !isMac && !isAppImage) {
+      this.logger.debug("Skipping update check (unsupported platform)", {
+        platform,
+      });
+      return false;
+    }
+
+    return true;
   }
 
   /**
-   * Handle update-available events by starting the download manually.
-   * (autoDownload is disabled to avoid unhandled promise rejections from
-   * electron-updater's internal download promise chain.)
+   * Handle update-available events — notify detected callbacks.
+   * Does NOT start download (autoDownload is false).
    */
-  private handleUpdateAvailable(): void {
-    autoUpdater.downloadUpdate().catch((error: unknown) => {
-      this.logger.warn("Update download failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
+  private handleUpdateAvailable(info: { version: string }): void {
+    this.logger.info("Update detected", { version: info.version });
+    for (const callback of this.detectedCallbacks) {
+      try {
+        callback(info.version);
+      } catch (error) {
+        this.logger.warn("Update detected callback error", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   /**
    * Handle electron-updater error events.
    */
   private handleError(error: Error): void {
-    // Log but don't crash - updates are non-critical
     this.logger.warn("Auto-update error", {
       error: error.message,
     });
+  }
+
+  /**
+   * Handle download-progress events.
+   */
+  private handleDownloadProgress(info: { percent: number }): void {
+    for (const callback of this.progressCallbacks) {
+      try {
+        callback(info);
+      } catch (error) {
+        this.logger.warn("Download progress callback error", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   /**
@@ -201,13 +290,11 @@ export class AutoUpdater {
    */
   private handleUpdateDownloaded(info: { version: string }): void {
     this.logger.info("Update downloaded", { version: info.version });
-
-    // Notify all registered callbacks
-    for (const callback of this.callbacks) {
+    for (const callback of this.downloadedCallbacks) {
       try {
         callback(info.version);
       } catch (error) {
-        this.logger.warn("Update callback error", {
+        this.logger.warn("Update downloaded callback error", {
           error: error instanceof Error ? error.message : String(error),
         });
       }

--- a/src/services/config/config-values.ts
+++ b/src/services/config/config-values.ts
@@ -24,10 +24,11 @@ export type ConfigAgentType = "claude" | "opencode" | null;
 
 /**
  * Auto-update behavior preference.
- * "always" = background check + download (default).
+ * "always" = skip choice, show progress, download, restart.
+ * "ask" = show choice overlay, user decides (default).
  * "never" = skip auto-update entirely.
  */
-export type AutoUpdatePreference = "always" | "never";
+export type AutoUpdatePreference = "always" | "ask" | "never";
 
 // =============================================================================
 // Name Derivation

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -3,7 +3,7 @@
  * This file is in shared/ so both main/preload and renderer can access the types.
  */
 
-import type { UIModeChangedEvent, LogContext, LifecycleAgentType } from "./ipc";
+import type { UIModeChangedEvent, LogContext, LifecycleAgentType, UpdateChoice } from "./ipc";
 import type { UIMode } from "./ipc";
 import type { ShortcutKey } from "./shortcuts";
 
@@ -130,6 +130,20 @@ export interface Api {
    * Fire-and-forget - does not return a promise.
    */
   sendRetry(): void;
+
+  /**
+   * Send update choice event to main process.
+   * Used when user responds to the update choice dialog.
+   * Fire-and-forget - does not return a promise.
+   */
+  sendUpdateChoice(choice: UpdateChoice): void;
+
+  /**
+   * Send cancel update event to main process.
+   * Used when user clicks Cancel during update download.
+   * Fire-and-forget - does not return a promise.
+   */
+  sendCancelUpdate(): void;
 }
 
 declare global {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -212,6 +212,10 @@ export const ApiIpcChannels = {
   WORKSPACE_LOADING_CHANGED: "api:workspace:loading-changed",
   UI_MODE_CHANGED: "api:ui:mode-changed",
   SHORTCUT_KEY: "api:shortcut:key",
+  // Update events
+  UPDATE_PROGRESS: "api:update:progress",
+  UPDATE_CHOICE: "api:update:choice",
+  UPDATE_CANCEL: "api:update:cancel",
 } as const satisfies Record<string, string>;
 
 // ============ Workspace Loading Types ============
@@ -292,4 +296,37 @@ export interface ApiLogPayload {
   readonly message: string;
   /** Optional context data */
   readonly context?: LogContext;
+}
+
+// ============ Update Progress Types ============
+
+/**
+ * Actions for the update progress overlay.
+ * - "show-choice": Show update choice dialog
+ * - "downloading": Show downloading state (initial)
+ * - "progress": Update download progress
+ */
+export type UpdateProgressAction = "show-choice" | "downloading" | "progress";
+
+/**
+ * Payload for api:update:progress events (main → renderer).
+ * Single event type for all update overlay state transitions.
+ */
+export interface UpdateProgressPayload {
+  readonly action: UpdateProgressAction;
+  readonly version: string;
+  readonly percent: number;
+  readonly finished?: boolean;
+}
+
+/**
+ * User's choice from the update dialog.
+ */
+export type UpdateChoice = "always" | "yes" | "skip" | "never";
+
+/**
+ * Payload for api:update:choice events (renderer → main).
+ */
+export interface UpdateChoicePayload {
+  readonly choice: UpdateChoice;
 }


### PR DESCRIPTION
- Add `"ask"` as new default for auto-update config (previously `"always"`)
- Create `UpdateApplyOperation` (`app:update`) with show-choice/await-choice/download/install hooks
- Add `UpdateOverlay` Svelte component with choice and downloading states
- Split auto-updater service: separate detection from download, add public `checkForUpdates()`, `downloadUpdate()`, `cancelDownload()`, `quitAndInstall()`
- Wire update progress through single domain event (`app:update:progress`) via IPC bridge
- Install triggers `app:shutdown` with `installUpdate` flag for clean restart via `quitAndInstall()`
- Add interceptor to reject update intent when config=`"never"` or no update detected
- Add integration tests for auto-updater module and UpdateOverlay component tests