### PR TITLE
fix: navigation over woken up workspaces failed

### DIFF
--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -162,7 +162,9 @@ export function addWorkspace(
     p.path === projectPath
       ? {
           ...p,
-          workspaces: [...p.workspaces, workspace],
+          workspaces: p.workspaces.some((w) => w.path === workspace.path)
+            ? p.workspaces
+            : [...p.workspaces, workspace],
           // Update defaultBaseBranch if provided (remembers last-used branch for next workspace creation)
           ...(defaultBaseBranch !== undefined ? { defaultBaseBranch } : {}),
         }

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -34,6 +34,7 @@ import {
   getAllWorkspaces,
   findWorkspaceIndex,
   wrapIndex,
+  getWorkspaceRefByIndex,
 } from "./projects.svelte.js";
 
 describe("projects store", () => {
@@ -237,6 +238,59 @@ describe("projects store", () => {
       addWorkspace("/test/project" as ProjectPath, newWorkspace, "feature/new-base");
 
       expect(projects.value[0]?.defaultBaseBranch).toBe("feature/new-base");
+    });
+
+    // Regression: wake/reopen path emits workspace:created for an already-known
+    // workspace, causing addWorkspace to be called for a path that already
+    // exists in the project's workspaces array. The duplicate entry produces
+    // phantom indices that break Alt+X arrow navigation (the duplicate sits
+    // adjacent to the original, so ↓ targets a ref whose path equals the
+    // current workspace, yielding a no-op switch).
+    it("does not duplicate workspace when added twice with the same path", () => {
+      const ws = createMockWorkspace({ path: "/test/project/.worktrees/ws1" });
+      const project = createMockProject({
+        path: "/test/project" as ProjectPath,
+        workspaces: [ws],
+      });
+      addProject(project);
+
+      addWorkspace("/test/project" as ProjectPath, ws);
+
+      expect(projects.value[0]?.workspaces).toHaveLength(1);
+    });
+
+    it("keeps arrow navigation consistent after a wake/reopen re-adds an existing workspace", () => {
+      // Reproduce the user-reported sidebar layout:
+      //   project A: ws-a
+      //   project B: ws-b (idle), ws-c (idle), ws-d (idle)
+      // Wake/reopen of ws-b re-adds it to project B, producing a duplicate
+      // entry between ws-b and ws-c. Arrow-down from ws-b would then target
+      // the duplicate (path === ws-b.path) instead of ws-c.
+      const wsA = createMockWorkspace({ path: "/A/.worktrees/ws-a" });
+      const wsB = createMockWorkspace({ path: "/B/.worktrees/ws-b" });
+      const wsC = createMockWorkspace({ path: "/B/.worktrees/ws-c" });
+      const wsD = createMockWorkspace({ path: "/B/.worktrees/ws-d" });
+      addProject(createMockProject({ path: "/A" as ProjectPath, workspaces: [wsA] }));
+      addProject(createMockProject({ path: "/B" as ProjectPath, workspaces: [wsB, wsC, wsD] }));
+
+      // Simulate the renderer-side handler of workspace:created with reopened=true
+      // (see src/renderer/lib/utils/domain-events.ts:120 — it calls addWorkspace
+      // unconditionally regardless of the reopened flag).
+      addWorkspace("/B" as ProjectPath, wsB);
+
+      // The flat workspace list backing both navigation and the sidebar's
+      // index-to-jump-key mapping must contain each path exactly once.
+      const all = getAllWorkspaces();
+      const paths = all.map((w) => w.path);
+      expect(new Set(paths).size).toBe(paths.length);
+      expect(all).toHaveLength(4);
+
+      // Concrete navigation symptom: from ws-b, ↓ must land on ws-c, not ws-b.
+      const currentIndex = findWorkspaceIndex(wsB.path);
+      expect(currentIndex).toBeGreaterThanOrEqual(0);
+      const nextIndex = wrapIndex(currentIndex + 1, all.length);
+      const nextRef = getWorkspaceRefByIndex(nextIndex);
+      expect(nextRef?.path).toBe(wsC.path);
     });
   });
 


### PR DESCRIPTION
- De-duplicate workspaces in `addWorkspace` so the wake/reopen path (manual Alt+X+H or `experimental.load-on-resume`) does not insert phantom duplicate entries when `workspace:created` fires for an already-known path.
- Add regression tests covering the duplicate-path case and the resulting Alt+X arrow-navigation symptom (↓ from the affected workspace silently no-op'd because the duplicate sat at the next index with the same path).