### PR TITLE
fix: processes of hibernated workspaces get killed

### DIFF
--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -23,6 +23,7 @@ import {
   type HibernateWorkspaceIntent,
   type CaptureHookResult,
   type HibernateShutdownHookResult,
+  type HibernateReleaseHookResult,
   type HibernatePipelineHookInput,
 } from "./hibernate-workspace";
 import {
@@ -63,7 +64,9 @@ const WORKSPACE_NAME = "feature-a" as WorkspaceName;
 interface Recorder {
   captureCalled: boolean;
   shutdownCalled: boolean;
+  releaseCalled: boolean;
   cleanupCalled: boolean;
+  callOrder: string[];
   metadataWrites: Array<{ key: string; value: string | null }>;
   events: DomainEvent[];
 }
@@ -72,7 +75,9 @@ function createRecorder(): Recorder {
   return {
     captureCalled: false,
     shutdownCalled: false,
+    releaseCalled: false,
     cleanupCalled: false,
+    callOrder: [],
     metadataWrites: [],
     events: [],
   };
@@ -123,7 +128,7 @@ function createMetadataModule(recorder: Recorder): IntentModule {
 
 function createHibernateHookModule(
   recorder: Recorder,
-  opts: { wasActive?: boolean } = {}
+  opts: { wasActive?: boolean; releaseThrows?: boolean } = {}
 ): IntentModule {
   return {
     name: "test-hibernate-hooks",
@@ -135,13 +140,27 @@ function createHibernateHookModule(
             expect(c.workspacePath).toBe(WORKSPACE_PATH);
             expect(c.projectId).toBe(PROJECT_ID);
             recorder.captureCalled = true;
+            recorder.callOrder.push("capture");
             return { captured: true };
           },
         },
         shutdown: {
           handler: async (): Promise<HibernateShutdownHookResult> => {
             recorder.shutdownCalled = true;
+            recorder.callOrder.push("shutdown");
             return opts.wasActive ? { wasActive: true } : {};
+          },
+        },
+        release: {
+          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+            const c = ctx as HibernatePipelineHookInput;
+            expect(c.workspacePath).toBe(WORKSPACE_PATH);
+            recorder.releaseCalled = true;
+            recorder.callOrder.push("release");
+            if (opts.releaseThrows) {
+              throw new Error("release boom");
+            }
+            return {};
           },
         },
       },
@@ -199,7 +218,7 @@ function buildHarness(buildHookModules: (recorder: Recorder) => IntentModule[]):
 }
 
 describe("workspace:hibernate", () => {
-  it("runs capture + shutdown, persists hibernated metadata, emits hibernated event", async () => {
+  it("runs capture + shutdown + release, persists hibernated metadata, emits hibernated event", async () => {
     const { dispatcher, recorder } = buildHarness((r) => [createHibernateHookModule(r)]);
 
     const intent: HibernateWorkspaceIntent = {
@@ -210,6 +229,8 @@ describe("workspace:hibernate", () => {
 
     expect(recorder.captureCalled).toBe(true);
     expect(recorder.shutdownCalled).toBe(true);
+    expect(recorder.releaseCalled).toBe(true);
+    expect(recorder.callOrder).toEqual(["capture", "shutdown", "release"]);
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
 
     const hibernated = recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED);
@@ -255,6 +276,25 @@ describe("workspace:hibernate", () => {
       recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATE_FAILED)
     ).toBeUndefined();
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
+  });
+
+  it("hibernate completes when release throws (best-effort)", async () => {
+    const { dispatcher, recorder } = buildHarness((r) => [
+      createHibernateHookModule(r, { releaseThrows: true }),
+    ]);
+
+    const intent: HibernateWorkspaceIntent = {
+      type: INTENT_HIBERNATE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    };
+    await dispatcher.dispatch(intent);
+
+    expect(recorder.releaseCalled).toBe(true);
+    expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
+    expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
+    expect(
+      recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATE_FAILED)
+    ).toBeUndefined();
   });
 });
 

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -101,6 +101,14 @@ export interface HibernateShutdownHookResult {
   readonly wasActive?: boolean;
 }
 
+/**
+ * Per-handler result for the "release" hook point.
+ * Best-effort CWD-rooted process kill before metadata persists.
+ */
+export interface HibernateReleaseHookResult {
+  readonly error?: string;
+}
+
 // =============================================================================
 // Operation
 // =============================================================================
@@ -147,6 +155,19 @@ export class HibernateWorkspaceOperation implements Operation<
       let wasActive = false;
       for (const r of shutdownResults) {
         if (r.wasActive) wasActive = true;
+      }
+
+      // Best-effort: kill processes whose CWD is rooted under the workspace.
+      // Errors here never block hibernation — the worktree stays on disk
+      // either way, so a stuck cleanup must not fail the operation.
+      const { results: releaseResults, errors: releaseCollectErrors } =
+        await ctx.hooks.collect<HibernateReleaseHookResult>("release", hookCtx);
+      for (const e of releaseCollectErrors) {
+        // collect errors are already logged by the dispatcher; nothing to do.
+        void e;
+      }
+      for (const r of releaseResults) {
+        void r;
       }
 
       // Persist hibernated flag via existing set-metadata pipeline

--- a/src/modules/posix-process-cleanup-module.integration.test.ts
+++ b/src/modules/posix-process-cleanup-module.integration.test.ts
@@ -17,6 +17,10 @@ import {
   type ReleaseHookResult,
 } from "../intents/delete-workspace";
 import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernateReleaseHookResult,
+} from "../intents/hibernate-workspace";
+import {
   createPosixProcessCleanupModule,
   detectCwdProcesses,
   killPosixProcesses,
@@ -364,6 +368,76 @@ describe("PosixProcessCleanupModule Integration", () => {
       // Only detection was spawned, no kill
       expect(runner.$.spawned(0).$.command).toBe("lsof");
       expect(() => runner.$.spawned(1)).toThrow();
+    });
+  });
+
+  describe("hibernate-workspace -> release", () => {
+    const hibernateReleaseOperation = createMinimalOperation<Intent, HibernateReleaseHookResult>(
+      HIBERNATE_WORKSPACE_OPERATION_ID,
+      "release",
+      {
+        hookContext: (ctx) => ({
+          intent: ctx.intent,
+          projectPath: "/projects/my-app",
+          workspacePath:
+            (ctx.intent as { payload: { workspacePath?: string } }).payload.workspacePath ?? "",
+          projectId: "proj-1",
+          workspaceName: "feature-1",
+        }),
+      }
+    );
+
+    function createHibernateReleaseSetup(r: MockProcessRunner) {
+      const dispatcher = new Dispatcher({
+        logger: createMockLogger(),
+        initialCapabilities: { posix: true },
+      });
+      dispatcher.registerOperation("workspace:hibernate", hibernateReleaseOperation);
+      dispatcher.registerModule(
+        createPosixProcessCleanupModule({ processRunner: r, logger: SILENT_LOGGER })
+      );
+      return dispatcher;
+    }
+
+    function makeHibernateIntent(): Intent {
+      return {
+        type: "workspace:hibernate",
+        payload: { workspacePath: "/workspaces/feature-1" },
+      } as unknown as Intent;
+    }
+
+    it("detects and kills CWD-blocking processes (no force gate)", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            return {
+              stdout: "p1234\ncbash\nn/workspaces/feature-1\n",
+              exitCode: 0,
+            };
+          }
+          return { exitCode: 0 };
+        },
+      });
+
+      const dispatcher = createHibernateReleaseSetup(runner);
+      await dispatcher.dispatch(makeHibernateIntent());
+
+      expect(runner.$.spawned(0).$.command).toBe("lsof");
+      expect(runner.$.spawned(1).$.command).toBe("kill");
+      expect(runner.$.spawned(1).$.args).toEqual(["-TERM", "1234"]);
+    });
+
+    it("swallows errors from detection during hibernation", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ exitCode: null, running: true }),
+      });
+
+      const dispatcher = createHibernateReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeHibernateIntent());
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/modules/posix-process-cleanup-module.ts
+++ b/src/modules/posix-process-cleanup-module.ts
@@ -1,8 +1,9 @@
 /**
- * PosixProcessCleanupModule — Kills processes whose CWD is under the workspace path during deletion.
+ * PosixProcessCleanupModule — Kills processes whose CWD is under the workspace path during deletion or hibernation.
  *
  * Hooks:
  * - delete-workspace → release: Use lsof to find CWD matches, kill with SIGTERM (best-effort)
+ * - hibernate-workspace → release: Same CWD scan + SIGTERM, runs after shutdown (best-effort)
  *
  * Detection uses `lsof -a -d cwd +c 0 -Fpnc +D <path>` for machine-parseable output
  * scoped to the workspace directory tree. The -a flag ANDs the -d and +D selections
@@ -20,6 +21,11 @@ import {
   type DeletePipelineHookInput,
   type ReleaseHookResult,
 } from "../intents/delete-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernatePipelineHookInput,
+  type HibernateReleaseHookResult,
+} from "../intents/hibernate-workspace";
 
 /** Detected process info from lsof. */
 export interface DetectedProcess {
@@ -159,30 +165,43 @@ export function createPosixProcessCleanupModule(deps: PosixProcessCleanupModuleD
               return {};
             }
 
-            try {
-              const detected = await detectCwdProcesses(
-                deps.processRunner,
-                workspacePath,
-                deps.logger
-              );
-
-              if (detected.length > 0) {
-                deps.logger.info("Killing CWD-blocking processes before deletion", {
-                  workspacePath,
-                  pids: detected.map((p) => p.pid).join(","),
-                });
-                await killPosixProcesses(
-                  deps.processRunner,
-                  detected.map((p) => p.pid)
-                );
-              }
-            } catch {
-              // Non-fatal: detection/kill failure shouldn't block deletion
-            }
+            await runCwdReleaseKill(deps, workspacePath, "deletion");
+            return {};
+          },
+        },
+      },
+      [HIBERNATE_WORKSPACE_OPERATION_ID]: {
+        release: {
+          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+            const { workspacePath } = ctx as HibernatePipelineHookInput;
+            await runCwdReleaseKill(deps, workspacePath, "hibernation");
             return {};
           },
         },
       },
     },
   };
+}
+
+async function runCwdReleaseKill(
+  deps: PosixProcessCleanupModuleDeps,
+  workspacePath: string,
+  phase: "deletion" | "hibernation"
+): Promise<void> {
+  try {
+    const detected = await detectCwdProcesses(deps.processRunner, workspacePath, deps.logger);
+
+    if (detected.length > 0) {
+      deps.logger.info(`Killing CWD-blocking processes before ${phase}`, {
+        workspacePath,
+        pids: detected.map((p) => p.pid).join(","),
+      });
+      await killPosixProcesses(
+        deps.processRunner,
+        detected.map((p) => p.pid)
+      );
+    }
+  } catch {
+    // Non-fatal: detection/kill failure shouldn't block the operation
+  }
 }

--- a/src/modules/windows-file-lock-module.integration.test.ts
+++ b/src/modules/windows-file-lock-module.integration.test.ts
@@ -20,6 +20,10 @@ import {
   type FlushHookResult,
   type FlushHookInput,
 } from "../intents/delete-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernateReleaseHookResult,
+} from "../intents/hibernate-workspace";
 import { createWindowsFileLockModule } from "./windows-file-lock-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createBehavioralLogger } from "../boundaries/platform/logging.test-utils";
@@ -354,6 +358,81 @@ describe("WindowsFileLockModule Integration", () => {
 
       // No processes spawned
       expect(() => runner.$.spawned(0)).toThrow();
+    });
+  });
+
+  describe("hibernate-workspace -> release", () => {
+    const hibernateReleaseOperation = createMinimalOperation<Intent, HibernateReleaseHookResult>(
+      HIBERNATE_WORKSPACE_OPERATION_ID,
+      "release",
+      {
+        hookContext: (ctx) => ({
+          intent: ctx.intent,
+          projectPath: "/projects/my-app",
+          workspacePath:
+            (ctx.intent as { payload: { workspacePath?: string } }).payload.workspacePath ?? "",
+          projectId: "proj-1",
+          workspaceName: "feature-1",
+        }),
+      }
+    );
+
+    function createHibernateReleaseSetup(r: MockProcessRunner) {
+      const dispatcher = new Dispatcher({
+        logger: createMockLogger(),
+        initialCapabilities: { platform: "win32" },
+      });
+      dispatcher.registerOperation("workspace:hibernate", hibernateReleaseOperation);
+      dispatcher.registerModule(
+        createWindowsFileLockModule({
+          processRunner: r,
+          scriptPath: SCRIPT_PATH,
+          logger: SILENT_LOGGER,
+        })
+      );
+      return dispatcher;
+    }
+
+    function makeHibernateIntent(): Intent {
+      return {
+        type: "workspace:hibernate",
+        payload: { workspacePath: "/workspaces/feature-1" },
+      } as unknown as Intent;
+    }
+
+    it("kills CWD-blocking processes (no force gate)", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            return {
+              stdout: createDetectJson([
+                { pid: 1234, name: "node.exe", commandLine: "node", cwd: "/workspaces/feature-1" },
+              ]),
+              exitCode: 0,
+            };
+          }
+          return { exitCode: 0 };
+        },
+      });
+
+      const dispatcher = createHibernateReleaseSetup(runner);
+      await dispatcher.dispatch(makeHibernateIntent());
+
+      expect(runner.$.spawned(0).$.command).toBe("powershell");
+      expect(runner.$.spawned(1).$.command).toBe("taskkill");
+    });
+
+    it("swallows errors from detection during hibernation", async () => {
+      runner = createMockProcessRunner({
+        onSpawn: () => ({ exitCode: 1, stderr: "boom" }),
+      });
+
+      const dispatcher = createHibernateReleaseSetup(runner);
+      const result = await dispatcher.dispatch(makeHibernateIntent());
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/modules/windows-file-lock-module.ts
+++ b/src/modules/windows-file-lock-module.ts
@@ -1,10 +1,11 @@
 /**
- * WindowsFileLockModule — Handles Windows file lock detection/removal during workspace deletion.
+ * WindowsFileLockModule — Handles Windows file lock detection/removal during workspace deletion or hibernation.
  *
  * Hooks:
  * - delete-workspace → release: CWD-only scan + kill blocking processes (best-effort)
  * - delete-workspace → detect: full handle detection
  * - delete-workspace → flush: kill PIDs collected by detect
+ * - hibernate-workspace → release: CWD-only scan + kill blocking processes (best-effort)
  *
  * Detection uses blocking-processes.ps1 with Restart Manager API, NtQuerySystemInformation,
  * and taskkill for process termination.
@@ -24,6 +25,11 @@ import {
   type FlushHookResult,
   type FlushHookInput,
 } from "../intents/delete-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernatePipelineHookInput,
+  type HibernateReleaseHookResult,
+} from "../intents/hibernate-workspace";
 import { Path } from "../utils/path/path";
 import { getErrorMessage } from "../shared/error-utils";
 
@@ -334,29 +340,7 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
               return {};
             }
 
-            // CWD-only scan: find and kill processes whose CWD is under workspace
-            try {
-              const cwdProcesses = await runDetectAction(
-                deps.processRunner,
-                deps.scriptPath,
-                new Path(workspacePath),
-                "DetectCwd",
-                deps.logger
-              );
-              if (cwdProcesses.length > 0) {
-                deps.logger.info("Killing CWD-blocking processes before deletion", {
-                  workspacePath,
-                  pids: cwdProcesses.map((p) => p.pid).join(","),
-                });
-                await killBlockingProcesses(
-                  deps.processRunner,
-                  cwdProcesses.map((p) => p.pid),
-                  deps.logger
-                );
-              }
-            } catch {
-              // Non-fatal: CWD detection/kill failure shouldn't block deletion
-            }
+            await runCwdReleaseKill(deps, workspacePath, "deletion");
             return {};
           },
         },
@@ -396,6 +380,44 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
           },
         },
       },
+      [HIBERNATE_WORKSPACE_OPERATION_ID]: {
+        release: {
+          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+            const { workspacePath } = ctx as HibernatePipelineHookInput;
+            await runCwdReleaseKill(deps, workspacePath, "hibernation");
+            return {};
+          },
+        },
+      },
     },
   };
+}
+
+async function runCwdReleaseKill(
+  deps: WindowsFileLockModuleDeps,
+  workspacePath: string,
+  phase: "deletion" | "hibernation"
+): Promise<void> {
+  try {
+    const cwdProcesses = await runDetectAction(
+      deps.processRunner,
+      deps.scriptPath,
+      new Path(workspacePath),
+      "DetectCwd",
+      deps.logger
+    );
+    if (cwdProcesses.length > 0) {
+      deps.logger.info(`Killing CWD-blocking processes before ${phase}`, {
+        workspacePath,
+        pids: cwdProcesses.map((p) => p.pid).join(","),
+      });
+      await killBlockingProcesses(
+        deps.processRunner,
+        cwdProcesses.map((p) => p.pid),
+        deps.logger
+      );
+    }
+  } catch {
+    // Non-fatal: CWD detection/kill failure shouldn't block the operation
+  }
 }


### PR DESCRIPTION
- Hibernate now runs the same best-effort CWD-kill release hook that delete already runs
- User processes whose CWD is rooted under the workspace are terminated (SIGTERM on POSIX, taskkill on Windows) after the agent server stops and before the hibernated metadata flag is persisted
- Errors during the kill are swallowed: hibernation never fails on cleanup