### PR TITLE
feat: Add 'Create on GitHub' option to clone dialog

### DIFF
--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -204,6 +204,17 @@ export class ViewManager implements IViewManager {
       },
     });
 
+    // Open external URLs from the UI view in the system browser
+    viewLayer.setWindowOpenHandler(this.uiViewHandle, (details: WindowOpenDetails) => {
+      this.appLayer.openUrl(details.url).catch((error: unknown) => {
+        this.logger.warn("Failed to open external URL from UI", {
+          url: details.url,
+          error: getErrorMessage(error),
+        });
+      });
+      return { action: "deny" };
+    });
+
     // Set transparent background for UI layer
     viewLayer.setBackgroundColor(this.uiViewHandle, "#00000000");
 

--- a/src/renderer/lib/components/GitCloneDialog.svelte
+++ b/src/renderer/lib/components/GitCloneDialog.svelte
@@ -5,6 +5,7 @@
   import { openCreateDialog, closeDialog } from "$lib/stores/dialogs.svelte.js";
   import { createLogger } from "$lib/logging";
   import { getErrorMessage } from "@shared/error-utils";
+  import { extractGitHubOwnerRepo, buildGitHubNewRepoUrl } from "@shared/github-utils";
 
   const logger = createLogger("ui");
 
@@ -48,6 +49,9 @@
   // Clone button disabled state
   const isCloneDisabled = $derived(!url.trim() || urlValidationError() !== null || isCloning);
 
+  // GitHub-specific error state: non-null when clone failed and URL is a GitHub repo
+  const gitHubInfo = $derived(submitError ? extractGitHubOwnerRepo(url.trim()) : null);
+
   // Handle form submission
   function handleSubmit(): void {
     if (isCloning || isCloneDisabled) return;
@@ -86,6 +90,20 @@
     logger.debug("Clone continuing in background", { url: cloneUrl });
     cloneUrl = null;
     closeDialog();
+  }
+
+  // Open GitHub new repo page with pre-filled owner and name
+  function handleCreateOnGitHub(): void {
+    if (!gitHubInfo) return;
+    const createUrl = buildGitHubNewRepoUrl(gitHubInfo.owner, gitHubInfo.repo);
+    logger.info("Opening GitHub repo creation", { url: createUrl });
+    window.open(createUrl);
+  }
+
+  // Retry clone after creating repo on GitHub
+  function handleRetryClone(): void {
+    submitError = null;
+    handleSubmit();
   }
 
   // Handle cancel (only available when not cloning)
@@ -148,7 +166,24 @@
       {/if}
     </div>
 
-    {#if submitError}
+    {#if submitError && gitHubInfo}
+      <div class="github-create-box" role="alert">
+        <p class="github-create-message">
+          {gitHubInfo.owner}/{gitHubInfo.repo} not found on GitHub.
+        </p>
+        <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+        <vscode-button onclick={handleCreateOnGitHub}>
+          <Icon name="github" />
+          Create on GitHub
+        </vscode-button>
+        <div class="ch-alert-box">
+          <span class="ch-alert-box-icon" aria-hidden="true">
+            <Icon name="warning" />
+          </span>
+          <span>Initialize with a README to enable cloning.</span>
+        </div>
+      </div>
+    {:else if submitError}
       <div class="ch-alert-box" role="alert">
         <span class="ch-alert-box-icon" aria-hidden="true">
           <Icon name="error" />
@@ -164,6 +199,9 @@
       <vscode-button onclick={handleContinueInBackground} class="clone-button">
         <span id={descriptionId}>Continue in background</span>
       </vscode-button>
+    {:else if gitHubInfo}
+      <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+      <vscode-button onclick={handleRetryClone} class="clone-button"> Retry Clone </vscode-button>
     {:else}
       <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
       <vscode-button onclick={handleSubmit} disabled={isCloneDisabled} class="clone-button">
@@ -187,5 +225,17 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+  }
+
+  .github-create-box {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .github-create-message {
+    margin: 0;
+    color: var(--ch-foreground);
   }
 </style>

--- a/src/renderer/lib/components/GitCloneDialog.test.ts
+++ b/src/renderer/lib/components/GitCloneDialog.test.ts
@@ -313,8 +313,11 @@ describe("GitCloneDialog component", () => {
       render(GitCloneDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
+      // Use non-GitHub URL to test generic error path
       const input = getUrlInput();
-      await fireEvent.input(input, { target: { value: testUrl } });
+      await fireEvent.input(input, {
+        target: { value: "https://gitlab.com/org/test-repo.git" },
+      });
 
       const cloneButton = screen.getByRole("button", { name: /clone/i });
       await fireEvent.click(cloneButton);
@@ -460,6 +463,146 @@ describe("GitCloneDialog component", () => {
       await vi.runAllTimersAsync();
 
       expect(mockCloneProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GitHub repo creation", () => {
+    const githubUrl = "https://github.com/org/new-repo.git";
+    const nonGithubUrl = "https://gitlab.com/org/repo.git";
+    const shorthandUrl = "org/new-repo";
+
+    it("shows GitHub-specific error for GitHub URL clone failure", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Repository not found"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: githubUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByText(/org\/new-repo not found on GitHub/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /create on github/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /retry clone/i })).toBeInTheDocument();
+      expect(screen.getByText(/initialize with a readme/i)).toBeInTheDocument();
+    });
+
+    it("shows GitHub-specific error for shorthand URL clone failure", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Repository not found"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: shorthandUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(screen.getByText(/org\/new-repo not found on GitHub/)).toBeInTheDocument();
+    });
+
+    it("shows generic error for non-GitHub URL clone failure", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Repository not found"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: nonGithubUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      // Should show generic error, not GitHub-specific
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText(/repository not found/i)).toBeInTheDocument();
+      expect(screen.queryByText(/not found on GitHub/)).not.toBeInTheDocument();
+    });
+
+    it('"Create on GitHub" opens browser with pre-filled URL', async () => {
+      mockCloneProject.mockRejectedValue(new Error("Repository not found"));
+      const mockWindowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: githubUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      const createButton = screen.getByRole("button", { name: /create on github/i });
+      await fireEvent.click(createButton);
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        expect.stringContaining("https://github.com/new?")
+      );
+      expect(mockWindowOpen).toHaveBeenCalledWith(expect.stringContaining("owner=org"));
+      expect(mockWindowOpen).toHaveBeenCalledWith(expect.stringContaining("name=new-repo"));
+
+      mockWindowOpen.mockRestore();
+    });
+
+    it('"Retry Clone" retries the clone', async () => {
+      mockCloneProject.mockRejectedValueOnce(new Error("Repository not found"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: githubUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      // Now resolve successfully on retry
+      mockCloneProject.mockResolvedValue(createProject(testProjectId));
+
+      const retryButton = screen.getByRole("button", { name: /retry clone/i });
+      await fireEvent.click(retryButton);
+
+      await vi.runAllTimersAsync();
+
+      expect(mockCloneProject).toHaveBeenCalledTimes(2);
+      expect(mockCloneProject).toHaveBeenLastCalledWith(githubUrl);
+    });
+
+    it("clears GitHub error state when user types", async () => {
+      mockCloneProject.mockRejectedValue(new Error("Repository not found"));
+
+      render(GitCloneDialog, { props: defaultProps });
+      await vi.runAllTimersAsync();
+
+      const input = getUrlInput();
+      await fireEvent.input(input, { target: { value: githubUrl } });
+
+      const cloneButton = screen.getByRole("button", { name: /clone/i });
+      await fireEvent.click(cloneButton);
+
+      await vi.runAllTimersAsync();
+
+      // GitHub error should be shown
+      expect(screen.getByText(/not found on GitHub/)).toBeInTheDocument();
+
+      // Type in the input
+      await fireEvent.input(input, { target: { value: "https://github.com/org/other.git" } });
+
+      // GitHub error should be cleared
+      expect(screen.queryByText(/not found on GitHub/)).not.toBeInTheDocument();
     });
   });
 

--- a/src/shared/github-utils.test.ts
+++ b/src/shared/github-utils.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Focused tests for GitHub URL utilities.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractGitHubOwnerRepo, buildGitHubNewRepoUrl } from "./github-utils";
+
+describe("extractGitHubOwnerRepo", () => {
+  describe("shorthand format", () => {
+    it("extracts from org/repo shorthand", () => {
+      expect(extractGitHubOwnerRepo("org/repo")).toEqual({ owner: "org", repo: "repo" });
+    });
+
+    it("handles hyphens and underscores in owner and repo", () => {
+      expect(extractGitHubOwnerRepo("my-org/my_repo")).toEqual({
+        owner: "my-org",
+        repo: "my_repo",
+      });
+    });
+
+    it("handles dots in repo name", () => {
+      expect(extractGitHubOwnerRepo("org/my.repo")).toEqual({ owner: "org", repo: "my.repo" });
+    });
+
+    it("strips .git suffix from shorthand", () => {
+      expect(extractGitHubOwnerRepo("org/repo.git")).toEqual({ owner: "org", repo: "repo" });
+    });
+  });
+
+  describe("HTTPS format", () => {
+    it("extracts from full HTTPS URL", () => {
+      expect(extractGitHubOwnerRepo("https://github.com/org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("extracts from HTTPS URL without .git suffix", () => {
+      expect(extractGitHubOwnerRepo("https://github.com/org/repo")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("handles HTTP protocol", () => {
+      expect(extractGitHubOwnerRepo("http://github.com/org/repo")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("handles mixed case hostname", () => {
+      expect(extractGitHubOwnerRepo("https://GitHub.COM/org/repo")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("handles trailing slash", () => {
+      expect(extractGitHubOwnerRepo("https://github.com/org/repo/")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("SSH format", () => {
+    it("extracts from git@github.com:org/repo.git", () => {
+      expect(extractGitHubOwnerRepo("git@github.com:org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("extracts from SSH without .git suffix", () => {
+      expect(extractGitHubOwnerRepo("git@github.com:org/repo")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("handles custom SSH user", () => {
+      expect(extractGitHubOwnerRepo("user@github.com:org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("SSH protocol format", () => {
+    it("extracts from ssh://git@github.com/org/repo.git", () => {
+      expect(extractGitHubOwnerRepo("ssh://git@github.com/org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("git protocol format", () => {
+    it("extracts from git://github.com/org/repo.git", () => {
+      expect(extractGitHubOwnerRepo("git://github.com/org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("partial URL format", () => {
+    it("extracts from github.com/org/repo", () => {
+      expect(extractGitHubOwnerRepo("github.com/org/repo")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+
+    it("extracts from github.com/org/repo.git", () => {
+      expect(extractGitHubOwnerRepo("github.com/org/repo.git")).toEqual({
+        owner: "org",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("non-GitHub URLs", () => {
+    it("returns null for GitLab HTTPS URL", () => {
+      expect(extractGitHubOwnerRepo("https://gitlab.com/org/repo.git")).toBeNull();
+    });
+
+    it("returns null for GitLab SSH URL", () => {
+      expect(extractGitHubOwnerRepo("git@gitlab.com:org/repo.git")).toBeNull();
+    });
+
+    it("returns null for Bitbucket URL", () => {
+      expect(extractGitHubOwnerRepo("https://bitbucket.org/org/repo.git")).toBeNull();
+    });
+
+    it("returns null for custom domain partial URL", () => {
+      expect(extractGitHubOwnerRepo("gitlab.com/org/repo")).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty string", () => {
+      expect(extractGitHubOwnerRepo("")).toBeNull();
+    });
+
+    it("returns null for whitespace", () => {
+      expect(extractGitHubOwnerRepo("   ")).toBeNull();
+    });
+
+    it("returns null for plain text", () => {
+      expect(extractGitHubOwnerRepo("not-a-url")).toBeNull();
+    });
+
+    it("handles leading and trailing whitespace", () => {
+      expect(extractGitHubOwnerRepo("  org/repo  ")).toEqual({ owner: "org", repo: "repo" });
+    });
+
+    it("returns null for GitHub URL with only owner (no repo)", () => {
+      expect(extractGitHubOwnerRepo("https://github.com/org")).toBeNull();
+    });
+  });
+});
+
+describe("buildGitHubNewRepoUrl", () => {
+  it("builds URL with owner and name params", () => {
+    expect(buildGitHubNewRepoUrl("org", "repo")).toBe("https://github.com/new?owner=org&name=repo");
+  });
+
+  it("encodes special characters", () => {
+    const url = buildGitHubNewRepoUrl("my org", "my repo");
+    expect(url).toContain("owner=my+org");
+    expect(url).toContain("name=my+repo");
+  });
+});

--- a/src/shared/github-utils.ts
+++ b/src/shared/github-utils.ts
@@ -1,0 +1,81 @@
+/**
+ * GitHub-specific URL utilities.
+ *
+ * Used by the renderer to detect GitHub URLs and build repo creation links.
+ * Self-contained — no dependency on src/utils/url-utils.ts (not importable from renderer).
+ */
+
+interface GitHubOwnerRepo {
+  readonly owner: string;
+  readonly repo: string;
+}
+
+/**
+ * Extract the GitHub owner and repo name from a user-provided URL or shorthand.
+ *
+ * Returns null for non-GitHub URLs or unrecognizable input.
+ *
+ * @example
+ * extractGitHubOwnerRepo("org/repo") // { owner: "org", repo: "repo" }
+ * extractGitHubOwnerRepo("github.com/org/repo") // { owner: "org", repo: "repo" }
+ * extractGitHubOwnerRepo("https://github.com/org/repo.git") // { owner: "org", repo: "repo" }
+ * extractGitHubOwnerRepo("git@github.com:org/repo.git") // { owner: "org", repo: "repo" }
+ * extractGitHubOwnerRepo("https://gitlab.com/org/repo") // null
+ */
+export function extractGitHubOwnerRepo(input: string): GitHubOwnerRepo | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Shorthand: org/repo (no dots in first segment, no protocol, no @)
+  const shorthandMatch = trimmed.match(/^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)$/);
+  if (shorthandMatch) {
+    return { owner: shorthandMatch[1]!, repo: stripGitSuffix(shorthandMatch[2]!) };
+  }
+
+  // SSH format: git@github.com:org/repo.git
+  const sshMatch = trimmed.match(/^[^@]+@([^:/]+):([^/]+)\/([^/]+)$/);
+  if (sshMatch && isGitHubHost(sshMatch[1]!)) {
+    return { owner: sshMatch[2]!, repo: stripGitSuffix(sshMatch[3]!) };
+  }
+
+  // URL formats: https://github.com/org/repo, ssh://git@github.com/org/repo, git://github.com/org/repo
+  // Also partial: github.com/org/repo
+  try {
+    const urlString = /^[a-z]+:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    const parsed = new URL(urlString);
+    if (!isGitHubHost(parsed.hostname)) return null;
+
+    const segments = parsed.pathname
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "")
+      .split("/")
+      .filter((s) => s.length > 0);
+
+    if (segments.length >= 2) {
+      return { owner: segments[0]!, repo: stripGitSuffix(segments[1]!) };
+    }
+  } catch {
+    // Not a parseable URL
+  }
+
+  return null;
+}
+
+/**
+ * Build a GitHub "new repository" URL with pre-filled owner and name.
+ *
+ * @example
+ * buildGitHubNewRepoUrl("org", "repo") // "https://github.com/new?owner=org&name=repo"
+ */
+export function buildGitHubNewRepoUrl(owner: string, repo: string): string {
+  const params = new URLSearchParams({ owner, name: repo });
+  return `https://github.com/new?${params.toString()}`;
+}
+
+function isGitHubHost(hostname: string): boolean {
+  return hostname.toLowerCase() === "github.com";
+}
+
+function stripGitSuffix(name: string): string {
+  return name.endsWith(".git") ? name.slice(0, -4) : name;
+}


### PR DESCRIPTION
- When cloning a GitHub URL fails, show a GitHub-specific error state with owner/repo info
- "Create on GitHub" button opens `github.com/new` pre-filled with owner and repo name
- "Retry Clone" button lets users retry after creating the repo
- Warning hint reminds users to initialize with a README to enable cloning
- Add `setWindowOpenHandler` to UI view so `window.open()` opens in system browser
- New `extractGitHubOwnerRepo` / `buildGitHubNewRepoUrl` shared utilities with tests