### PR TITLE
fix: more consistent startup screen

### DIFF
--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -58,7 +58,9 @@ import type { ProjectOpenedEvent, SelectFolderHookResult } from "../intents/open
 import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
 import { SET_MODE_OPERATION_ID } from "../intents/set-mode";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
+import { EVENT_APP_STARTED } from "../intents/app-ready";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import { WORKSPACE_LOADING_TIMEOUT_MS } from "../boundaries/shell/view-manager.interface";
 import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
 import { APP_RESUME_OPERATION_ID, APP_RESUME_HOOK_RESUME } from "../intents/app-resume";
@@ -177,6 +179,35 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
   let loadingDialog: { path: string | null; handle: DialogHandle } | null = null;
   /** Track the setup dialog handle (for show-ui/hide-ui). */
   let setupDialogHandle: DialogHandle | null = null;
+  /**
+   * Startup splash state — the "CodeHydra is starting..." dialog is held open
+   * across renderer mount, project loading, and the first workspace becoming
+   * ready (first agent:status-updated), so the user sees one unified loading
+   * screen instead of starting → blank → projects-loading → workspace-loading.
+   *
+   * Closes on whichever fires first:
+   *  - first `agent:status-updated` for any workspace
+   *  - `app:started` event with no active workspace (empty-state path)
+   *  - 10s fallback timeout
+   *
+   * While active, per-workspace "Loading workspace..." dialogs are suppressed
+   * (the splash already covers the window). Subsequent workspace switches
+   * show their own loading dialog as before.
+   */
+  let startupSplashActive = false;
+  let startupSplashTimeout: ReturnType<typeof setTimeout> | null = null;
+  function closeStartupSplash(): void {
+    if (!startupSplashActive) return;
+    startupSplashActive = false;
+    if (startupSplashTimeout) {
+      clearTimeout(startupSplashTimeout);
+      startupSplashTimeout = null;
+    }
+    if (setupDialogHandle) {
+      setupDialogHandle.close();
+      setupDialogHandle = null;
+    }
+  }
   /** Accumulated setup row state (persists across progress events). */
   const setupRowState = new Map<
     string,
@@ -253,6 +284,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
                 modal: true,
               };
               setupDialogHandle = deps.dialogManager.open(config);
+              startupSplashActive = true;
             }
             if (!deps.dialogManager) return {};
             return {
@@ -299,9 +331,10 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
                 if (!deps.dialogManager) return;
                 if (loading) {
                   loadingPaths.add(path);
-                  // Show dialog only if this is the active workspace
+                  // Show dialog only if this is the active workspace AND the
+                  // startup splash isn't already covering the window.
                   const activePath = cachedActiveRef?.path ?? null;
-                  if (path === activePath) {
+                  if (path === activePath && !startupSplashActive) {
                     if (loadingDialog && loadingDialog.path === null) {
                       // Associate path with dialog opened early by workspace:loading event
                       loadingDialog = { path, handle: loadingDialog.handle };
@@ -342,10 +375,28 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
               logger.warn("UI not available for mount");
               return;
             }
-            // Close starting/setup dialog before mounting
-            if (setupDialogHandle) {
-              setupDialogHandle.close();
-              setupDialogHandle = null;
+            // Keep the startup splash visible through renderer mount + project
+            // loading + first workspace ready. If setup ran, the splash was
+            // closed during setup/show-ui — reopen it for the workspace-loading
+            // phase. Closes via closeStartupSplash() from agent:status-updated,
+            // app:started (no active workspace), or the timeout below.
+            if (deps.dialogManager && !setupDialogHandle) {
+              setupDialogHandle = deps.dialogManager.open({
+                sections: [
+                  {
+                    type: "progress",
+                    items: [
+                      { id: "starting", label: "CodeHydra is starting...", status: "running" },
+                    ],
+                    style: "spinner",
+                  },
+                ],
+                modal: true,
+              });
+              startupSplashActive = true;
+            }
+            if (startupSplashActive) {
+              startupSplashTimeout = setTimeout(closeStartupSplash, WORKSPACE_LOADING_TIMEOUT_MS);
             }
 
             logger.debug("Mounting renderer");
@@ -363,9 +414,17 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
         "show-ui": {
           handler: async () => {
             if (deps.dialogManager) {
-              // Close any existing setup dialog and reset accumulated state
+              // Close any existing setup dialog and reset accumulated state.
+              // If the startup splash was open, this closes it — app-start/start
+              // will reopen the splash after setup completes (via hide-ui).
               if (setupDialogHandle) {
                 setupDialogHandle.close();
+                setupDialogHandle = null;
+              }
+              startupSplashActive = false;
+              if (startupSplashTimeout) {
+                clearTimeout(startupSplashTimeout);
+                startupSplashTimeout = null;
               }
               setupRowState.clear();
               const config: DialogConfig = {
@@ -605,6 +664,11 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
               setupDialogHandle.close();
               setupDialogHandle = null;
             }
+            if (startupSplashTimeout) {
+              clearTimeout(startupSplashTimeout);
+              startupSplashTimeout = null;
+            }
+            startupSplashActive = false;
 
             // Destroy all views before disposing layers (uses viewLayer internally)
             viewManager.destroy();
@@ -630,7 +694,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [EVENT_WORKSPACE_LOADING]: {
         handler: async (): Promise<void> => {
-          if (deps.dialogManager && !loadingDialog) {
+          if (deps.dialogManager && !loadingDialog && !startupSplashActive) {
             const handle = deps.dialogManager.open({
               sections: [
                 {
@@ -819,11 +883,29 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
 
       // -------------------------------------------------------------------
       // agent:status-updated → clear loading screen (idempotent)
+      // Also closes the startup splash on the first such event — by the time
+      // any agent reports status, at least one workspace is far enough along
+      // to be visually meaningful.
       // -------------------------------------------------------------------
       [EVENT_AGENT_STATUS_UPDATED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as AgentStatusUpdatedEvent).payload;
           viewManager.setWorkspaceLoaded(payload.workspacePath);
+          closeStartupSplash();
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // app:started → close startup splash if there's no workspace to wait
+      // for. With workspaces present, the splash stays up until the first
+      // agent:status-updated above (or the 10s timeout falls through).
+      // -------------------------------------------------------------------
+      [EVENT_APP_STARTED]: {
+        handler: async (): Promise<void> => {
+          if (!startupSplashActive) return;
+          if (cachedActiveRef === null) {
+            closeStartupSplash();
+          }
         },
       },
     },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -27,7 +27,6 @@
     handleWindowBlur,
     handleShortcutKey,
   } from "$lib/stores/shortcuts.svelte.js";
-  import { loadingState } from "$lib/stores/projects.svelte.js";
   import { createLogger } from "$lib/logging";
   import MainView from "$lib/components/MainView.svelte";
   import DialogHost from "$lib/components/DialogHost.svelte";
@@ -96,12 +95,11 @@
     };
   });
 
-  // Announce "Application ready." once when projects finish loading
-  // (the startup overlay disappears at this point).
+  // Announce "Application ready." once when the main view becomes visible.
   // One-shot guard prevents re-announcing if reactive deps are re-read.
   let announcedReady = false;
   $effect(() => {
-    if (appMode.type === "ready" && loadingState.value === "loaded" && !announcedReady) {
+    if (appMode.type === "ready" && !announcedReady) {
       announcedReady = true;
       announceMessage = "Application ready.";
       setTimeout(() => {
@@ -115,10 +113,7 @@
 
   // Get aria-label for main element based on mode
   function getAriaLabel(): string {
-    if (appMode.type === "ready") {
-      return loadingState.value === "loading" ? "Loading projects" : "Application workspace";
-    }
-    return "Application starting";
+    return appMode.type === "ready" ? "Application workspace" : "Application starting";
   }
 </script>
 
@@ -134,9 +129,8 @@
     <!-- Minimal blank state while waiting for main process IPC -->
     <div class="initializing-container" aria-busy="true"></div>
   {:else}
-    <!-- Ready mode - MainView must mount to call lifecycle.ready() -->
-    <!-- Startup overlay stays visible until projects finish loading -->
-    <div class="main-view-container" inert={loadingState.value === "loading"}>
+    <!-- Ready mode - MainView mounts and calls lifecycle.ready() -->
+    <div class="main-view-container">
       <MainView />
     </div>
   {/if}

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -96,6 +96,7 @@ vi.mock("$lib/api", () => mockApi);
 // Import after mock setup
 import App from "./App.svelte";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as dialogsStore from "$lib/stores/dialogs.svelte.js";
 import * as shortcutsStore from "$lib/stores/shortcuts.svelte.js";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
@@ -104,6 +105,7 @@ describe("App component", () => {
     vi.clearAllMocks();
     // Reset stores before each test
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     dialogsStore.reset();
     shortcutsStore.reset();
     agentStatusStore.reset();
@@ -208,7 +210,7 @@ describe("App component", () => {
       });
     });
 
-    it("sets loadingState to 'loaded' after successful listProjects", async () => {
+    it("marks bootstrap initialized after successful listProjects", async () => {
       const mockProjects = [
         {
           id: asProjectId("test-project-12345678"),
@@ -225,20 +227,7 @@ describe("App component", () => {
 
       // Wait for loading to complete
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
-      });
-    });
-
-    it("sets loadingState to 'error' with message on listProjects failure", async () => {
-      // Now uses v2 API
-      mockApi.projects.list.mockRejectedValue(new Error("Network error"));
-
-      render(App);
-      showMainView();
-
-      await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("error");
-        expect(projectsStore.loadingError.value).toBe("Network error");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
     });
   });
@@ -578,7 +567,7 @@ describe("App component", () => {
       // This ensures the "Application ready." announcement has already fired
       // before we trigger shortcut mode.
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
         expect(getEventCallback("ui:mode-changed")).toBeDefined();
       });
 
@@ -1050,60 +1039,15 @@ describe("App component", () => {
   });
 
   describe("startup overlay", () => {
-    it("marks main-view-container as inert during loading", async () => {
-      // Block lifecycle.ready() to keep loading state
-      mockApi.lifecycle.ready.mockImplementation(() => new Promise(() => {}));
+    // The renderer's projects-loading overlay was removed; the main process
+    // now keeps a single startup splash visible until the first workspace's
+    // agent reports status. The renderer no longer marks the main-view
+    // container inert during loading.
 
+    it("announces 'Application ready' when the main view becomes visible", async () => {
       render(App);
       showMainView();
 
-      await waitFor(() => {
-        const container = document.querySelector(".main-view-container");
-        expect(container).toHaveAttribute("inert");
-      });
-    });
-
-    it("removes inert from main-view-container after loading completes", async () => {
-      render(App);
-      showMainView();
-
-      // Wait for loading to complete (default mock resolves lifecycle.ready)
-      await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
-      });
-
-      const container = document.querySelector(".main-view-container");
-      expect(container).not.toHaveAttribute("inert");
-    });
-
-    it("announces 'Application ready' only after loading completes", async () => {
-      // Block lifecycle.ready() initially
-      let resolveReady!: (value: { defaultAgent: null; availableAgents: readonly [] }) => void;
-      mockApi.lifecycle.ready.mockImplementation(
-        () =>
-          new Promise<{ defaultAgent: null; availableAgents: readonly [] }>((resolve) => {
-            resolveReady = resolve;
-          })
-      );
-
-      render(App);
-      showMainView();
-
-      // During loading, should NOT announce "Application ready"
-      await waitFor(() => {
-        const container = document.querySelector(".main-view-container");
-        expect(container).toHaveAttribute("inert");
-      });
-      const liveRegion = document.querySelector('[aria-live="polite"]');
-      expect(liveRegion).not.toHaveTextContent("Application ready");
-
-      // Complete loading
-      resolveReady({ defaultAgent: null, availableAgents: [] });
-      await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
-      });
-
-      // Now should announce
       await waitFor(() => {
         const region = document.querySelector('[aria-live="polite"]');
         expect(region).toHaveTextContent("Application ready");

--- a/src/renderer/lib/components/MainView.integration.test.ts
+++ b/src/renderer/lib/components/MainView.integration.test.ts
@@ -72,6 +72,7 @@ vi.mock("$lib/services/agent-notifications", () => ({
 // Import after mock setup
 import MainView from "./MainView.svelte";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as dialogsStore from "$lib/stores/dialogs.svelte.js";
 import * as shortcutsStore from "$lib/stores/shortcuts.svelte.js";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
@@ -109,6 +110,7 @@ describe("MainView close project integration", () => {
     vi.useFakeTimers();
     // Reset stores before each test
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     dialogsStore.reset();
     shortcutsStore.reset();
     agentStatusStore.reset();
@@ -140,7 +142,7 @@ describe("MainView close project integration", () => {
 
       // Wait for projects to load
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -168,7 +170,7 @@ describe("MainView close project integration", () => {
 
       // Wait for projects to load
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -193,7 +195,7 @@ describe("MainView close project integration", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -215,7 +217,7 @@ describe("MainView close project integration", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -237,7 +239,7 @@ describe("MainView close project integration", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -266,7 +268,7 @@ describe("MainView close project integration", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 
@@ -317,7 +319,7 @@ describe("MainView close project integration", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
       await vi.runAllTimersAsync();
 

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -21,10 +21,9 @@
     projects,
     activeWorkspacePath,
     activeWorkspace,
-    loadingState,
-    loadingError,
     getAllWorkspaces,
   } from "$lib/stores/projects.svelte.js";
+  import { bootstrap } from "$lib/stores/bootstrap.svelte.js";
   import {
     dialogState,
     openCreateDialog,
@@ -127,7 +126,7 @@
     // Read all reactive dependencies
     const effectiveCount = effectiveWorkspaceCount;
     const projectList = projects.value;
-    const loading = loadingState.value;
+    const initialized = bootstrap.initialized;
     const dialog = dialogState.value;
 
     // Reset dismissed state when effective workspaces exist (allows auto-show in future)
@@ -150,7 +149,7 @@
     const firstProject = projectList[0];
     if (
       effectiveCount === 0 &&
-      loading === "loaded" &&
+      initialized &&
       dialog.type === "closed" &&
       !autoShowDismissed &&
       !cloneRunning &&
@@ -282,8 +281,6 @@
   <Sidebar
     projects={projects.value}
     activeWorkspacePath={activeWorkspacePath.value}
-    loadingState={loadingState.value}
-    loadingError={loadingError.value}
     shortcutModeActive={shortcutModeActive.value}
     totalWorkspaces={getAllWorkspaces().length}
     onCloseProject={handleCloseProject}

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -97,6 +97,7 @@ vi.mock("$lib/services/agent-notifications", () => ({
 // Import after mock setup
 import MainView from "./MainView.svelte";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as dialogsStore from "$lib/stores/dialogs.svelte.js";
 import * as shortcutsStore from "$lib/stores/shortcuts.svelte.js";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
@@ -109,6 +110,7 @@ describe("MainView component", () => {
     vi.clearAllMocks();
     // Reset stores before each test
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     dialogsStore.reset();
     shortcutsStore.reset();
     agentStatusStore.reset();
@@ -172,7 +174,7 @@ describe("MainView component", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // No active workspace = backdrop should be visible
@@ -184,7 +186,7 @@ describe("MainView component", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // Logo should be inside the backdrop
@@ -217,7 +219,7 @@ describe("MainView component", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // Simulate workspace switch to activate a workspace
@@ -283,7 +285,7 @@ describe("MainView component", () => {
       });
     });
 
-    it("sets loadingState to 'loaded' after successful projects.list", async () => {
+    it("marks bootstrap initialized after successful projects.list", async () => {
       const mockProjects = [
         {
           id: asProjectId("test-project-12345678"),
@@ -297,18 +299,7 @@ describe("MainView component", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
-      });
-    });
-
-    it("sets loadingState to 'error' on projects.list failure", async () => {
-      mockApi.projects.list.mockRejectedValue(new Error("Network error"));
-
-      render(MainView);
-
-      await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("error");
-        expect(projectsStore.loadingError.value).toBe("Network error");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
     });
   });
@@ -1305,7 +1296,7 @@ describe("MainView component", () => {
       render(MainView);
 
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // Manually open create dialog (user clicked +)
@@ -1343,7 +1334,7 @@ describe("MainView component", () => {
 
       // Wait for loading to complete
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // Open a remove dialog (not create)

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -22,8 +22,6 @@
   interface SidebarProps {
     projects: readonly Project[];
     activeWorkspacePath: string | null;
-    loadingState: "loading" | "loaded" | "error";
-    loadingError: string | null;
     shortcutModeActive?: boolean;
     totalWorkspaces: number;
     onCloseProject: (projectId: ProjectId) => void;
@@ -35,8 +33,6 @@
   let {
     projects,
     activeWorkspacePath,
-    loadingState,
-    loadingError,
     shortcutModeActive = false,
     totalWorkspaces,
     onCloseProject,
@@ -130,16 +126,7 @@
   </header>
 
   <div class="sidebar-content">
-    {#if loadingState === "loading"}
-      <div class="loading-state" role="status">
-        <vscode-progress-ring class="loading-spinner"></vscode-progress-ring>
-        Loading projects...
-      </div>
-    {:else if loadingState === "error"}
-      <div class="error-state" role="alert">
-        <p>{loadingError}</p>
-      </div>
-    {:else if projects.length === 0}
+    {#if projects.length === 0}
       <EmptyState />
     {:else}
       <ul class="project-list">
@@ -393,21 +380,6 @@
 
   .sidebar-header h2.visually-collapsed {
     visibility: hidden;
-  }
-
-  .loading-state,
-  .error-state {
-    padding: 20px;
-    text-align: center;
-  }
-
-  .loading-spinner {
-    margin-right: 8px;
-    vertical-align: middle;
-  }
-
-  .error-state {
-    color: var(--ch-error-fg);
   }
 
   .sidebar-content {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -73,8 +73,6 @@ describe("Sidebar component", () => {
   const defaultProps = {
     projects: [],
     activeWorkspacePath: null,
-    loadingState: "loaded" as const,
-    loadingError: null,
     shortcutModeActive: false,
     totalWorkspaces: 0,
     onCloseProject: vi.fn(),
@@ -124,28 +122,10 @@ describe("Sidebar component", () => {
   });
 
   describe("state rendering", () => {
-    it("shows loading state when loadingState is 'loading'", () => {
-      render(Sidebar, { props: { ...defaultProps, loadingState: "loading" } });
-
-      expect(screen.getByText(/loading/i)).toBeInTheDocument();
-    });
-
     it("shows empty state when no projects", () => {
       render(Sidebar, { props: defaultProps });
 
       expect(screen.getByText(/No projects open\./)).toBeInTheDocument();
-    });
-
-    it("shows error state with error message when loadingState is 'error'", () => {
-      render(Sidebar, {
-        props: {
-          ...defaultProps,
-          loadingState: "error",
-          loadingError: "Failed to load projects",
-        },
-      });
-
-      expect(screen.getByText(/failed to load projects/i)).toBeInTheDocument();
     });
   });
 

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -161,6 +161,7 @@ vi.mock("$lib/stores/ui-mode.svelte", () => mockUiModeStore);
 // Import after mock setup
 import App from "../App.svelte";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as dialogsStore from "$lib/stores/dialogs.svelte.js";
 import * as shortcutsStore from "$lib/stores/shortcuts.svelte.js";
 import * as uiModeStore from "$lib/stores/ui-mode.svelte.js";
@@ -199,6 +200,7 @@ describe("Integration tests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     dialogsStore.reset();
     shortcutsStore.reset();
     agentStatusStore.reset();
@@ -522,20 +524,6 @@ describe("Integration tests", () => {
       expect(screen.getByText("existing")).toBeInTheDocument();
     });
 
-    it("API rejection during load → loadingState is 'error', loadingError has message", async () => {
-      mockApi.projects.list.mockRejectedValue(new Error("Database connection failed"));
-
-      render(App);
-      showMainView();
-
-      await waitFor(() => {
-        expect(screen.getByText(/database connection failed/i)).toBeInTheDocument();
-      });
-
-      expect(projectsStore.loadingState.value).toBe("error");
-      expect(projectsStore.loadingError.value).toBe("Database connection failed");
-    });
-
     it("createWorkspace API error handling is tested in CreateWorkspaceDialog.test.ts", async () => {
       // The full form validation and API error handling is tested in the component test
       // This integration test verifies the dialog opens and receives the project context
@@ -795,7 +783,7 @@ describe("Integration tests", () => {
 
       // Wait for load
       await waitFor(() => {
-        expect(projectsStore.loadingState.value).toBe("loaded");
+        expect(bootstrapStore.bootstrap.initialized).toBe(true);
       });
 
       // Verify store and UI match

--- a/src/renderer/lib/stores/bootstrap.svelte.ts
+++ b/src/renderer/lib/stores/bootstrap.svelte.ts
@@ -7,6 +7,7 @@ import type { AgentInfo, LifecycleAgentType } from "@shared/ipc";
 
 let _defaultAgent = $state<LifecycleAgentType | null>(null);
 let _availableAgents = $state<readonly AgentInfo[]>([]);
+let _initialized = $state<boolean>(false);
 
 export const bootstrap = {
   get defaultAgent(): LifecycleAgentType | null {
@@ -14,6 +15,9 @@ export const bootstrap = {
   },
   get availableAgents(): readonly AgentInfo[] {
     return _availableAgents;
+  },
+  get initialized(): boolean {
+    return _initialized;
   },
 };
 
@@ -23,4 +27,12 @@ export function setBootstrap(value: {
 }): void {
   _defaultAgent = value.defaultAgent;
   _availableAgents = value.availableAgents;
+  _initialized = true;
+}
+
+/** Reset bootstrap state. Used for testing. */
+export function resetBootstrap(): void {
+  _defaultAgent = null;
+  _availableAgents = [];
+  _initialized = false;
 }

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -24,8 +24,6 @@ import type { Project, Workspace, ProjectId, WorkspaceName, WorkspaceRef } from 
 
 let _projects = $state<Project[]>([]);
 let _activeWorkspacePath = $state<string | null>(null);
-let _loadingState = $state<"loading" | "loaded" | "error">("loading");
-let _loadingError = $state<string | null>(null);
 
 // ============ Derived ============
 
@@ -92,18 +90,6 @@ export const activeWorkspacePath = {
   },
 };
 
-export const loadingState = {
-  get value() {
-    return _loadingState;
-  },
-};
-
-export const loadingError = {
-  get value() {
-    return _loadingError;
-  },
-};
-
 export const activeProject = {
   get value() {
     return _activeProject;
@@ -142,15 +128,6 @@ export function removeProject(path: string): void {
 
 export function setActiveWorkspace(path: string | null): void {
   _activeWorkspacePath = path;
-}
-
-export function setLoaded(): void {
-  _loadingState = "loaded";
-}
-
-export function setError(message: string): void {
-  _loadingState = "error";
-  _loadingError = message;
 }
 
 export function addWorkspace(
@@ -210,8 +187,6 @@ export function updateWorkspaceMetadata(
 export function reset(): void {
   _projects = [];
   _activeWorkspacePath = null;
-  _loadingState = "loading";
-  _loadingError = null;
 }
 
 // ============ Helper Functions ============

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -19,15 +19,11 @@ window.api = mockApi;
 import {
   projects,
   activeWorkspacePath,
-  loadingState,
-  loadingError,
   activeProject,
   setProjects,
   addProject,
   removeProject,
   setActiveWorkspace,
-  setLoaded,
-  setError,
   addWorkspace,
   removeWorkspace,
   reset,
@@ -47,14 +43,6 @@ describe("projects store", () => {
   describe("initial state", () => {
     it("initializes with empty projects array", () => {
       expect(projects.value).toEqual([]);
-    });
-
-    it("initializes with loadingState 'loading'", () => {
-      expect(loadingState.value).toBe("loading");
-    });
-
-    it("initializes with loadingError null", () => {
-      expect(loadingError.value).toBeNull();
     });
 
     it("initializes with activeWorkspacePath null", () => {
@@ -165,22 +153,6 @@ describe("projects store", () => {
       setActiveWorkspace("/nonexistent/path");
 
       expect(activeProject.value).toBeUndefined();
-    });
-  });
-
-  describe("setError", () => {
-    it("sets loadingState to 'error' and stores message", () => {
-      setError("Something went wrong");
-
-      expect(loadingState.value).toBe("error");
-      expect(loadingError.value).toBe("Something went wrong");
-    });
-  });
-
-  describe("setLoaded", () => {
-    it("sets loadingState to 'loaded'", () => {
-      setLoaded();
-      expect(loadingState.value).toBe("loaded");
     });
   });
 

--- a/src/renderer/lib/utils/initialize-app.test.ts
+++ b/src/renderer/lib/utils/initialize-app.test.ts
@@ -20,6 +20,7 @@ vi.mock("$lib/api", () => ({
 
 import { initializeApp, type InitializeAppApi, type InitializeAppOptions } from "./initialize-app";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
 import { AgentNotificationService } from "$lib/services/agent-notifications";
 
@@ -125,11 +126,13 @@ describe("initializeApp", () => {
   beforeEach(() => {
     notificationService = new AgentNotificationService();
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     agentStatusStore.reset();
   });
 
   afterEach(() => {
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     agentStatusStore.reset();
     vi.restoreAllMocks();
     // Clean up any containers
@@ -147,7 +150,7 @@ describe("initializeApp", () => {
       await initializeApp(options, api);
 
       expect(projectsStore.projects.value).toContainEqual(TEST_PROJECT);
-      expect(projectsStore.loadingState.value).toBe("loaded");
+      expect(bootstrapStore.bootstrap.initialized).toBe(true);
     });
 
     it("sets active workspace from events", async () => {
@@ -181,21 +184,6 @@ describe("initializeApp", () => {
       await initializeApp(options, api);
 
       expect(projectsStore.activeWorkspacePath.value).toBeNull();
-    });
-
-    it("sets error state when lifecycle.ready() fails", async () => {
-      const api = createMockApi({
-        projectsError: new Error("Network error"),
-      });
-      const options: InitializeAppOptions = {
-        containerRef: undefined,
-        notificationService,
-      };
-
-      await initializeApp(options, api);
-
-      expect(projectsStore.loadingState.value).toBe("error");
-      expect(projectsStore.loadingError.value).toBe("Network error");
     });
   });
 
@@ -247,7 +235,7 @@ describe("initializeApp", () => {
 
       // Projects should still be loaded
       expect(projectsStore.projects.value).toContainEqual(TEST_PROJECT);
-      expect(projectsStore.loadingState.value).toBe("loaded");
+      expect(bootstrapStore.bootstrap.initialized).toBe(true);
     });
   });
 

--- a/src/renderer/lib/utils/initialize-app.ts
+++ b/src/renderer/lib/utils/initialize-app.ts
@@ -10,9 +10,12 @@
  * @returns Cleanup function (no-op for consistent composition pattern)
  */
 import { tick } from "svelte";
-import { projects, setLoaded, setError } from "$lib/stores/projects.svelte.js";
+import { projects } from "$lib/stores/projects.svelte.js";
 import { setAllStatuses } from "$lib/stores/agent-status.svelte.js";
 import { setBootstrap } from "$lib/stores/bootstrap.svelte.js";
+import { createLogger } from "$lib/logging";
+
+const logger = createLogger("ui");
 import type { Project, WorkspaceStatus, AgentStatus } from "@shared/api/types";
 import type { AgentInfo, LifecycleAgentType } from "@shared/ipc";
 import type { AgentNotificationService } from "$lib/services/agent-notifications";
@@ -109,8 +112,6 @@ export async function initializeApp(
     const bootstrap = await apiImpl.lifecycle.ready();
     setBootstrap(bootstrap);
 
-    setLoaded();
-
     // Focus first focusable element (including VSCode Elements)
     await tick();
     const firstFocusable = containerRef?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
@@ -135,7 +136,12 @@ export async function initializeApp(
       // Agent status is optional, don't fail initialization
     }
   } catch (err: unknown) {
-    setError(err instanceof Error ? err.message : "Failed to load projects");
+    // lifecycle.ready() failure leaves bootstrap.initialized=false; the main
+    // process's startup splash will fall through on its 10s timeout. Log so
+    // the failure is visible in the renderer console.
+    logger.error("Failed to initialize app", {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   // Return no-op cleanup for consistent composition pattern

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -21,6 +21,7 @@ vi.mock("$lib/api", () => ({
 import { setupDomainEventBindings } from "./setup-domain-event-bindings";
 import type { DomainEventApi, ApiEvents } from "./domain-events";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
+import * as bootstrapStore from "$lib/stores/bootstrap.svelte.js";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
 import * as dialogsStore from "$lib/stores/dialogs.svelte.js";
 import { AgentNotificationService } from "$lib/services/agent-notifications";
@@ -101,12 +102,14 @@ describe("setupDomainEventBindings", () => {
     mockApi = createMockApi();
     notificationService = new AgentNotificationService();
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     agentStatusStore.reset();
     dialogsStore.reset();
   });
 
   afterEach(() => {
     projectsStore.reset();
+    bootstrapStore.resetBootstrap();
     agentStatusStore.reset();
     dialogsStore.reset();
     vi.restoreAllMocks();
@@ -135,7 +138,7 @@ describe("setupDomainEventBindings", () => {
 
     it("auto-opens create dialog when project with no workspaces is opened after loading", () => {
       // Simulate post-startup state (loading complete)
-      projectsStore.setLoaded();
+      bootstrapStore.setBootstrap({ defaultAgent: null, availableAgents: [] });
 
       setupDomainEventBindings(notificationService, mockApi.api);
 
@@ -148,8 +151,8 @@ describe("setupDomainEventBindings", () => {
     });
 
     it("does not auto-open create dialog during initial loading", () => {
-      // loadingState is "loading" by default after reset
-      expect(projectsStore.loadingState.value).toBe("loading");
+      // bootstrap.initialized is false by default after reset
+      expect(bootstrapStore.bootstrap.initialized).toBe(false);
 
       setupDomainEventBindings(notificationService, mockApi.api);
 

--- a/src/renderer/lib/utils/setup-domain-event-bindings.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.ts
@@ -8,7 +8,6 @@
  */
 import {
   projects,
-  loadingState,
   activeWorkspacePath,
   addProject,
   removeProject,
@@ -17,6 +16,7 @@ import {
   removeWorkspace,
   updateWorkspaceMetadata,
 } from "$lib/stores/projects.svelte.js";
+import { bootstrap } from "$lib/stores/bootstrap.svelte.js";
 import { updateStatus } from "$lib/stores/agent-status.svelte.js";
 import { dialogState, openCreateDialog } from "$lib/stores/dialogs.svelte.js";
 import { hasSpinnerNotifications } from "$lib/stores/notification-store.svelte.js";
@@ -124,7 +124,7 @@ export function setupDomainEventBindings(
         // The auto-show $effect in MainView.svelte handles the post-load case.
         // Skip when a background clone just completed — the project appears silently.
         if (
-          loadingState.value === "loaded" &&
+          bootstrap.initialized &&
           project.workspaces.length === 0 &&
           dialogState.value.type === "closed" &&
           !hasSpinnerNotifications.value


### PR DESCRIPTION
- Keep the "CodeHydra is starting..." splash visible from launch until the first workspace's agent reports status, replacing the starting → blank → projects-loading → workspace-loading cycle with a single unified loading screen
- Splash closes on first `agent:status-updated`, on `app:started` with no active workspace (empty-state path), or after a 10s fallback timeout
- Setup wizard closes the splash and the start hook reopens it for the workspace-loading phase
- Suppress the per-workspace "Loading workspace..." dialog while the startup splash is up; subsequent switches show it as before
- Remove the renderer's projects-loading sidebar state, error UI, and `inert` startup overlay; auto-show guards now use `bootstrap.initialized`