### PR TITLE
fix(bug-report): scroll textarea to top and tighten spacing before config

### DIFF
--- a/src/modules/bug-report-config-block.ts
+++ b/src/modules/bug-report-config-block.ts
@@ -54,7 +54,7 @@ export function buildConfigBlock(config: BuildDeps): ConfigBlock {
 
   // Cursor sits on the empty line right after the header.
   const prefix = `${HEADER}\n`;
-  const value = [prefix, "", "", OPEN, body, CLOSE, ""].join("\n");
+  const value = [prefix, "", OPEN, body, CLOSE, ""].join("\n");
 
   return { value, cursorOffset: prefix.length };
 }

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -86,6 +86,7 @@
     queueMicrotask(() => {
       node.focus();
       node.setSelectionRange(offset, offset);
+      node.scrollTop = 0;
     });
   }
 


### PR DESCRIPTION
- Reduce blank lines between header and config delimiter from 2 to 1
- Force textarea scrollTop to 0 after focus so dialog opens at the top