### PR TITLE
feat: Initialize git repository when opening non-git project

### DIFF
--- a/src/boundaries/platform/git-client.state-mock.ts
+++ b/src/boundaries/platform/git-client.state-mock.ts
@@ -670,6 +670,24 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
       const repo = getRepoOrThrow(repoPath);
       return repo.isBare;
     },
+
+    async init(targetPath: Path, options?: { initialCommit?: string }): Promise<void> {
+      const normalizedTarget = normalizePath(targetPath);
+      if (state.repositories.has(normalizedTarget)) {
+        throw new GitError(`Repository already exists: ${normalizedTarget}`);
+      }
+      const hasCommit = !!options?.initialCommit;
+      (state as GitClientMockStateImpl).addRepository(normalizedTarget, {
+        branches: hasCommit ? new Set(["main"]) : new Set(),
+        remoteBranches: new Set(),
+        remotes: new Set(),
+        worktrees: new Map(),
+        branchConfigs: new Map(),
+        mainIsDirty: false,
+        currentBranch: hasCommit ? "main" : null,
+        isBare: false,
+      });
+    },
   };
 
   return Object.assign(client, { $: state });

--- a/src/boundaries/platform/git-client.ts
+++ b/src/boundaries/platform/git-client.ts
@@ -203,6 +203,16 @@ export interface IGitClient {
   isBare(repoPath: Path): Promise<boolean>;
 
   /**
+   * Initialize a new git repository at the given path.
+   * @param targetPath Absolute path to the directory to initialize
+   * @param options Optional configuration
+   * @param options.initialCommit If provided, creates an empty initial commit with this message
+   * @returns Promise resolving when the repository is initialized
+   * @throws GitError if initialization fails
+   */
+  init(targetPath: Path, options?: { initialCommit?: string }): Promise<void>;
+
+  /**
    * Count commits on a branch whose patch content has not been merged into a base ref.
    * Uses `git rev-list --count --cherry-pick --right-only <base>...<branch>` to detect
    * squash-merged and rebase-merged commits by comparing patch-ids.

--- a/src/boundaries/platform/simple-git-client.ts
+++ b/src/boundaries/platform/simple-git-client.ts
@@ -481,6 +481,17 @@ export class SimpleGitClient implements IGitClient {
     }, "Failed to check if repository is bare");
   }
 
+  async init(targetPath: Path, options?: { initialCommit?: string }): Promise<void> {
+    await this.wrapGitOperation(async () => {
+      const git = this.getGit(targetPath);
+      await git.init();
+      if (options?.initialCommit) {
+        await git.commit(options.initialCommit, { "--allow-empty": null });
+      }
+    }, `Failed to initialize repository at ${targetPath.toString()}`);
+    this.logger.debug("Init", { path: targetPath.toString() });
+  }
+
   async countUnmergedCommits(repoPath: Path, branch: string, base: string): Promise<number> {
     return this.wrapGitOperation(async () => {
       const git = this.getGit(repoPath);

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -36,6 +36,7 @@ import {
 import type {
   OpenProjectIntent,
   SelectFolderHookResult,
+  PrepareHookResult,
   ResolveHookResult,
   DiscoverHookResult,
   RegisterHookInput,
@@ -1206,5 +1207,61 @@ describe("OpenProjectOperation", () => {
     expect(event.payload.project.id).toBe(PROJECT_ID);
     expect(event.payload.path).toEqual(new Path(PROJECT_PATH));
     expect(event.payload.git).toBeUndefined();
+  });
+
+  it("returns null when prepare hook cancels", async () => {
+    const harness = createTestHarness();
+
+    // Register a prepare module that cancels
+    const prepareModule: IntentModule = {
+      name: "test",
+      hooks: {
+        [OPEN_PROJECT_OPERATION_ID]: {
+          prepare: {
+            handler: async (): Promise<PrepareHookResult> => {
+              return { canceled: true };
+            },
+          },
+        },
+      },
+    };
+    harness.dispatcher.registerModule(prepareModule);
+
+    const result = await harness.dispatcher.dispatch(
+      buildOpenIntent({ path: new Path(PROJECT_PATH) })
+    );
+
+    expect(result).toBeNull();
+
+    // No project registered
+    expect(harness.projectState.registeredProjects).toHaveLength(0);
+  });
+
+  it("skips prepare hook for git URL intents", async () => {
+    const harness = createTestHarness();
+
+    // Register a prepare module that would cancel if called
+    const prepareSpy = vi.fn().mockResolvedValue({ canceled: true });
+    const prepareModule: IntentModule = {
+      name: "test",
+      hooks: {
+        [OPEN_PROJECT_OPERATION_ID]: {
+          prepare: {
+            handler: prepareSpy,
+          },
+        },
+      },
+    };
+    harness.dispatcher.registerModule(prepareModule);
+
+    const result = await harness.dispatcher.dispatch(
+      buildOpenIntent({ git: "https://github.com/org/repo.git" })
+    );
+
+    // prepare should not have been called (git URL bypasses prepare)
+    expect(prepareSpy).not.toHaveBeenCalled();
+
+    // Project should have been created successfully
+    expect(result).toBeDefined();
   });
 });

--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -92,6 +92,12 @@ export interface SelectFolderHookResult {
   readonly folderPath: string | null;
 }
 
+/** Result returned by handlers on the "prepare" hook point. */
+export interface PrepareHookResult {
+  /** If true, user canceled — abort the open operation. */
+  readonly canceled?: boolean;
+}
+
 /** Result returned by handlers on the "resolve" hook point. */
 export interface ResolveHookResult {
   /** Optional when using collect() — handler may skip via self-selection. */
@@ -193,6 +199,23 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
         ...intent,
         payload: { ...intent.payload, path: new Path(folderPath) },
       };
+    }
+
+    // 0.5. Prepare: give modules a chance to prepare the directory (e.g., git init)
+    // Only runs for local paths, not git URLs
+    if (effectiveIntent.payload.path && !effectiveIntent.payload.git) {
+      const prepareCtx: HookContext = { intent: effectiveIntent };
+      const { results: prepareResults, errors: prepareErrors } =
+        await ctx.hooks.collect<PrepareHookResult>("prepare", prepareCtx);
+      if (prepareErrors.length === 1) {
+        throw prepareErrors[0]!;
+      }
+      if (prepareErrors.length > 1) {
+        throw new AggregateError(prepareErrors, "project:open prepare hooks failed");
+      }
+      for (const r of prepareResults) {
+        if (r.canceled) return null;
+      }
     }
 
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -475,6 +475,8 @@ const localProjectModule = createLocalProjectModule({
   projectsDir: pathProvider.dataPath("projects").toString(),
   fs: fileSystemLayer,
   gitWorktreeProvider,
+  dialogManager,
+  gitClient,
 });
 const remoteProjectModule = createRemoteProjectModule({
   fs: fileSystemLayer,

--- a/src/modules/local-project-module.integration.test.ts
+++ b/src/modules/local-project-module.integration.test.ts
@@ -31,6 +31,7 @@ import { createLocalProjectModule, type LocalProjectModuleDeps } from "./local-p
 import {
   OPEN_PROJECT_OPERATION_ID,
   INTENT_OPEN_PROJECT,
+  type PrepareHookResult,
   type ResolveHookResult,
   type RegisterHookResult,
   type RegisterHookInput,
@@ -67,10 +68,86 @@ const PROJECTS_DIR = "/test/app-data/projects";
 // Mock Factories
 // =============================================================================
 
+interface MockDialogHandle {
+  id: string;
+  config: unknown;
+  closed: boolean;
+  eventListeners: Array<(event: { dialogId: string; actionId: string }) => void>;
+  close(): void;
+  nextEvent(): Promise<{ dialogId: string; actionId: string }>;
+  onEvent(handler: (event: { dialogId: string; actionId: string }) => void): () => void;
+  emitEvent(event: { dialogId: string; actionId: string }): void;
+  readonly closed_promise: Promise<void>;
+}
+
+function createMockDialogManager(): {
+  dialogManager: LocalProjectModuleDeps["dialogManager"];
+  handles: MockDialogHandle[];
+  lastHandle: MockDialogHandle | null;
+} {
+  const handles: MockDialogHandle[] = [];
+  const state = { lastHandle: null as MockDialogHandle | null };
+
+  const dialogManager = {
+    open: vi.fn().mockImplementation((config: unknown) => {
+      const listeners: Array<(event: { dialogId: string; actionId: string }) => void> = [];
+      let resolveClosed: () => void;
+      const closedPromise = new Promise<void>((resolve) => {
+        resolveClosed = resolve;
+      });
+
+      const handle: MockDialogHandle = {
+        id: `dlg-${handles.length + 1}`,
+        config,
+        closed: false,
+        eventListeners: listeners,
+        close() {
+          this.closed = true;
+          resolveClosed();
+        },
+        nextEvent() {
+          return new Promise((resolve) => {
+            listeners.push((event) => resolve(event));
+          });
+        },
+        onEvent(handler: (event: { dialogId: string; actionId: string }) => void) {
+          listeners.push(handler);
+          return () => {
+            const idx = listeners.indexOf(handler);
+            if (idx >= 0) listeners.splice(idx, 1);
+          };
+        },
+        emitEvent(event: { dialogId: string; actionId: string }) {
+          for (const listener of [...listeners]) {
+            listener(event);
+          }
+        },
+        get closed_promise() {
+          return closedPromise;
+        },
+      };
+      handles.push(handle);
+      state.lastHandle = handle;
+      return handle;
+    }),
+    routeEvent() {},
+  } as unknown as LocalProjectModuleDeps["dialogManager"];
+
+  return {
+    dialogManager,
+    handles,
+    get lastHandle() {
+      return state.lastHandle;
+    },
+  };
+}
+
 function createMockDeps(fsOverrides?: Parameters<typeof createFileSystemMock>[0]): {
   deps: LocalProjectModuleDeps;
   fs: ReturnType<typeof createFileSystemMock>;
   gitWorktreeProvider: LocalProjectModuleDeps["gitWorktreeProvider"];
+  dialogManager: ReturnType<typeof createMockDialogManager>;
+  gitClient: LocalProjectModuleDeps["gitClient"];
 } {
   const fs = createFileSystemMock({
     entries: {
@@ -83,14 +160,25 @@ function createMockDeps(fsOverrides?: Parameters<typeof createFileSystemMock>[0]
     validateRepository: vi.fn().mockResolvedValue(undefined),
   };
 
+  const dialog = createMockDialogManager();
+
+  const gitClient = {
+    isRepositoryRoot: vi.fn().mockResolvedValue(true),
+    init: vi.fn().mockResolvedValue(undefined),
+  };
+
   return {
     deps: {
       projectsDir: PROJECTS_DIR,
       fs,
       gitWorktreeProvider,
+      dialogManager: dialog.dialogManager,
+      gitClient,
     },
     fs,
     gitWorktreeProvider,
+    dialogManager: dialog,
+    gitClient,
   };
 }
 
@@ -127,10 +215,12 @@ interface TestSetup {
   readyHooks: ResolvedHooks;
   fs: ReturnType<typeof createFileSystemMock>;
   gitWorktreeProvider: LocalProjectModuleDeps["gitWorktreeProvider"];
+  dialogManager: ReturnType<typeof createMockDialogManager>;
+  gitClient: LocalProjectModuleDeps["gitClient"];
 }
 
 function createTestSetup(fsOverrides?: Parameters<typeof createFileSystemMock>[0]): TestSetup {
-  const { deps, fs, gitWorktreeProvider } = createMockDeps(fsOverrides);
+  const { deps, fs, gitWorktreeProvider, dialogManager, gitClient } = createMockDeps(fsOverrides);
 
   const module = createLocalProjectModule(deps);
 
@@ -140,6 +230,8 @@ function createTestSetup(fsOverrides?: Parameters<typeof createFileSystemMock>[0
     readyHooks: resolveHooksFromModule(module, APP_READY_OPERATION_ID),
     fs,
     gitWorktreeProvider,
+    dialogManager,
+    gitClient,
   };
 }
 
@@ -656,6 +748,125 @@ describe("LocalProjectModule Integration", () => {
       expect(results).toHaveLength(1);
       // Local project config has no remoteUrl, so result is empty
       expect(results[0]).toEqual({});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // project:open → prepare
+  // ---------------------------------------------------------------------------
+
+  describe("project:open prepare", () => {
+    it("skips for git URL payloads", async () => {
+      const { openHooks, gitClient } = createTestSetup();
+
+      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openGitIntent("https://github.com/user/repo.git"),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({});
+      expect(gitClient.isRepositoryRoot).not.toHaveBeenCalled();
+    });
+
+    it("skips when directory is already a git repo", async () => {
+      const { openHooks, dialogManager, gitClient } = createTestSetup();
+      vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(true);
+
+      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({});
+      expect(dialogManager.dialogManager.open).not.toHaveBeenCalled();
+    });
+
+    it("skips when project is already open", async () => {
+      const setup = createTestSetup();
+
+      // Register project first so it's in internal state
+      const registerCtx: RegisterHookInput = {
+        intent: openLocalIntent(PROJECT_PATH),
+        projectPath: new Path(PROJECT_PATH).toString(),
+      };
+      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+
+      const { results, errors } = await setup.openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({});
+      expect(setup.gitClient.isRepositoryRoot).not.toHaveBeenCalled();
+    });
+
+    it("shows dialog and inits repo when user confirms", async () => {
+      const { openHooks, dialogManager, gitClient } = createTestSetup();
+      vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
+
+      // Start the prepare hook (will block on dialog.nextEvent())
+      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      // Simulate user clicking "Initialize"
+      await vi.waitFor(() => expect(dialogManager.lastHandle).not.toBeNull());
+      dialogManager.lastHandle!.emitEvent({
+        dialogId: dialogManager.lastHandle!.id,
+        actionId: "init",
+      });
+
+      const { results, errors } = await preparePromise;
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({});
+      expect(gitClient.init).toHaveBeenCalledWith(new Path(PROJECT_PATH), {
+        initialCommit: "Initial commit",
+      });
+      expect(dialogManager.lastHandle!.closed).toBe(true);
+    });
+
+    it("returns canceled when user clicks cancel", async () => {
+      const { openHooks, dialogManager, gitClient } = createTestSetup();
+      vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
+
+      // Start the prepare hook (will block on dialog.nextEvent())
+      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      // Simulate user clicking "Cancel"
+      await vi.waitFor(() => expect(dialogManager.lastHandle).not.toBeNull());
+      dialogManager.lastHandle!.emitEvent({
+        dialogId: dialogManager.lastHandle!.id,
+        actionId: "cancel",
+      });
+
+      const { results, errors } = await preparePromise;
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({ canceled: true });
+      expect(gitClient.init).not.toHaveBeenCalled();
+      expect(dialogManager.lastHandle!.closed).toBe(true);
+    });
+
+    it("lets resolve handle the error when isRepositoryRoot throws", async () => {
+      const { openHooks, dialogManager, gitClient } = createTestSetup();
+      vi.mocked(gitClient.isRepositoryRoot).mockRejectedValue(new Error("Path not found"));
+
+      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({});
+      expect(dialogManager.dialogManager.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/local-project-module.ts
+++ b/src/modules/local-project-module.ts
@@ -28,10 +28,13 @@ import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-pr
 import {
   OPEN_PROJECT_OPERATION_ID,
   type OpenProjectIntent,
+  type PrepareHookResult,
   type ResolveHookResult,
   type RegisterHookInput,
   type RegisterHookResult,
 } from "../intents/open-project";
+import type { DialogManager } from "./dialog-manager";
+import type { IGitClient } from "../boundaries/platform/git-client";
 import {
   CLOSE_PROJECT_OPERATION_ID,
   type CloseProjectIntent,
@@ -75,6 +78,8 @@ export interface LocalProjectModuleDeps {
     "readdir" | "readFile" | "writeFile" | "mkdir" | "unlink" | "rm" | "rename"
   >;
   readonly gitWorktreeProvider: Pick<GitWorktreeProvider, "validateRepository">;
+  readonly dialogManager: DialogManager;
+  readonly gitClient: Pick<IGitClient, "isRepositoryRoot" | "init">;
 }
 
 // =============================================================================
@@ -290,7 +295,7 @@ async function removeProject(
  * @returns IntentModule with hook handlers for project:open, project:close, app:start
  */
 export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentModule {
-  const { projectsDir, fs, gitWorktreeProvider } = deps;
+  const { projectsDir, fs, gitWorktreeProvider, dialogManager, gitClient } = deps;
 
   /** Internal state: all projects keyed by normalized path string. */
   const projects = new Map<string, LocalProject>();
@@ -312,6 +317,53 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       },
 
       [OPEN_PROJECT_OPERATION_ID]: {
+        // prepare: offer git init for non-git directories
+        prepare: {
+          handler: async (ctx: HookContext): Promise<PrepareHookResult> => {
+            const intent = ctx.intent as OpenProjectIntent;
+            const { path, git } = intent.payload;
+
+            // Self-select: only handle local paths
+            if (git || !path) return {};
+
+            // Already open — skip
+            if (projects.has(path.toString())) return {};
+
+            // Check if it's already a git repo
+            let isRepo: boolean;
+            try {
+              isRepo = await gitClient.isRepositoryRoot(path);
+            } catch {
+              // Path doesn't exist or inaccessible — let resolve handle the error
+              return {};
+            }
+            if (isRepo) return {};
+
+            // Not a git repo — ask user
+            const dialog = dialogManager.open({
+              sections: [
+                { type: "text", content: "Initialize Git Repository?", style: "heading" },
+                { type: "text", content: path.toString(), style: "subtitle" },
+              ],
+              actions: [
+                { id: "init", label: "Initialize" },
+                { id: "cancel", label: "Cancel", variant: "secondary" },
+              ],
+              modal: true,
+            });
+
+            const event = await dialog.nextEvent();
+            dialog.close();
+
+            if (event.actionId !== "init") {
+              return { canceled: true };
+            }
+
+            await gitClient.init(path, { initialCommit: "Initial commit" });
+            return {};
+          },
+        },
+
         // resolve: validate .git exists for local paths
         resolve: {
           handler: async (ctx: HookContext): Promise<ResolveHookResult> => {

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -83,6 +83,15 @@
     setDialogOpen(isDialogOpen);
   });
 
+  // Close renderer-side dialog when a modal framework dialog opens
+  // (framework dialogs have lower z-index and would be hidden otherwise)
+  $effect(() => {
+    const hasModalFrameworkDialog = [...dialogs.value.values()].some((entry) => entry.config.modal);
+    if (hasModalFrameworkDialog && dialogState.value.type !== "closed") {
+      closeDialog();
+    }
+  });
+
   // Sync desiredMode with main process (single IPC sync point)
   // Note: desiredMode.value is accessed to establish reactive dependency,
   // then syncMode() reads it internally and sends to main process
@@ -133,14 +142,17 @@
     // Check all conditions
     // Show Create Workspace dialog when no effective workspaces exist (even if no projects)
     // Suppress when a background operation is running — don't interrupt with the dialog
+    // Suppress when a framework dialog is open (e.g., git init confirmation)
     const cloneRunning = hasSpinnerNotifications.value;
+    const hasFrameworkDialog = dialogs.value.size > 0;
     const firstProject = projectList[0];
     if (
       effectiveCount === 0 &&
       loading === "loaded" &&
       dialog.type === "closed" &&
       !autoShowDismissed &&
-      !cloneRunning
+      !cloneRunning &&
+      !hasFrameworkDialog
     ) {
       // Debounce to avoid showing during rapid state changes
       autoShowTimeout = setTimeout(() => {


### PR DESCRIPTION
- Add `prepare` hook point to `project:open` operation between `select-folder` and `resolve`
- Add `init()` method to `IGitClient` with optional `initialCommit` parameter
- Show dialog prompting user to initialize git when opening a non-git directory
- Close renderer-side dialogs when a modal framework dialog opens (z-index fix)
- Suppress auto-show of CreateWorkspaceDialog while framework dialogs are open

resolves #446