### PR TITLE
fix: claude did not work when installed via npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ pnpm-debug.log*
 
 # Build artifacts
 *.vsix
+
+# Claude Code scheduler
+.claude/scheduled_tasks.lock

--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -223,7 +223,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args).toContain("--ide");
@@ -246,7 +249,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.env.CLAUDECODE).toBeNull();
@@ -290,7 +296,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args).toContain("Hello world");
@@ -335,7 +344,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       // Verify full multi-line prompt is received as a single argument
@@ -362,7 +374,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       // Without initial prompt, first non-continue arg should be a flag, not a prompt string
@@ -383,7 +398,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args).toContain("--dangerously-skip-permissions");
@@ -407,7 +425,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args).toContain("--allow-dangerously-skip-permissions");
@@ -429,7 +450,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args[0]).toBe("--continue");
@@ -450,7 +474,10 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const outputs = parseAllFakeClaudeOutputs(result.stdout);
       expect(outputs).toHaveLength(2);
       // First call has --continue
@@ -474,10 +501,139 @@ describe("ch-claude.cjs boundary tests", () => {
         tempDir.path
       );
 
-      expect(result.status).toBe(0);
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.args[0]).not.toBe("--continue");
     });
+  });
+});
+
+/**
+ * Create a fake claude.cmd shim (mimics npm-installed claude on Windows).
+ * The .cmd forwards %* to a Node script — the same pattern npm uses for
+ * global bin shims when no native .exe is present.
+ */
+async function createFakeClaudeCmdShim(binDir: string): Promise<string> {
+  await mkdir(binDir, { recursive: true });
+
+  const fakeScriptPath = join(binDir, "fake-claude.cjs");
+  const fakeNodeContent = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+if (process.argv.includes("--version")) {
+  console.log("fake-claude 1.0.0");
+  process.exit(0);
+}
+
+const output = {
+  args: process.argv.slice(2),
+  env: { CLAUDECODE: process.env.CLAUDECODE ?? null },
+};
+
+const counterFile = process.env.CLAUDE_COUNTER_FILE;
+let callIndex = 0;
+if (counterFile) {
+  try { callIndex = parseInt(fs.readFileSync(counterFile, "utf-8"), 10); } catch {}
+  fs.writeFileSync(counterFile, String(callIndex + 1));
+}
+
+const exitCodes = process.env.CLAUDE_EXIT_CODES;
+let exitCode = 0;
+if (exitCodes) {
+  const codes = exitCodes.split(",").map(Number);
+  exitCode = codes[callIndex] ?? codes[codes.length - 1] ?? 0;
+} else {
+  exitCode = parseInt(process.env.CLAUDE_EXIT_CODE || "0", 10);
+}
+
+console.log(JSON.stringify(output));
+process.exit(isNaN(exitCode) ? 0 : exitCode);
+`;
+  await writeFile(fakeScriptPath, fakeNodeContent);
+
+  // Embed the absolute path to fake-claude.cjs rather than relying on
+  // %~dp0 — when a .cmd is invoked through a PATH lookup, %~dp0 can
+  // resolve to the caller's CWD rather than the script's directory.
+  const cmdContent = `@echo off\r\nnode "${fakeScriptPath}" %*\r\n`;
+  await writeFile(join(binDir, "claude.cmd"), cmdContent);
+
+  return binDir;
+}
+
+describe.skipIf(!isWindows)("ch-claude.cjs Windows .cmd shim (npm install)", () => {
+  let tempDir: { path: string; cleanup: () => Promise<void> };
+  let cmdBinDir: string;
+
+  beforeAll(async () => {
+    try {
+      await access(COMPILED_SCRIPT_PATH, constants.R_OK);
+    } catch {
+      throw new Error(
+        `Compiled script not found at ${COMPILED_SCRIPT_PATH}. Run 'pnpm build:wrappers' first.`
+      );
+    }
+  });
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    cmdBinDir = await createFakeClaudeCmdShim(join(tempDir.path, "bin"));
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  it("discovers and spawns claude.cmd when no claude.exe exists", async () => {
+    const result = await executeScript(
+      COMPILED_SCRIPT_PATH,
+      {
+        _CH_CLAUDE_SETTINGS: "/tmp/settings.json",
+        _CH_CLAUDE_MCP_CONFIG: "/tmp/mcp.json",
+        PATH: buildPath(cmdBinDir),
+      },
+      tempDir.path
+    );
+
+    expect(
+      result.status,
+      `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+    ).toBe(0);
+    const output = parseFakeClaudeOutput(result.stdout);
+    expect(output).not.toBeNull();
+    expect(output!.args).toContain("--ide");
+    expect(output!.args).toContain("--settings");
+    expect(output!.args).toContain("/tmp/settings.json");
+    expect(output!.args).toContain("--mcp-config");
+    expect(output!.args).toContain("/tmp/mcp.json");
+  });
+
+  it("forwards initial-prompt argument through .cmd shim intact", async () => {
+    const promptDir = join(tempDir.path, "prompt-dir");
+    await mkdir(promptDir, { recursive: true });
+    const promptFile = join(promptDir, "initial-prompt.json");
+    await writeFile(promptFile, JSON.stringify({ prompt: "hello world" }));
+
+    const result = await executeScript(
+      COMPILED_SCRIPT_PATH,
+      {
+        _CH_CLAUDE_SETTINGS: "/tmp/settings.json",
+        _CH_CLAUDE_MCP_CONFIG: "/tmp/mcp.json",
+        _CH_INITIAL_PROMPT_FILE: promptFile,
+        PATH: buildPath(cmdBinDir),
+      },
+      tempDir.path
+    );
+
+    expect(
+      result.status,
+      `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+    ).toBe(0);
+    const output = parseFakeClaudeOutput(result.stdout);
+    expect(output).not.toBeNull();
+    expect(output!.args).toContain("hello world");
   });
 });

--- a/src/modules/agent-module/claude/wrapper.ts
+++ b/src/modules/agent-module/claude/wrapper.ts
@@ -156,6 +156,8 @@ export interface SpawnResult {
 export interface RunClaudeOptions {
   /** Skip the automatic --continue attempt (new workspace with no prior session) */
   skipContinue?: boolean;
+  /** Spawn through a shell (required on Windows when invoking .cmd/.bat shims) */
+  useShell?: boolean;
 }
 
 /**
@@ -170,15 +172,43 @@ interface SpawnSyncResult {
  * Dependencies for runClaude that can be injected for testing.
  */
 export interface RunClaudeDeps {
-  spawnSync: (command: string, args: string[], options: { stdio: "inherit" }) => SpawnSyncResult;
+  spawnSync: (
+    command: string,
+    args: string[],
+    options: { stdio: "inherit"; shell: boolean }
+  ) => SpawnSyncResult;
+}
+
+/**
+ * Quote an argument for cmd.exe. Wraps in double quotes and doubles any
+ * embedded quotes so cmd.exe parses it as a single token. Used together
+ * with windowsVerbatimArguments to bypass Node's arg mangling.
+ */
+function quoteForCmd(arg: string): string {
+  return `"${arg.replace(/"/g, '""')}"`;
 }
 
 /**
  * Default dependencies using real implementations.
+ *
+ * Node's `shell: true` joins the file + args with single spaces and wraps the
+ * whole line in one outer pair of quotes — it does NOT quote individual args.
+ * Args containing spaces (like a prompt "hello world") therefore get split
+ * by cmd.exe's tokenizer. Pre-quote each arg ourselves so the inner tokens
+ * survive cmd.exe's parse after /S strips the outer pair.
  */
 const defaultDeps: RunClaudeDeps = {
   spawnSync: (command, args, options) => {
-    const result = spawnSync(command, args, { ...options, shell: false });
+    if (options.shell && process.platform === "win32") {
+      const quotedCommand = quoteForCmd(command);
+      const quotedArgs = args.map(quoteForCmd);
+      const result = spawnSync(quotedCommand, quotedArgs, {
+        stdio: "inherit",
+        shell: true,
+      });
+      return { status: result.status, error: result.error };
+    }
+    const result = spawnSync(command, args, options);
     return { status: result.status, error: result.error };
   },
 };
@@ -216,10 +246,13 @@ export function runClaude(
   options: RunClaudeOptions,
   deps: RunClaudeDeps = defaultDeps
 ): SpawnResult {
+  const shell = options.useShell ?? false;
+
   // Check if user already passed resume flags or skipContinue is set
   if (hasUserResumeFlag(baseArgs) || options.skipContinue) {
     const result = deps.spawnSync(claudeBinary, baseArgs, {
       stdio: "inherit",
+      shell,
     });
     return {
       exitCode: result.status,
@@ -231,6 +264,7 @@ export function runClaude(
   const continueArgs = ["--continue", ...baseArgs];
   const firstResult = deps.spawnSync(claudeBinary, continueArgs, {
     stdio: "inherit",
+    shell,
   });
 
   // If successful, return
@@ -244,6 +278,7 @@ export function runClaude(
   // Retry without --continue
   const retryResult = deps.spawnSync(claudeBinary, baseArgs, {
     stdio: "inherit",
+    shell,
   });
 
   return {
@@ -290,16 +325,35 @@ function getUserArgs(): string[] {
 
 /**
  * Find the system-installed claude binary.
- * Uses --version to verify the binary is executable and functional.
- * Returns the binary name (not full path) - spawn uses PATH resolution.
+ *
+ * On Windows we probe explicit extensions because npm-installed claude only
+ * drops a `claude.cmd` shim (no `.exe`), and `.cmd` files require `shell: true`
+ * for spawnSync (Node refuses direct execution since CVE-2024-27980).
+ *
+ * Returns the command name and whether spawn must go through a shell, or null
+ * when no working binary is found on PATH.
  */
-function findSystemClaude(): string | null {
-  try {
-    execSync("claude --version", { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
-    return "claude"; // Binary name, not full path - spawn will use PATH resolution
-  } catch {
-    return null;
+function findSystemClaude(): { command: string; useShell: boolean } | null {
+  const candidates =
+    process.platform === "win32"
+      ? [
+          { command: "claude.exe", useShell: false },
+          { command: "claude.cmd", useShell: true },
+        ]
+      : [{ command: "claude", useShell: false }];
+
+  for (const candidate of candidates) {
+    try {
+      execSync(`${candidate.command} --version`, {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return candidate;
+    } catch {
+      // Try next candidate
+    }
   }
+  return null;
 }
 
 /**
@@ -439,8 +493,9 @@ async function main(): Promise<never> {
 
   // 8. Spawn Claude with automatic session resume
   // Skip --continue attempt for new workspaces (no prior session to resume)
-  const result = runClaude(claudeBinary, args, {
+  const result = runClaude(claudeBinary.command, args, {
     skipContinue: consumeNoSessionMarker(),
+    useShell: claudeBinary.useShell,
   });
 
   // 9. Notify wrapper end (Claude has exited)


### PR DESCRIPTION
- Probe explicit binary names on Windows (`claude.exe`, then `claude.cmd`) so the wrapper finds an npm-installed Claude shim that has no native `.exe`.
- Spawn `.cmd` shims through `shell: true` with pre-quoted args so prompts containing spaces survive cmd.exe's tokenizer.
- Boundary tests covering the npm-on-Windows install: discovery + arg forwarding through the `.cmd` shim.