### PR TITLE
fix: close auto-workspaces could be re-opened after app-restart

### DIFF
--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -18,6 +18,7 @@ import {
   INTENT_APP_START,
   type AppStartIntent,
 } from "../../intents/app-start";
+import { EVENT_APP_STARTED } from "../../intents/app-ready";
 import {
   AppShutdownOperation,
   INTENT_APP_SHUTDOWN,
@@ -86,6 +87,8 @@ class MinimalActivateOperation implements Operation<AppStartIntent, void> {
     const hookCtx: HookContext = { intent: ctx.intent };
     const { errors } = await ctx.hooks.collect<void>("start", hookCtx);
     if (errors.length > 0) throw errors[0]!;
+    // Simulate app:ready emitting app:started after projects are loaded
+    await ctx.emit({ type: EVENT_APP_STARTED, payload: {} });
   }
 }
 

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -8,10 +8,11 @@
  * A source needs both a template-path and source.isConfigured() to be active.
  *
  * Hooks:
- * - app:start -> "start": initialize active sources, load state, run initial poll, start timer
+ * - app:start -> "start": read template paths from config
  * - app:shutdown -> "stop": clear poll timer, dispose sources
  *
  * Events:
+ * - app:started: initialize active sources, load state, run initial poll, start timer
  * - workspace:deleted: clean up state entry
  * - workspace:delete-failed: clear tracking metadata, set red tag
  */
@@ -20,6 +21,7 @@ import type { IntentModule } from "../../intents/lib/module";
 import type { Dispatcher } from "../../intents/lib/dispatcher";
 import type { DomainEvent } from "../../intents/lib/types";
 import { APP_START_OPERATION_ID } from "../../intents/app-start";
+import { EVENT_APP_STARTED } from "../../intents/app-ready";
 import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
 import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "../../intents/open-workspace";
 import {
@@ -533,8 +535,6 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
               const tplValue = deps.configService.get(tplKey) as string | null;
               templatePaths.set(source.name, tplValue);
             }
-
-            await activateAll();
           },
         },
       },
@@ -547,6 +547,11 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
       },
     },
     events: {
+      [EVENT_APP_STARTED]: {
+        handler: async (): Promise<void> => {
+          await activateAll();
+        },
+      },
       [EVENT_WORKSPACE_DELETED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const { workspacePath } = (event as WorkspaceDeletedEvent).payload;


### PR DESCRIPTION
- Defer auto-workspace activation from `app:start` hook to `app:started` event handler
- Ensures projects are fully loaded before first poll, fixing empty `buildTrackedPaths()` that prevented auto-deletion of disappeared items