### PR TITLE
feat(logging): capture Chromium native logs in bug reports

### DIFF
--- a/src/boundaries/platform/electron-log.ts
+++ b/src/boundaries/platform/electron-log.ts
@@ -471,6 +471,7 @@ export class ElectronLog implements Logging {
   private logFormat: LogFormat = "text";
   private allowedLoggers: Set<LoggerName> | undefined;
   private readonly logPath: string;
+  private readonly electronLogPath: string;
 
   constructor(pathProvider: PathProvider) {
     // Transports start silent — configure() enables them
@@ -481,6 +482,8 @@ export class ElectronLog implements Logging {
     const logsDir = pathProvider.dataPath("logs").toNative();
     const filename = generateSessionFilename();
     this.logPath = join(logsDir, filename);
+    // Fixed filename: Chromium overwrites on each launch with --log-file.
+    this.electronLogPath = join(logsDir, "electron.log");
     log.transports.file.resolvePathFn = (): string => this.logPath;
 
     // 20 MB before rotation. Bug reports include the rotated archive plus the
@@ -563,5 +566,9 @@ export class ElectronLog implements Logging {
 
   getLogFilePath(): string {
     return this.logPath;
+  }
+
+  getElectronLogFilePath(): string {
+    return this.electronLogPath;
   }
 }

--- a/src/boundaries/platform/logging-types.ts
+++ b/src/boundaries/platform/logging-types.ts
@@ -204,6 +204,15 @@ export interface Logging {
    * @returns Absolute path to the session log file
    */
   getLogFilePath(): string;
+
+  /**
+   * Get the path where Chromium writes its native log when --enable-logging=file
+   * is set. This is a fixed path (not session-suffixed) because Chromium
+   * overwrites the file on each launch.
+   *
+   * @returns Absolute path to the Electron/Chromium log file
+   */
+  getElectronLogFilePath(): string;
 }
 
 /**

--- a/src/boundaries/platform/logging.test-utils.ts
+++ b/src/boundaries/platform/logging.test-utils.ts
@@ -106,6 +106,7 @@ export function createMockLogging(): MockLogging {
     initialize: vi.fn(),
     dispose: vi.fn(),
     getLogFilePath: vi.fn().mockReturnValue("/mock/logs/test-session.log"),
+    getElectronLogFilePath: vi.fn().mockReturnValue("/mock/logs/electron.log"),
 
     getCreatedLoggerNames(): LoggerName[] {
       return Array.from(loggers.keys());

--- a/src/intents/submit-bug-report.ts
+++ b/src/intents/submit-bug-report.ts
@@ -15,6 +15,8 @@ import type { Operation, OperationContext } from "./lib/operation";
 export interface SubmitBugReportPayload {
   readonly description: string;
   readonly logs: string;
+  /** Chromium/Electron native log (--enable-logging=file output). */
+  readonly electronLogs: string;
 }
 
 export interface SubmitBugReportIntent extends Intent<void> {
@@ -31,6 +33,8 @@ export const INTENT_SUBMIT_BUG_REPORT = "bug-report:submit" as const;
 export interface BugReportSubmittedPayload {
   readonly description: string;
   readonly logs: string;
+  /** Chromium/Electron native log (--enable-logging=file output). */
+  readonly electronLogs: string;
 }
 
 export interface BugReportSubmittedEvent extends DomainEvent {
@@ -55,6 +59,7 @@ export class SubmitBugReportOperation implements Operation<SubmitBugReportIntent
       payload: {
         description: ctx.intent.payload.description,
         logs: ctx.intent.payload.logs,
+        electronLogs: ctx.intent.payload.electronLogs,
       },
     };
     ctx.emit(event);

--- a/src/main.ts
+++ b/src/main.ts
@@ -576,6 +576,8 @@ const loggingModule = createLoggingModule({
   platformInfo,
   logger: appLogger,
   configService,
+  app,
+  fileSystem: fileSystemLayer,
 });
 
 const scriptModule = createScriptModule({

--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -107,11 +107,15 @@ function createMockDeps(
           if (path === "/logs/test-session.log") {
             return Promise.resolve("test log content\nline 2\nline 3");
           }
+          if (path === "/logs/electron.log") {
+            return Promise.resolve("electron log content");
+          }
           return Promise.reject(new Error("ENOENT"));
         }),
       },
       loggingService: {
         getLogFilePath: vi.fn().mockReturnValue("/logs/test-session.log"),
+        getElectronLogFilePath: vi.fn().mockReturnValue("/logs/electron.log"),
       },
       dispatcher: {
         dispatch: vi.fn().mockResolvedValue(undefined),
@@ -316,6 +320,7 @@ describe("BugReportModule", () => {
           payload: {
             description: "It crashed",
             logs: "test log content\nline 2\nline 3",
+            electronLogs: "electron log content",
           },
         })
       );
@@ -377,6 +382,58 @@ describe("BugReportModule", () => {
       expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: expect.objectContaining({ logs: "ARCHIVE\nCURRENT" }),
+        })
+      );
+    });
+  });
+
+  it("attaches electron.log content alongside app log", async () => {
+    const { deps, handle } = createMockDeps();
+    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+      if (path === "/logs/test-session.log") return Promise.resolve("APP");
+      if (path === "/logs/electron.log") return Promise.resolve("CHROMIUM-NATIVE");
+      return Promise.reject(new Error("ENOENT"));
+    });
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+    handle._emitEvent({
+      dialogId: "dlg-test",
+      actionId: "send",
+      data: { inputs: { description: "both logs" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            logs: "APP",
+            electronLogs: "CHROMIUM-NATIVE",
+          }),
+        })
+      );
+    });
+  });
+
+  it("uses empty electronLogs when electron.log is missing", async () => {
+    const { deps, handle } = createMockDeps();
+    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+      if (path === "/logs/test-session.log") return Promise.resolve("APP");
+      return Promise.reject(new Error("ENOENT"));
+    });
+    const module = createBugReportModule(deps);
+
+    await emitKeyEvent(module, "b");
+    handle._emitEvent({
+      dialogId: "dlg-test",
+      actionId: "send",
+      data: { inputs: { description: "no electron yet" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({ logs: "APP", electronLogs: "" }),
         })
       );
     });

--- a/src/modules/bug-report-module.ts
+++ b/src/modules/bug-report-module.ts
@@ -29,7 +29,7 @@ const MAX_LOG_SIZE = 20 * 1024 * 1024;
 export interface BugReportModuleDeps {
   readonly dialogManager: DialogManager;
   readonly fileSystem: Pick<FileSystemBoundary, "readFile">;
-  readonly loggingService: Pick<Logging, "getLogFilePath">;
+  readonly loggingService: Pick<Logging, "getLogFilePath" | "getElectronLogFilePath">;
   readonly dispatcher: Pick<IDispatcher, "dispatch">;
   readonly config: Pick<Config, "getDefinitions" | "getEffective" | "getDefaults">;
   readonly logger: Logger;
@@ -89,6 +89,18 @@ export function createBugReportModule(deps: BugReportModuleDeps): IntentModule {
     return combined.length > MAX_LOG_SIZE ? combined.slice(-MAX_LOG_SIZE) : combined;
   }
 
+  async function readElectronLogContent(): Promise<string> {
+    const path = deps.loggingService.getElectronLogFilePath();
+    // File is bounded by the truncation watcher in logging-module
+    // (ELECTRON_LOG_MAX_BYTES = 20 MB). May be missing if Chromium hasn't
+    // flushed yet on a very short session.
+    const content = await deps.fileSystem.readFile(path).catch(() => {
+      deps.logger.warn("Failed to read electron log file");
+      return "";
+    });
+    return content.length > MAX_LOG_SIZE ? content.slice(-MAX_LOG_SIZE) : content;
+  }
+
   function openDialog(): void {
     if (activeHandle) return;
 
@@ -99,13 +111,16 @@ export function createBugReportModule(deps: BugReportModuleDeps): IntentModule {
     handle.onEvent((event) => {
       if (event.actionId === "send") {
         void (async () => {
-          const logs = await readLogContent();
+          const [logs, electronLogs] = await Promise.all([
+            readLogContent(),
+            readElectronLogContent(),
+          ]);
           const inputs = (event.data?.inputs ?? {}) as Record<string, string>;
           const description = inputs["description"] ?? "";
 
           void deps.dispatcher.dispatch({
             type: INTENT_SUBMIT_BUG_REPORT,
-            payload: { description, logs },
+            payload: { description, logs, electronLogs },
           } as SubmitBugReportIntent);
 
           handle.close();

--- a/src/modules/logging-module.integration.test.ts
+++ b/src/modules/logging-module.integration.test.ts
@@ -12,6 +12,8 @@ import type { Operation, OperationContext, HookContext } from "../intents/lib/op
 import type { Intent } from "../intents/lib/types";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, InitHookContext, ConfigureResult } from "../intents/app-start";
+import { INTENT_APP_SHUTDOWN, APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import type { AppShutdownIntent } from "../intents/app-shutdown";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { createLoggingModule } from "./logging-module";
 import type { Config } from "../boundaries/platform/config";
@@ -62,6 +64,15 @@ class MinimalAppStartOperation implements Operation<Intent, void> {
   }
 }
 
+/** Runs the "stop" hook for shutdown. */
+class MinimalAppShutdownOperation implements Operation<Intent, void> {
+  readonly id = APP_SHUTDOWN_OPERATION_ID;
+  async execute(ctx: OperationContext<Intent>): Promise<void> {
+    const hookCtx: HookContext = { intent: ctx.intent };
+    await ctx.hooks.collect<void>("stop", hookCtx);
+  }
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -70,6 +81,7 @@ function createDeps(configValues?: Record<string, unknown>) {
   const loggingService = {
     initialize: vi.fn(),
     configure: vi.fn(),
+    getElectronLogFilePath: vi.fn().mockReturnValue("/logs/electron.log"),
   };
   const buildInfo = {
     version: "2026.2.0-test",
@@ -87,8 +99,43 @@ function createDeps(configValues?: Record<string, unknown>) {
     "log.format": "text",
     ...configValues,
   });
+  const app = {
+    commandLine: { appendSwitch: vi.fn() },
+  };
+  const files = new Map<string, string>();
+  const fileSystem = {
+    readFile: vi.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error("ENOENT");
+      return files.get(path)!;
+    }),
+    writeFile: vi.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+  };
+  const scheduledTicks: Array<{ handler: () => void; ms: number; cleared: boolean }> = [];
+  const scheduler = {
+    setInterval: vi.fn((handler: () => void, ms: number) => {
+      const entry = { handler, ms, cleared: false };
+      scheduledTicks.push(entry);
+      return entry;
+    }),
+    clearInterval: vi.fn((handle: unknown) => {
+      (handle as { cleared: boolean }).cleared = true;
+    }),
+  };
 
-  return { loggingService, buildInfo, platformInfo, logger, configService };
+  return {
+    loggingService,
+    buildInfo,
+    platformInfo,
+    logger,
+    configService,
+    app,
+    fileSystem,
+    scheduler,
+    scheduledTicks,
+    files,
+  };
 }
 
 // =============================================================================
@@ -197,5 +244,103 @@ describe("LoggingModule Integration", () => {
       allowedLoggers: undefined,
       logFormat: "text",
     });
+  });
+
+  it("appends --enable-logging=file, --log-file, and --v=1 during before-ready", async () => {
+    const deps = createDeps();
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+
+    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith("enable-logging", "file");
+    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      "log-file",
+      "/logs/electron.log"
+    );
+    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith("v", "1");
+  });
+
+  it("starts the truncation watcher during init", async () => {
+    const deps = createDeps();
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+
+    expect(deps.scheduler.setInterval).toHaveBeenCalledOnce();
+    expect(deps.scheduledTicks).toHaveLength(1);
+    expect(deps.scheduledTicks[0]!.ms).toBe(15 * 60 * 1000);
+  });
+
+  it("truncates electron.log to last 20 MB when the watcher fires on an oversize file", async () => {
+    const deps = createDeps();
+    // Seed an oversize file (21 MB of 'A')
+    const oversize = "A".repeat(21 * 1024 * 1024);
+    deps.files.set("/logs/electron.log", oversize);
+
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+
+    // Manually fire the watcher tick
+    deps.scheduledTicks[0]!.handler();
+    // Tick handler is sync-scheduled but async-internal; wait a microtask
+    await new Promise((r) => setImmediate(r));
+
+    const truncated = deps.files.get("/logs/electron.log");
+    expect(truncated).toBeDefined();
+    expect(Buffer.byteLength(truncated!, "utf8")).toBe(20 * 1024 * 1024);
+  });
+
+  it("does nothing when the watcher fires and the file is within size", async () => {
+    const deps = createDeps();
+    deps.files.set("/logs/electron.log", "small");
+
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+
+    deps.scheduledTicks[0]!.handler();
+    await new Promise((r) => setImmediate(r));
+
+    expect(deps.fileSystem.writeFile).not.toHaveBeenCalled();
+    expect(deps.files.get("/logs/electron.log")).toBe("small");
+  });
+
+  it("silently ignores missing electron.log when the watcher fires", async () => {
+    const deps = createDeps();
+    // No file seeded — readFile rejects with ENOENT
+
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+
+    deps.scheduledTicks[0]!.handler();
+    await new Promise((r) => setImmediate(r));
+
+    expect(deps.fileSystem.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("stops the truncation watcher on app:shutdown stop hook", async () => {
+    const deps = createDeps();
+    const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new MinimalAppShutdownOperation());
+    dispatcher.registerModule(createLoggingModule(deps));
+
+    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+    await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
+
+    expect(deps.scheduler.clearInterval).toHaveBeenCalledOnce();
+    expect(deps.scheduledTicks[0]!.cleared).toBe(true);
   });
 });

--- a/src/modules/logging-module.ts
+++ b/src/modules/logging-module.ts
@@ -2,8 +2,12 @@
  * LoggingModule - Initializes the logging service and logs startup info.
  *
  * Hooks:
- * - app:start → "before-ready": configures logging from Config, logs build info
- * - app:start → "init": initializes logging service
+ * - app:start → "before-ready": configures logging from Config, enables
+ *   Chromium's --enable-logging=file with --v=1 so native Electron/Chromium
+ *   logs are captured to a known path, logs build info
+ * - app:start → "init": initializes logging service, starts the electron.log
+ *   truncation watcher (Chromium has no native log rotation)
+ * - app:shutdown → "stop": stops the truncation watcher
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -12,20 +16,47 @@ import type { Logger, LogFormat } from "../boundaries/platform/logging-types";
 import type { BuildInfo } from "../boundaries/platform/build-info";
 import type { PlatformInfo } from "../boundaries/platform/platform-info";
 import type { Config } from "../boundaries/platform/config";
+import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import { parseLogLevelSpec, splitLogLevelSpec } from "../boundaries/platform/electron-log";
 import { configCustom, configEnum, configEnumList } from "../boundaries/platform/config-definition";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
+import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Hard cap on the electron.log file. Watcher truncates to this size when exceeded. */
+const ELECTRON_LOG_MAX_BYTES = 20 * 1024 * 1024;
+
+/** How often the truncation watcher runs. */
+const ELECTRON_LOG_WATCHER_INTERVAL_MS = 15 * 60 * 1000;
 
 // =============================================================================
 // Dependency Interface
 // =============================================================================
 
+/** Minimal app.commandLine surface used by this module. */
+export interface CommandLineLike {
+  appendSwitch(key: string, value?: string): void;
+}
+
 export interface LoggingModuleDeps {
-  readonly loggingService: Pick<Logging, "initialize" | "configure">;
+  readonly loggingService: Pick<Logging, "initialize" | "configure" | "getElectronLogFilePath">;
   readonly buildInfo: Pick<BuildInfo, "version" | "isDevelopment" | "isPackaged">;
   readonly platformInfo: Pick<PlatformInfo, "platform" | "arch">;
   readonly logger: Logger;
   readonly configService: Config;
+  readonly app: { commandLine: CommandLineLike };
+  readonly fileSystem: Pick<FileSystemBoundary, "readFile" | "writeFile">;
+  /**
+   * Schedule a recurring tick. Defaults to setInterval/clearInterval. Injectable
+   * so integration tests can drive ticks deterministically.
+   */
+  readonly scheduler?: {
+    setInterval(handler: () => void, ms: number): unknown;
+    clearInterval(handle: unknown): void;
+  };
 }
 
 // =============================================================================
@@ -61,12 +92,45 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     ...configEnum(["text", "json"]),
   });
 
+  const scheduler = deps.scheduler ?? {
+    setInterval: (h: () => void, ms: number) => setInterval(h, ms),
+    clearInterval: (handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>),
+  };
+
+  let watcherHandle: unknown = null;
+
+  async function truncateElectronLogIfOversize(): Promise<void> {
+    const path = deps.loggingService.getElectronLogFilePath();
+    const content = await deps.fileSystem.readFile(path).catch(() => null);
+    if (content === null) return; // not yet created
+    const bytes = Buffer.byteLength(content, "utf8");
+    if (bytes <= ELECTRON_LOG_MAX_BYTES) return;
+    // Slice the last N bytes off the end. Slicing by code-unit count would
+    // mis-handle multi-byte UTF-8 sequences; convert via Buffer to be exact.
+    const buf = Buffer.from(content, "utf8");
+    const tail = buf.subarray(buf.length - ELECTRON_LOG_MAX_BYTES).toString("utf8");
+    await deps.fileSystem.writeFile(path, tail).catch((err: unknown) =>
+      deps.logger.warn("Failed to truncate electron.log", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+  }
+
   return {
     name: "logging",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
           handler: async (): Promise<void> => {
+            // Enable Chromium/Electron native logging to a known file. Must be
+            // appended before app.whenReady. --v=1 captures verbose internals
+            // useful in bug reports (GPU, IPC, renderer crashes). The file is
+            // overwritten on each launch by Chromium itself.
+            const electronLogPath = deps.loggingService.getElectronLogFilePath();
+            deps.app.commandLine.appendSwitch("enable-logging", "file");
+            deps.app.commandLine.appendSwitch("log-file", electronLogPath);
+            deps.app.commandLine.appendSwitch("v", "1");
+
             // Configure logging from loaded config
             const levelSpec = deps.configService.get("log.level") as string;
             const { level, filter } = splitLogLevelSpec(levelSpec);
@@ -93,6 +157,25 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
           requires: { "app-ready": true },
           handler: async (): Promise<void> => {
             deps.loggingService.initialize();
+            // Chromium has no native log rotation. Cap on-disk size with a
+            // simple periodic watcher (stat-then-truncate-tail). Memory cost
+            // is bounded by ELECTRON_LOG_MAX_BYTES on each tick.
+            if (watcherHandle === null) {
+              watcherHandle = scheduler.setInterval(
+                () => void truncateElectronLogIfOversize(),
+                ELECTRON_LOG_WATCHER_INTERVAL_MS
+              );
+            }
+          },
+        },
+      },
+      [APP_SHUTDOWN_OPERATION_ID]: {
+        stop: {
+          handler: async (): Promise<void> => {
+            if (watcherHandle !== null) {
+              scheduler.clearInterval(watcherHandle);
+              watcherHandle = null;
+            }
           },
         },
       },

--- a/src/modules/posthog-module.integration.test.ts
+++ b/src/modules/posthog-module.integration.test.ts
@@ -169,8 +169,12 @@ function appResumeIntent(): AppResumeIntent {
   return { type: INTENT_APP_RESUME, payload: {} as AppResumeIntent["payload"] };
 }
 
-function submitBugReportIntent(description: string, logs: string): SubmitBugReportIntent {
-  return { type: INTENT_SUBMIT_BUG_REPORT, payload: { description, logs } };
+function submitBugReportIntent(
+  description: string,
+  logs: string,
+  electronLogs = ""
+): SubmitBugReportIntent {
+  return { type: INTENT_SUBMIT_BUG_REPORT, payload: { description, logs, electronLogs } };
 }
 
 // =============================================================================
@@ -671,7 +675,7 @@ describe("PosthogModule Integration", () => {
       expect(decompressed).toBe("log line 1\nlog line 2");
     });
 
-    it("trims raw logs until compressed payload fits PostHog's 1MB limit", async () => {
+    it("trims each log field independently to the 450 KB per-field cap", async () => {
       const { dispatcher, getMock } = createTestSetup({
         configValues: {
           "telemetry.enabled": true,
@@ -680,23 +684,79 @@ describe("PosthogModule Integration", () => {
         },
       });
 
-      // Truly random bytes don't compress, so 5MB of them blows past the 1MB
-      // cap even after gzip+base64, forcing the trim loop to drop bytes.
+      // Truly random bytes don't compress, so each blob blows past the
+      // 450 KB per-field cap and forces the trim loop to drop bytes.
       const { randomBytes } = await import("node:crypto");
-      const incompressible = randomBytes(5 * 1024 * 1024).toString("binary");
+      const appRaw = randomBytes(3 * 1024 * 1024).toString("binary");
+      const electronRaw = randomBytes(3 * 1024 * 1024).toString("binary");
 
       await dispatcher.dispatch(startIntent());
-      await dispatcher.dispatch(submitBugReportIntent("big report", incompressible));
+      await dispatcher.dispatch(submitBugReportIntent("big report", appRaw, electronRaw));
 
       const mock = getMock()!;
       const captured = mock.$.capturedEvents.find((e) => e.event === "$exception");
       expect(captured).toBeDefined();
       const props = captured!.properties as Record<string, unknown>;
-      expect((props["logs"] as string).length).toBeLessThanOrEqual(1_000_000);
+
+      expect((props["logs"] as string).length).toBeLessThanOrEqual(450_000);
       expect(props["logs_raw_bytes_dropped"]).toBeGreaterThan(0);
       expect(
         (props["logs_raw_bytes"] as number) + (props["logs_raw_bytes_dropped"] as number)
-      ).toBe(incompressible.length);
+      ).toBe(appRaw.length);
+
+      expect((props["electron_logs"] as string).length).toBeLessThanOrEqual(450_000);
+      expect(props["electron_logs_format"]).toBe("gzip+base64");
+      expect(props["electron_logs_raw_bytes_dropped"]).toBeGreaterThan(0);
+      expect(
+        (props["electron_logs_raw_bytes"] as number) +
+          (props["electron_logs_raw_bytes_dropped"] as number)
+      ).toBe(electronRaw.length);
+    });
+
+    it("includes electron_logs alongside app logs when both are present", async () => {
+      const { dispatcher, getMock } = createTestSetup({
+        configValues: {
+          "telemetry.enabled": true,
+          "telemetry.distinct-id": "test-id",
+          agent: "claude",
+        },
+      });
+
+      await dispatcher.dispatch(startIntent());
+      await dispatcher.dispatch(
+        submitBugReportIntent("two streams", "APP-LOG-CONTENT", "CHROMIUM-LOG-CONTENT")
+      );
+
+      const mock = getMock()!;
+      const captured = mock.$.capturedEvents.find((e) => e.event === "$exception");
+      const props = captured!.properties as Record<string, unknown>;
+      const { gunzipSync } = await import("node:zlib");
+      const decodedApp = gunzipSync(Buffer.from(props["logs"] as string, "base64")).toString();
+      const decodedElectron = gunzipSync(
+        Buffer.from(props["electron_logs"] as string, "base64")
+      ).toString();
+      expect(decodedApp).toBe("APP-LOG-CONTENT");
+      expect(decodedElectron).toBe("CHROMIUM-LOG-CONTENT");
+    });
+
+    it("encodes electron_logs format as 'none' when empty", async () => {
+      const { dispatcher, getMock } = createTestSetup({
+        configValues: {
+          "telemetry.enabled": true,
+          "telemetry.distinct-id": "test-id",
+          agent: "claude",
+        },
+      });
+
+      await dispatcher.dispatch(startIntent());
+      await dispatcher.dispatch(submitBugReportIntent("no electron", "APP", ""));
+
+      const mock = getMock()!;
+      const captured = mock.$.capturedEvents.find((e) => e.event === "$exception");
+      const props = captured!.properties as Record<string, unknown>;
+      expect(props["electron_logs"]).toBe("");
+      expect(props["electron_logs_format"]).toBe("none");
+      expect(props["electron_logs_raw_bytes"]).toBe(0);
     });
 
     it("sends bug report even when telemetry is disabled", async () => {

--- a/src/modules/posthog-module.ts
+++ b/src/modules/posthog-module.ts
@@ -32,6 +32,39 @@ import type { ConfigAgentType } from "../boundaries/platform/config-values";
 import type { Logger } from "../boundaries/platform/logging";
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Per-field compressed cap for log payloads on the bug_report event. With two
+ * log streams (app + electron) this gives ~900 KB combined, leaving ~148 KB
+ * under PostHog's 1 MB hard cap for description, metadata, and SDK overhead.
+ */
+const LOG_FIELD_COMPRESSED_CAP = 450_000;
+const COMPRESS_SAFETY_FACTOR = 0.95;
+
+/**
+ * Compress `raw` with gzip+base64 and, if the result exceeds the cap, trim
+ * the raw input from the front (keeping the most recent tail) and re-compress.
+ * Each iteration scales the raw size down by the observed overshoot ratio
+ * with a safety margin, so we usually converge in 1–2 passes.
+ */
+function compressAndTrim(raw: string): { compressed: string; rawBytesKept: number } {
+  let kept = raw;
+  let compressed = kept ? gzipSync(kept).toString("base64") : "";
+  while (compressed.length > LOG_FIELD_COMPRESSED_CAP && kept.length > 0) {
+    const scaled = Math.floor(
+      (kept.length * LOG_FIELD_COMPRESSED_CAP * COMPRESS_SAFETY_FACTOR) / compressed.length
+    );
+    // Guarantee progress even if rounding/SAFETY_FACTOR don't shrink enough
+    const nextLen = Math.max(0, Math.min(scaled, kept.length - 1));
+    kept = nextLen > 0 ? kept.slice(kept.length - nextLen) : "";
+    compressed = kept ? gzipSync(kept).toString("base64") : "";
+  }
+  return { compressed, rawBytesKept: kept.length };
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -204,7 +237,7 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
    * Bug reports are explicit user actions, not passive telemetry.
    * No-op only if API key is missing.
    */
-  function captureBugReport(description: string, logs: string): void {
+  function captureBugReport(description: string, logs: string, electronLogs: string): void {
     if (!deps.apiKey || deps.apiKey.trim() === "") return;
 
     // Lazily create client if telemetry was disabled
@@ -214,7 +247,7 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
         void result.then((c) => {
           client = c;
           // Retry after async client creation
-          captureBugReport(description, logs);
+          captureBugReport(description, logs, electronLogs);
         });
         return;
       }
@@ -231,31 +264,22 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
 
     deps.logger.info("Bug report captured");
 
-    // PostHog discards events larger than 1 MB. Compress logs (gzip+base64) and,
-    // if the payload overshoots, trim the raw input from the front (keeping the
-    // most recent tail). Each iteration scales the raw size down by the observed
-    // overshoot ratio with a safety margin, so we usually converge in 1–2 passes
-    // and keep close to the cap (vs. naive halving which would ship ~half on a
-    // small overshoot).
-    const POSTHOG_EVENT_LIMIT = 1_000_000;
-    const SAFETY_FACTOR = 0.95;
-    let rawLogs = logs;
-    let logsCompressed = rawLogs ? gzipSync(rawLogs).toString("base64") : "";
-    while (logsCompressed.length > POSTHOG_EVENT_LIMIT && rawLogs.length > 0) {
-      const scaled = Math.floor(
-        (rawLogs.length * POSTHOG_EVENT_LIMIT * SAFETY_FACTOR) / logsCompressed.length
-      );
-      // Guarantee progress even if rounding/SAFETY_FACTOR don't shrink enough
-      const nextLen = Math.max(0, Math.min(scaled, rawLogs.length - 1));
-      rawLogs = nextLen > 0 ? rawLogs.slice(rawLogs.length - nextLen) : "";
-      logsCompressed = rawLogs ? gzipSync(rawLogs).toString("base64") : "";
-    }
+    // PostHog discards events larger than 1 MB. We carry two log streams (app
+    // log + Chromium native log) and cap each independently at 450 KB
+    // compressed, leaving ~148 KB headroom under the 1 MB hard cap for
+    // description + metadata + SDK overhead.
+    const appLogs = compressAndTrim(logs);
+    const electronLogsBlob = compressAndTrim(electronLogs);
 
     client.captureException(bugError, id, {
-      logs: logsCompressed,
-      logs_format: logsCompressed ? "gzip+base64" : "none",
-      logs_raw_bytes: rawLogs.length,
-      logs_raw_bytes_dropped: logs.length - rawLogs.length,
+      logs: appLogs.compressed,
+      logs_format: appLogs.compressed ? "gzip+base64" : "none",
+      logs_raw_bytes: appLogs.rawBytesKept,
+      logs_raw_bytes_dropped: logs.length - appLogs.rawBytesKept,
+      electron_logs: electronLogsBlob.compressed,
+      electron_logs_format: electronLogsBlob.compressed ? "gzip+base64" : "none",
+      electron_logs_raw_bytes: electronLogsBlob.rawBytesKept,
+      electron_logs_raw_bytes_dropped: electronLogs.length - electronLogsBlob.rawBytesKept,
       ...eventProperties(),
       version: deps.buildInfo.version,
     });
@@ -370,8 +394,8 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
       },
       [EVENT_BUG_REPORT_SUBMITTED]: {
         handler: async (event: DomainEvent): Promise<void> => {
-          const { description, logs } = (event as BugReportSubmittedEvent).payload;
-          captureBugReport(description, logs);
+          const { description, logs, electronLogs } = (event as BugReportSubmittedEvent).payload;
+          captureBugReport(description, logs, electronLogs);
         },
       },
     },


### PR DESCRIPTION
- Enable `--enable-logging=file --v=1` so Chromium internals (GPU, IPC, renderer crashes) are written to `<logs>/electron.log`
- 15-min watcher in logging-module caps the file at 20 MB (Chromium has no native rotation)
- Bug-report module reads `electron.log` alongside the app log
- PostHog `bug_report` event now carries a second `electron_logs` field; each log is independently capped at 450 KB compressed (~900 KB combined, safely under the 1 MB event limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)