### PR TITLE
fix: status went to idle on auto-compaction

### DIFF
--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -337,6 +337,44 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
     });
 
+    it("Stop between PreCompact and SessionStart stays busy", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      // Automatic compaction mid-turn: PreCompact while busy sets flag
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+      // Inner session ends (Stop) while compaction is in progress — must not go idle
+      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+      // Compaction continues with a fresh SessionStart, still busy
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
+    });
+
+    it("StopFailure between PreCompact and SessionStart stays busy", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
+      // Auto-compaction wrapper observes a non-zero exit during the swap
+      await sendHook(port, "StopFailure", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+
+      expect(statusChanges).toEqual(["idle", "busy"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
+    });
+
     it("manual compact: SessionStart goes idle normally", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -716,11 +716,18 @@ export class ClaudeCodeServerManager implements AgentServerManager {
 
     // Special handling for compaction flow:
     // PreCompact while busy sets flag (automatic compaction mid-turn).
+    // Stop/StopFailure between PreCompact and SessionStart is suppressed so the
+    // workspace doesn't blip to idle while compaction is running.
     // SessionStart during compaction stays busy instead of going idle.
     // Manual /compact starts from idle, so flag is NOT set and SessionStart goes idle normally.
     // Terminal hooks (WrapperEnd, SessionEnd) clear the flag as defensive cleanup.
     if (hookName === "PreCompact" && state.status === "busy") {
       state.ignoreNextSessionStart = true;
+    } else if (
+      (hookName === "Stop" || hookName === "StopFailure") &&
+      state.ignoreNextSessionStart
+    ) {
+      newStatus = null;
     } else if (hookName === "SessionStart" && state.ignoreNextSessionStart) {
       state.ignoreNextSessionStart = false;
       newStatus = "busy";


### PR DESCRIPTION
- Suppress Stop/StopFailure between PreCompact and SessionStart so workspace status stays busy during auto-compaction mid-turn
- Add integration tests covering both Stop and StopFailure variants of the sequence