### PR TITLE
chore(actions): bump GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ description: Setup pnpm with caching
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - id: pnpm-cache
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -158,7 +158,7 @@ jobs:
           _CH_BUILD_VERSION: ${{ needs.prepare.outputs.version }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          pnpm pkg set "version=$_CH_BUILD_VERSION"
+          npm pkg set "version=$_CH_BUILD_VERSION"
           pnpm dist:${{ matrix.target }} -- --publish=never
 
       - name: Rename artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -41,7 +41,7 @@ jobs:
         working-directory: packages/npm
         run: pnpm pack
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Build PyPI package
         working-directory: packages/pypi

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -32,11 +32,11 @@ jobs:
 
       - run: pnpm site:build
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set package version
         working-directory: packages/pypi


### PR DESCRIPTION
- Bump `actions/configure-pages` v5 → v6
- Bump `actions/upload-pages-artifact` v4 → v5
- Bump `actions/deploy-pages` v4 → v5
- Bump `pnpm/action-setup` v4 → v6 (version inferred from packageManager field)
- Bump `astral-sh/setup-uv` v7 → v8.1.0 (no floating v8 tag available)