### PR TITLE
fix(proxy): disable proxy lookups by default to suppress WPAD probes

### DIFF
--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -311,7 +311,7 @@ describe("ElectronLifecycleModule Integration", () => {
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("use-gl", "swiftshader");
     });
 
-    it("does not apply flags when electron.flags is null", async () => {
+    it("applies --no-proxy-server by default to suppress WPAD probes", async () => {
       const mockApp = createMockApp();
       const dispatcher = new Dispatcher({ logger: createMockLogger() });
 
@@ -330,7 +330,7 @@ describe("ElectronLifecycleModule Integration", () => {
         payload: {},
       } as AppStartIntent);
 
-      expect(mockApp.commandLine.appendSwitch).not.toHaveBeenCalled();
+      expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("no-proxy-server");
     });
   });
 

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -110,6 +110,10 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
                 deps.app.setPath(name, deps.pathProvider.dataPath(`electron/${name}`).toNative());
               }
             }
+            // Disable proxy lookups by default to avoid WPAD/wpad.dat probes.
+            // Users can override via electron.flags (e.g. --proxy-server=...).
+            deps.app.commandLine.appendSwitch("no-proxy-server");
+            deps.logger.info("Applied Electron flag", { flag: "no-proxy-server" });
             // Apply electron flags from config
             const flagsValue = deps.configService.get("electron.flags") as string | null;
             const flags = parseElectronFlags(flagsValue ?? undefined);


### PR DESCRIPTION
- Append `--no-proxy-server` in the `before-ready` lifecycle hook so Electron skips WPAD/wpad.dat probes by default
- Users can still override via `electron.flags` (e.g. `--proxy-server=...`)
- Updated lifecycle integration test to assert the default switch is applied