### PR TITLE
feat: shows notification for new updates on app resume

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -471,6 +471,7 @@ const autoUpdaterLifecycleModule = createAutoUpdaterModule({
   dispatcher,
   dialogManager,
   configService,
+  notificationManager,
 });
 const localProjectModule = createLocalProjectModule({
   projectsDir: pathProvider.dataPath("projects").toString(),

--- a/src/modules/auto-updater-module.integration.test.ts
+++ b/src/modules/auto-updater-module.integration.test.ts
@@ -24,6 +24,7 @@ import {
   INTENT_APP_SHUTDOWN,
   type AppShutdownIntent,
 } from "../intents/app-shutdown";
+import { AppResumeOperation, INTENT_APP_RESUME, type AppResumeIntent } from "../intents/app-resume";
 import { INTENT_UPDATE_AVAILABLE, type UpdateAvailableIntent } from "../intents/update-available";
 import {
   UpdateApplyOperation,
@@ -42,6 +43,8 @@ import type {
 import type { Config } from "../boundaries/platform/config";
 import type { DialogManager, DialogHandle } from "./dialog-manager";
 import type { DialogConfig, DialogUserEvent } from "../shared/dialog-types";
+import type { NotificationManager, NotificationHandle } from "./notification-manager";
+import type { NotificationConfig, NotificationUserEvent } from "../shared/notification-types";
 
 // =============================================================================
 // Mock Config
@@ -273,10 +276,35 @@ function createMockDialogManager(): MockDialogManager {
   };
 }
 
+interface MockNotificationManager {
+  manager: NotificationManager;
+  opened: NotificationConfig[];
+}
+
+function createMockNotificationManager(): MockNotificationManager {
+  const opened: NotificationConfig[] = [];
+  const manager = {
+    open(config: NotificationConfig): NotificationHandle {
+      opened.push(config);
+      return {
+        id: `ntf-${opened.length}`,
+        update: () => {},
+        close: () => {},
+        onEvent: () => () => {},
+        nextEvent: () => new Promise<NotificationUserEvent>(() => {}),
+        closed: new Promise<void>(() => {}),
+      } satisfies NotificationHandle;
+    },
+    routeEvent: () => {},
+  } as unknown as NotificationManager;
+  return { manager, opened };
+}
+
 interface TestSetup {
   dispatcher: Dispatcher;
   autoUpdater: MockAutoUpdater;
   dialogManager: MockDialogManager;
+  notificationManager: MockNotificationManager;
   updateOperation: TrackingUpdateOperation;
   mockConfig: Config;
   module: IntentModule;
@@ -290,6 +318,7 @@ function createTestSetup(overrides?: {
 }): TestSetup {
   const autoUpdater = createMockAutoUpdater(overrides);
   const dialogManager = createMockDialogManager();
+  const notificationManager = createMockNotificationManager();
   const updateOperation = new TrackingUpdateOperation();
   const emittedEvents: DomainEvent[] = [];
   const mockConfig = createMockConfig({
@@ -304,6 +333,7 @@ function createTestSetup(overrides?: {
     dispatcher,
     dialogManager: dialogManager.manager,
     configService: mockConfig,
+    notificationManager: notificationManager.manager,
   });
 
   // Register minimal operations for the hooks we test
@@ -312,6 +342,7 @@ function createTestSetup(overrides?: {
     createMinimalOperation(APP_START_OPERATION_ID, "start")
   );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+  dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
   dispatcher.registerOperation(INTENT_UPDATE_AVAILABLE, updateOperation);
   dispatcher.registerOperation(INTENT_UPDATE_APPLY, new UpdateApplyOperation(mockConfig));
 
@@ -324,6 +355,7 @@ function createTestSetup(overrides?: {
     dispatcher,
     autoUpdater,
     dialogManager,
+    notificationManager,
     updateOperation,
     mockConfig,
     module: autoUpdaterModule,
@@ -340,6 +372,10 @@ function shutdownIntent(installUpdate?: boolean): AppShutdownIntent {
     type: INTENT_APP_SHUTDOWN,
     payload: { ...(installUpdate !== undefined && { installUpdate }) },
   };
+}
+
+function resumeIntent(): AppResumeIntent {
+  return { type: INTENT_APP_RESUME, payload: {} as AppResumeIntent["payload"] };
 }
 
 // =============================================================================
@@ -446,5 +482,163 @@ describe("AutoUpdaterModule Integration", () => {
     // Factory registers "auto-update" via configService.register
     // Verify the config service was provided and module created without error
     expect(mockConfig).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // app:resume -> resume hook
+  // ---------------------------------------------------------------------------
+
+  it("app:resume with config=never skips check and notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "never" },
+      checkReturns: true,
+    });
+    // App starts cleanly (never bypasses startup update flow too).
+    await dispatcher.dispatch(startIntent());
+    // Reset tracking: startup already called checkForUpdates via check-deps.
+    const startupChecks = autoUpdater.checkForUpdatesCalled;
+
+    await dispatcher.dispatch(resumeIntent());
+
+    // No additional check beyond startup's (which would be the same single flag).
+    // Concretely: config=never → resume handler returns early before checkForUpdates.
+    expect(autoUpdater.checkForUpdatesCalled).toBe(startupChecks);
+    expect(notificationManager.opened).toHaveLength(0);
+  });
+
+  it("app:resume with config=ask and update detected opens info notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "ask" },
+      checkReturns: false,
+    });
+    await dispatcher.dispatch(startIntent());
+
+    // Now simulate a new version being released during the session.
+    autoUpdater.setCheckResult(true);
+    await dispatcher.dispatch(resumeIntent());
+
+    expect(autoUpdater.downloadCalled).toBe(false);
+    expect(notificationManager.opened).toHaveLength(1);
+    const cfg = notificationManager.opened[0]!;
+    expect(cfg.type).toBe("info");
+    expect(cfg.title).toBe("Update available");
+    expect(cfg.message).toContain("2.0.0");
+    expect(cfg.dismissible).toBe(true);
+  });
+
+  it("app:resume with config=ask and no update — no notification", async () => {
+    const { dispatcher, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "ask" },
+      checkReturns: false,
+    });
+    await dispatcher.dispatch(startIntent());
+
+    await dispatcher.dispatch(resumeIntent());
+
+    expect(notificationManager.opened).toHaveLength(0);
+  });
+
+  it("app:resume with config=always downloads silently then opens ready notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "always" },
+      checkReturns: false,
+    });
+    await dispatcher.dispatch(startIntent());
+
+    autoUpdater.setCheckResult(true);
+    const resumePromise = dispatcher.dispatch(resumeIntent());
+
+    // Let the check complete and download start
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(autoUpdater.downloadCalled).toBe(true);
+    expect(notificationManager.opened).toHaveLength(0);
+
+    // Complete the download
+    autoUpdater.resolveDownload!();
+    await resumePromise;
+
+    expect(notificationManager.opened).toHaveLength(1);
+    const cfg = notificationManager.opened[0]!;
+    expect(cfg.type).toBe("info");
+    expect(cfg.title).toBe("Update ready");
+    expect(cfg.message).toContain("2.0.0");
+    expect(cfg.message).toContain("next restart");
+  });
+
+  it("app:resume with config=always and download failure — no notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "always" },
+      checkReturns: false,
+    });
+    await dispatcher.dispatch(startIntent());
+
+    autoUpdater.setCheckResult(true);
+    const resumePromise = dispatcher.dispatch(resumeIntent());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    autoUpdater.rejectDownload!(new Error("network down"));
+    await resumePromise;
+
+    expect(notificationManager.opened).toHaveLength(0);
+  });
+
+  it("second app:resume with same detected version does not re-notify", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "ask" },
+      checkReturns: false,
+    });
+    await dispatcher.dispatch(startIntent());
+
+    autoUpdater.setCheckResult(true);
+    await dispatcher.dispatch(resumeIntent());
+    expect(notificationManager.opened).toHaveLength(1);
+
+    await dispatcher.dispatch(resumeIntent());
+    expect(notificationManager.opened).toHaveLength(1);
+  });
+
+  it("app:resume after startup already detected a version — no new notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "ask" },
+      checkReturns: false,
+    });
+
+    // Startup registers persistent onUpdateDetected callback.
+    await dispatcher.dispatch(startIntent());
+    // Simulate startup having detected a version (via the persistent callback).
+    autoUpdater.capturedDetectedCb!("1.9.0");
+
+    await dispatcher.dispatch(resumeIntent());
+
+    // detectedVersion !== null guard short-circuits resume.
+    expect(notificationManager.opened).toHaveLength(0);
+  });
+
+  it("app:resume skipped while startup download is in flight", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      configValues: { "auto-update": "always" },
+      checkReturns: false,
+    });
+
+    await dispatcher.dispatch(startIntent());
+    // Simulate startup having detected a version.
+    autoUpdater.capturedDetectedCb!("2.0.0");
+
+    // Kick off the startup download (app:update → download hook) but don't resolve.
+    const updatePromise = dispatcher.dispatch({
+      type: INTENT_UPDATE_APPLY,
+      payload: { needsChoice: false },
+    } as UpdateApplyIntent);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(autoUpdater.downloadCalled).toBe(true);
+
+    // System resume fires mid-download.
+    await dispatcher.dispatch(resumeIntent());
+
+    // Resume saw detectedVersion already set + checkInProgress → no new notification.
+    expect(notificationManager.opened).toHaveLength(0);
+
+    // Clean up: complete the download.
+    autoUpdater.resolveDownload!();
+    await updatePromise;
   });
 });

--- a/src/modules/auto-updater-module.ts
+++ b/src/modules/auto-updater-module.ts
@@ -7,6 +7,7 @@
  * - update-apply -> "show-choice": emit show-choice UI event (no-op when no update detected)
  * - update-apply -> "download": download update, report progress, handle cancel (no-op when no update detected)
  * - update-apply -> "install": dispatch app:shutdown with installUpdate (no-op when no update detected)
+ * - app:resume -> "resume": re-check for updates; ask=notify, always=silent-download+notify
  * - app:shutdown -> "stop": dispose auto-updater
  * - app:shutdown -> "quit": quitAndInstall if installUpdate flag is set
  *
@@ -20,6 +21,7 @@ import type { Intent } from "../intents/lib/types";
 import type { HookContext } from "../intents/lib/operation";
 import { APP_START_OPERATION_ID, type CheckDepsResult } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID, type AppShutdownIntent } from "../intents/app-shutdown";
+import { APP_RESUME_OPERATION_ID, APP_RESUME_HOOK_RESUME } from "../intents/app-resume";
 import { INTENT_UPDATE_AVAILABLE, type UpdateAvailableIntent } from "../intents/update-available";
 import {
   UPDATE_APPLY_OPERATION_ID,
@@ -35,6 +37,7 @@ import type { Config } from "../boundaries/platform/config";
 import type { AutoUpdater } from "./auto-updater";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { DialogManager } from "./dialog-manager";
+import type { NotificationManager } from "./notification-manager";
 import type { DialogConfig, DialogSection, DialogAction } from "../shared/dialog-types";
 
 /** Timeout for update check during startup (ms). */
@@ -85,10 +88,12 @@ interface AutoUpdaterModuleDeps {
   readonly dispatcher: Dispatcher;
   readonly dialogManager: DialogManager;
   readonly configService: Config;
+  readonly notificationManager: NotificationManager;
 }
 
 export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModule {
   let detectedVersion: string | null = null;
+  let checkInProgress = false;
 
   // Register config key
   deps.configService.register("auto-update", {
@@ -223,6 +228,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
               }
             });
 
+            checkInProgress = true;
             try {
               await deps.autoUpdater.downloadUpdate();
             } catch {
@@ -236,6 +242,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
               report("downloading", 0, version, true);
               return { cancelled: true };
             } finally {
+              checkInProgress = false;
               unsubProgress();
               unsubEvent();
             }
@@ -257,6 +264,52 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
               type: INTENT_APP_SHUTDOWN,
               payload: { installUpdate: true },
             });
+          },
+        },
+      },
+      [APP_RESUME_OPERATION_ID]: {
+        [APP_RESUME_HOOK_RESUME]: {
+          handler: async (): Promise<void> => {
+            const autoUpdate = deps.configService.get("auto-update") as AutoUpdatePreference;
+            if (autoUpdate === "never") return;
+            if (checkInProgress) return;
+            // Already detected (dialog shown at startup, or prior resume notified).
+            // "Never re-show until restart" — fresh session resets state.
+            if (detectedVersion !== null) return;
+
+            checkInProgress = true;
+            try {
+              await deps.autoUpdater.checkForUpdates();
+            } finally {
+              checkInProgress = false;
+            }
+
+            const version = detectedVersion;
+            if (version === null) return;
+
+            if (autoUpdate === "always") {
+              checkInProgress = true;
+              try {
+                await deps.autoUpdater.downloadUpdate();
+              } catch {
+                return;
+              } finally {
+                checkInProgress = false;
+              }
+              deps.notificationManager.open({
+                type: "info",
+                title: "Update ready",
+                message: `Version ${version} will be installed on next restart.`,
+                dismissible: true,
+              });
+            } else {
+              deps.notificationManager.open({
+                type: "info",
+                title: "Update available",
+                message: `Version ${version} will be offered at next startup.`,
+                dismissible: true,
+              });
+            }
           },
         },
       },


### PR DESCRIPTION
- Re-check for updates on system resume (app:resume hook)
- config=ask: show a dismissible info notification ("Update available")
- config=always: silently download, then notify ("Update ready — installs on next restart")
- config=never: skipped entirely
- Guards against concurrent checks/downloads and against re-notifying the same version in a single session