### PR TITLE
fix: Stop preloading view for hibernated workspaces

### DIFF
--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -49,7 +49,10 @@ import type {
   HibernatePipelineHookInput,
   HibernateShutdownHookResult,
 } from "../intents/hibernate-workspace";
-import { HIBERNATE_WORKSPACE_OPERATION_ID } from "../intents/hibernate-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  HIBERNATED_METADATA_KEY,
+} from "../intents/hibernate-workspace";
 import type { WorkspaceCreatedEvent } from "../intents/open-workspace";
 import type { ProjectOpenedEvent, SelectFolderHookResult } from "../intents/open-project";
 import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
@@ -660,6 +663,12 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [EVENT_WORKSPACE_CREATED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as WorkspaceCreatedEvent).payload;
+          // Hibernated workspaces re-discovered on startup must not have a
+          // view created — otherwise the live WebContentsView occludes
+          // HibernatedOverlay, masking the wake-on-click affordance and
+          // leaving the sidebar's hibernated indicator out of sync with
+          // what the user sees in the pane.
+          if (payload.metadata?.[HIBERNATED_METADATA_KEY] === "true") return;
           viewManager.createWorkspaceView(
             payload.workspacePath,
             payload.workspaceUrl,

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -289,8 +289,11 @@ export async function handleHibernateToggle(): Promise<void> {
     if (isHibernated) {
       if (!project) return;
       // Snapshot the reactive metadata into a plain object — Svelte 5 $state
-      // proxies can't traverse Electron's structured-clone boundary.
+      // proxies can't traverse Electron's structured-clone boundary. Drop the
+      // hibernated flag here: wake clears it server-side, and shipping a stale
+      // "true" through reopen would resurface it in the workspace:created event.
       const metadataSnapshot: Record<string, string> = { ...(workspace.metadata ?? {}) };
+      delete metadataSnapshot["hibernated"];
       await api.workspaces.wake(ref.path);
       await api.workspaces.reopen(
         project.path,


### PR DESCRIPTION
- Skip view creation + URL preload in `view-module`'s `workspace:created` handler when `metadata.hibernated === "true"`, so on startup re-discovery a hibernated workspace no longer gets a live WebContentsView occluding `HibernatedOverlay` (which also masked the wake-on-click affordance and desynced the sidebar indicator from the pane).
- Drop the `hibernated` flag from the metadata snapshot `handleHibernateToggle` ships through `reopen`, preventing a stale `"true"` from re-riding `workspace:created` after `wake` clears it.