### PR TITLE
feat: bug report includes config

### DIFF
--- a/src/boundaries/platform/config-definition.ts
+++ b/src/boundaries/platform/config-definition.ts
@@ -37,6 +37,8 @@ export interface ConfigKeyDefinition<T> {
   readonly description?: string;
   /** Valid values hint for help text (e.g. "true|false", "claude|opencode"). */
   readonly validValues?: string;
+  /** When true, the value is redacted in contexts like bug reports. */
+  readonly sensitive?: boolean;
 }
 
 /**

--- a/src/boundaries/platform/config.ts
+++ b/src/boundaries/platform/config.ts
@@ -54,6 +54,9 @@ export interface Config {
   /** Get all effective config values (for help text). */
   getEffective(): Readonly<Record<string, unknown>>;
 
+  /** Get the resolved defaults (static + computed) for all registered keys. */
+  getDefaults(): Readonly<Record<string, unknown>>;
+
   /** Generate human-readable config help text. */
   getHelpText(): string;
 }
@@ -274,6 +277,7 @@ export function buildDefaults(
 export class DefaultConfig implements Config {
   private readonly definitions = new Map<string, ConfigKeyDefinition<unknown>>();
   private readonly effective: Record<string, unknown> = {};
+  private readonly defaults: Record<string, unknown> = {};
   private loaded = false;
 
   constructor(private readonly deps: ConfigDeps) {}
@@ -303,6 +307,7 @@ export class DefaultConfig implements Config {
     const defaults = buildDefaults(this.definitions, computedDefaultCtx);
     for (const [key, value] of Object.entries(defaults)) {
       this.effective[key] = value;
+      this.defaults[key] = value;
     }
 
     // 2. Read config.json from disk (sync)
@@ -411,6 +416,10 @@ export class DefaultConfig implements Config {
 
   getEffective(): Readonly<Record<string, unknown>> {
     return this.effective;
+  }
+
+  getDefaults(): Readonly<Record<string, unknown>> {
+    return this.defaults;
   }
 
   getHelpText(): string {

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -62,6 +62,7 @@ function createMockConfig(agent: ConfigAgentType | null = "opencode"): Config {
     set: async () => {},
     getDefinitions: () => new Map(),
     getEffective: () => ({}),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -584,6 +584,7 @@ const bugReportModule = createBugReportModule({
   fileSystem: fileSystemLayer,
   loggingService,
   dispatcher,
+  config: configService,
   logger: loggingService.createLogger("bug-report"),
 });
 

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -60,6 +60,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/agent-module/claude/module-provider.integration.test.ts
+++ b/src/modules/agent-module/claude/module-provider.integration.test.ts
@@ -95,6 +95,7 @@ function createMockConfigService(version: string | null = null) {
     set: vi.fn(),
     getDefinitions: vi.fn().mockReturnValue(new Map()),
     getEffective: vi.fn().mockReturnValue({}),
+    getDefaults: vi.fn().mockReturnValue({}),
     getHelpText: vi.fn().mockReturnValue(""),
   };
 }

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -172,6 +172,7 @@ function createMockConfigService(version: string | null = "1.0.223") {
     set: vi.fn(),
     getDefinitions: vi.fn().mockReturnValue(new Map()),
     getEffective: vi.fn().mockReturnValue({}),
+    getDefaults: vi.fn().mockReturnValue({}),
     getHelpText: vi.fn().mockReturnValue(""),
   };
 }

--- a/src/modules/agent-module/opencode/server-manager.boundary.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.boundary.test.ts
@@ -37,6 +37,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     set: async () => {},
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/agent-module/opencode/server-manager.integration.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.integration.test.ts
@@ -59,6 +59,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     set: async () => {},
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/agent-module/opencode/server-manager.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.test.ts
@@ -63,6 +63,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     set: async () => {},
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/auto-updater-module.integration.test.ts
+++ b/src/modules/auto-updater-module.integration.test.ts
@@ -58,6 +58,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/auto-workspace/github-source.integration.test.ts
+++ b/src/modules/auto-workspace/github-source.integration.test.ts
@@ -21,6 +21,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -76,6 +76,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -120,6 +120,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
       name: templatePathConfigKey(source.name),
       default: null,
       description: `Path to Liquid template for ${source.name} auto-workspaces`,
+      sensitive: true,
       ...configPath({ nullable: true }),
     });
   }

--- a/src/modules/auto-workspace/youtrack-source.integration.test.ts
+++ b/src/modules/auto-workspace/youtrack-source.integration.test.ts
@@ -20,6 +20,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/auto-workspace/youtrack-source.ts
+++ b/src/modules/auto-workspace/youtrack-source.ts
@@ -32,12 +32,14 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
     name: CONFIG_KEYS.baseUrl,
     default: null,
     description: "YouTrack instance URL (e.g. https://youtrack.example.com)",
+    sensitive: true,
     ...configString({ nullable: true }),
   });
   deps.configService.register(CONFIG_KEYS.token, {
     name: CONFIG_KEYS.token,
     default: null,
     description: "YouTrack API permanent token",
+    sensitive: true,
     ...configString({ nullable: true }),
   });
   deps.configService.register(CONFIG_KEYS.query, {

--- a/src/modules/bug-report-config-block.ts
+++ b/src/modules/bug-report-config-block.ts
@@ -1,0 +1,68 @@
+/**
+ * Build the prefilled content for the bug-report description textarea.
+ *
+ * Layout:
+ *
+ *   # describe your issue
+ *   <cursor lands here — empty line for the user to start typing>
+ *
+ *   ----------- config -----------------
+ *   { ...non-default values, with sensitive keys redacted as "<redacted>" }
+ *   ------------------------------------
+ *
+ * When no non-default values exist, the JSON is replaced with:
+ *
+ *   # default configuration
+ *
+ * Returns { value, cursorOffset } so the renderer can place the cursor
+ * on the empty line after the hint.
+ */
+
+import type { ConfigKeyDefinition } from "../boundaries/platform/config-definition";
+
+const REDACTED = "<redacted>";
+const HEADER = "# describe your issue";
+const OPEN = "----------- config -----------------";
+const CLOSE = "------------------------------------";
+
+interface BuildDeps {
+  getDefinitions(): ReadonlyMap<string, ConfigKeyDefinition<unknown>>;
+  getEffective(): Readonly<Record<string, unknown>>;
+  getDefaults(): Readonly<Record<string, unknown>>;
+}
+
+export interface ConfigBlock {
+  readonly value: string;
+  readonly cursorOffset: number;
+}
+
+export function buildConfigBlock(config: BuildDeps): ConfigBlock {
+  const definitions = config.getDefinitions();
+  const effective = config.getEffective();
+  const defaults = config.getDefaults();
+
+  const overrides: Record<string, unknown> = {};
+  for (const [key, def] of definitions) {
+    if (equals(effective[key], defaults[key])) continue;
+    overrides[key] = def.sensitive === true ? REDACTED : effective[key];
+  }
+
+  const body =
+    Object.keys(overrides).length === 0
+      ? "# default configuration"
+      : JSON.stringify(overrides, null, 2);
+
+  // Cursor sits on the empty line right after the header.
+  const prefix = `${HEADER}\n`;
+  const value = [prefix, "", "", OPEN, body, CLOSE, ""].join("\n");
+
+  return { value, cursorOffset: prefix.length };
+}
+
+function equals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a === "object") return JSON.stringify(a) === JSON.stringify(b);
+  return false;
+}

--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -12,7 +12,8 @@ import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../int
 import { INTENT_SUBMIT_BUG_REPORT } from "../intents/submit-bug-report";
 import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 import type { DialogHandle } from "./dialog-manager";
-import type { DialogUserEvent, DialogConfig } from "../shared/dialog-types";
+import type { DialogUserEvent, DialogConfig, DialogSection } from "../shared/dialog-types";
+import type { ConfigKeyDefinition } from "../boundaries/platform/config-definition";
 
 // =============================================================================
 // Helpers
@@ -47,8 +48,52 @@ function createMockHandle(): DialogHandle & {
   };
 }
 
-function createMockDeps(overrides?: Partial<BugReportModuleDeps>) {
+interface ConfigFixture {
+  readonly definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>;
+  readonly defaults: Readonly<Record<string, unknown>>;
+  readonly effective: Readonly<Record<string, unknown>>;
+}
+
+function defineKey(
+  name: string,
+  defaultValue: unknown,
+  options?: { sensitive?: boolean }
+): [string, ConfigKeyDefinition<unknown>] {
+  return [
+    name,
+    {
+      name,
+      default: defaultValue,
+      parse: () => undefined,
+      validate: () => undefined,
+      ...(options?.sensitive !== undefined && { sensitive: options.sensitive }),
+    },
+  ];
+}
+
+function createConfigFixture(overrides?: {
+  entries?: ReadonlyArray<[string, ConfigKeyDefinition<unknown>]>;
+  effective?: Readonly<Record<string, unknown>>;
+}): ConfigFixture {
+  const entries = overrides?.entries ?? [
+    defineKey("agent", null),
+    defineKey("log.level", "warn"),
+    defineKey("telemetry.distinct-id", null, { sensitive: true }),
+    defineKey("experimental.youtrack.token", null, { sensitive: true }),
+  ];
+  const definitions = new Map(entries);
+  const defaults: Record<string, unknown> = {};
+  for (const [key, def] of definitions) defaults[key] = def.default;
+  const effective = { ...defaults, ...(overrides?.effective ?? {}) };
+  return { definitions, defaults, effective };
+}
+
+function createMockDeps(
+  overrides?: Partial<BugReportModuleDeps> & { configFixture?: ConfigFixture }
+) {
   const handle = createMockHandle();
+  const { configFixture, ...rest } = overrides ?? {};
+  const fixture = configFixture ?? createConfigFixture();
 
   return {
     handle,
@@ -66,10 +111,23 @@ function createMockDeps(overrides?: Partial<BugReportModuleDeps>) {
       dispatcher: {
         dispatch: vi.fn().mockResolvedValue(undefined),
       },
+      config: {
+        getDefinitions: () => fixture.definitions,
+        getDefaults: () => fixture.defaults,
+        getEffective: () => fixture.effective,
+      },
       logger: createMockLogger(),
-      ...overrides,
+      ...rest,
     } as unknown as BugReportModuleDeps,
   };
+}
+
+function getDescriptionInitialValue(config: DialogConfig): string {
+  const input = config.sections.find(
+    (s: DialogSection): s is DialogSection & { type: "input" } => s.type === "input"
+  );
+  if (!input) throw new Error("no input section");
+  return input.initialValue ?? "";
 }
 
 async function emitKeyEvent(
@@ -111,8 +169,106 @@ describe("BugReportModule", () => {
     expect(config.sections[2]).toMatchObject({
       type: "text",
       style: "subtitle",
+      content: expect.stringContaining("config") as unknown as string,
+    });
+    expect(config.sections[3]).toMatchObject({
+      type: "text",
+      style: "subtitle",
+      content: expect.stringContaining("logs") as unknown as string,
     });
     expect(config.actions).toHaveLength(2);
+  });
+
+  it("prefills description with '# default configuration' when no overrides", async () => {
+    const { deps } = createMockDeps();
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+
+    const config = (deps.dialogManager.open as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as DialogConfig;
+    const initial = getDescriptionInitialValue(config);
+    expect(initial).toContain("# describe your issue");
+    expect(initial).toContain("----------- config -----------------");
+    expect(initial).toContain("# default configuration");
+    expect(initial).not.toContain("{");
+  });
+
+  it("places cursor on the empty line after the hint", async () => {
+    const { deps } = createMockDeps();
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+
+    const config = (deps.dialogManager.open as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as DialogConfig;
+    const input = config.sections.find(
+      (s: DialogSection): s is DialogSection & { type: "input" } => s.type === "input"
+    );
+    expect(input?.cursorOffset).toBe("# describe your issue\n".length);
+  });
+
+  it("prefills description with JSON of non-default values", async () => {
+    const fixture = createConfigFixture({
+      effective: { agent: "claude", "log.level": "debug" },
+    });
+    const { deps } = createMockDeps({ configFixture: fixture });
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+
+    const config = (deps.dialogManager.open as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as DialogConfig;
+    const initial = getDescriptionInitialValue(config);
+    expect(initial).toContain('"agent": "claude"');
+    expect(initial).toContain('"log.level": "debug"');
+    expect(initial).not.toContain("telemetry.distinct-id");
+    expect(initial).not.toContain("# default configuration");
+  });
+
+  it("redacts sensitive keys in the prefilled block", async () => {
+    const fixture = createConfigFixture({
+      effective: {
+        agent: "claude",
+        "telemetry.distinct-id": "abc-123-real-uuid",
+        "experimental.youtrack.token": "super-secret-token",
+      },
+    });
+    const { deps } = createMockDeps({ configFixture: fixture });
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+
+    const config = (deps.dialogManager.open as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as DialogConfig;
+    const initial = getDescriptionInitialValue(config);
+    expect(initial).toContain('"telemetry.distinct-id": "<redacted>"');
+    expect(initial).toContain('"experimental.youtrack.token": "<redacted>"');
+    expect(initial).not.toContain("abc-123-real-uuid");
+    expect(initial).not.toContain("super-secret-token");
+    expect(initial).toContain('"agent": "claude"');
+  });
+
+  it("sends description verbatim on 'send', preserving user edits to the block", async () => {
+    const { deps, handle } = createMockDeps();
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+    handle._emitEvent({
+      dialogId: "dlg-test",
+      actionId: "send",
+      data: { inputs: { description: "My edited report\n--- Config ---\n{}\n---" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            description: "My edited report\n--- Config ---\n{}\n---",
+          }),
+        })
+      );
+    });
   });
 
   it("ignores non-'b' keys", async () => {

--- a/src/modules/bug-report-module.ts
+++ b/src/modules/bug-report-module.ts
@@ -17,9 +17,11 @@ import type { IDispatcher } from "../intents/lib/dispatcher";
 import type { DialogManager, DialogHandle } from "./dialog-manager";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { Logging, Logger } from "../boundaries/platform/logging";
+import type { Config } from "../boundaries/platform/config";
 import type { DialogConfig } from "../shared/dialog-types";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 import { INTENT_SUBMIT_BUG_REPORT, type SubmitBugReportIntent } from "../intents/submit-bug-report";
+import { buildConfigBlock } from "./bug-report-config-block";
 
 /** Maximum log content to send via PostHog (~1MB). */
 const MAX_LOG_SIZE = 1_000_000;
@@ -29,10 +31,11 @@ export interface BugReportModuleDeps {
   readonly fileSystem: Pick<FileSystemBoundary, "readFile">;
   readonly loggingService: Pick<Logging, "getLogFilePath">;
   readonly dispatcher: Pick<IDispatcher, "dispatch">;
+  readonly config: Pick<Config, "getDefinitions" | "getEffective" | "getDefaults">;
   readonly logger: Logger;
 }
 
-function buildDialogConfig(): DialogConfig {
+function buildDialogConfig(initial: { value: string; cursorOffset: number }): DialogConfig {
   return {
     sections: [
       { type: "text", content: "Report a Bug", style: "heading", icon: "bug" },
@@ -41,6 +44,14 @@ function buildDialogConfig(): DialogConfig {
         id: "description",
         placeholder: "Describe the issue...",
         multiline: true,
+        initialValue: initial.value,
+        cursorOffset: initial.cursorOffset,
+      },
+      {
+        type: "text",
+        content:
+          "Your non-default config is included below — review for sensitive values before sending.",
+        style: "subtitle",
       },
       {
         type: "text",
@@ -76,7 +87,8 @@ export function createBugReportModule(deps: BugReportModuleDeps): IntentModule {
   function openDialog(): void {
     if (activeHandle) return;
 
-    const handle = deps.dialogManager.open(buildDialogConfig());
+    const initial = buildConfigBlock(deps.config);
+    const handle = deps.dialogManager.open(buildDialogConfig(initial));
     activeHandle = handle;
 
     handle.onEvent((event) => {

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -207,6 +207,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/debug-module.integration.test.ts
+++ b/src/modules/debug-module.integration.test.ts
@@ -37,6 +37,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -39,6 +39,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/logging-module.integration.test.ts
+++ b/src/modules/logging-module.integration.test.ts
@@ -31,6 +31,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/posthog-module.integration.test.ts
+++ b/src/modules/posthog-module.integration.test.ts
@@ -62,6 +62,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/modules/posthog-module.ts
+++ b/src/modules/posthog-module.ts
@@ -106,6 +106,7 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
     name: "telemetry.distinct-id",
     default: null,
     description: "Telemetry user ID (auto-generated)",
+    sensitive: true,
     ...configString({ nullable: true }),
   });
 

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -96,6 +96,7 @@ function createMockConfig(values?: Record<string, unknown>): Config {
     },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
+    getDefaults: () => ({}),
     getHelpText: () => "",
   };
 }

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -49,6 +49,25 @@
     selectionState = newState;
   });
 
+  // Seed input state from initialValue on first sight of each input id.
+  // Existing edits are preserved; re-seeds would overwrite user content.
+  $effect(() => {
+    const seeded: Record<string, string> = {};
+    let changed = false;
+    for (const section of config.sections) {
+      if (section.type !== "input") continue;
+      const existing = untrack(() => inputState[section.id]);
+      if (existing !== undefined) continue;
+      if (section.initialValue !== undefined) {
+        seeded[section.id] = section.initialValue;
+        changed = true;
+      }
+    }
+    if (changed) {
+      inputState = { ...untrack(() => inputState), ...seeded };
+    }
+  });
+
   // Auto-focus the selected card on mount (for keyboard navigation)
   onMount(() => {
     setTimeout(() => {
@@ -56,6 +75,19 @@
       selected?.focus();
     }, 0);
   });
+
+  /** Place the caret at `cursorOffset` and focus, once, after the textarea seeds itself. */
+  function seedCursor(
+    node: HTMLTextAreaElement,
+    params: { initialValue: string | undefined; cursorOffset: number | undefined }
+  ): void {
+    if (params.initialValue === undefined || params.cursorOffset === undefined) return;
+    const offset = Math.max(0, Math.min(params.cursorOffset, params.initialValue.length));
+    queueMicrotask(() => {
+      node.focus();
+      node.setSelectionRange(offset, offset);
+    });
+  }
 
   /** Get the current selection data to include in events.
    * NOTE: Supports one selection section per dialog. If multiple exist, last wins. */
@@ -299,6 +331,10 @@
             placeholder={s.placeholder ?? ""}
             aria-label={s.placeholder ?? "Text input"}
             value={inputState[s.id] ?? ""}
+            use:seedCursor={{
+              initialValue: s.initialValue,
+              cursorOffset: s.cursorOffset,
+            }}
             oninput={(e) => {
               inputState = { ...inputState, [s.id]: e.currentTarget.value };
             }}
@@ -681,7 +717,8 @@
 
   .input-textarea {
     width: 100%;
-    min-height: 80px;
+    min-height: 30vh;
+    max-height: 60vh;
     padding: 0.5rem;
     font-family: inherit;
     font-size: 0.875rem;

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -64,6 +64,9 @@ interface TableSection {
  *
  * - multiline false (default): single-line text field
  * - multiline true: multi-line textarea
+ * - initialValue seeds the field on first render only; later edits are preserved
+ * - cursorOffset places the caret at this character offset after seeding
+ *   (only applied when initialValue is set)
  * - Input values are included in DialogUserEvent.data.inputs when actions fire
  */
 interface InputSection {
@@ -71,6 +74,8 @@ interface InputSection {
   readonly id: string;
   readonly placeholder?: string;
   readonly multiline?: boolean;
+  readonly initialValue?: string;
+  readonly cursorOffset?: number;
 }
 
 export type DialogSection =


### PR DESCRIPTION
- Prefills the bug-report description textarea with a JSON block of non-default config values
- Sensitive keys (telemetry.distinct-id, youtrack.token, github/youtrack template-path, youtrack.base-url) are pre-redacted as `<redacted>`
- Dialog shows an explicit reminder to review before sending; cursor is placed above the config block so typing stays clean
- Adds `sensitive?: boolean` flag to `ConfigKeyDefinition` and `initialValue?`/`cursorOffset?` to the shared `InputSection` dialog type
- Textarea uses relative sizing (`min-height: 30vh; max-height: 60vh`) for a roomier input area

🤖 Generated with [Claude Code](https://claude.com/claude-code)