### PR TITLE
fix: remove button was not auto-focused

### DIFF
--- a/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/RemoveWorkspaceDialog.svelte
@@ -51,9 +51,6 @@
       })
       .finally(() => {
         isCheckingStatus = false;
-        setTimeout(() => {
-          document.querySelector<HTMLElement>(".dialog-actions vscode-button")?.focus();
-        }, 0);
       });
   });
 
@@ -86,7 +83,14 @@
   const descriptionId = "remove-workspace-desc";
 </script>
 
-<Dialog {open} onClose={handleCancel} busy={false} {titleId} {descriptionId}>
+<Dialog
+  {open}
+  onClose={handleCancel}
+  busy={false}
+  {titleId}
+  {descriptionId}
+  initialFocusSelector="vscode-button"
+>
   {#snippet title()}
     <h2 id={titleId} class="ch-dialog-title">Remove Workspace</h2>
   {/snippet}


### PR DESCRIPTION
- Focus the Remove button immediately when the Remove Workspace dialog opens, instead of waiting for the workspace status check to finish.
- Use Dialog's `initialFocusSelector` so focus is set once on open and not stolen when `getStatus` resolves.