### PR TITLE
chore(observability): expand bug-report log capture and auto-workspace logging

### DIFF
--- a/src/boundaries/platform/electron-log.ts
+++ b/src/boundaries/platform/electron-log.ts
@@ -483,6 +483,11 @@ export class ElectronLog implements Logging {
     this.logPath = join(logsDir, filename);
     log.transports.file.resolvePathFn = (): string => this.logPath;
 
+    // 20 MB before rotation. Bug reports include the rotated archive plus the
+    // current file (gzip+base64 compressed), so a single rotation boundary fits
+    // inside one report; smaller caps would hide context across rotations.
+    log.transports.file.maxSize = 20 * 1024 * 1024;
+
     // Format: [timestamp] [level] [scope] message
     log.transports.file.format = TEXT_FORMAT;
     log.transports.console.format = TEXT_FORMAT;

--- a/src/modules/auto-workspace/github-source.ts
+++ b/src/modules/auto-workspace/github-source.ts
@@ -162,8 +162,6 @@ export function createGitHubSource(deps: GitHubSourceDeps): AutoWorkspaceSource 
     },
 
     async poll(trackedKeys: ReadonlySet<string>): Promise<PollResult> {
-      deps.logger.debug("Polling GitHub for review-requested PRs");
-
       const items = await fetchSearchResults();
 
       const activeKeys = new Set<string>();

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -405,6 +405,19 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
     }
     const { activeKeys, newItems } = pollResult;
 
+    deps.logger.debug("Poll completed", {
+      source: source.name,
+      total: activeKeys.size,
+      tracked: activeKeys.size - newItems.length,
+      new: newItems.length,
+    });
+    if (newItems.length > 0) {
+      deps.logger.debug("Poll new items", {
+        source: source.name,
+        keys: newItems.map((i) => i.key).join(","),
+      });
+    }
+
     let stateChanged = false;
     const stateBefore = state;
 
@@ -422,15 +435,25 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
 
       if (entry === null) {
         // Dismissed entry — remove from state
+        deps.logger.info("Forgot dismissed entry (item disappeared from poll)", {
+          source: source.name,
+          key,
+        });
         const remaining = Object.fromEntries(
           Object.entries(state.entries).filter(([k]) => k !== key)
         );
         state = { ...state, entries: remaining };
       } else if (trackedPaths.has(entry.workspacePath)) {
-        // Active entry with tracked metadata — auto-delete
+        // Active entry with tracked metadata — auto-delete (deleteWorkspace logs)
         await deleteWorkspace(source, key, entry);
+      } else {
+        // Entry exists but workspace not tracked → previous failure, leave entry
+        deps.logger.info("Leaving stale entry to prevent recreation", {
+          source: source.name,
+          key,
+          workspaceName: entry.workspaceName,
+        });
       }
-      // Entry exists but not tracked → previous failure, leave entry to prevent recreation
     }
 
     // Create workspaces for new items

--- a/src/modules/auto-workspace/youtrack-source.ts
+++ b/src/modules/auto-workspace/youtrack-source.ts
@@ -96,8 +96,6 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
     },
 
     async poll(trackedKeys: ReadonlySet<string>): Promise<PollResult> {
-      deps.logger.debug("Polling YouTrack for issues");
-
       const issues = await fetchIssues();
 
       const activeKeys = new Set<string>();

--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -103,7 +103,12 @@ function createMockDeps(
         routeEvent: vi.fn(),
       },
       fileSystem: {
-        readFile: vi.fn().mockResolvedValue("test log content\nline 2\nline 3"),
+        readFile: vi.fn().mockImplementation((path: string) => {
+          if (path === "/logs/test-session.log") {
+            return Promise.resolve("test log content\nline 2\nline 3");
+          }
+          return Promise.reject(new Error("ENOENT"));
+        }),
       },
       loggingService: {
         getLogFilePath: vi.fn().mockReturnValue("/logs/test-session.log"),
@@ -350,6 +355,31 @@ describe("BugReportModule", () => {
 
     expect(handle.close).toHaveBeenCalled();
     expect(deps.dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("includes rotated archive log content alongside current log", async () => {
+    const { deps, handle } = createMockDeps();
+    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+      if (path === "/logs/test-session.log") return Promise.resolve("CURRENT");
+      if (path === "/logs/test-session.old.log") return Promise.resolve("ARCHIVE\n");
+      return Promise.reject(new Error("ENOENT"));
+    });
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+    handle._emitEvent({
+      dialogId: "dlg-test",
+      actionId: "send",
+      data: { inputs: { description: "rotated" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({ logs: "ARCHIVE\nCURRENT" }),
+        })
+      );
+    });
   });
 
   it("handles log file read failure gracefully", async () => {

--- a/src/modules/bug-report-module.ts
+++ b/src/modules/bug-report-module.ts
@@ -23,8 +23,8 @@ import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../int
 import { INTENT_SUBMIT_BUG_REPORT, type SubmitBugReportIntent } from "../intents/submit-bug-report";
 import { buildConfigBlock } from "./bug-report-config-block";
 
-/** Maximum log content to send via PostHog (~1MB). */
-const MAX_LOG_SIZE = 1_000_000;
+/** Maximum raw log bytes captured per bug report (compressed before send). */
+const MAX_LOG_SIZE = 20 * 1024 * 1024;
 
 export interface BugReportModuleDeps {
   readonly dialogManager: DialogManager;
@@ -71,17 +71,22 @@ export function createBugReportModule(deps: BugReportModuleDeps): IntentModule {
   let activeHandle: DialogHandle | null = null;
 
   async function readLogContent(): Promise<string> {
-    try {
-      const logPath = deps.loggingService.getLogFilePath();
-      const content = await deps.fileSystem.readFile(logPath);
-      if (content.length > MAX_LOG_SIZE) {
-        return content.slice(-MAX_LOG_SIZE);
-      }
-      return content;
-    } catch {
+    const logPath = deps.loggingService.getLogFilePath();
+
+    // electron-log rotates `<name>.log` to `<name>.old.log` once it exceeds maxSize.
+    // Include the archive so reports submitted after a rotation still carry context.
+    const dot = logPath.lastIndexOf(".");
+    const archivePath =
+      dot >= 0 ? `${logPath.slice(0, dot)}.old${logPath.slice(dot)}` : `${logPath}.old`;
+
+    const archive = await deps.fileSystem.readFile(archivePath).catch(() => "");
+    const current = await deps.fileSystem.readFile(logPath).catch((): string => {
       deps.logger.warn("Failed to read log file");
       return "";
-    }
+    });
+
+    const combined = archive ? `${archive}${current}` : current;
+    return combined.length > MAX_LOG_SIZE ? combined.slice(-MAX_LOG_SIZE) : combined;
   }
 
   function openDialog(): void {

--- a/src/modules/posthog-module.integration.test.ts
+++ b/src/modules/posthog-module.integration.test.ts
@@ -657,10 +657,46 @@ describe("PosthogModule Integration", () => {
       );
 
       const mock = getMock()!;
-      expect(mock).toHaveCaptured("$exception", {
-        $exception_list: [{ type: "BugReport", value: "App freezes on startup" }],
-        logs: "log line 1\nlog line 2",
+      const captured = mock.$.capturedEvents.find((e) => e.event === "$exception");
+      expect(captured).toBeDefined();
+      const props = captured!.properties as Record<string, unknown>;
+      expect(props["$exception_list"]).toEqual([
+        expect.objectContaining({ type: "BugReport", value: "App freezes on startup" }),
+      ]);
+      expect(props["logs_format"]).toBe("gzip+base64");
+      expect(props["logs_raw_bytes"]).toBe("log line 1\nlog line 2".length);
+      const decompressed = (await import("node:zlib"))
+        .gunzipSync(Buffer.from(props["logs"] as string, "base64"))
+        .toString();
+      expect(decompressed).toBe("log line 1\nlog line 2");
+    });
+
+    it("trims raw logs until compressed payload fits PostHog's 1MB limit", async () => {
+      const { dispatcher, getMock } = createTestSetup({
+        configValues: {
+          "telemetry.enabled": true,
+          "telemetry.distinct-id": "test-id",
+          agent: "claude",
+        },
       });
+
+      // Truly random bytes don't compress, so 5MB of them blows past the 1MB
+      // cap even after gzip+base64, forcing the trim loop to drop bytes.
+      const { randomBytes } = await import("node:crypto");
+      const incompressible = randomBytes(5 * 1024 * 1024).toString("binary");
+
+      await dispatcher.dispatch(startIntent());
+      await dispatcher.dispatch(submitBugReportIntent("big report", incompressible));
+
+      const mock = getMock()!;
+      const captured = mock.$.capturedEvents.find((e) => e.event === "$exception");
+      expect(captured).toBeDefined();
+      const props = captured!.properties as Record<string, unknown>;
+      expect((props["logs"] as string).length).toBeLessThanOrEqual(1_000_000);
+      expect(props["logs_raw_bytes_dropped"]).toBeGreaterThan(0);
+      expect(
+        (props["logs_raw_bytes"] as number) + (props["logs_raw_bytes_dropped"] as number)
+      ).toBe(incompressible.length);
     });
 
     it("sends bug report even when telemetry is disabled", async () => {

--- a/src/modules/posthog-module.ts
+++ b/src/modules/posthog-module.ts
@@ -12,6 +12,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { gzipSync } from "node:zlib";
 import { PostHog } from "posthog-node";
 import type { IntentModule } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
@@ -230,8 +231,31 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
 
     deps.logger.info("Bug report captured");
 
+    // PostHog discards events larger than 1 MB. Compress logs (gzip+base64) and,
+    // if the payload overshoots, trim the raw input from the front (keeping the
+    // most recent tail). Each iteration scales the raw size down by the observed
+    // overshoot ratio with a safety margin, so we usually converge in 1–2 passes
+    // and keep close to the cap (vs. naive halving which would ship ~half on a
+    // small overshoot).
+    const POSTHOG_EVENT_LIMIT = 1_000_000;
+    const SAFETY_FACTOR = 0.95;
+    let rawLogs = logs;
+    let logsCompressed = rawLogs ? gzipSync(rawLogs).toString("base64") : "";
+    while (logsCompressed.length > POSTHOG_EVENT_LIMIT && rawLogs.length > 0) {
+      const scaled = Math.floor(
+        (rawLogs.length * POSTHOG_EVENT_LIMIT * SAFETY_FACTOR) / logsCompressed.length
+      );
+      // Guarantee progress even if rounding/SAFETY_FACTOR don't shrink enough
+      const nextLen = Math.max(0, Math.min(scaled, rawLogs.length - 1));
+      rawLogs = nextLen > 0 ? rawLogs.slice(rawLogs.length - nextLen) : "";
+      logsCompressed = rawLogs ? gzipSync(rawLogs).toString("base64") : "";
+    }
+
     client.captureException(bugError, id, {
-      logs,
+      logs: logsCompressed,
+      logs_format: logsCompressed ? "gzip+base64" : "none",
+      logs_raw_bytes: rawLogs.length,
+      logs_raw_bytes_dropped: logs.length - rawLogs.length,
       ...eventProperties(),
       version: deps.buildInfo.version,
     });


### PR DESCRIPTION
- electron-log rotation threshold raised from 1 MB to 20 MB so typical sessions fit in a single file.
- Bug reports now also include the rotated `<name>.old.log` alongside the current file (tailed to 20 MB raw).
- posthog-module gzip+base64 compresses the bug-report log payload and trims the raw input from the front (proportional scaling) until the compressed result fits PostHog's 1 MB per-event hard limit; new event properties `logs_format`, `logs_raw_bytes`, `logs_raw_bytes_dropped`.
- auto-workspace `pollSource` now emits info "Poll completed" with source/total/tracked/new counts after each source poll, and a debug "Poll new items" line when newItems is non-empty.
- The previously-silent cleanup branches now log: tombstone drop ("Forgot dismissed entry") and leave-as-failure ("Leaving stale entry to prevent recreation"). The recent silent PR-recreation incident would have been a one-grep diagnosis with these in place.
- Removed redundant pre-fetch debug "Polling..." lines from github-source and youtrack-source.