### PR TITLE
fix(code-server): recover from unhealthy state after system resume on Windows

### DIFF
--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -1,11 +1,20 @@
 /**
- * AppResumeOperation - Emits app:resumed after system wake from sleep/hibernate.
+ * AppResumeOperation - Orchestrates recovery after system wake from sleep/hibernate.
  *
- * Trivial operation (no hooks) that emits a domain event for subscribers.
+ * Single hook point:
+ * - "resume" - Probe code-server health and reload workspace views.
+ *              code-server-module provides `codeServerReady`; view-module's
+ *              reload handler requires it so the reload only runs after the
+ *              server is confirmed healthy (or has been restarted).
+ *              Hook context includes `emit` so handlers can fire their own
+ *              domain events (e.g. code-server:restart-failed).
+ *
+ * After hooks complete, emits `app:resumed` for telemetry subscribers
+ * (posthog-module) that don't depend on server state.
  */
 
 import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext } from "./lib/operation";
+import type { Operation, OperationContext, HookContext } from "./lib/operation";
 
 // =============================================================================
 // Intent Types
@@ -19,6 +28,21 @@ export interface AppResumeIntent extends Intent<void> {
 export const INTENT_APP_RESUME = "app:resume" as const;
 
 // =============================================================================
+// Operation + Hook Point IDs
+// =============================================================================
+
+export const APP_RESUME_OPERATION_ID = "app-resume";
+export const APP_RESUME_HOOK_RESUME = "resume";
+
+/**
+ * Extended context for the "resume" hook point.
+ * Exposes `emit` so handlers can fire domain events (e.g., restart failures).
+ */
+export interface ResumeHookContext extends HookContext {
+  readonly emit: (event: DomainEvent) => Promise<void>;
+}
+
+// =============================================================================
 // Event Types
 // =============================================================================
 
@@ -29,14 +53,31 @@ export interface AppResumedEvent extends DomainEvent {
 
 export const EVENT_APP_RESUMED = "app:resumed" as const;
 
+/**
+ * Emitted by any handler on the `resume` hook point when recovery fails.
+ * Generic by design — the operation doesn't know which module failed; the
+ * emitter provides a human-readable error for display.
+ */
+export interface AppResumeFailedEvent extends DomainEvent {
+  readonly type: typeof EVENT_APP_RESUME_FAILED;
+  readonly payload: { readonly error: string };
+}
+
+export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
+
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class AppResumeOperation implements Operation<AppResumeIntent, void> {
-  readonly id = "app-resume";
+  readonly id = APP_RESUME_OPERATION_ID;
 
   async execute(ctx: OperationContext<AppResumeIntent>): Promise<void> {
-    ctx.emit({ type: EVENT_APP_RESUMED, payload: {} });
+    const hookCtx: ResumeHookContext = {
+      intent: ctx.intent,
+      emit: ctx.emit,
+    };
+    await ctx.hooks.collect(APP_RESUME_HOOK_RESUME, hookCtx);
+    await ctx.emit({ type: EVENT_APP_RESUMED, payload: {} });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ import type { AppStartIntent } from "./intents/app-start";
 import { AppReadyOperation, INTENT_APP_READY } from "./intents/app-ready";
 // ConfigSetValuesOperation removed — config is now a plain service
 import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "./intents/app-shutdown";
-import { AppResumeOperation, INTENT_APP_RESUME } from "./intents/app-resume";
+import { AppResumeOperation, INTENT_APP_RESUME, EVENT_APP_RESUMED } from "./intents/app-resume";
 import type { AppShutdownIntent } from "./intents/app-shutdown";
 import { SetupOperation, INTENT_SETUP, EVENT_SETUP_ERROR } from "./intents/setup";
 import { SetModeOperation, INTENT_SET_MODE } from "./intents/set-mode";
@@ -331,6 +331,7 @@ const viewManager = new ViewManager({
 const idempotencyModule = createIdempotencyModule([
   { intentType: INTENT_APP_SHUTDOWN },
   { intentType: INTENT_APP_READY },
+  { intentType: INTENT_APP_RESUME, resetOn: EVENT_APP_RESUMED },
   { intentType: INTENT_SETUP, resetOn: EVENT_SETUP_ERROR },
   {
     intentType: INTENT_DELETE_WORKSPACE,

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -19,6 +19,13 @@ import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
 import type { CheckDepsHookContext, CheckDepsResult, ConfigureResult } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import {
+  AppResumeOperation,
+  INTENT_APP_RESUME,
+  EVENT_APP_RESUMED,
+  EVENT_APP_RESUME_FAILED,
+} from "../intents/app-resume";
+import type { DomainEvent } from "../intents/lib/types";
 import { SETUP_OPERATION_ID } from "../intents/setup";
 import type { BinaryHookInput, ExtensionsHookInput } from "../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
@@ -1165,6 +1172,126 @@ describe("CodeServerModule", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // app-resume: probe + restart
+  // ---------------------------------------------------------------------------
+
+  describe("app-resume probe + restart", () => {
+    async function startCodeServer(
+      deps: CodeServerModuleDeps
+    ): Promise<{ dispatcher: ReturnType<typeof createTestSetup>["dispatcher"] }> {
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+      dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+      return { dispatcher };
+    }
+
+    it("passes through without restart when /healthz succeeds", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = await startCodeServer(deps);
+
+      const initialRunCount = (deps.processRunner.run as ReturnType<typeof vi.fn>).mock.calls
+        .length;
+
+      await dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+
+      // No additional process spawned (no restart)
+      expect(deps.processRunner.run).toHaveBeenCalledTimes(initialRunCount);
+    });
+
+    it("restarts code-server when probe fails (unhealthy response)", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const deps = createMockDeps();
+        const { dispatcher } = await startCodeServer(deps);
+
+        const initialProcess = (deps.processRunner.run as ReturnType<typeof vi.fn>).mock.results[0]!
+          .value as SpawnedProcess;
+
+        // Flip /healthz to 503 for the probe, then back to 200 for the restart
+        const fetch = deps.httpClient.fetch as ReturnType<typeof vi.fn>;
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValue({ status: 200 });
+
+        const resumePromise = dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+
+        // Drive the 5s probe timeout + any intervals
+        await vi.advanceTimersByTimeAsync(6000);
+        await resumePromise;
+
+        // Old process killed, new process spawned
+        expect(initialProcess.kill).toHaveBeenCalled();
+        expect(deps.processRunner.run).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("emits app:resume-failed and blocks codeServerReady when restart fails", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const deps = createMockDeps();
+        const { dispatcher } = await startCodeServer(deps);
+
+        // Force probe to keep returning unhealthy
+        (deps.httpClient.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 503 });
+        // Force restart failure: next isPortAvailable returns false
+        (deps.portManager.isPortAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+        const failureEvents: DomainEvent[] = [];
+        dispatcher.subscribe(EVENT_APP_RESUME_FAILED, (e) => failureEvents.push(e));
+
+        const resumePromise = dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+        await vi.advanceTimersByTimeAsync(6000);
+        await resumePromise;
+
+        expect(failureEvents).toHaveLength(1);
+        const payload = failureEvents[0]!.payload as { error: string };
+        expect(payload.error).toContain("already in use");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("provides codeServerReady capability and emits app:resumed when healthy", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = await startCodeServer(deps);
+
+      const resumedEvents: DomainEvent[] = [];
+      dispatcher.subscribe(EVENT_APP_RESUMED, (e) => resumedEvents.push(e));
+
+      await dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+
+      expect(resumedEvents).toHaveLength(1);
+    });
+
+    it("skips probe when code-server was never started", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+
+      const fetchMock = deps.httpClient.fetch as ReturnType<typeof vi.fn>;
+      fetchMock.mockClear();
+
+      await dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+
+      // No /healthz called — currentPort is null
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -40,6 +40,12 @@ import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import type { DeleteHookResult, DeletePipelineHookInput } from "../intents/delete-workspace";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import {
+  APP_RESUME_OPERATION_ID,
+  APP_RESUME_HOOK_RESUME,
+  EVENT_APP_RESUME_FAILED,
+  type ResumeHookContext,
+} from "../intents/app-resume";
 import { SETUP_OPERATION_ID } from "../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
@@ -725,6 +731,51 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
             // Update internal port (consumed by finalize hook for workspace URLs)
             codeServerPort = port;
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // app-resume -> resume: probe /healthz, restart on failure
+      // -------------------------------------------------------------------
+      [APP_RESUME_OPERATION_ID]: {
+        [APP_RESUME_HOOK_RESUME]: {
+          provides: () => ({ codeServerReady: true }),
+          handler: async (ctx: HookContext): Promise<void> => {
+            const port = currentPort;
+            if (port === null) {
+              // Never started — nothing to probe. Still provide capability so
+              // view-module's reload runs (it will be a no-op with no workspaces).
+              return;
+            }
+
+            try {
+              await waitForHealthy({
+                checkFn: () => checkHealth(port),
+                timeoutMs: 5000,
+                intervalMs: 500,
+                errorMessage: "Code-server health check timed out after 5s",
+              });
+              return;
+            } catch {
+              // Fall through to restart
+            }
+
+            logger.warn("Code-server unhealthy after resume, restarting");
+            try {
+              await stop();
+              await ensureRunning();
+              logger.info("Code-server restarted after resume");
+            } catch (error) {
+              const message = getErrorMessage(error);
+              logger.error("Code-server restart failed after resume", { error: message });
+              const resumeCtx = ctx as ResumeHookContext;
+              await resumeCtx.emit({
+                type: EVENT_APP_RESUME_FAILED,
+                payload: { error: message },
+              });
+              throw error;
+            }
           },
         },
       },

--- a/src/modules/error-notification-module.integration.test.ts
+++ b/src/modules/error-notification-module.integration.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EVENT_WORKSPACE_CREATE_FAILED } from "../intents/open-workspace";
 import type { WorkspaceCreateFailedEvent } from "../intents/open-workspace";
+import { EVENT_APP_RESUME_FAILED, type AppResumeFailedEvent } from "../intents/app-resume";
 import { createErrorNotificationModule } from "./error-notification-module";
 import type { IntentModule } from "../intents/lib/module";
 import type { NotificationManager } from "./notification-manager";
@@ -179,6 +180,38 @@ describe("ErrorNotificationModule", () => {
     await module.events![EVENT_WORKSPACE_CREATE_FAILED]!.handler(event);
 
     expect(notificationManager.open).toHaveBeenCalledOnce();
+  });
+
+  it("should open error notification on app:resume-failed", async () => {
+    const event: AppResumeFailedEvent = {
+      type: EVENT_APP_RESUME_FAILED,
+      payload: { error: "Port 25448 already in use" },
+    };
+
+    await module.events![EVENT_APP_RESUME_FAILED]!.handler(event);
+
+    expect(notificationManager.open).toHaveBeenCalledOnce();
+    expect(notificationManager.open).toHaveBeenCalledWith({
+      type: "error",
+      title: "Failed to recover after system resume",
+      message: "Port 25448 already in use",
+      dismissible: true,
+    });
+  });
+
+  it("should close resume-failed notification on user dismiss", async () => {
+    const event: AppResumeFailedEvent = {
+      type: EVENT_APP_RESUME_FAILED,
+      payload: { error: "health check timed out" },
+    };
+
+    await module.events![EVENT_APP_RESUME_FAILED]!.handler(event);
+
+    const handle = notificationManager.lastHandle!;
+    handle.emitEvent({ notificationId: handle.id, actionId: "dismiss" });
+
+    const returnedHandle = notificationManager.open.mock.results[0]!.value;
+    expect(returnedHandle.close).toHaveBeenCalledOnce();
   });
 
   it("should handle multiple failures independently", async () => {

--- a/src/modules/error-notification-module.ts
+++ b/src/modules/error-notification-module.ts
@@ -9,6 +9,8 @@ import type { IntentModule, EventDeclarations } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
 import type { WorkspaceCreateFailedEvent } from "../intents/open-workspace";
 import { EVENT_WORKSPACE_CREATE_FAILED } from "../intents/open-workspace";
+import type { AppResumeFailedEvent } from "../intents/app-resume";
+import { EVENT_APP_RESUME_FAILED } from "../intents/app-resume";
 import type { NotificationManager } from "./notification-manager";
 
 export interface ErrorNotificationModuleDeps {
@@ -24,6 +26,20 @@ export function createErrorNotificationModule(deps: ErrorNotificationModuleDeps)
         const handle = deps.notificationManager.open({
           type: "error",
           title: `Failed to create "${workspaceName}"`,
+          message: error,
+          dismissible: true,
+        });
+        handle.onEvent(() => {
+          handle.close();
+        });
+      },
+    },
+    [EVENT_APP_RESUME_FAILED]: {
+      handler: async (event: DomainEvent): Promise<void> => {
+        const { error } = (event as AppResumeFailedEvent).payload;
+        const handle = deps.notificationManager.open({
+          type: "error",
+          title: "Failed to recover after system resume",
           message: error,
           dismissible: true,
         });

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -69,8 +69,11 @@ import {
 import type { ProjectOpenedEvent, SelectFolderHookResult } from "../intents/open-project";
 import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
 import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
-import { EVENT_APP_RESUMED } from "../intents/app-resume";
-import type { AppResumedEvent } from "../intents/app-resume";
+import {
+  APP_RESUME_OPERATION_ID,
+  APP_RESUME_HOOK_RESUME,
+  INTENT_APP_RESUME,
+} from "../intents/app-resume";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import type { Config } from "../boundaries/platform/config";
 import { createViewModule, type ViewModuleDeps } from "./view-module";
@@ -1211,17 +1214,19 @@ describe("ViewModule Integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // app:resumed event
+  // app:resume hook
   // -------------------------------------------------------------------------
-  describe("app:resumed event", () => {
-    const resumedEvent: AppResumedEvent = { type: EVENT_APP_RESUMED, payload: {} };
+  describe("app:resume resume hook", () => {
+    const hookCtx = {
+      intent: { type: INTENT_APP_RESUME, payload: {} },
+    };
 
     it("calls reloadAllViews when experimental.load-on-resume is true", async () => {
       const { viewManager, module } = createTestSetup(undefined, {
         configValues: { "experimental.load-on-resume": true },
       });
 
-      await module.events![EVENT_APP_RESUMED]!.handler(resumedEvent);
+      await module.hooks![APP_RESUME_OPERATION_ID]![APP_RESUME_HOOK_RESUME]!.handler(hookCtx);
 
       expect(viewManager.reloadAllViews).toHaveBeenCalledOnce();
     });
@@ -1229,7 +1234,7 @@ describe("ViewModule Integration", () => {
     it("does NOT call reloadAllViews when config is false (default)", async () => {
       const { viewManager, module } = createTestSetup();
 
-      await module.events![EVENT_APP_RESUMED]!.handler(resumedEvent);
+      await module.hooks![APP_RESUME_OPERATION_ID]![APP_RESUME_HOOK_RESUME]!.handler(hookCtx);
 
       expect(viewManager.reloadAllViews).not.toHaveBeenCalled();
     });
@@ -1239,9 +1244,16 @@ describe("ViewModule Integration", () => {
         configValues: { "experimental.load-on-resume": false },
       });
 
-      await module.events![EVENT_APP_RESUMED]!.handler(resumedEvent);
+      await module.hooks![APP_RESUME_OPERATION_ID]![APP_RESUME_HOOK_RESUME]!.handler(hookCtx);
 
       expect(viewManager.reloadAllViews).not.toHaveBeenCalled();
+    });
+
+    it("declares requires: { codeServerReady: ANY_VALUE }", () => {
+      const { module } = createTestSetup();
+      const hook = module.hooks![APP_RESUME_OPERATION_ID]![APP_RESUME_HOOK_RESUME]!;
+      expect(hook.requires).toBeDefined();
+      expect(hook.requires).toHaveProperty("codeServerReady");
     });
   });
 });

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -53,7 +53,7 @@ import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
 import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
-import { EVENT_APP_RESUMED } from "../intents/app-resume";
+import { APP_RESUME_OPERATION_ID, APP_RESUME_HOOK_RESUME } from "../intents/app-resume";
 import { SETUP_OPERATION_ID } from "../intents/setup";
 import { EVENT_SETUP_PROGRESS, EVENT_SETUP_ERROR } from "../intents/setup";
 import type { SetupProgressEvent, SetupErrorEvent } from "../intents/setup";
@@ -532,6 +532,23 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       },
 
       // -------------------------------------------------------------------
+      // app-resume → resume: reload workspace views (gated by config)
+      // Requires codeServerReady from code-server-module so reload only runs
+      // after the server is confirmed healthy (or has been restarted).
+      // -------------------------------------------------------------------
+      [APP_RESUME_OPERATION_ID]: {
+        [APP_RESUME_HOOK_RESUME]: {
+          requires: { codeServerReady: ANY_VALUE },
+          handler: async (): Promise<void> => {
+            const loadOnResume = deps.configService.get("experimental.load-on-resume") as boolean;
+            if (!loadOnResume) return;
+            logger.info("Reloading workspace views after system resume");
+            viewManager.reloadAllViews();
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
       // app-shutdown → stop: cleanup + layer disposal
       // -------------------------------------------------------------------
       [APP_SHUTDOWN_OPERATION_ID]: {
@@ -768,18 +785,6 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as AgentStatusUpdatedEvent).payload;
           viewManager.setWorkspaceLoaded(payload.workspacePath);
-        },
-      },
-
-      // -------------------------------------------------------------------
-      // app:resumed → reload workspace views (gated by config)
-      // -------------------------------------------------------------------
-      [EVENT_APP_RESUMED]: {
-        handler: async (): Promise<void> => {
-          const loadOnResume = deps.configService.get("experimental.load-on-resume") as boolean;
-          if (!loadOnResume) return;
-          logger.info("Reloading workspace views after system resume");
-          viewManager.reloadAllViews();
         },
       },
     },


### PR DESCRIPTION
- Probe code-server `/healthz` on system resume; restart (`stop()` + `ensureRunning()`) when it doesn't recover.
- Gate the workspace-view reload on a new `codeServerReady` capability, so the forced reload (still opt-in via `experimental.load-on-resume`) only runs after the server is confirmed healthy.
- Surface restart failures as a dismissible error notification via a new generic `app:resume-failed` domain event (owned by the app-resume operation, not tied to code-server specifically).
- Serialize overlapping resume dispatches via the existing idempotency module (singleton reset by `app:resumed`).