### PR TITLE
feat: hibernated workspaces are not jumpable

### DIFF
--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -217,7 +217,7 @@
                         class="workspace-btn"
                         aria-label={workspace.name + (shortcutModeActive ? shortcutHint : "")}
                       >
-                        {#if shortcutModeActive}
+                        {#if shortcutModeActive && !hibernated}
                           <vscode-badge
                             class="shortcut-badge"
                             class:badge-dimmed={displayIndex === null}

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -247,6 +247,29 @@ export function getWorkspaceRefByIndex(index: number): WorkspaceRef | undefined 
 }
 
 /**
+ * Get WorkspaceRef by global index (0-based) over awake workspaces only.
+ * Hibernated workspaces are skipped, so index N targets the (N+1)-th awake
+ * workspace. Used by number-key shortcuts where hibernated rows have no badge.
+ */
+export function getAwakeWorkspaceRefByIndex(index: number): WorkspaceRef | undefined {
+  let currentIndex = 0;
+  for (const project of projects.value) {
+    for (const workspace of project.workspaces) {
+      if (workspace.metadata?.["hibernated"] === "true") continue;
+      if (currentIndex === index) {
+        return {
+          projectId: project.id,
+          workspaceName: workspace.name as WorkspaceName,
+          path: workspace.path,
+        };
+      }
+      currentIndex++;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Find the index of a workspace by its path.
  * @returns 0-based index, or -1 if not found.
  */

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -32,6 +32,7 @@ import {
   removeWorkspace,
   reset,
   getAllWorkspaces,
+  getAwakeWorkspaceRefByIndex,
   findWorkspaceIndex,
   wrapIndex,
   getWorkspaceRefByIndex,
@@ -384,6 +385,29 @@ describe("projects store", () => {
     it("should-return-empty-array-when-no-projects", () => {
       const result = getAllWorkspaces();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("getAwakeWorkspaceRefByIndex", () => {
+    it("skips hibernated workspaces in the index sequence", () => {
+      const ws1 = createMockWorkspace({ path: "/test/p1/ws1", name: "ws1" });
+      const ws2 = createMockWorkspace({
+        path: "/test/p1/ws2",
+        name: "ws2",
+        metadata: { hibernated: "true" },
+      });
+      const ws3 = createMockWorkspace({ path: "/test/p1/ws3", name: "ws3" });
+
+      addProject(
+        createMockProject({
+          path: "/test/p1" as ProjectPath,
+          workspaces: [ws1, ws2, ws3],
+        })
+      );
+
+      expect(getAwakeWorkspaceRefByIndex(0)?.path).toBe("/test/p1/ws1");
+      expect(getAwakeWorkspaceRefByIndex(1)?.path).toBe("/test/p1/ws3");
+      expect(getAwakeWorkspaceRefByIndex(2)).toBeUndefined();
     });
   });
 

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -15,6 +15,7 @@ import { getDeletionStatus } from "./deletion.svelte";
 import {
   getAllWorkspaces,
   getWorkspaceRefByIndex,
+  getAwakeWorkspaceRefByIndex,
   findWorkspaceIndex,
   wrapIndex,
   activeWorkspacePath,
@@ -249,12 +250,13 @@ function findNextByStatusType(
 
 /**
  * Handle number key jump to specific workspace.
+ * Targets the Nth awake workspace (hibernated workspaces are unnumbered).
  * No-op if index out of range or switch in progress.
  * Does not focus workspace to keep shortcut mode active.
  */
 async function handleJump(key: JumpKey): Promise<void> {
   const index = jumpKeyToIndex(key);
-  const workspaceRef = getWorkspaceRefByIndex(index);
+  const workspaceRef = getAwakeWorkspaceRefByIndex(index);
   if (!workspaceRef) return;
   if (_switchingWorkspace) return;
 

--- a/src/renderer/lib/stores/shortcuts.test.ts
+++ b/src/renderer/lib/stores/shortcuts.test.ts
@@ -48,6 +48,10 @@ const mockProjectsStore = vi.hoisted(() => ({
     void index;
     return undefined;
   }),
+  getAwakeWorkspaceRefByIndex: vi.fn((index: number): MockWorkspaceRef | undefined => {
+    void index;
+    return undefined;
+  }),
   findWorkspaceIndex: vi.fn((path: string | null): number => {
     void path;
     return -1;
@@ -270,7 +274,9 @@ describe("shortcuts store", () => {
         { projectId: "test-project-12345678", workspaceName: "ws2", path: "/ws2" },
       ];
       mockProjectsStore.getAllWorkspaces.mockReturnValue(workspaces);
-      mockProjectsStore.getWorkspaceRefByIndex.mockImplementation((i: number) => workspaceRefs[i]);
+      mockProjectsStore.getAwakeWorkspaceRefByIndex.mockImplementation(
+        (i: number) => workspaceRefs[i]
+      );
 
       // Make switchWorkspace slow so we can test blur during switch
       let resolveSwitch: () => void;
@@ -739,7 +745,7 @@ describe("shortcuts store", () => {
         const workspaces = createWorkspaces(9);
         const workspaceRefs = createWorkspaceRefs(9);
         mockProjectsStore.getAllWorkspaces.mockReturnValue(workspaces);
-        mockProjectsStore.getWorkspaceRefByIndex.mockImplementation(
+        mockProjectsStore.getAwakeWorkspaceRefByIndex.mockImplementation(
           (i: number) => workspaceRefs[i]
         );
 
@@ -758,7 +764,7 @@ describe("shortcuts store", () => {
         const workspaces = createWorkspaces(10);
         const workspaceRefs = createWorkspaceRefs(10);
         mockProjectsStore.getAllWorkspaces.mockReturnValue(workspaces);
-        mockProjectsStore.getWorkspaceRefByIndex.mockImplementation(
+        mockProjectsStore.getAwakeWorkspaceRefByIndex.mockImplementation(
           (i: number) => workspaceRefs[i]
         );
 
@@ -775,7 +781,7 @@ describe("shortcuts store", () => {
         const workspaces = createWorkspaces(3);
         const workspaceRefs = createWorkspaceRefs(3);
         mockProjectsStore.getAllWorkspaces.mockReturnValue(workspaces);
-        mockProjectsStore.getWorkspaceRefByIndex.mockImplementation(
+        mockProjectsStore.getAwakeWorkspaceRefByIndex.mockImplementation(
           (i: number) => workspaceRefs[i]
         );
 
@@ -784,6 +790,27 @@ describe("shortcuts store", () => {
         handleShortcutKey("5");
 
         expect(mockApi.ui.switchWorkspace).not.toHaveBeenCalled();
+      });
+
+      it("should-target-awake-list-skipping-hibernated", async () => {
+        // 4 workspaces in list; getAwakeWorkspaceRefByIndex resolves index 1
+        // to ws3 (the second awake workspace) — proves jump uses the awake-only mapping.
+        const workspaces = createWorkspaces(4);
+        const workspaceRefs = createWorkspaceRefs(4);
+        mockProjectsStore.getAllWorkspaces.mockReturnValue(workspaces);
+        mockProjectsStore.getAwakeWorkspaceRefByIndex.mockImplementation((i: number) => {
+          // index 0 -> ws1, index 1 -> ws3 (skipping hibernated ws2)
+          if (i === 0) return workspaceRefs[0];
+          if (i === 1) return workspaceRefs[2];
+          return undefined;
+        });
+
+        enableShortcutMode();
+        handleShortcutKey("2");
+
+        await vi.waitFor(() => {
+          expect(mockApi.ui.switchWorkspace).toHaveBeenCalledWith("/ws3", false);
+        });
       });
     });
 

--- a/src/renderer/lib/utils/sidebar-utils.test.ts
+++ b/src/renderer/lib/utils/sidebar-utils.test.ts
@@ -54,6 +54,52 @@ describe("sidebar-utils", () => {
 
       expect(getWorkspaceGlobalIndex(projects, 2, 0)).toBe(3);
     });
+
+    it("returns null for hibernated workspace", () => {
+      const projects = [
+        createMockProject({
+          workspaces: [
+            { name: "w1" },
+            { name: "w2", metadata: { hibernated: "true" } },
+            { name: "w3" },
+          ],
+        }),
+      ];
+
+      expect(getWorkspaceGlobalIndex(projects, 0, 1)).toBe(null);
+    });
+
+    it("skips hibernated workspaces in numbering sequence", () => {
+      const projects = [
+        createMockProject({
+          workspaces: [
+            { name: "w1" },
+            { name: "w2", metadata: { hibernated: "true" } },
+            { name: "w3" },
+          ],
+        }),
+      ];
+
+      // w1 stays at 0; w3 takes index 1 (w2 is skipped)
+      expect(getWorkspaceGlobalIndex(projects, 0, 0)).toBe(0);
+      expect(getWorkspaceGlobalIndex(projects, 0, 2)).toBe(1);
+    });
+
+    it("skips hibernated across project boundaries", () => {
+      const projects = [
+        createMockProject({
+          id: "p1-12345678" as ProjectId,
+          workspaces: [{ name: "w1" }, { name: "w2", metadata: { hibernated: "true" } }],
+        }),
+        createMockProject({
+          id: "p2-12345678" as ProjectId,
+          workspaces: [{ name: "w3" }],
+        }),
+      ];
+
+      // p1 contributes only 1 awake workspace, so p2's first workspace is at index 1
+      expect(getWorkspaceGlobalIndex(projects, 1, 0)).toBe(1);
+    });
   });
 
   describe("formatIndexDisplay", () => {
@@ -71,6 +117,10 @@ describe("sidebar-utils", () => {
       expect(formatIndexDisplay(10)).toBe(null);
       expect(formatIndexDisplay(15)).toBe(null);
     });
+
+    it("returns null for null input (hibernated)", () => {
+      expect(formatIndexDisplay(null)).toBe(null);
+    });
   });
 
   describe("getShortcutHint", () => {
@@ -86,6 +136,10 @@ describe("sidebar-utils", () => {
     it("returns empty string for index > 9", () => {
       expect(getShortcutHint(10)).toBe("");
       expect(getShortcutHint(15)).toBe("");
+    });
+
+    it("returns empty string for null input (hibernated)", () => {
+      expect(getShortcutHint(null)).toBe("");
     });
   });
 

--- a/src/renderer/lib/utils/sidebar-utils.ts
+++ b/src/renderer/lib/utils/sidebar-utils.ts
@@ -1,35 +1,47 @@
 import type { Project } from "$lib/api";
 
 /**
- * Calculate the global index of a workspace across all projects.
- * Returns the sum of all workspaces in previous projects plus the workspace index.
+ * Calculate the global index of a workspace across all projects, counting
+ * only awake workspaces. Hibernated workspaces are skipped in the sequence
+ * and the function returns null when the target workspace itself is hibernated.
  */
 export function getWorkspaceGlobalIndex(
   projects: readonly Project[],
   projectIndex: number,
   workspaceIndex: number
-): number {
+): number | null {
+  const target = projects[projectIndex]?.workspaces[workspaceIndex];
+  if (target?.metadata?.["hibernated"] === "true") return null;
+
   let globalIndex = 0;
   for (let p = 0; p < projectIndex; p++) {
-    globalIndex += projects[p]?.workspaces.length ?? 0;
+    for (const w of projects[p]?.workspaces ?? []) {
+      if (w.metadata?.["hibernated"] !== "true") globalIndex++;
+    }
   }
-  return globalIndex + workspaceIndex;
+  const currentProjectWorkspaces = projects[projectIndex]?.workspaces ?? [];
+  for (let i = 0; i < workspaceIndex; i++) {
+    if (currentProjectWorkspaces[i]?.metadata?.["hibernated"] !== "true") globalIndex++;
+  }
+  return globalIndex;
 }
 
 /**
  * Format a global index as a shortcut key display.
- * Returns "1"-"9" for indices 0-8, "0" for index 9, null for 10+.
+ * Returns "1"-"9" for indices 0-8, "0" for index 9, null for 10+ or hibernated (null input).
  */
-export function formatIndexDisplay(globalIndex: number): string | null {
-  if (globalIndex > 9) return null; // No shortcut for 11+
+export function formatIndexDisplay(globalIndex: number | null): string | null {
+  if (globalIndex === null) return null;
+  if (globalIndex > 9) return null;
   return globalIndex === 9 ? "0" : String(globalIndex + 1);
 }
 
 /**
  * Get the shortcut hint for a workspace at a given global index.
  */
-export function getShortcutHint(globalIndex: number): string {
-  if (globalIndex > 9) return ""; // No shortcut
+export function getShortcutHint(globalIndex: number | null): string {
+  if (globalIndex === null) return "";
+  if (globalIndex > 9) return "";
   const key = globalIndex === 9 ? "0" : String(globalIndex + 1);
   return ` - Press ${key} to jump`;
 }


### PR DESCRIPTION
- Hibernated workspaces no longer receive a number badge in the sidebar shortcut overlay
- Number keys (1-9, 0) now target the Nth awake workspace globally, skipping hibernated ones
- Up/down arrow navigation still includes hibernated workspaces so they remain reachable for waking with `h`