### PR TITLE
feat: workspace can be woken up with overlay icon

### DIFF
--- a/src/renderer/lib/components/HibernatedOverlay.svelte
+++ b/src/renderer/lib/components/HibernatedOverlay.svelte
@@ -9,6 +9,7 @@
 <script lang="ts">
   import * as api from "$lib/api";
   import Icon from "./Icon.svelte";
+  import { handleHibernateToggle } from "$lib/stores/shortcuts.svelte";
   import type { WorkspaceRef } from "$lib/api";
 
   interface Props {
@@ -35,16 +36,21 @@
   });
 </script>
 
-<div class="hibernated-overlay" aria-label="Workspace hibernated" role="img">
+<div class="hibernated-overlay">
   {#if screenshotUrl && !imageBroken}
     <img class="screenshot" src={screenshotUrl} alt="" onerror={() => (imageBroken = true)} />
   {/if}
   <div class="dim" aria-hidden="true"></div>
-  <div class="indicator">
-    <Icon name="debug-pause" size={48} />
+  <button
+    class="indicator"
+    type="button"
+    aria-label="Wake workspace"
+    onclick={() => void handleHibernateToggle()}
+  >
+    <Icon name="debug-start" size={48} />
     <span class="label">Hibernated</span>
-    <span class="hint">Press Alt+X then H to wake</span>
-  </div>
+    <span class="hint">Click or press Alt+X H to wake up</span>
+  </button>
 </div>
 
 <style>
@@ -86,6 +92,16 @@
     color: var(--ch-foreground);
     opacity: 0.8;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    background: transparent;
+    border: none;
+    padding: 8px;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .indicator:hover,
+  .indicator:focus-visible {
+    opacity: 1;
   }
 
   .label {

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -276,7 +276,7 @@ async function handleJump(key: JumpKey): Promise<void> {
  * Awake → hibernate (workspace stays in sidebar with sleeping indicator).
  * Hibernated → wake + re-open via workspace:open existingWorkspace flow.
  */
-async function handleHibernateToggle(): Promise<void> {
+export async function handleHibernateToggle(): Promise<void> {
   const ref = activeWorkspace.value;
   if (!ref) return;
 


### PR DESCRIPTION
- Replace pause icon on hibernated workspace overlay with a clickable play icon
- Click anywhere on the centered indicator to wake the workspace (reuses Alt+X H toggle)
- Update hint text to "Click or press Alt+X H to wake up"