### PR TITLE
feat: other agents can be selected on workspace creation

### DIFF
--- a/planning/PER_WORKSPACE_AGENT_SELECTION.md
+++ b/planning/PER_WORKSPACE_AGENT_SELECTION.md
@@ -1,0 +1,148 @@
+# Per-Workspace Agent Selection
+
+## Goal
+
+Allow each workspace to use its own agent (claude / opencode), while keeping a
+single global default agent chosen at first startup.
+
+## User-Facing Behavior
+
+- First-startup picker stays as-is. Picks the **global default agent**;
+  downloads only that binary.
+- Create-workspace dialog: inside the existing collapsed "Advanced" section, a
+  dropdown lists agents whose binaries are currently present (initially: just
+  the default). Pre-selected value = global default.
+- Agent choice is **fixed at workspace creation**. No post-create switching.
+- Discovered/existing workspaces with no per-workspace agent metadata fall back
+  to the global default at runtime.
+- Additional agents are installed via a future settings UI (out of scope here).
+  Restart required to pick up newly installed agents.
+- No new badge/icon in the workspace list.
+
+## Storage
+
+- Per-workspace agent persisted via the existing **metadata-module** (git
+  worktree config), key `agent`.
+- Only written when the chosen agent **differs from `config.agent`**. Absent
+  key ⇒ fall back to `config.agent`.
+
+## Intent System Integration
+
+### New: workspace-agent-resolver module
+
+A small module that, for each workspace-scoped operation, runs an early handler
+that:
+
+1. Reads `agent` from workspace metadata; falls back to `config.agent`.
+2. For `workspace:create` only: if the intent payload's `agent` differs from
+   `config.agent`, writes it to metadata first.
+3. Emits an `agent` capability with the resolved value.
+
+Agent modules `requires: { agent: provider.type }` on the six
+workspace-scoped hooks — the dispatcher routes only the matching module.
+
+Operations it runs in:
+
+- `workspace:open` (setup)
+- `workspace:delete` (shutdown)
+- `workspace:hibernate` (shutdown)
+- `workspace:get-status` (get)
+- `workspace:get-agent-session` (get)
+- `workspace:restart-agent` (restart)
+
+### Changes in `src/modules/agent-module/agent-module.ts`
+
+- Remove `isActive()` and all six gates that use it (lines 166, 266, 291, 308,
+  319, 331, 343 in current file).
+- Each of the six workspace-scoped hooks declares
+  `requires: { agent: provider.type }`. Dispatcher handles routing.
+- `app:start` `start` hook: **no longer initializes** the provider. It only
+  stashes `mcpPort` into closure (still `requires: { mcpPort }`). No status
+  subscription here either.
+- `workspace:open` setup hook: **lazy init**. On first invocation for this
+  module:
+  - Call `provider.initialize(mcpPort)`.
+  - Subscribe to `provider.onStatusChange` and dispatch
+    `agent:update-status` intents.
+  - Set `initialized = true`.
+  - Then call `provider.startWorkspace(...)` as today.
+- `app:shutdown` stop hook: unchanged — still disposes the provider; safe even
+  when `initialized` is false.
+- `check-deps` (line 149) and setup `binary` (line 224) hooks: **unchanged**.
+  They still serve the first-run download of the default agent.
+
+### Intent payload changes
+
+- `OpenWorkspacePayload` gains optional field: `agent?: AgentType`.
+- `api:workspace:create` IPC payload gains optional `agent?: AgentType`.
+- Preload signature: `workspaces.create(projectPath, name, base, options?)`
+  options gains `agent?`.
+
+## IPC / Bootstrap
+
+Extend `api:lifecycle:ready` (currently returns `void`) to return:
+
+```ts
+{
+  defaultAgent: AgentType | null;
+  availableAgents: ReadonlyArray<{ type: AgentType; label: string; icon: string }>;
+}
+```
+
+- `defaultAgent` = `config.agent`.
+- `availableAgents` = registered agents filtered by `provider.preflight()`
+  reporting the binary as present. Computed once at startup; not re-queried.
+
+Scope deliberately tight: don't fold in other bootstrap data in this change.
+
+## Renderer Changes
+
+### Bootstrap
+
+- Store `{ defaultAgent, availableAgents }` returned from `lifecycle.ready()`
+  in a renderer store.
+
+### CreateWorkspaceDialog.svelte
+
+- In the existing collapsed "Advanced" section, add an agent dropdown:
+  - Options: `availableAgents` from the bootstrap store.
+  - Initial value: `defaultAgent`.
+  - If only one agent is available, the dropdown may still render (read-only
+    indicator) — finalize during implementation.
+- On submit, pass `agent` in the `options` argument **only when it differs
+  from `defaultAgent`**, so default-case calls stay identical to today.
+
+## Migration / Compatibility
+
+- No metadata migration. Workspaces created before this change have no `agent`
+  metadata key → resolver returns `config.agent` (= today's behavior).
+- IPC payload changes are additive (optional field). Backwards compatible.
+
+## Testing
+
+| Area                          | Test                                                                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Resolver module               | Integration: emits capability from metadata; falls back to config; writes metadata only when create payload's agent differs from default |
+| Agent module routing          | Integration: with two agent modules registered, only the one matching `agent` capability runs each workspace hook                        |
+| Lazy init                     | Integration: provider not initialized at `app:start`; initialized on first `workspace:open`; not re-initialized on subsequent opens      |
+| Status subscription           | Integration: status events emitted by a lazily-initialized provider reach the dispatcher                                                 |
+| Create dialog                 | Integration: dropdown reflects `availableAgents`; defaults to `defaultAgent`; submits agent only when non-default                        |
+| `lifecycle:ready` IPC         | Boundary: returns bootstrap payload with defaultAgent + filtered availableAgents                                                         |
+| Existing workspaces fall back | Integration: workspace with no `agent` metadata resolves to config.agent end-to-end                                                      |
+
+## Out of Scope
+
+- Settings UI to install additional agent binaries (separate work).
+- Changing a workspace's agent after creation.
+- Workspace-list agent badge/icon.
+- Per-agent capability divergence (e.g. agents that don't support plan mode).
+
+## Implementation Order
+
+1. Add `agent?: AgentType` to `OpenWorkspacePayload` and IPC types.
+2. Add workspace-agent-resolver module; register it ahead of agent modules.
+3. Change agent module hooks: lazy init in `workspace:open`; remove
+   `isActive()` gates in workspace-scoped hooks and add capability requires.
+4. Extend `api:lifecycle:ready` response + renderer store.
+5. Update CreateWorkspaceDialog to show the dropdown and pass `agent`.
+6. Tests at each step; `pnpm validate:fix` at the end.

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -23,6 +23,20 @@ import type { OpenProjectIntent } from "./open-project";
 import type { IntentModule } from "./lib/module";
 import type { Operation, OperationContext } from "./lib/operation";
 import type { Project } from "../shared/api/types";
+import type { Config } from "../boundaries/platform/config";
+
+function createStubConfig(): Config {
+  return {
+    register: () => {},
+    load: () => {},
+    get: () => null,
+    set: async () => {},
+    getDefinitions: () => new Map(),
+    getEffective: () => ({}),
+    getDefaults: () => ({}),
+    getHelpText: () => "",
+  };
+}
 
 // =============================================================================
 // Test Helpers
@@ -84,7 +98,7 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = new Dispatcher({ logger: createMockLogger() });
 
-  dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation());
+  dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(createStubConfig()));
   dispatcher.registerOperation(INTENT_OPEN_PROJECT, stub);
 
   for (const m of modules) dispatcher.registerModule(m);

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -16,6 +16,8 @@ import type { Intent, DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
 import { Path } from "../utils/path/path";
+import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
+import type { Config } from "../boundaries/platform/config";
 
 // =============================================================================
 // Intent Types
@@ -26,7 +28,17 @@ export interface AppReadyPayload {
   readonly [key: string]: never;
 }
 
-export interface AppReadyIntent extends Intent<void> {
+/**
+ * Bootstrap data the renderer needs immediately after lifecycle.ready().
+ */
+export interface AppReadyResult {
+  /** Global default agent (config.agent). Null when not yet chosen (first-run pending). */
+  readonly defaultAgent: LifecycleAgentType | null;
+  /** Agents whose binaries are currently present on disk. */
+  readonly availableAgents: readonly AgentInfo[];
+}
+
+export interface AppReadyIntent extends Intent<AppReadyResult> {
   readonly type: "app:ready";
   readonly payload: AppReadyPayload;
 }
@@ -59,25 +71,46 @@ export interface LoadProjectsResult {
   readonly projectPaths?: readonly string[];
 }
 
+/**
+ * Per-handler result for the "available-agents" hook point.
+ * Each agent module returns its `AgentInfo` only if its binary is present.
+ */
+export interface AvailableAgentsResult {
+  readonly agent?: AgentInfo;
+}
+
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class AppReadyOperation implements Operation<AppReadyIntent, void> {
+export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResult> {
   readonly id = APP_READY_OPERATION_ID;
 
-  async execute(ctx: OperationContext<AppReadyIntent>): Promise<void> {
+  constructor(private readonly configService: Config) {}
+
+  async execute(ctx: OperationContext<AppReadyIntent>): Promise<AppReadyResult> {
     const hookCtx: HookContext = { intent: ctx.intent };
 
-    // Collect saved project paths from modules
-    const { results, errors } = await ctx.hooks.collect<LoadProjectsResult>(
-      "load-projects",
-      hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
+    // Collect bootstrap data: available agents + saved project paths in parallel.
+    const [agentsResult, projectsResult] = await Promise.all([
+      ctx.hooks.collect<AvailableAgentsResult>("available-agents", hookCtx),
+      ctx.hooks.collect<LoadProjectsResult>("load-projects", hookCtx),
+    ]);
+    if (projectsResult.errors.length > 0) throw projectsResult.errors[0]!;
+    // available-agents errors are best-effort: an agent that fails preflight just
+    // doesn't appear in the list.
+
+    const availableAgents: AgentInfo[] = [];
+    for (const result of agentsResult.results) {
+      if (result.agent) availableAgents.push(result.agent);
+    }
+
+    const defaultAgentRaw = this.configService.get("agent") as string | null;
+    const defaultAgent: LifecycleAgentType | null =
+      defaultAgentRaw === "claude" || defaultAgentRaw === "opencode" ? defaultAgentRaw : null;
 
     const projectPaths: string[] = [];
-    for (const result of results) {
+    for (const result of projectsResult.results) {
       if (result.projectPaths) projectPaths.push(...result.projectPaths);
     }
 
@@ -96,5 +129,7 @@ export class AppReadyOperation implements Operation<AppReadyIntent, void> {
 
     // Signal that initial project:open dispatches are complete.
     ctx.emit({ type: EVENT_APP_STARTED, payload: {} });
+
+    return { defaultAgent, availableAgents };
   }
 }

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -69,6 +69,8 @@ export interface OpenWorkspacePayload {
   readonly projectPath: string;
   /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
   readonly source?: WorkspaceOpenSource;
+  /** Optional per-workspace agent override. When omitted, falls back to the global default. */
+  readonly agent?: AgentType;
 }
 
 export type OpenWorkspaceResult = Workspace;

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,6 +141,7 @@ import { createCodeServerModule } from "./modules/code-server-module";
 import { createPluginServerModule } from "./modules/plugin-server-module";
 import { createAgentModule } from "./modules/agent-module/agent-module";
 import { createMetadataModule } from "./modules/metadata-module";
+import { createWorkspaceAgentResolverModule } from "./modules/workspace-agent-resolver-module";
 import { createKeepFilesModule } from "./modules/keepfiles-module";
 import { createWindowsFileLockModule } from "./modules/windows-file-lock-module";
 import { createPosixProcessCleanupModule } from "./modules/posix-process-cleanup-module";
@@ -466,6 +467,11 @@ const opencodeAgentModule = createAgentModule(
 const metadataModule = createMetadataModule({
   gitWorktreeProvider,
 });
+const workspaceAgentResolverModule = createWorkspaceAgentResolverModule({
+  gitWorktreeProvider,
+  configService,
+  logger: loggingService.createLogger("agent-resolver"),
+});
 const keepFilesModule = createKeepFilesModule({
   fileSystem: fileSystemLayer,
   logger: loggingService.createLogger("keepfiles"),
@@ -619,7 +625,7 @@ const bugReportModule = createBugReportModule({
 dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
 dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(configService));
-dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation());
+dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(configService));
 // config:set-values operation removed — config is now a plain service
 dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
@@ -677,6 +683,7 @@ dispatcher.registerModule(viewModule);
 dispatcher.registerModule(pluginServerModule);
 dispatcher.registerModule(extensionModule);
 dispatcher.registerModule(codeServerModule);
+dispatcher.registerModule(workspaceAgentResolverModule);
 dispatcher.registerModule(claudeAgentModule);
 dispatcher.registerModule(opencodeAgentModule);
 dispatcher.registerModule(badgeModule);

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -254,9 +254,11 @@ class MinimalSetupOperation implements Operation<
 > {
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
   private readonly hookInput: Partial<SetupHookInput>;
+  private readonly agentCapability: string | null;
 
-  constructor(hookInput: Partial<SetupHookInput> = {}) {
+  constructor(hookInput: Partial<SetupHookInput> = {}, agentCapability: string | null = "claude") {
     this.hookInput = hookInput;
+    this.agentCapability = agentCapability;
   }
 
   async execute(
@@ -269,6 +271,9 @@ class MinimalSetupOperation implements Operation<
         workspacePath: "/test/workspace",
         projectPath: "/test/project",
         ...this.hookInput,
+        ...(this.agentCapability !== null && {
+          capabilities: { agent: this.agentCapability },
+        }),
       }
     );
     if (errors.length > 0) throw errors[0]!;
@@ -286,6 +291,11 @@ class MinimalShutdownOperation implements Operation<
   ShutdownHookResult | undefined
 > {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
+  private readonly agentCapability: string | null;
+
+  constructor(agentCapability: string | null = "claude") {
+    this.agentCapability = agentCapability;
+  }
 
   async execute(
     ctx: OperationContext<DeleteWorkspaceIntent>
@@ -295,6 +305,9 @@ class MinimalShutdownOperation implements Operation<
       intent: ctx.intent,
       projectPath: "/test/project",
       workspacePath: payload.workspacePath ?? "/test/workspace",
+      ...(this.agentCapability !== null && {
+        capabilities: { agent: this.agentCapability },
+      }),
     };
     const { results, errors } = await ctx.hooks.collect<ShutdownHookResult | undefined>(
       "shutdown",
@@ -448,40 +461,118 @@ describe("createAgentModule", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // start
+  // start (mcpPort capture; provider.initialize is now deferred to first workspace:open)
   // ---------------------------------------------------------------------------
 
   describe("start", () => {
-    it("calls provider.initialize with mcpConfig when active and port provided", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "claude");
+    it("does not initialize provider during app:start (lazy init)", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
       dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
+      expect(mockProvider.initialize).not.toHaveBeenCalled();
+      expect(mockProvider.onStatusChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // lazy init via workspace:open setup
+  // ---------------------------------------------------------------------------
+
+  describe("lazy init", () => {
+    it("initializes provider with captured mcpPort on first workspace:open", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678",
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as unknown as OpenWorkspaceIntent);
+
       expect(mockProvider.initialize).toHaveBeenCalledWith({ port: 9999 });
+      expect(mockProvider.onStatusChange).toHaveBeenCalled();
     });
 
-    it("calls provider.initialize with null when mcpPort is null", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "claude");
+    it("passes null mcpConfig when no mcpPort was captured", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
       dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(null));
-
       await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: {
+          projectId: "test-12345678",
+          workspaceName: "feature-1",
+          base: "main",
+        },
+      } as unknown as OpenWorkspaceIntent);
 
       expect(mockProvider.initialize).toHaveBeenCalledWith(null);
     });
 
-    it("subscribes to provider.onStatusChange when active", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+    it("only initializes once across multiple workspace:open calls", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      expect(mockProvider.onStatusChange).toHaveBeenCalled();
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "a", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "b", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
+
+      expect(mockProvider.initialize).toHaveBeenCalledTimes(1);
     });
 
     it("dispatches INTENT_UPDATE_AGENT_STATUS when onStatusChange fires", async () => {
-      const { dispatcher, mockConfig, moduleDeps } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, moduleDeps } = createTestSetup();
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "a", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
 
       expect(capturedStatusCallback).not.toBeNull();
 
@@ -493,23 +584,31 @@ describe("createAgentModule", () => {
       expect(dispatchSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: INTENT_UPDATE_AGENT_STATUS,
-          payload: {
-            workspacePath: "/test/workspace",
-            status,
-          },
+          payload: { workspacePath: "/test/workspace", status },
         })
       );
     });
 
-    it("does not call initialize when inactive", async () => {
+    it("does not initialize when agent capability does not match provider type", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      // No config:updated event -- module stays inactive
       dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation(
+          {
+            workspacePath: "/test/workspace",
+            projectPath: "/test/project",
+          },
+          "opencode"
+        )
+      );
 
       await dispatcher.dispatch({
-        type: "app:start",
-        payload: {},
-      });
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "a", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
 
       expect(mockProvider.initialize).not.toHaveBeenCalled();
     });
@@ -766,18 +865,18 @@ describe("createAgentModule", () => {
       });
     });
 
-    it("returns undefined when inactive", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
 
       dispatcher.registerOperation(
         "workspace:open",
-        new MinimalSetupOperation({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
-        })
+        new MinimalSetupOperation(
+          {
+            workspacePath: "/test/workspace",
+            projectPath: "/test/project",
+          },
+          "opencode"
+        )
       );
 
       const result = (await dispatcher.dispatch({
@@ -882,13 +981,10 @@ describe("createAgentModule", () => {
       ).rejects.toThrow("server busy");
     });
 
-    it("returns undefined when inactive", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
+      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation("opencode"));
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -925,7 +1021,13 @@ describe("createAgentModule", () => {
         createMinimalOperation<Intent, GetStatusHookResult | undefined>(
           GET_WORKSPACE_STATUS_OPERATION_ID,
           "get",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "claude" },
+            }),
+          }
         )
       );
 
@@ -938,18 +1040,21 @@ describe("createAgentModule", () => {
       expect(result!.agentStatus).toEqual(idleStatus);
     });
 
-    it("returns undefined when inactive", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher } = createTestSetup();
 
       dispatcher.registerOperation(
         "workspace:get-status",
         createMinimalOperation<Intent, GetStatusHookResult | undefined>(
           GET_WORKSPACE_STATUS_OPERATION_ID,
           "get",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "opencode" },
+            }),
+          }
         )
       );
 
@@ -976,7 +1081,13 @@ describe("createAgentModule", () => {
         createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
           "get",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "claude" },
+            }),
+          }
         )
       );
 
@@ -1000,7 +1111,13 @@ describe("createAgentModule", () => {
         createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
           "get",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "claude" },
+            }),
+          }
         )
       );
 
@@ -1013,18 +1130,21 @@ describe("createAgentModule", () => {
       expect(result!.session).toBeNull();
     });
 
-    it("returns undefined when inactive", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher } = createTestSetup();
 
       dispatcher.registerOperation(
         "agent:get-session",
         createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
           "get",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "opencode" },
+            }),
+          }
         )
       );
 
@@ -1051,7 +1171,13 @@ describe("createAgentModule", () => {
         createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
           "restart",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "claude" },
+            }),
+          }
         )
       );
 
@@ -1080,7 +1206,13 @@ describe("createAgentModule", () => {
         createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
           "restart",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "claude" },
+            }),
+          }
         )
       );
 
@@ -1092,18 +1224,21 @@ describe("createAgentModule", () => {
       ).rejects.toThrow("restart failed");
     });
 
-    it("returns undefined when inactive", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
 
       dispatcher.registerOperation(
         "agent:restart",
         createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
           "restart",
-          { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) }
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: "/test/workspace",
+              capabilities: { agent: "opencode" },
+            }),
+          }
         )
       );
 
@@ -1124,10 +1259,23 @@ describe("createAgentModule", () => {
   describe("stop", () => {
     it("cleans up statusChange subscription and disposes provider", async () => {
       const cleanupFn = vi.fn();
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup({
+      const { dispatcher, mockProvider } = createTestSetup({
         onStatusChange: vi.fn().mockReturnValue(cleanupFn),
       });
-      await activateModule(dispatcher, mockConfig);
+      // Initialize provider via lazy path so dispose has something to clean up.
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "a", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
 
       dispatcher.registerOperation(
         "app:shutdown",
@@ -1140,10 +1288,9 @@ describe("createAgentModule", () => {
       expect(mockProvider.dispose).toHaveBeenCalled();
     });
 
-    it("disposes provider even when inactive (cleanup is unconditional)", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+    it("skips dispose when provider was never initialized", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
@@ -1153,14 +1300,27 @@ describe("createAgentModule", () => {
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
 
-      expect(mockProvider.dispose).toHaveBeenCalled();
+      expect(mockProvider.dispose).not.toHaveBeenCalled();
     });
 
     it("collect catches stop error, dispatch still resolves", async () => {
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher } = createTestSetup({
         dispose: vi.fn().mockRejectedValue(new Error("dispose failed")),
       });
-      await activateModule(dispatcher, mockConfig);
+      // Initialize first so dispose runs
+      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+      dispatcher.registerOperation(
+        "workspace:open",
+        new MinimalSetupOperation({
+          workspacePath: "/test/workspace",
+          projectPath: "/test/project",
+        })
+      );
+      await dispatcher.dispatch({
+        type: "workspace:open",
+        payload: { projectId: "p1", workspaceName: "a", base: "main" },
+      } as unknown as OpenWorkspaceIntent);
 
       dispatcher.registerOperation(
         "app:shutdown",
@@ -1170,55 +1330,6 @@ describe("createAgentModule", () => {
       await expect(
         dispatcher.dispatch({ type: "app:shutdown", payload: {} })
       ).resolves.not.toThrow();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // config-based activation
-  // ---------------------------------------------------------------------------
-
-  describe("config-based activation", () => {
-    it("sets active=true when agent matches provider type", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "claude");
-
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
-
-      expect(mockProvider.initialize).toHaveBeenCalled();
-    });
-
-    it("sets active=false when agent does not match provider type", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", "opencode");
-
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
-
-      expect(mockProvider.initialize).not.toHaveBeenCalled();
-    });
-
-    it("does not activate claude module when agent is null", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await mockConfig.set("agent", null);
-
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
-
-      expect(mockProvider.initialize).not.toHaveBeenCalled();
-    });
-
-    it("does not activate opencode module when agent is null", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup({
-        type: "opencode",
-      });
-      await mockConfig.set("agent", null);
-
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
-      await dispatcher.dispatch({ type: "app:start", payload: {} });
-
-      // null agent does not match any provider type
-      expect(mockProvider.initialize).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -49,6 +49,7 @@ import type { RestartAgentHookInput, RestartAgentHookResult } from "../../intent
 import type { UpdateAgentStatusIntent } from "../../intents/update-agent-status";
 import { APP_START_OPERATION_ID } from "../../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
+import { APP_READY_OPERATION_ID, type AvailableAgentsResult } from "../../intents/app-ready";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
@@ -95,17 +96,30 @@ export function createAgentModule(
   // Internal closure state
   // =========================================================================
 
-  /** Check if this module is the active agent by reading config. */
-  function isActive(): boolean {
-    const agentType = deps.configService.get("agent") as string;
-    return agentType === provider.type;
-  }
-
   /** Capability: agentType provided by setup handler. */
   let capAgentType: AgentType | undefined;
 
+  /** MCP port captured during app:start; consumed on lazy initialize. */
+  let capturedMcpPort: number | null = null;
+
+  /** Whether the provider has been initialized (lazy on first workspace:open). */
+  let initialized = false;
+
   /** Cleanup function for onStatusChange subscription. */
   let statusChangeCleanup: (() => void) | null = null;
+
+  /** Initialize the provider on demand. Idempotent. */
+  function ensureInitialized(): void {
+    if (initialized) return;
+    provider.initialize(capturedMcpPort !== null ? { port: capturedMcpPort } : null);
+    statusChangeCleanup = provider.onStatusChange((workspacePath, status) => {
+      void deps.dispatcher.dispatch({
+        type: INTENT_UPDATE_AGENT_STATUS,
+        payload: { workspacePath, status },
+      } as UpdateAgentStatusIntent);
+    });
+    initialized = true;
+  }
 
   /**
    * Shared agent-server teardown used by delete + hibernate.
@@ -163,19 +177,30 @@ export function createAgentModule(
         start: {
           requires: { mcpPort: ANY_VALUE },
           handler: async (ctx: HookContext): Promise<void> => {
-            if (!isActive()) return;
+            const mcpPort = ctx.capabilities?.mcpPort as number | null | undefined;
+            capturedMcpPort = mcpPort !== null && mcpPort !== undefined ? mcpPort : null;
+            // Initialization is deferred until the first workspace using this
+            // agent is opened (see open-workspace setup hook).
+          },
+        },
+      },
 
-            const mcpPort = ctx.capabilities?.mcpPort as number | null;
-            provider.initialize(
-              mcpPort !== null && mcpPort !== undefined ? { port: mcpPort } : null
-            );
-
-            statusChangeCleanup = provider.onStatusChange((workspacePath, status) => {
-              void deps.dispatcher.dispatch({
-                type: INTENT_UPDATE_AGENT_STATUS,
-                payload: { workspacePath, status },
-              } as UpdateAgentStatusIntent);
-            });
+      [APP_READY_OPERATION_ID]: {
+        "available-agents": {
+          handler: async (): Promise<AvailableAgentsResult> => {
+            try {
+              const result = await provider.preflight();
+              if (!result.success || result.needsDownload) return {};
+              return {
+                agent: {
+                  agent: provider.type,
+                  label: provider.displayName,
+                  icon: provider.icon,
+                },
+              };
+            } catch {
+              return {};
+            }
           },
         },
       },
@@ -187,8 +212,10 @@ export function createAgentModule(
               statusChangeCleanup();
               statusChangeCleanup = null;
             }
-
-            await provider.dispose();
+            if (initialized) {
+              await provider.dispose();
+              initialized = false;
+            }
           },
         },
       },
@@ -258,12 +285,13 @@ export function createAgentModule(
 
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
+          requires: { agent: provider.type },
           provides: () => ({
             ...(capAgentType !== undefined && { agentType: capAgentType }),
           }),
           handler: async (ctx: HookContext): Promise<SetupHookResult | undefined> => {
             capAgentType = undefined;
-            if (!isActive()) return undefined;
+            ensureInitialized();
 
             const setupCtx = ctx as SetupHookInput;
             const intent = ctx.intent as OpenWorkspaceIntent;
@@ -287,8 +315,8 @@ export function createAgentModule(
 
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
+          requires: { agent: provider.type },
           handler: async (ctx: HookContext): Promise<ShutdownHookResult | undefined> => {
-            if (!isActive()) return undefined;
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             const result = await stopAgentForWorkspace(workspacePath, "delete shutdown");
@@ -304,8 +332,8 @@ export function createAgentModule(
 
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
+          requires: { agent: provider.type },
           handler: async (ctx: HookContext): Promise<HibernateShutdownHookResult | undefined> => {
-            if (!isActive()) return undefined;
             const { workspacePath } = ctx as HibernatePipelineHookInput;
             await stopAgentForWorkspace(workspacePath, "hibernate shutdown");
             return {};
@@ -315,8 +343,8 @@ export function createAgentModule(
 
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
+          requires: { agent: provider.type },
           handler: async (ctx: HookContext): Promise<GetStatusHookResult | undefined> => {
-            if (!isActive()) return undefined;
             const { workspacePath } = ctx as GetStatusHookInput;
             return {
               agentStatus: provider.getStatus(workspacePath as WorkspacePath),
@@ -327,8 +355,8 @@ export function createAgentModule(
 
       [GET_AGENT_SESSION_OPERATION_ID]: {
         get: {
+          requires: { agent: provider.type },
           handler: async (ctx: HookContext): Promise<GetAgentSessionHookResult | undefined> => {
-            if (!isActive()) return undefined;
             const { workspacePath } = ctx as GetAgentSessionHookInput;
             return {
               session: provider.getSession(workspacePath as WorkspacePath),
@@ -339,8 +367,8 @@ export function createAgentModule(
 
       [RESTART_AGENT_OPERATION_ID]: {
         restart: {
+          requires: { agent: provider.type },
           handler: async (ctx: HookContext): Promise<RestartAgentHookResult | undefined> => {
-            if (!isActive()) return undefined;
             const { workspacePath } = ctx as RestartAgentHookInput;
             const result = await provider.restartWorkspace(workspacePath);
             if (result.success) {

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -339,7 +339,7 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
   // ---------------------------------------------------------------------------
 
   registerIpc(ApiIpcChannels.LIFECYCLE_READY, async () => {
-    await dispatcher.dispatch({
+    return await dispatcher.dispatch({
       type: INTENT_APP_READY,
       payload: {},
     } as AppReadyIntent);
@@ -366,6 +366,7 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
         base: p.base,
         ...(p.initialPrompt !== undefined && { initialPrompt: p.initialPrompt }),
         ...(p.stealFocus !== undefined && { stealFocus: p.stealFocus }),
+        ...(p.agent !== undefined && { agent: p.agent }),
         source: "ui-ipc",
       },
     };

--- a/src/modules/workspace-agent-resolver-module.ts
+++ b/src/modules/workspace-agent-resolver-module.ts
@@ -1,0 +1,163 @@
+/**
+ * WorkspaceAgentResolver - Resolves the per-workspace agent for workspace operations.
+ *
+ * On each workspace-scoped hook point, this module:
+ *  1. Reads the per-workspace `agent` from worktree metadata (fallback: global default).
+ *  2. For workspace:open: if the intent payload sets a non-default agent, writes it
+ *     to metadata first so subsequent operations see the same resolution.
+ *  3. Emits an `agent` capability so per-agent modules can gate via
+ *     `requires: { agent: provider.type }`.
+ */
+import type { IntentModule } from "../intents/lib/module";
+import type { HookContext, HookHandler } from "../intents/lib/operation";
+import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
+import type { Config } from "../boundaries/platform/config";
+import type { Logger } from "../boundaries/platform/logging-types";
+import type { AgentType } from "../shared/plugin-protocol";
+import { Path } from "../utils/path/path";
+
+import {
+  OPEN_WORKSPACE_OPERATION_ID,
+  type OpenWorkspaceIntent,
+  type SetupHookInput,
+} from "../intents/open-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  type DeletePipelineHookInput,
+} from "../intents/delete-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernatePipelineHookInput,
+} from "../intents/hibernate-workspace";
+import {
+  GET_WORKSPACE_STATUS_OPERATION_ID,
+  type GetStatusHookInput,
+} from "../intents/get-workspace-status";
+import {
+  GET_AGENT_SESSION_OPERATION_ID,
+  type GetAgentSessionHookInput,
+} from "../intents/get-agent-session";
+import { RESTART_AGENT_OPERATION_ID, type RestartAgentHookInput } from "../intents/restart-agent";
+
+export const AGENT_METADATA_KEY = "agent";
+
+interface WorkspaceAgentResolverDeps {
+  readonly gitWorktreeProvider: GitWorktreeProvider;
+  readonly configService: Config;
+  readonly logger: Logger;
+}
+
+/**
+ * Lookup agent for a workspace: metadata first, then global default.
+ * Returns null only when both metadata and config are unset.
+ */
+async function resolveAgent(
+  workspacePath: string,
+  deps: WorkspaceAgentResolverDeps
+): Promise<AgentType | null> {
+  try {
+    const metadata = await deps.gitWorktreeProvider.getMetadata(new Path(workspacePath));
+    const fromMetadata = metadata[AGENT_METADATA_KEY];
+    if (fromMetadata === "claude" || fromMetadata === "opencode") {
+      return fromMetadata;
+    }
+  } catch (error) {
+    deps.logger.debug("metadata read failed; using global default", {
+      workspacePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const fromConfig = deps.configService.get("agent") as string | null;
+  if (fromConfig === "claude" || fromConfig === "opencode") {
+    return fromConfig;
+  }
+  return null;
+}
+
+/**
+ * Build a handler that resolves the workspace agent and exposes it as the
+ * `agent` capability. `getWorkspacePath` adapts the hook context per operation.
+ */
+function makeResolverHandler(
+  deps: WorkspaceAgentResolverDeps,
+  getWorkspacePath: (ctx: HookContext) => string | undefined
+): HookHandler {
+  let resolved: AgentType | null = null;
+  return {
+    provides: () => (resolved !== null ? { agent: resolved } : {}),
+    handler: async (ctx: HookContext): Promise<void> => {
+      resolved = null;
+      const workspacePath = getWorkspacePath(ctx);
+      if (workspacePath === undefined) return;
+      resolved = await resolveAgent(workspacePath, deps);
+    },
+  };
+}
+
+export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverDeps): IntentModule {
+  // workspace:open is special — the intent payload may carry a per-workspace
+  // override that must be persisted before downstream hooks read it.
+  let openResolved: AgentType | null = null;
+  const openSetupHandler: HookHandler = {
+    provides: () => (openResolved !== null ? { agent: openResolved } : {}),
+    handler: async (ctx: HookContext): Promise<void> => {
+      openResolved = null;
+      const setupCtx = ctx as SetupHookInput;
+      const intent = ctx.intent as OpenWorkspaceIntent;
+      const { workspacePath } = setupCtx;
+      if (!workspacePath) return;
+
+      const defaultAgent = deps.configService.get("agent") as string | null;
+      const requested = intent.payload.agent;
+
+      if (requested !== undefined && requested !== defaultAgent) {
+        // Persist a non-default agent choice so future operations resolve to it.
+        try {
+          await deps.gitWorktreeProvider.setMetadata(
+            new Path(workspacePath),
+            AGENT_METADATA_KEY,
+            requested
+          );
+        } catch (error) {
+          deps.logger.warn("failed to persist workspace agent metadata", {
+            workspacePath,
+            requested,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      openResolved = await resolveAgent(workspacePath, deps);
+    },
+  };
+
+  return {
+    name: "workspace-agent-resolver",
+    hooks: {
+      [OPEN_WORKSPACE_OPERATION_ID]: {
+        setup: openSetupHandler,
+      },
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        shutdown: makeResolverHandler(
+          deps,
+          (ctx) => (ctx as DeletePipelineHookInput).workspacePath
+        ),
+      },
+      [HIBERNATE_WORKSPACE_OPERATION_ID]: {
+        shutdown: makeResolverHandler(
+          deps,
+          (ctx) => (ctx as HibernatePipelineHookInput).workspacePath
+        ),
+      },
+      [GET_WORKSPACE_STATUS_OPERATION_ID]: {
+        get: makeResolverHandler(deps, (ctx) => (ctx as GetStatusHookInput).workspacePath),
+      },
+      [GET_AGENT_SESSION_OPERATION_ID]: {
+        get: makeResolverHandler(deps, (ctx) => (ctx as GetAgentSessionHookInput).workspacePath),
+      },
+      [RESTART_AGENT_OPERATION_ID]: {
+        restart: makeResolverHandler(deps, (ctx) => (ctx as RestartAgentHookInput).workspacePath),
+      },
+    },
+  };
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,7 +5,7 @@
 
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
 import { ApiIpcChannels } from "../shared/ipc";
-import type { UIModeChangedEvent, LogContext } from "../shared/ipc";
+import type { UIModeChangedEvent, LogContext, LifecycleAgentType } from "../shared/ipc";
 import type { DialogUserEvent } from "../shared/dialog-types";
 import type { NotificationUserEvent } from "../shared/notification-types";
 import type { ShortcutKey } from "../shared/shortcuts";
@@ -49,7 +49,11 @@ contextBridge.exposeInMainWorld("api", {
       projectPath: string,
       name: string,
       base: string,
-      options?: { initialPrompt?: InitialPrompt; stealFocus?: boolean }
+      options?: {
+        initialPrompt?: InitialPrompt;
+        stealFocus?: boolean;
+        agent?: LifecycleAgentType;
+      }
     ) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_CREATE, {
         projectPath,

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -134,6 +134,7 @@ describe("App component", () => {
       }
       const activeRef = await mockApi.ui.getActiveWorkspace();
       projectsStore.setActiveWorkspace(activeRef?.path ?? null);
+      return { defaultAgent: null, availableAgents: [] };
     });
   });
 
@@ -1077,10 +1078,10 @@ describe("App component", () => {
 
     it("announces 'Application ready' only after loading completes", async () => {
       // Block lifecycle.ready() initially
-      let resolveReady!: () => void;
+      let resolveReady!: (value: { defaultAgent: null; availableAgents: readonly [] }) => void;
       mockApi.lifecycle.ready.mockImplementation(
         () =>
-          new Promise<void>((resolve) => {
+          new Promise<{ defaultAgent: null; availableAgents: readonly [] }>((resolve) => {
             resolveReady = resolve;
           })
       );
@@ -1097,7 +1098,7 @@ describe("App component", () => {
       expect(liveRegion).not.toHaveTextContent("Application ready");
 
       // Complete loading
-      resolveReady();
+      resolveReady({ defaultAgent: null, availableAgents: [] });
       await waitFor(() => {
         expect(projectsStore.loadingState.value).toBe("loaded");
       });

--- a/src/renderer/lib/components/CreateWorkspaceDialog.svelte
+++ b/src/renderer/lib/components/CreateWorkspaceDialog.svelte
@@ -12,6 +12,8 @@
     type Project,
   } from "$lib/api";
   import { validateWorkspaceName, type InitialPrompt } from "@shared/api/types";
+  import type { LifecycleAgentType } from "@shared/ipc";
+  import { bootstrap } from "$lib/stores/bootstrap.svelte.js";
   import { closeDialog, openGitCloneDialog } from "$lib/stores/dialogs.svelte.js";
   import {
     getProjectById,
@@ -79,6 +81,28 @@
   let agentMode = $state<"" | "plan">("");
   let openInBackground = $state(false);
   let agentModeRef: HTMLElement | undefined = $state();
+  // Per-workspace agent override. Defaults to the global default; "" means
+  // "use the global default" (no override is sent to the IPC layer).
+  let selectedAgent = $state<LifecycleAgentType | "">("");
+  let agentSelectRef: HTMLElement | undefined = $state();
+
+  // Default agent dropdown when bootstrap data arrives.
+  $effect(() => {
+    if (selectedAgent === "" && bootstrap.defaultAgent) {
+      selectedAgent = bootstrap.defaultAgent;
+    }
+  });
+
+  // vscode-single-select's change event doesn't bubble — bind directly.
+  $effect(() => {
+    const el = agentSelectRef;
+    if (!el) return;
+    const handler = (e: Event) => {
+      selectedAgent = (e.target as HTMLSelectElement).value as LifecycleAgentType | "";
+    };
+    el.addEventListener("change", handler);
+    return () => el.removeEventListener("change", handler);
+  });
 
   // Direct event listener for vscode-single-select: its change event doesn't bubble,
   // but Svelte 5 delegates 'change' to the document root, so onchange= misses it.
@@ -180,7 +204,11 @@
     logger.debug("Dialog submitted", { type: "create-workspace" });
 
     // Build options from "More options" fields
-    const options: { initialPrompt?: InitialPrompt; stealFocus?: boolean } = {};
+    const options: {
+      initialPrompt?: InitialPrompt;
+      stealFocus?: boolean;
+      agent?: LifecycleAgentType;
+    } = {};
     const trimmedPrompt = initialPrompt.trim();
     if (trimmedPrompt || agentMode) {
       options.initialPrompt = agentMode
@@ -189,6 +217,10 @@
     }
     if (openInBackground) {
       options.stealFocus = false;
+    }
+    // Only send agent when the user picked one that differs from the global default.
+    if (selectedAgent !== "" && selectedAgent !== bootstrap.defaultAgent) {
+      options.agent = selectedAgent;
     }
 
     // Snapshot reactive state before closing dialog. closeDialog() sets
@@ -403,8 +435,24 @@
           ></vscode-textarea>
         </div>
 
+        {#if bootstrap.availableAgents.length > 1}
+          <div class="ch-form-field">
+            <label for="agent-select" class="ch-form-label">Agent</label>
+            <vscode-single-select
+              id="agent-select"
+              bind:this={agentSelectRef}
+              value={selectedAgent}
+              disabled={isSubmitting}
+            >
+              {#each bootstrap.availableAgents as info (info.agent)}
+                <vscode-option value={info.agent}>{info.label}</vscode-option>
+              {/each}
+            </vscode-single-select>
+          </div>
+        {/if}
+
         <div class="ch-form-field">
-          <label for="agent-mode" class="ch-form-label">Agent</label>
+          <label for="agent-mode" class="ch-form-label">Agent mode</label>
           <vscode-single-select
             id="agent-mode"
             bind:this={agentModeRef}

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -125,6 +125,7 @@ describe("MainView close project integration", () => {
       }
       const activeRef = await mockApi.ui.getActiveWorkspace();
       projectsStore.setActiveWorkspace(activeRef?.path ?? null);
+      return { defaultAgent: null, availableAgents: [] };
     });
   });
 

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -128,6 +128,7 @@ describe("MainView component", () => {
       }
       const activeRef = await mockApi.ui.getActiveWorkspace();
       projectsStore.setActiveWorkspace(activeRef?.path ?? null);
+      return { defaultAgent: null, availableAgents: [] };
     });
     // Agent statuses are fetched per-workspace via workspaces.getStatus (already mocked in mockApi)
     // Reset notification service mocks

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -230,6 +230,7 @@ describe("Integration tests", () => {
       }
       const activeRef = await mockApi.ui.getActiveWorkspace();
       projectsStore.setActiveWorkspace(activeRef?.path ?? null);
+      return { defaultAgent: null, availableAgents: [] };
     });
     // Legacy mocks that may still be used in some places
     mockApi.listBases.mockResolvedValue([

--- a/src/renderer/lib/stores/bootstrap.svelte.ts
+++ b/src/renderer/lib/stores/bootstrap.svelte.ts
@@ -1,0 +1,26 @@
+/**
+ * Bootstrap store: app-wide data returned by lifecycle.ready().
+ * Currently holds the global default agent and the list of agents whose
+ * binaries are present on disk (for the create-workspace dropdown).
+ */
+import type { AgentInfo, LifecycleAgentType } from "@shared/ipc";
+
+let _defaultAgent = $state<LifecycleAgentType | null>(null);
+let _availableAgents = $state<readonly AgentInfo[]>([]);
+
+export const bootstrap = {
+  get defaultAgent(): LifecycleAgentType | null {
+    return _defaultAgent;
+  },
+  get availableAgents(): readonly AgentInfo[] {
+    return _availableAgents;
+  },
+};
+
+export function setBootstrap(value: {
+  defaultAgent: LifecycleAgentType | null;
+  availableAgents: readonly AgentInfo[];
+}): void {
+  _defaultAgent = value.defaultAgent;
+  _availableAgents = value.availableAgents;
+}

--- a/src/renderer/lib/utils/initialize-app.test.ts
+++ b/src/renderer/lib/utils/initialize-app.test.ts
@@ -78,6 +78,7 @@ function createMockApi(config?: {
           projectsStore.addProject(p);
         }
         projectsStore.setActiveWorkspace(activeWorkspace?.path ?? null);
+        return { defaultAgent: null, availableAgents: [] };
       }),
     },
     workspaces: {

--- a/src/renderer/lib/utils/initialize-app.ts
+++ b/src/renderer/lib/utils/initialize-app.ts
@@ -12,7 +12,9 @@
 import { tick } from "svelte";
 import { projects, setLoaded, setError } from "$lib/stores/projects.svelte.js";
 import { setAllStatuses } from "$lib/stores/agent-status.svelte.js";
+import { setBootstrap } from "$lib/stores/bootstrap.svelte.js";
 import type { Project, WorkspaceStatus, AgentStatus } from "@shared/api/types";
+import type { AgentInfo, LifecycleAgentType } from "@shared/ipc";
 import type { AgentNotificationService } from "$lib/services/agent-notifications";
 import * as api from "$lib/api";
 
@@ -24,7 +26,12 @@ export interface InitializeAppOptions {
 }
 
 export interface InitializeAppApi {
-  lifecycle: { ready(): Promise<void> };
+  lifecycle: {
+    ready(): Promise<{
+      defaultAgent: LifecycleAgentType | null;
+      availableAgents: readonly AgentInfo[];
+    }>;
+  };
   workspaces: { getStatus(workspacePath: string): Promise<WorkspaceStatus> };
 }
 
@@ -99,7 +106,8 @@ export async function initializeApp(
   try {
     // Signal ready — unblocks mount in app:start so project:open dispatches fire.
     // The renderer's event subscriptions (set up before this call) handle incoming events.
-    await apiImpl.lifecycle.ready();
+    const bootstrap = await apiImpl.lifecycle.ready();
+    setBootstrap(bootstrap);
 
     setLoaded();
 

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -3,7 +3,7 @@
  * This file is in shared/ so both main/preload and renderer can access the types.
  */
 
-import type { UIModeChangedEvent, LogContext } from "./ipc";
+import type { UIModeChangedEvent, LogContext, LifecycleAgentType, AgentInfo } from "./ipc";
 import type { UIMode } from "./ipc";
 import type { ShortcutKey } from "./shortcuts";
 import type { DialogUserEvent } from "./dialog-types";
@@ -45,7 +45,11 @@ export interface Api {
       projectPath: string,
       name: string,
       base: string,
-      options?: { initialPrompt?: InitialPrompt; stealFocus?: boolean }
+      options?: {
+        initialPrompt?: InitialPrompt;
+        stealFocus?: boolean;
+        agent?: LifecycleAgentType;
+      }
     ): Promise<Workspace>;
     /**
      * Start workspace removal (fire-and-forget).
@@ -113,8 +117,12 @@ export interface Api {
     /**
      * Signal that the renderer is ready to receive state.
      * The main process emits domain events for all current state before resolving.
+     * Returns app-wide bootstrap data (default agent + available agents).
      */
-    ready(): Promise<void>;
+    ready(): Promise<{
+      defaultAgent: LifecycleAgentType | null;
+      availableAgents: readonly AgentInfo[];
+    }>;
     /**
      * Quit the application.
      */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -107,6 +107,8 @@ export interface WorkspaceCreatePayload {
   /** If true, steal focus from current workspace. If false, don't steal focus but still
    *  switch when no workspace is active. Default: switch (undefined treated as true). */
   readonly stealFocus?: boolean;
+  /** Optional per-workspace agent override. When omitted, falls back to the global default. */
+  readonly agent?: LifecycleAgentType;
 }
 
 /** workspaces.remove */


### PR DESCRIPTION
- Workspaces can choose their agent (claude/opencode) at creation time; absent metadata falls back to the global default
- New `workspace-agent-resolver` module emits an `agent` capability that gates per-agent module hooks via `requires`
- Agent providers initialize lazily on the first `workspace:open` that selects them; `app:start` now only captures `mcpPort`
- Create Workspace dialog shows an agent dropdown in Advanced options when more than one agent binary is available
- `lifecycle.ready()` returns `{ defaultAgent, availableAgents }` so the renderer can populate the picker