### PR TITLE
fix: speed up workspace creation by reducing network calls

### DIFF
--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -830,6 +830,16 @@ describe("CodeServerModule", () => {
         new Path("/test/project/.worktrees/feature-1.code-workspace"),
         expect.stringContaining('"claudeCode.useTerminal":')
       );
+      const writeCall = vi
+        .mocked(deps.fileSystemLayer.writeFile)
+        .mock.calls.find(
+          ([p]) => p.toString() === "/test/project/.worktrees/feature-1.code-workspace"
+        );
+      expect(writeCall).toBeDefined();
+      const written = writeCall![1] as string;
+      expect(written).toContain('"chat.agent.enabled": false');
+      expect(written).toContain('"extensions.autoUpdate": false');
+      expect(written).toContain('"extensions.autoCheckUpdates": false');
     });
 
     it("falls back to folder URL on workspace file error", async () => {

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -917,6 +917,9 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
                 "claudeCode.useTerminal": true,
                 "claudeCode.claudeProcessWrapper": deps.wrapperPath,
                 "claudeCode.environmentVariables": envVarsArray,
+                "chat.agent.enabled": false,
+                "extensions.autoUpdate": false,
+                "extensions.autoCheckUpdates": false,
               };
               const wsFilePath = await writeWorkspaceFile(workspacePathObj, agentSettings);
               capWorkspaceUrl = urlForWorkspace(codeServerPort, wsFilePath.toString());


### PR DESCRIPTION
- Disable VS Code per-workspace extension auto-update checks (`extensions.autoUpdate`, `extensions.autoCheckUpdates`) so workspace launches no longer trigger marketplace pings
- Disable `chat.agent.enabled` by default in workspaces