### PR TITLE
fix: deletion dialog was showing stale unmerged commits

### DIFF
--- a/extensions/sidekick/api.d.ts
+++ b/extensions/sidekick/api.d.ts
@@ -201,7 +201,7 @@ export interface WorkspaceApi {
    * }
    * ```
    */
-  getStatus(): Promise<WorkspaceStatus>;
+  getStatus(options?: { refresh?: boolean }): Promise<WorkspaceStatus>;
 
   /**
    * Get the agent session info for this workspace.

--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { io } from "socket.io-client";
 import cssColorNames from "color-name";
-import type { CodehydraApi } from "../api";
+import type { CodehydraApi, WorkspaceStatus } from "../api";
 import type {
   TypedSocket,
   PluginResult,
@@ -353,8 +353,11 @@ const codehydraApi = {
    * All methods require the connection to be established (use whenReady() first).
    */
   workspace: {
-    getStatus() {
-      return emitApiCall("api:workspace:getStatus");
+    getStatus(options?: { refresh?: boolean }) {
+      return emitApiCall<WorkspaceStatus>(
+        "api:workspace:getStatus",
+        options !== undefined ? options : undefined
+      );
     },
 
     getAgentSession() {

--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -42,6 +42,10 @@ export interface SetMetadataRequest {
   readonly value: string | null;
 }
 
+export interface GetWorkspaceStatusRequest {
+  readonly refresh?: boolean;
+}
+
 export interface LogRequest {
   readonly level: "silly" | "debug" | "info" | "warn" | "error";
   readonly message: string;
@@ -136,7 +140,10 @@ export interface ServerToClientEvents {
 }
 
 export interface ClientToServerEvents {
-  "api:workspace:getStatus": (ack: (result: PluginResult<WorkspaceStatus>) => void) => void;
+  "api:workspace:getStatus": (
+    request: GetWorkspaceStatusRequest | undefined,
+    ack: (result: PluginResult<WorkspaceStatus>) => void
+  ) => void;
   "api:workspace:getMetadata": (
     ack: (result: PluginResult<Record<string, string>>) => void
   ) => void;

--- a/src/intents/get-workspace-status.ts
+++ b/src/intents/get-workspace-status.ts
@@ -14,6 +14,7 @@ import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import { INTENT_GET_PROJECT_BASES, type GetProjectBasesIntent } from "./get-project-bases";
 
 // =============================================================================
 // Intent Types
@@ -21,6 +22,12 @@ import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve
 
 export interface GetWorkspaceStatusPayload {
   readonly workspacePath: string;
+  /**
+   * If true, fetch remotes (via project:get-bases with refresh+wait) before
+   * reading status. Best-effort: fetch failures are swallowed and the status
+   * is read against possibly-stale local refs.
+   */
+  readonly refresh?: boolean;
 }
 
 export interface GetWorkspaceStatusIntent extends Intent<WorkspaceStatus> {
@@ -67,12 +74,25 @@ export class GetWorkspaceStatusOperation implements Operation<
     const { payload } = ctx.intent;
 
     // 1. Dispatch shared workspace resolution
-    await ctx.dispatch({
+    const { projectPath } = await ctx.dispatch({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath: payload.workspacePath },
     } as ResolveWorkspaceIntent);
 
-    // 2. get — each handler contributes its piece
+    // 2. Optional refresh — fetch remotes so unmerged-commit counts reflect
+    // server-merged branches. Best-effort; errors are swallowed.
+    if (payload.refresh) {
+      try {
+        await ctx.dispatch({
+          type: INTENT_GET_PROJECT_BASES,
+          payload: { projectPath, refresh: true, wait: true },
+        } as GetProjectBasesIntent);
+      } catch {
+        // Fall through to status read with possibly-stale refs.
+      }
+    }
+
+    // 3. get — each handler contributes its piece
     const getCtx: GetStatusHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -480,16 +480,21 @@ export class McpServer implements IMcpServer {
       "workspace_get_status",
       {
         description: "Get the current workspace status including dirty flag and agent status",
-        inputSchema: z.object({}),
+        inputSchema: z.object({ refresh: z.boolean().optional() }),
       },
-      this.createWorkspaceHandler(async (workspacePath) => {
-        const result = await this.dispatcher.dispatch({
-          type: INTENT_GET_WORKSPACE_STATUS,
-          payload: { workspacePath },
-        } as GetWorkspaceStatusIntent);
-        if (!result) throw new Error("Get workspace status dispatch returned no result");
-        return result;
-      })
+      this.createWorkspaceHandler(
+        async (workspacePath, args: { refresh?: boolean | undefined }) => {
+          const result = await this.dispatcher.dispatch({
+            type: INTENT_GET_WORKSPACE_STATUS,
+            payload: {
+              workspacePath,
+              ...(typeof args.refresh === "boolean" && { refresh: args.refresh }),
+            },
+          } as GetWorkspaceStatusIntent);
+          if (!result) throw new Error("Get workspace status dispatch returned no result");
+          return result;
+        }
+      )
     );
 
     // workspace_get_metadata

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -24,7 +24,7 @@ import type { Logger } from "../boundaries/platform/logging-types";
 import { SILENT_LOGGER, logAtLevel } from "../boundaries/platform/logging";
 import { LogLevel } from "../boundaries/platform/logging-types";
 import type { PortManager } from "../boundaries/platform/network";
-import type { Workspace } from "../shared/api/types";
+import type { Workspace, WorkspaceStatus } from "../shared/api/types";
 import type {
   ServerToClientEvents,
   ClientToServerEvents,
@@ -38,6 +38,7 @@ import type {
   DeleteWorkspaceResponse,
   ExecuteCommandRequest,
   WorkspaceCreateRequest,
+  GetWorkspaceStatusRequest,
   LogContext,
   ShowNotificationRequest,
   ShowNotificationResponse,
@@ -55,6 +56,7 @@ import {
   validateExecuteCommandRequest,
   validateOpenSystemPathRequest,
   validateWorkspaceCreateRequest,
+  validateGetWorkspaceStatusRequest,
   validateLogRequest,
 } from "../shared/plugin-protocol";
 import type { OpenSystemPathRequest } from "../shared/plugin-protocol";
@@ -565,17 +567,26 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
     // No-arg handlers
     socket.on(
       "api:workspace:getStatus",
-      createNoArgHandler("api:workspace:getStatus", workspacePath, async () => {
-        const intent: GetWorkspaceStatusIntent = {
-          type: INTENT_GET_WORKSPACE_STATUS,
-          payload: { workspacePath },
-        };
-        const result = await dispatcher.dispatch(intent);
-        if (!result) {
-          throw new Error("Get workspace status dispatch returned no result");
-        }
-        return result;
-      })
+      createValidatedHandler<
+        GetWorkspaceStatusRequest | undefined,
+        GetWorkspaceStatusRequest,
+        WorkspaceStatus
+      >("api:workspace:getStatus", workspacePath, validateGetWorkspaceStatusRequest, (req) =>
+        handlePluginApiCall(workspacePath, "getStatus", async () => {
+          const intent: GetWorkspaceStatusIntent = {
+            type: INTENT_GET_WORKSPACE_STATUS,
+            payload: {
+              workspacePath,
+              ...(req.refresh !== undefined && { refresh: req.refresh }),
+            },
+          };
+          const result = await dispatcher.dispatch(intent);
+          if (!result) {
+            throw new Error("Get workspace status dispatch returned no result");
+          }
+          return result;
+        })
+      )
     );
 
     socket.on(

--- a/src/modules/plugin-server.boundary.test.ts
+++ b/src/modules/plugin-server.boundary.test.ts
@@ -20,7 +20,7 @@ import {
   type TestClientSocket,
 } from "./plugin-server.test-utils";
 import type { WorkspaceStatus } from "../shared/api/types";
-import type { PluginConfig } from "../shared/plugin-protocol";
+import type { PluginConfig, PluginResult } from "../shared/plugin-protocol";
 import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
 import { INTENT_GET_AGENT_SESSION } from "../intents/get-agent-session";
 import { INTENT_SET_METADATA } from "../intents/set-metadata";
@@ -264,7 +264,9 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         data?: WorkspaceStatus;
         error?: string;
       }>((resolve) => {
-        client.emit("api:workspace:getStatus", (res) => resolve(res));
+        client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+          resolve(res)
+        );
       });
 
       expect(result.success).toBe(true);
@@ -431,7 +433,9 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       await waitForConnect(client);
 
       await new Promise<{ success: boolean }>((resolve) => {
-        client.emit("api:workspace:getStatus", (res) => resolve(res));
+        client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+          resolve(res)
+        );
       });
 
       expect(env.mockDispatch).toHaveBeenCalledWith(
@@ -458,10 +462,14 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       // Make concurrent calls
       const [result1, result2] = await Promise.all([
         new Promise<{ success: boolean }>((resolve) => {
-          client1.emit("api:workspace:getStatus", (res) => resolve(res));
+          client1.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+            resolve(res)
+          );
         }),
         new Promise<{ success: boolean }>((resolve) => {
-          client2.emit("api:workspace:getStatus", (res) => resolve(res));
+          client2.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+            resolve(res)
+          );
         }),
       ]);
 
@@ -486,13 +494,19 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       // Make rapid sequential calls
       const results = await Promise.all([
         new Promise<{ success: boolean }>((resolve) => {
-          client.emit("api:workspace:getStatus", (res) => resolve(res));
+          client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+            resolve(res)
+          );
         }),
         new Promise<{ success: boolean }>((resolve) => {
-          client.emit("api:workspace:getStatus", (res) => resolve(res));
+          client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+            resolve(res)
+          );
         }),
         new Promise<{ success: boolean }>((resolve) => {
-          client.emit("api:workspace:getStatus", (res) => resolve(res));
+          client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+            resolve(res)
+          );
         }),
       ]);
 
@@ -512,7 +526,9 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       await waitForConnect(client);
 
       const result = await new Promise<{ success: boolean; error?: string }>((resolve) => {
-        client.emit("api:workspace:getStatus", (res) => resolve(res));
+        client.emit("api:workspace:getStatus", undefined, (res: PluginResult<WorkspaceStatus>) =>
+          resolve(res)
+        );
       });
 
       expect(result.success).toBe(false);

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -19,6 +19,7 @@ import type {
   WorkspaceRemovePayload,
   WorkspaceSetMetadataPayload,
   WorkspaceGetPayload,
+  WorkspaceGetStatusPayload,
   UiSwitchWorkspacePayload,
   UiSetModePayload,
 } from "../shared/ipc";
@@ -491,10 +492,13 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
   });
 
   registerIpc(ApiIpcChannels.WORKSPACE_GET_STATUS, async (payload) => {
-    const p = payload as WorkspaceGetPayload;
+    const p = payload as WorkspaceGetStatusPayload;
     const intent: GetWorkspaceStatusIntent = {
       type: INTENT_GET_WORKSPACE_STATUS,
-      payload: { workspacePath: p.workspacePath },
+      payload: {
+        workspacePath: p.workspacePath,
+        ...(p.refresh !== undefined && { refresh: p.refresh }),
+      },
     };
     const result = await dispatcher.dispatch(intent);
     if (!result) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,8 +71,11 @@ contextBridge.exposeInMainWorld("api", {
         workspacePath,
         ...options,
       }),
-    getStatus: (workspacePath: string) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_STATUS, { workspacePath }),
+    getStatus: (workspacePath: string, options?: { refresh?: boolean }) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_STATUS, {
+        workspacePath,
+        ...(options?.refresh !== undefined && { refresh: options.refresh }),
+      }),
     getAgentSession: (workspacePath: string) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_AGENT_SESSION, { workspacePath }),
     setMetadata: (workspacePath: string, key: string, value: string | null) =>

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Dialog from "./Dialog.svelte";
   import Icon from "./Icon.svelte";
-  import { workspaces, type WorkspaceRef } from "$lib/api";
+  import { projects, workspaces, type WorkspaceRef } from "$lib/api";
   import { closeDialog } from "$lib/stores/dialogs.svelte.js";
-  import { getAllWorkspaces } from "$lib/stores/projects.svelte.js";
+  import { getAllWorkspaces, getProjectById } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
 
   const logger = createLogger("ui");
@@ -30,7 +30,8 @@
     return ws?.metadata?.base;
   });
 
-  // Check workspace status on mount
+  // Check workspace status on mount: fetch remotes first so unmerged-commit
+  // counts reflect server-merged branches, then read status.
   $effect(() => {
     if (!open) return;
 
@@ -38,22 +39,30 @@
     isDirty = false;
     unmergedCommits = 0;
 
-    workspaces
-      .getStatus(workspaceRef.path)
-      .then((status) => {
+    const projectPath = getProjectById(workspaceRef.projectId)?.path;
+
+    void (async () => {
+      if (projectPath !== undefined) {
+        try {
+          await projects.fetchBases(projectPath);
+        } catch {
+          // best-effort; fall through to status read with possibly stale data
+        }
+      }
+      try {
+        const status = await workspaces.getStatus(workspaceRef.path);
         isDirty = status.isDirty;
         unmergedCommits = status.unmergedCommits;
-      })
-      .catch(() => {
+      } catch {
         isDirty = false;
         unmergedCommits = 0;
-      })
-      .finally(() => {
+      } finally {
         isCheckingStatus = false;
         setTimeout(() => {
           document.querySelector<HTMLElement>(".dialog-actions vscode-button")?.focus();
         }, 0);
-      });
+      }
+    })();
   });
 
   // Handle form submission (fire-and-forget)
@@ -63,7 +72,7 @@
     // Progress is shown via DeletionProgressView in MainView
     void workspaces.remove(workspaceRef.path, {
       keepBranch,
-      ignoreWarnings: isDirty || unmergedCommits > 0,
+      ignoreWarnings: true,
     });
     closeDialog();
   }
@@ -125,7 +134,7 @@
 
   {#snippet actions()}
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <vscode-button disabled={isCheckingStatus} onclick={handleSubmit}>Remove</vscode-button>
+    <vscode-button onclick={handleSubmit}>Remove</vscode-button>
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
     <vscode-button secondary={true} onclick={handleCancel}>Cancel</vscode-button>
   {/snippet}

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Dialog from "./Dialog.svelte";
   import Icon from "./Icon.svelte";
-  import { projects, workspaces, type WorkspaceRef } from "$lib/api";
+  import { workspaces, type WorkspaceRef } from "$lib/api";
   import { closeDialog } from "$lib/stores/dialogs.svelte.js";
-  import { getAllWorkspaces, getProjectById } from "$lib/stores/projects.svelte.js";
+  import { getAllWorkspaces } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
 
   const logger = createLogger("ui");
@@ -30,8 +30,8 @@
     return ws?.metadata?.base;
   });
 
-  // Check workspace status on mount: fetch remotes first so unmerged-commit
-  // counts reflect server-merged branches, then read status.
+  // Check workspace status on mount. refresh:true tells the operation to fetch
+  // remotes first so unmerged-commit counts reflect server-merged branches.
   $effect(() => {
     if (!open) return;
 
@@ -39,30 +39,22 @@
     isDirty = false;
     unmergedCommits = 0;
 
-    const projectPath = getProjectById(workspaceRef.projectId)?.path;
-
-    void (async () => {
-      if (projectPath !== undefined) {
-        try {
-          await projects.fetchBases(projectPath);
-        } catch {
-          // best-effort; fall through to status read with possibly stale data
-        }
-      }
-      try {
-        const status = await workspaces.getStatus(workspaceRef.path);
+    workspaces
+      .getStatus(workspaceRef.path, { refresh: true })
+      .then((status) => {
         isDirty = status.isDirty;
         unmergedCommits = status.unmergedCommits;
-      } catch {
+      })
+      .catch(() => {
         isDirty = false;
         unmergedCommits = 0;
-      } finally {
+      })
+      .finally(() => {
         isCheckingStatus = false;
         setTimeout(() => {
           document.querySelector<HTMLElement>(".dialog-actions vscode-button")?.focus();
         }, 0);
-      }
-    })();
+      });
   });
 
   // Handle form submission (fire-and-forget)

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
@@ -7,9 +7,10 @@ import { render, screen, fireEvent } from "@testing-library/svelte";
 import type { ProjectId, WorkspaceName, WorkspaceRef } from "@shared/api/types";
 
 // Create mock functions with vi.hoisted
-const { mockRemoveWorkspace, mockGetStatus, mockCloseDialog } = vi.hoisted(() => ({
+const { mockRemoveWorkspace, mockGetStatus, mockFetchBases, mockCloseDialog } = vi.hoisted(() => ({
   mockRemoveWorkspace: vi.fn(),
   mockGetStatus: vi.fn(),
+  mockFetchBases: vi.fn(),
   mockCloseDialog: vi.fn(),
 }));
 
@@ -33,6 +34,9 @@ vi.mock("$lib/api", () => ({
     remove: mockRemoveWorkspace,
     getStatus: mockGetStatus,
   },
+  projects: {
+    fetchBases: mockFetchBases,
+  },
 }));
 
 // Mock $lib/stores/dialogs.svelte.js
@@ -51,6 +55,15 @@ vi.mock("$lib/stores/projects.svelte.js", () => ({
       projectId: "test-project-12345678",
     },
   ],
+  getProjectById: (id: string) =>
+    id === "test-project-12345678"
+      ? {
+          id: "test-project-12345678",
+          name: "project",
+          path: "/test/project",
+          workspaces: [],
+        }
+      : undefined,
 }));
 
 // Import component after mocks
@@ -94,6 +107,7 @@ describe("RemoveWorkspaceDialog component", () => {
       unmergedCommits: 0,
       agent: { type: "none" },
     });
+    mockFetchBases.mockResolvedValue({ bases: [] });
   });
 
   afterEach(() => {
@@ -157,7 +171,7 @@ describe("RemoveWorkspaceDialog component", () => {
       await vi.runAllTimersAsync();
     });
 
-    it("disables Remove button while checking status", async () => {
+    it("keeps Remove button enabled while checking status", async () => {
       mockGetStatus.mockImplementation(
         () =>
           new Promise((resolve) =>
@@ -170,15 +184,14 @@ describe("RemoveWorkspaceDialog component", () => {
 
       render(RemoveWorkspaceDialog, { props: defaultProps });
 
-      // vscode-button is a web component — Svelte sets the disabled property
       const buttons = document.querySelectorAll("vscode-button");
       const removeButton = buttons[0] as HTMLElement & { disabled?: boolean };
       expect(removeButton).toHaveTextContent("Remove");
-      expect(removeButton.disabled).toBe(true);
+      expect(removeButton.disabled).toBeFalsy();
 
       await vi.runAllTimersAsync();
 
-      expect(removeButton.disabled).toBe(false);
+      expect(removeButton.disabled).toBeFalsy();
     });
 
     it("shows warning box when workspace is dirty", async () => {
@@ -265,7 +278,7 @@ describe("RemoveWorkspaceDialog component", () => {
       // API uses keepBranch (inverted from old deleteBranch)
       expect(workspaces.remove).toHaveBeenCalledWith(testWorkspaceRef.path, {
         keepBranch: false,
-        ignoreWarnings: false,
+        ignoreWarnings: true,
       });
     });
 
@@ -287,7 +300,7 @@ describe("RemoveWorkspaceDialog component", () => {
 
       expect(workspaces.remove).toHaveBeenCalledWith(testWorkspaceRef.path, {
         keepBranch: true,
-        ignoreWarnings: false,
+        ignoreWarnings: true,
       });
     });
 

--- a/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.test.ts
@@ -7,10 +7,9 @@ import { render, screen, fireEvent } from "@testing-library/svelte";
 import type { ProjectId, WorkspaceName, WorkspaceRef } from "@shared/api/types";
 
 // Create mock functions with vi.hoisted
-const { mockRemoveWorkspace, mockGetStatus, mockFetchBases, mockCloseDialog } = vi.hoisted(() => ({
+const { mockRemoveWorkspace, mockGetStatus, mockCloseDialog } = vi.hoisted(() => ({
   mockRemoveWorkspace: vi.fn(),
   mockGetStatus: vi.fn(),
-  mockFetchBases: vi.fn(),
   mockCloseDialog: vi.fn(),
 }));
 
@@ -34,9 +33,6 @@ vi.mock("$lib/api", () => ({
     remove: mockRemoveWorkspace,
     getStatus: mockGetStatus,
   },
-  projects: {
-    fetchBases: mockFetchBases,
-  },
 }));
 
 // Mock $lib/stores/dialogs.svelte.js
@@ -55,15 +51,6 @@ vi.mock("$lib/stores/projects.svelte.js", () => ({
       projectId: "test-project-12345678",
     },
   ],
-  getProjectById: (id: string) =>
-    id === "test-project-12345678"
-      ? {
-          id: "test-project-12345678",
-          name: "project",
-          path: "/test/project",
-          workspaces: [],
-        }
-      : undefined,
 }));
 
 // Import component after mocks
@@ -107,7 +94,6 @@ describe("RemoveWorkspaceDialog component", () => {
       unmergedCommits: 0,
       agent: { type: "none" },
     });
-    mockFetchBases.mockResolvedValue({ bases: [] });
   });
 
   afterEach(() => {
@@ -149,7 +135,7 @@ describe("RemoveWorkspaceDialog component", () => {
       render(RemoveWorkspaceDialog, { props: defaultProps });
       await vi.runAllTimersAsync();
 
-      expect(workspaces.getStatus).toHaveBeenCalledWith(testWorkspaceRef.path);
+      expect(workspaces.getStatus).toHaveBeenCalledWith(testWorkspaceRef.path, { refresh: true });
     });
 
     it("shows spinner while checking status", async () => {

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -423,7 +423,7 @@ describe("Integration tests", () => {
       await waitFor(() => {
         expect(mockApi.workspaces.remove).toHaveBeenCalledWith(
           workspace.path, // workspacePath
-          { keepBranch: false, ignoreWarnings: false } // keepBranch (default is unchecked, so keepBranch=false)
+          { keepBranch: false, ignoreWarnings: true } // keepBranch (default is unchecked, so keepBranch=false)
         );
       });
 
@@ -601,7 +601,7 @@ describe("Integration tests", () => {
       // API was called
       expect(mockApi.workspaces.remove).toHaveBeenCalledWith(
         workspace.path, // workspacePath
-        { keepBranch: false, ignoreWarnings: false } // keepBranch default, ignoreWarnings default
+        { keepBranch: false, ignoreWarnings: true } // keepBranch default, ignoreWarnings default
       );
     });
   });

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -65,7 +65,7 @@ export interface Api {
         blockingPids?: readonly number[];
       }
     ): Promise<{ started: boolean }>;
-    getStatus(workspacePath: string): Promise<WorkspaceStatus>;
+    getStatus(workspacePath: string, options?: { refresh?: boolean }): Promise<WorkspaceStatus>;
     getAgentSession(workspacePath: string): Promise<unknown>;
     setMetadata(workspacePath: string, key: string, value: string | null): Promise<void>;
     getMetadata(workspacePath: string): Promise<Readonly<Record<string, string>>>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -123,9 +123,17 @@ export interface WorkspaceRemovePayload {
   readonly blockingPids?: readonly number[];
 }
 
-/** workspaces.getStatus, workspaces.getAgentSession, workspaces.getMetadata, workspaces.restartAgentServer */
+/** workspaces.getAgentSession, workspaces.getMetadata, workspaces.restartAgentServer */
 export interface WorkspaceGetPayload {
   readonly workspacePath: string;
+}
+
+/** workspaces.getStatus */
+export interface WorkspaceGetStatusPayload {
+  readonly workspacePath: string;
+  /** If true, fetch remotes before reading status so unmerged-commit counts
+   * reflect server-merged branches. Best-effort. */
+  readonly refresh?: boolean;
 }
 
 /** workspaces.setMetadata */

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -433,6 +433,44 @@ export function validateDeleteWorkspaceRequest(
   };
 }
 
+/**
+ * Request to get workspace status.
+ *
+ * Optional refresh flag triggers a remote fetch before reading status, so
+ * unmerged-commit counts reflect server-merged branches. Best-effort.
+ */
+export interface GetWorkspaceStatusRequest {
+  readonly refresh?: boolean;
+}
+
+/**
+ * Runtime validation for GetWorkspaceStatusRequest.
+ */
+export function validateGetWorkspaceStatusRequest(
+  payload: unknown
+): { valid: true; request: GetWorkspaceStatusRequest } | { valid: false; error: string } {
+  if (payload === undefined || payload === null) {
+    return { valid: true, request: {} };
+  }
+
+  if (typeof payload !== "object") {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if ("refresh" in request && typeof request.refresh !== "boolean") {
+    return { valid: false, error: "Field 'refresh' must be a boolean" };
+  }
+
+  return {
+    valid: true,
+    request: {
+      ...(typeof request.refresh === "boolean" && { refresh: request.refresh }),
+    },
+  };
+}
+
 // ============================================================================
 // UI Request/Response Types
 // ============================================================================
@@ -533,7 +571,10 @@ export interface ClientToServerEvents {
    *
    * @param ack - Acknowledgment callback with workspace status
    */
-  "api:workspace:getStatus": (ack: (result: PluginResult<WorkspaceStatus>) => void) => void;
+  "api:workspace:getStatus": (
+    request: GetWorkspaceStatusRequest | undefined,
+    ack: (result: PluginResult<WorkspaceStatus>) => void
+  ) => void;
 
   /**
    * Get the agent session info for the connected workspace.


### PR DESCRIPTION
- Add `refresh?: boolean` to the `workspace:get-status` intent; when set, dispatch `project:get-bases` with `refresh+wait` before reading status so unmerged-commit counts reflect server-merged branches (best-effort, fetch errors are swallowed)
- Expose the flag through the renderer IPC, MCP `workspace_get_status` tool input schema, and the plugin Socket.IO API (sidekick + plugin-server)
- Remove Workspace dialog: enable the Remove button while checking, always send `ignoreWarnings: true` (the dialog itself owns the warning surface), and replace the prior `fetchBases` + `getStatus` pair with a single `getStatus(path, { refresh: true })`