### PR TITLE
fix: failed workspace creations via mcp do not show notifications

### DIFF
--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -299,6 +299,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
                 existingWorkspace,
                 projectPath,
                 stealFocus: false,
+                source: "open-project",
               },
             };
 

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -37,6 +37,14 @@ import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./ge
 // Intent Types
 // =============================================================================
 
+/** Identifies which module dispatched a workspace:open intent. */
+export type WorkspaceOpenSource =
+  | "ui-ipc"
+  | "mcp"
+  | "plugin-server"
+  | "auto-workspace"
+  | "open-project";
+
 /** Data for activating an existing (discovered) workspace via workspace:open */
 export interface ExistingWorkspaceData {
   readonly path: string;
@@ -59,6 +67,8 @@ export interface OpenWorkspacePayload {
   readonly existingWorkspace?: ExistingWorkspaceData;
   /** Authoritative project path. */
   readonly projectPath: string;
+  /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
+  readonly source?: WorkspaceOpenSource;
 }
 
 export type OpenWorkspaceResult = Workspace;
@@ -88,6 +98,8 @@ export interface WorkspaceCreatedPayload {
   readonly stealFocus?: boolean;
   /** True when re-activating a discovered workspace (not a fresh creation). */
   readonly reopened?: boolean;
+  /** Which module dispatched the original intent. */
+  readonly source?: WorkspaceOpenSource;
 }
 
 export interface WorkspaceCreatedEvent extends DomainEvent {
@@ -112,6 +124,8 @@ export interface WorkspaceCreateFailedPayload {
   readonly workspaceName: string;
   readonly projectPath: string;
   readonly error: string;
+  /** Which module dispatched the original intent. */
+  readonly source?: WorkspaceOpenSource;
 }
 
 export interface WorkspaceCreateFailedEvent extends DomainEvent {
@@ -202,6 +216,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
           workspaceName: ctx.intent.payload.workspaceName,
           projectPath,
           error: error instanceof Error ? error.message : String(error),
+          ...(ctx.intent.payload.source !== undefined && { source: ctx.intent.payload.source }),
         },
       } as WorkspaceCreateFailedEvent);
       throw error;
@@ -303,6 +318,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
         stealFocus: ctx.intent.payload.stealFocus,
       }),
       ...(ctx.intent.payload.existingWorkspace !== undefined && { reopened: true }),
+      ...(ctx.intent.payload.source !== undefined && { source: ctx.intent.payload.source }),
     };
 
     const event: WorkspaceCreatedEvent = {

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -263,6 +263,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
           stealFocus: config.focus ?? false,
           projectPath: project.path,
           initialPrompt,
+          source: "auto-workspace",
         },
       } as OpenWorkspaceIntent);
 

--- a/src/modules/error-notification-module.integration.test.ts
+++ b/src/modules/error-notification-module.integration.test.ts
@@ -134,6 +134,53 @@ describe("ErrorNotificationModule", () => {
     expect(returnedHandle.close).toHaveBeenCalledOnce();
   });
 
+  it("should skip notification for mcp source", async () => {
+    const event: WorkspaceCreateFailedEvent = {
+      type: EVENT_WORKSPACE_CREATE_FAILED,
+      payload: {
+        workspaceName: "mcp-workspace",
+        projectPath: "/projects/test",
+        error: "Some MCP error",
+        source: "mcp",
+      },
+    };
+
+    await module.events![EVENT_WORKSPACE_CREATE_FAILED]!.handler(event);
+
+    expect(notificationManager.open).not.toHaveBeenCalled();
+  });
+
+  it("should show notification for non-mcp sources", async () => {
+    const event: WorkspaceCreateFailedEvent = {
+      type: EVENT_WORKSPACE_CREATE_FAILED,
+      payload: {
+        workspaceName: "plugin-workspace",
+        projectPath: "/projects/test",
+        error: "Some plugin error",
+        source: "plugin-server",
+      },
+    };
+
+    await module.events![EVENT_WORKSPACE_CREATE_FAILED]!.handler(event);
+
+    expect(notificationManager.open).toHaveBeenCalledOnce();
+  });
+
+  it("should show notification when source is undefined", async () => {
+    const event: WorkspaceCreateFailedEvent = {
+      type: EVENT_WORKSPACE_CREATE_FAILED,
+      payload: {
+        workspaceName: "unknown-workspace",
+        projectPath: "/projects/test",
+        error: "Some error",
+      },
+    };
+
+    await module.events![EVENT_WORKSPACE_CREATE_FAILED]!.handler(event);
+
+    expect(notificationManager.open).toHaveBeenCalledOnce();
+  });
+
   it("should handle multiple failures independently", async () => {
     const event1: WorkspaceCreateFailedEvent = {
       type: EVENT_WORKSPACE_CREATE_FAILED,

--- a/src/modules/error-notification-module.ts
+++ b/src/modules/error-notification-module.ts
@@ -19,7 +19,8 @@ export function createErrorNotificationModule(deps: ErrorNotificationModuleDeps)
   const events: EventDeclarations = {
     [EVENT_WORKSPACE_CREATE_FAILED]: {
       handler: async (event: DomainEvent): Promise<void> => {
-        const { workspaceName, error } = (event as WorkspaceCreateFailedEvent).payload;
+        const { workspaceName, error, source } = (event as WorkspaceCreateFailedEvent).payload;
+        if (source === "mcp") return;
         const handle = deps.notificationManager.open({
           type: "error",
           title: `Failed to create "${workspaceName}"`,

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -681,6 +681,7 @@ export class McpServer implements IMcpServer {
               ...(tracking !== undefined && { tracking }),
               ...(finalPrompt !== undefined && { initialPrompt: finalPrompt }),
               stealFocus,
+              source: "mcp",
             },
           };
           const result = await this.dispatcher.dispatch(intent);

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -742,6 +742,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
                 ...(req.stealFocus !== undefined && {
                   stealFocus: req.stealFocus,
                 }),
+                source: "plugin-server",
               },
             };
             const result = await dispatcher.dispatch(intent);

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -307,6 +307,7 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
         base: p.base,
         ...(p.initialPrompt !== undefined && { initialPrompt: p.initialPrompt }),
         ...(p.stealFocus !== undefined && { stealFocus: p.stealFocus }),
+        source: "ui-ipc",
       },
     };
     const result = await dispatcher.dispatch(intent);


### PR DESCRIPTION
- Add `WorkspaceOpenSource` typed union to track which module dispatched `workspace:open` intents
- Set source at all 5 dispatch sites: ui-ipc, mcp, plugin-server, auto-workspace, open-project
- Propagate source to both `workspace:created` and `workspace:create-failed` domain events
- Skip error notification in `error-notification-module` when source is `mcp`
- Add tests for MCP suppression, non-MCP pass-through, and undefined-source default