### PR TITLE
fix: disabled unused chromium features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,22 +303,23 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                                 | Default | Description                                                                           |
-| ----------------------------------- | ------- | ------------------------------------------------------------------------------------- |
-| `agent`                             | `null`  | Agent selection: claude\|opencode                                                     |
-| `auto-update`                       | `ask`   | Auto-update preference: always\|ask\|never                                            |
-| `version.claude`                    | `null`  | Claude agent version override                                                         |
-| `version.opencode`                  | `null`  | OpenCode agent version override                                                       |
-| `code-server.port`                  | (auto)  | Code-server port (auto = 25448 in prod, branch-derived in dev)                        |
-| `version.code-server`               | `null`  | Code-server version override (null = built-in)                                        |
-| `telemetry.enabled`                 | `true`  | Enable telemetry (false in dev/unpackaged)                                            |
-| `telemetry.distinct-id`             | —       | Telemetry user ID (auto-generated)                                                    |
-| `log.level`                         | `warn`  | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)               |
-| `log.output`                        | `file`  | Output destinations: `file`, `console`, or `file,console`                             |
-| `electron.flags`                    | —       | Electron switches (e.g., `--disable-gpu`)                                             |
-| `experimental.github.query`         | (below) | GitHub search query; default: `is:open is:pr review-requested:@me`                    |
-| `experimental.github.template-path` | `null`  | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI) |
-| `help`                              | `false` | Print config help and exit                                                            |
+| Key                                 | Default   | Description                                                                                                                                       |
+| ----------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                             | `null`    | Agent selection: claude\|opencode                                                                                                                 |
+| `auto-update`                       | `ask`     | Auto-update preference: always\|ask\|never                                                                                                        |
+| `version.claude`                    | `null`    | Claude agent version override                                                                                                                     |
+| `version.opencode`                  | `null`    | OpenCode agent version override                                                                                                                   |
+| `code-server.port`                  | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                    |
+| `version.code-server`               | `null`    | Code-server version override (null = built-in)                                                                                                    |
+| `telemetry.enabled`                 | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                        |
+| `telemetry.distinct-id`             | —         | Telemetry user ID (auto-generated)                                                                                                                |
+| `log.level`                         | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                           |
+| `log.output`                        | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                         |
+| `electron.flags`                    | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                         |
+| `electron.disabled-features`        | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults |
+| `experimental.github.query`         | (below)   | GitHub search query; default: `is:open is:pr review-requested:@me`                                                                                |
+| `experimental.github.template-path` | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI)                                                             |
+| `help`                              | `false`   | Print config help and exit                                                                                                                        |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -20,6 +20,7 @@ import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "../intents/app-shutdo
 import type { AppShutdownIntent } from "../intents/app-shutdown";
 import {
   createElectronLifecycleModule,
+  DEFAULT_DISABLED_FEATURES,
   type ElectronLifecycleModuleDeps,
 } from "./electron-lifecycle-module";
 import type { Config } from "../boundaries/platform/config";
@@ -332,6 +333,139 @@ describe("ElectronLifecycleModule Integration", () => {
 
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("no-proxy-server");
     });
+
+    it("applies curated default --disable-features when electron.disabled-features is unset", async () => {
+      const mockApp = createMockApp();
+      const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+
+      const module = createElectronLifecycleModule({
+        app: mockApp,
+        logger: SILENT_LOGGER,
+        configService: createMockConfig(),
+      });
+
+      dispatcher.registerModule(module);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      const expected = DEFAULT_DISABLED_FEATURES.join(",");
+      expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("disable-features", expected);
+    });
+
+    it("user-supplied electron.disabled-features fully replaces defaults", async () => {
+      const mockApp = createMockApp();
+      const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+
+      const module = createElectronLifecycleModule({
+        app: mockApp,
+        logger: SILENT_LOGGER,
+        configService: createMockConfig({
+          "electron.disabled-features": "FeatureA, FeatureB",
+        }),
+      });
+
+      dispatcher.registerModule(module);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith(
+        "disable-features",
+        "FeatureA,FeatureB"
+      );
+      // Defaults are NOT applied
+      const defaultExpected = DEFAULT_DISABLED_FEATURES.join(",");
+      expect(mockApp.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+        "disable-features",
+        defaultExpected
+      );
+    });
+
+    it("empty string for electron.disabled-features disables nothing (no --disable-features switch)", async () => {
+      const mockApp = createMockApp();
+      const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+
+      const module = createElectronLifecycleModule({
+        app: mockApp,
+        logger: SILENT_LOGGER,
+        configService: createMockConfig({ "electron.disabled-features": "" }),
+      });
+
+      dispatcher.registerModule(module);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      const disableFeaturesCalls = (
+        mockApp.commandLine.appendSwitch as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call) => call[0] === "disable-features");
+      expect(disableFeaturesCalls).toEqual([]);
+    });
+
+    it("explicit null for electron.disabled-features still applies defaults", async () => {
+      const mockApp = createMockApp();
+      const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+
+      const module = createElectronLifecycleModule({
+        app: mockApp,
+        logger: SILENT_LOGGER,
+        configService: createMockConfig({ "electron.disabled-features": null }),
+      });
+
+      dispatcher.registerModule(module);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      const expected = DEFAULT_DISABLED_FEATURES.join(",");
+      expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("disable-features", expected);
+    });
+
+    it("logs the disabled features list at info level", async () => {
+      const mockApp = createMockApp();
+      const logger = createMockLogger();
+      const dispatcher = new Dispatcher({ logger: createMockLogger() });
+
+      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+
+      const module = createElectronLifecycleModule({
+        app: mockApp,
+        logger,
+        configService: createMockConfig({
+          "electron.disabled-features": "Foo,Bar",
+        }),
+      });
+
+      dispatcher.registerModule(module);
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_START,
+        payload: {},
+      } as AppStartIntent);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "Disabled Chromium features",
+        expect.objectContaining({ count: 2, features: "Foo,Bar" })
+      );
+    });
+
   });
 
   // ---------------------------------------------------------------------------

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -465,7 +465,6 @@ describe("ElectronLifecycleModule Integration", () => {
         expect.objectContaining({ count: 2, features: "Foo,Bar" })
       );
     });
-
   });
 
   // ---------------------------------------------------------------------------

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -61,6 +61,57 @@ export function parseElectronFlags(flags: string | undefined): { name: string; v
   return result;
 }
 
+/**
+ * Default Chromium features to disable. Curated for CodeHydra's use case:
+ * a desktop dev tool hosting code-server and agent UIs, with no media playback,
+ * autofill, translate, casting, ad-tech, or web device APIs.
+ *
+ * Excludes BackForwardCache, IsolateOrigins/SitePerProcess, NetworkService,
+ * GPU-pipeline features, Spellcheck, and the web Notifications API — those
+ * carry risk or have a real upside we want to keep.
+ */
+export const DEFAULT_DISABLED_FEATURES: readonly string[] = [
+  // Occlusion (Windows) — we manage view visibility ourselves
+  "CalculateNativeWinOcclusion",
+  // Media — no playback / casting / media-key hijacking
+  "MediaSessionService",
+  "HardwareMediaKeyHandling",
+  "GlobalMediaControls",
+  "MediaRouter",
+  "DialMediaRouteProvider",
+  // Autofill / Translate / SafeBrowsing — not useful in an IDE host
+  "AutofillServerCommunication",
+  "Translate",
+  "TranslateUI",
+  "TranslateSubFrames",
+  "SafeBrowsingEnhancedProtection",
+  "SafeBrowsingExtendedReportingOptInAllowed",
+  // Cloud-ML hints — phones home
+  "OptimizationHints",
+  "OptimizationGuideModelDownloading",
+  // Privacy Sandbox / ad-tech APIs — dead weight in Electron
+  "PrivacySandboxSettings4",
+  "BrowsingTopics",
+  "AttributionReporting",
+  "FedCm",
+  // Misc web platform we don't use
+  "AcceptCHFrame",
+  "WebOTP",
+  "IdleDetection",
+  // Service-worker background machinery — we use Electron native notifications
+  "BackgroundFetch",
+  "BackgroundSync",
+  "PushMessaging",
+  // Web device APIs — reduce attack surface
+  "WebBluetooth",
+  "WebUSB",
+  "WebSerial",
+  "WebHID",
+  // Chrome browser-UI features that don't apply to Electron
+  "LensOverlay",
+  "ReadAnything",
+];
+
 // =============================================================================
 // Dependency Interface
 // =============================================================================
@@ -86,11 +137,19 @@ export interface ElectronLifecycleModuleDeps {
 // =============================================================================
 
 export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps): IntentModule {
-  // Register config key
+  // Register config keys
   deps.configService.register("electron.flags", {
     name: "electron.flags",
     default: null,
     description: "Electron switches (e.g., --disable-gpu)",
+    ...configString({ nullable: true }),
+  });
+  deps.configService.register("electron.disabled-features", {
+    name: "electron.disabled-features",
+    default: null,
+    description:
+      "Comma-separated Chromium features to disable via --disable-features. " +
+      "null = use curated defaults; empty string = disable nothing; any value fully replaces defaults.",
     ...configString({ nullable: true }),
   });
 
@@ -114,6 +173,27 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
             // Users can override via electron.flags (e.g. --proxy-server=...).
             deps.app.commandLine.appendSwitch("no-proxy-server");
             deps.logger.info("Applied Electron flag", { flag: "no-proxy-server" });
+            // Apply --disable-features from config (or curated defaults).
+            // null/undefined = use defaults; "" = disable nothing; any other value fully replaces defaults.
+            const disabledFeaturesValue = deps.configService.get("electron.disabled-features") as
+              | string
+              | null
+              | undefined;
+            const disabledFeatures =
+              disabledFeaturesValue === null || disabledFeaturesValue === undefined
+                ? [...DEFAULT_DISABLED_FEATURES]
+                : disabledFeaturesValue
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+            if (disabledFeatures.length > 0) {
+              const joined = disabledFeatures.join(",");
+              deps.app.commandLine.appendSwitch("disable-features", joined);
+              deps.logger.info("Disabled Chromium features", {
+                count: disabledFeatures.length,
+                features: joined,
+              });
+            }
             // Apply electron flags from config
             const flagsValue = deps.configService.get("electron.flags") as string | null;
             const flags = parseElectronFlags(flagsValue ?? undefined);


### PR DESCRIPTION
- Add `electron.disabled-features` config key with a curated default list of Chromium features to disable
- Emit a single `--disable-features=...` switch in the `before-ready` hook; final list logged at info
- Covers occlusion (CalculateNativeWinOcclusion), media/casting, autofill/translate/safebrowsing, optimization hints, privacy sandbox, AcceptCHFrame/WebOTP/IdleDetection, background fetch/sync/push, Web{Bluetooth,USB,Serial,HID}, LensOverlay/ReadAnything
- Excludes BackForwardCache, IsolateOrigins/SitePerProcess, NetworkService, GPU pipeline, Spellcheck — features with real upside or risk
- `null` (unset) = curated defaults; `""` = disable nothing; any value fully replaces defaults