### PR TITLE
refactor(view-manager): extract BaseViewManager + capability getters

### DIFF
--- a/planning/view-manager-refactor.md
+++ b/planning/view-manager-refactor.md
@@ -1,0 +1,411 @@
+# View Manager Refactor — Design Doc
+
+## Context
+
+`src/boundaries/shell/view-manager.ts` is a ~1.4k-line `ViewManager` class that mixes
+per-workspace `WebContentsView` lifecycle with UI-level concerns that have nothing to
+do with Electron's view model (UI mode state machine, z-order rules, focus routing,
+loading-overlay coordination, active-workspace switching with attach-before-detach
+sequencing, etc.).
+
+A separate branch is exploring an alternative implementation (different rendering
+model). To unblock that work cleanly — and to let both implementations live behind a
+feature flag without duplicating fragile coordination logic — the existing code needs
+to be re-shaped so the seam is sharp:
+
+- An **abstract base class** owns all the UI/state-machine logic that any
+  implementation must share.
+- A **concrete subclass** owns only the Electron-`WebContentsView`-specific bits
+  (creation/security, attach/detach, URL load + retry, render-process-gone recovery,
+  watchdog, etc.).
+- A **conformance test suite** that runs against any `IViewManager` implementation,
+  so the alternative implementation can prove it honors the same contracts.
+- Narrow **capability interfaces** (`DevtoolsTarget`, `KeyboardTarget`) replace the
+  current `ViewHandle` escape hatches so consumers stop coupling to Electron's view
+  layer.
+
+This refactor is **behavior-preserving**. No new features. No iframe work. No feature
+flag yet — just the seam.
+
+---
+
+## Findings from the current code
+
+`IViewManager` (`src/boundaries/shell/view-manager.interface.ts`) is Electron-agnostic
+at the type level. The two leaks are `getUIViewHandle()` and `getWorkspaceView()`,
+which return raw `ViewHandle`s. Consumers use them only as tokens passed back to
+`viewLayer`:
+
+- `devtools-module.ts:45,52` — handle goes into `viewLayer.openDevTools/closeDevTools/
+isDevToolsOpened`.
+- `shortcut-module.ts:90-104,229,253` — handle goes into
+  `viewLayer.onBeforeInputEvent`/`onDestroyed`, and `handle.id` is a map key.
+
+That's it. Both can be replaced by tiny capability interfaces the view-manager
+returns, with no loss of functionality.
+
+What's genuinely shared (UI/coordination, identical for any implementation):
+
+- UI mode state machine (`"workspace" | "shortcut" | "dialog" | "hover"`) + mode bus.
+- Active-workspace tracking and the **attach-before-detach** sequencing in
+  `setActiveWorkspace` (visual continuity guarantee).
+- Z-order re-adjustment after switching while in `dialog`/`shortcut`/`hover` mode
+  (`view-manager.ts:858-892`, `1137-1150`).
+- Loading-state coordinator: `loadingWorkspaces` map, 10s timeout,
+  `setWorkspaceLoaded` idempotency guard, **immediate replay of `loading=false` for
+  already-loaded workspaces** on `onLoadingChange` subscription
+  (`view-manager.ts:1177-1194`).
+- Focus router (`getTopView()` + mode-switched `focus()` at
+  `view-manager.ts:927-977`).
+- Bounds math: clamp to 800×600, UI gets full window, active workspace offset by
+  `SIDEBAR_MINIMIZED_WIDTH`, loading workspaces still receive full bounds while
+  detached so the renderer re-layouts (`view-manager.ts:616-657`).
+- Workspace registry, event-callback sets, IPC `sendToUI` passthrough,
+  `destroy()` bookkeeping, reentrancy guard.
+- Concrete default for `reloadAllViews()` (iterate, skip loading, call a
+  per-workspace reload primitive).
+- Concrete default for `updateCodeServerPort()` (store the port on the base;
+  subclass primitives read it when they care).
+
+What's genuinely WebContents-specific:
+
+- Electron security/partition config (`webviewTag`, `focusOnNavigation`,
+  `backgroundThrottling`, permission/header handlers).
+- Wiring of `will-navigate`, `did-fail-load`, `render-process-gone`,
+  `did-finish-load`, `unresponsive`/`responsive`.
+- Exponential-backoff retry on main-frame load failure (`RETRY_DELAYS_MS`).
+- `needsReloadOnAttach` flag + 15s watchdog + `recreateWorkspaceView()`.
+- Windows DirectComposition re-composite workaround (inline in the subclass's
+  `attachView` override).
+- Calls into `viewLayer`/`sessionLayer`.
+
+Consumers: only `main.ts` references the **concrete** class. Every other module uses
+`IViewManager` or `Pick<IViewManager, …>`. After commits 7–8, `devtools-module` and
+`shortcut-module` stop importing `ViewBoundary` for view-manager-owned handles.
+
+---
+
+## Target structure
+
+Composition + a template-method base class. Concrete impl is a thin subclass that
+fills in primitive operations; the base owns all state and orchestration.
+
+```
+src/boundaries/shell/
+  view-manager.interface.ts          # IViewManager — invariants in JSDoc;
+                                       capability getters replace handle getters
+  view-manager-base.ts               # abstract BaseViewManager<TImplState> (new)
+  view-manager-types.ts              # WorkspaceState<TImplState>, UIMode,
+                                       DevtoolsTarget, KeyboardTarget,
+                                       pure bounds/z-order helpers (new)
+  webcontents-view-manager.ts        # concrete impl (renamed from view-manager.ts)
+  view-manager.conformance.ts        # impl-agnostic test suite + Probe type (new)
+  webcontents-view-manager.integration.test.ts
+                                     # invokes conformance suite with a
+                                       WebContents factory + impl-specific tests
+```
+
+### `BaseViewManager<TImplState>` — owns the state machine
+
+Generic only over `TImplState`, the per-workspace impl-private slot
+(e.g. `WebContentsImplState` carries retry counters + watchdog timers).
+Handles stay typed via existing abstract `ViewHandle` — no extra generics there.
+
+State (moved from current `ViewManager`):
+
+- `workspaceStates: Map<string, WorkspaceState<TImplState>>`.
+- `mode`, `activeWorkspacePath`, `attachedWorkspacePath`, `destroying`,
+  `isChangingWorkspace` reentrancy guard.
+- `loadingWorkspaces: Map<string, NodeJS.Timeout>`, event-callback sets.
+- `codeServerPort: number` (set by `updateCodeServerPort`, read by subclass).
+
+Concrete methods (full implementations live here):
+
+- `create()`, `destroy()`
+- `setMode`, `getMode`, `onModeChange`
+- `setActiveWorkspace` (incl. attach-before-detach + z-order re-adjustment),
+  `getActiveWorkspacePath`
+- `focus()`, `getTopView()`
+- `isWorkspaceLoading`, `setWorkspaceLoaded`, `onLoadingChange` (with immediate
+  replay), 10s loading timeout
+- `updateBounds()` (uses bounds-math helpers from `view-manager-types.ts`)
+- `getWorkspaceState`, `isUIAvailable`
+- `getUIDevtoolsTarget`, `getWorkspaceDevtoolsTarget(path)`,
+  `getUIKeyboardTarget`, `getWorkspaceKeyboardTarget(path)` — default impls call
+  protected primitives `makeDevtoolsTarget(handle)` / `makeKeyboardTarget(handle)`
+- `sendToUI` (delegated to a `sendIpc` primitive)
+- `reloadAllViews()` (default: iterate, skip loading, call `reloadView(state)`)
+- `updateCodeServerPort()` (default: store the port; subclass reads via getter)
+
+Abstract primitives (subclass fills in):
+
+```ts
+protected abstract createUIView(): ViewHandle;
+protected abstract loadUIContent(handle: ViewHandle): Promise<void>;
+protected abstract disposeUIView(handle: ViewHandle): void;
+
+protected abstract createUnderlyingView(
+  path: string, url: string, projectPath: string, isNew: boolean,
+): { handle: ViewHandle; implState: TImplState };
+protected abstract loadWorkspaceUrl(state: WorkspaceState<TImplState>): void;
+protected abstract attachView(state: WorkspaceState<TImplState>): void;
+protected abstract detachView(state: WorkspaceState<TImplState>): void;
+protected abstract applyBounds(handle: ViewHandle, rect: Rect): void;
+protected abstract focusHandle(handle: ViewHandle): void;
+protected abstract disposeView(state: WorkspaceState<TImplState>): Promise<void>;
+protected abstract captureViewPng(handle: ViewHandle): Promise<Buffer | null>;
+protected abstract sendIpc(channel: string, ...args: unknown[]): void;
+protected abstract reloadView(state: WorkspaceState<TImplState>): void;
+
+protected abstract makeDevtoolsTarget(handle: ViewHandle): DevtoolsTarget;
+protected abstract makeKeyboardTarget(handle: ViewHandle): KeyboardTarget;
+```
+
+### `WebContentsViewManager` — concrete subclass
+
+Owns everything currently inline that is `WebContents`-specific:
+
+- Electron security/partition wiring inside `createUnderlyingView`.
+- `wireEventHandlers()` (`will-navigate`, `did-fail-load`, `render-process-gone`,
+  `did-finish-load`, `unresponsive`/`responsive`).
+- `handleLoadFailure()` + `RETRY_DELAYS_MS` exponential backoff
+  (state held in `WebContentsImplState`).
+- `needsReloadOnAttach` flag + `RELOAD_WATCHDOG_MS` watchdog +
+  `recreateWorkspaceView()`.
+- Windows DirectComposition re-composite — **inline inside `attachView` override**.
+- `makeDevtoolsTarget(handle)` and `makeKeyboardTarget(handle)` — closures over
+  `viewLayer` that adapt the calls (`openDevTools`/`closeDevTools`/
+  `isDevToolsOpened`, `onBeforeInputEvent`/`onDestroyed`). Each returned target
+  carries a stable `id` (the handle id) so consumers can keep using it as a map key.
+- Concrete delegation to `viewLayer.attachToWindow`/`detachFromWindow`/
+  `setBounds`/`focus`/`reload` and `sessionLayer`.
+
+### Why template-method + composition (and not pure composition)
+
+Composition forces the base to call into a strategy via an interface, but most
+"primitives" need access to shared state (the registry, the attached path, etc.).
+Template-method keeps shared state encapsulated and the subclass override surface
+flat — closer to what's there today, lower risk per commit. Stateless concerns
+(bounds math, mode→z-order mapping) are **plain functions** in
+`view-manager-types.ts` regardless, so they're trivially unit-testable.
+
+### Construction
+
+`create()` stays on `IViewManager` (two-phase init: `new` then `await create()`).
+`main.ts` picks the concrete class; `view-module.ts` keeps calling
+`viewManager.create()` in the `app-start/init` hook. No factory indirection.
+A future feature flag becomes a one-line `new A() vs new B()` swap in `main.ts`.
+
+### Narrow capability interfaces
+
+```ts
+// in view-manager-types.ts
+export interface DevtoolsTarget {
+  readonly id: string; // stable; was handle.id
+  toggle(): void; // open if closed, close if open
+  isOpen(): boolean;
+}
+
+export interface KeyboardTarget {
+  readonly id: string;
+  onBeforeInput(cb: (input: KeyboardInput) => void): Unsubscribe;
+  onDestroyed(cb: () => void): Unsubscribe;
+}
+```
+
+`IViewManager` exposes:
+
+- `getUIDevtoolsTarget(): DevtoolsTarget`
+- `getWorkspaceDevtoolsTarget(path): DevtoolsTarget | undefined`
+- `getUIKeyboardTarget(): KeyboardTarget`
+- `getWorkspaceKeyboardTarget(path): KeyboardTarget | undefined`
+
+`getUIViewHandle()` and `getWorkspaceView()` are **removed** in commit 8.
+
+---
+
+## Conformance test suite
+
+`view-manager.conformance.ts` exports:
+
+```ts
+export interface ConformanceProbe {
+  attachLog: string[]; // paths in attach order
+  detachLog: string[]; // paths in detach order
+  isAttached(path: string): boolean;
+  uiIsTop(): boolean; // for z-order assertions
+}
+
+export function runViewManagerConformance(opts: {
+  name: string;
+  makeFactory: () => Promise<{
+    create(): Promise<IViewManager>; // tests call this per case
+    probe: ConformanceProbe; // populated by the factory's mocks
+  }>;
+}): void;
+```
+
+Each implementation's test file builds its own probe over its own mocks. For
+`WebContentsViewManager`, the probe wraps `ViewBoundaryMock`'s call log. The alt
+impl, when it lands, ships its own probe over whatever mock surface it uses — the
+conformance suite stays oblivious.
+
+Cross-impl assertions inside the suite:
+
+- `setActiveWorkspace` attaches new view **before** detaching old (probe ordering).
+- Idempotency: re-`setActiveWorkspace`(samePath), `setMode`(sameMode),
+  `setWorkspaceLoaded`, `destroyWorkspaceView` are all no-ops on repeat.
+- `onLoadingChange` replays `loading=false` immediately for already-loaded
+  workspaces.
+- Loading-state 10s timeout flips a workspace to loaded.
+- Z-order: switching active workspace while in `shortcut`/`dialog`/`hover` leaves
+  the UI handle on top (`probe.uiIsTop()`).
+- `updateBounds()` is O(1) over workspaces (only UI + active touched on resize).
+- `focus()` routes per mode.
+- `destroy()` is idempotent and tears down every workspace.
+- `getUIDevtoolsTarget()` / `getWorkspaceDevtoolsTarget(path)` round-trip
+  toggle → isOpen.
+- `KeyboardTarget.onBeforeInput` fires for input events on the underlying view.
+
+`webcontents-view-manager.integration.test.ts` invokes
+`runViewManagerConformance(...)` and retains WebContents-specific tests:
+retry backoff, watchdog, render-process-gone flag, navigation/origin handler,
+Windows DirectComposition workaround.
+
+---
+
+## Critical files
+
+| File                                                                | Change                                                                                                                                                                                 |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/boundaries/shell/view-manager.interface.ts`                    | Add JSDoc invariants. Replace `getUIViewHandle`/`getWorkspaceView` with the four capability getters (commits 7–8).                                                                     |
+| `src/boundaries/shell/view-manager.ts`                              | Renamed to `webcontents-view-manager.ts`; class renamed to `WebContentsViewManager`; reduced to subclass + WebContents specifics.                                                      |
+| `src/boundaries/shell/view-manager-base.ts`                         | **New.** Abstract `BaseViewManager<TImplState>`.                                                                                                                                       |
+| `src/boundaries/shell/view-manager-types.ts`                        | **New.** `WorkspaceState<TImplState>`, `UIMode`, `DevtoolsTarget`, `KeyboardTarget`, bounds-math helpers (`computeUIRect`, `computeWorkspaceRect`, `clampSize`), mode→z-order helpers. |
+| `src/boundaries/shell/view-manager.conformance.ts`                  | **New.** `ConformanceProbe` + `runViewManagerConformance`.                                                                                                                             |
+| `src/boundaries/shell/webcontents-view-manager.integration.test.ts` | Renamed from `view-manager.integration.test.ts`. Invokes conformance suite; keeps WebContents-specific tests.                                                                          |
+| `src/main.ts`                                                       | `new ViewManager(...)` → `new WebContentsViewManager(...)`.                                                                                                                            |
+| `src/modules/view-module.ts`                                        | No call-site changes — still uses `IViewManager`, still calls `viewManager.create()`.                                                                                                  |
+| `src/modules/devtools-module.ts`                                    | Uses `DevtoolsTarget` getters; stops depending on `ViewBoundary`.                                                                                                                      |
+| `src/modules/shortcut-module.ts`                                    | Uses `KeyboardTarget` getters; stops depending on `ViewBoundary` for view-manager-owned handles.                                                                                       |
+
+Modules unaffected: `notification-manager`, `theme-module`, `ui-ipc-module`,
+`hibernation-screenshot-module`.
+
+---
+
+## Commit sequence
+
+Each commit compiles, passes `pnpm validate`, leaves tests green.
+
+1. **docs(view-manager): tighten interface invariants in JSDoc.**
+   Doc-only change on `view-manager.interface.ts` — attach-before-detach,
+   idempotency rules, immediate-replay contract, focus routing per mode.
+
+2. **refactor(view-manager): extract pure helpers and types.**
+   Create `view-manager-types.ts`. Move `UIMode`, `WorkspaceState` shape, and pure
+   bounds/z-order helpers out of `view-manager.ts`. `view-manager.ts` imports them.
+
+3. **refactor(view-manager): rename ViewManager → WebContentsViewManager.**
+   Rename `view-manager.ts` → `webcontents-view-manager.ts`. Rename
+   `view-manager.integration.test.ts` →
+   `webcontents-view-manager.integration.test.ts`. Update class name + `main.ts`
+   import. Tests still target the concrete class.
+
+4. **refactor(view-manager): extract BaseViewManager (template method).**
+   Add `view-manager-base.ts`. Move mode / active-workspace / focus / loading /
+   bounds / registry / event-bus state and orchestration into
+   `BaseViewManager<TImplState>`. Convert `WebContentsViewManager` to extend it
+   and implement the protected abstract primitives. Largest commit — keep it
+   mechanical: cut-and-paste with `protected abstract` stubs filled in, no logic
+   edits. The existing integration test is the safety net.
+
+5. **test(view-manager): introduce conformance suite and Probe type.**
+   Add `view-manager.conformance.ts`. Move impl-agnostic test cases out of the
+   integration file into the suite. The integration file calls
+   `runViewManagerConformance({ makeFactory })` and retains only WebContents-
+   specific tests. The WebContents factory builds a `ConformanceProbe` over the
+   existing `ViewBoundaryMock`.
+
+6. **refactor(view-manager): concrete defaults for reloadAllViews + port.**
+   Move the iterate-and-reload body into `BaseViewManager.reloadAllViews` (calls
+   the `reloadView` primitive). Move port storage into the base; subclass reads
+   via `getCodeServerPort()`. Keeps the `WebContentsViewManager` lighter and
+   forces the shape that the alt impl will get for free.
+
+7. **feat(view-manager): introduce DevtoolsTarget + KeyboardTarget capabilities.**
+   Add the two interfaces in `view-manager-types.ts`. Add the four capability
+   getters on `IViewManager`. Implement on `BaseViewManager` via abstract
+   `makeDevtoolsTarget` / `makeKeyboardTarget` primitives. Implement those on
+   `WebContentsViewManager` as closures over `viewLayer`. **Both old and new
+   getters coexist** in this commit — nothing is removed yet, so consumers stay
+   green. Conformance suite picks up its capability-getter assertions.
+
+8. **refactor(view-manager): drop getUIViewHandle / getWorkspaceView.**
+   Rewire `devtools-module` and `shortcut-module` to use the capability getters.
+   Remove the old methods from `IViewManager`, `BaseViewManager`, and
+   `WebContentsViewManager`. `devtools-module` and `shortcut-module` no longer
+   need `ViewBoundary` for view-manager-owned handles (verify imports).
+
+> Commits 7–8 modify `IViewManager` and therefore trigger CLAUDE.md's
+> "API/IPC Interface Changes" rule. Surface this explicitly on the PR for
+> approval before merging those commits.
+
+---
+
+## Verification
+
+After each commit:
+
+- `pnpm test` — all green; no skipped tests.
+- `pnpm validate` — typecheck + lint + format pass.
+
+After commit 8:
+
+- Inspect the conformance suite: at least the 10 listed behavioral assertions
+  run; impl-specific tests cover retry, watchdog, render-process-gone,
+  navigation, DirectComposition.
+- `pnpm dev`: create a workspace, switch between workspaces in normal mode, enter
+  shortcut mode (Alt+X), open a dialog, hover the sidebar — verify no visual
+  flicker on switch, no focus loss, loading overlay appears for new workspaces
+  and clears on first agent status update.
+- Devtools shortcuts (Ctrl+Shift+D on UI, Ctrl+Shift+W on active workspace) both
+  work — exercises the new `DevtoolsTarget` path end-to-end.
+- Shortcut mode keyboard navigation still works — exercises the new
+  `KeyboardTarget` path end-to-end.
+- Resume from sleep (or trigger the experimental resume path): `reloadAllViews()`
+  still recovers all workspaces.
+
+End-to-end UI verification matters: tests verify code correctness, not the
+visual-continuity / focus / z-order behavior that this refactor explicitly
+preserves.
+
+---
+
+## Risks & hidden couplings (must-preserve list)
+
+1. **Attach-before-detach sequencing** in `setActiveWorkspace` is a hard visual
+   continuity contract (no blank frame).
+2. **Z-order re-adjustment after active-workspace switch** while in
+   `dialog`/`shortcut`/`hover`: the UI handle must end up on top again.
+3. **Immediate replay of `loading=false`** when an `onLoadingChange` subscriber
+   registers after a workspace already loaded. The startup-splash flow in
+   `view-module.ts` depends on this.
+4. **Loading-workspace bounds updated while detached** so code-server's layout
+   is right the moment it's revealed.
+5. **Reentrancy guard** `isChangingWorkspace` — bounds + focus calls inside the
+   guarded section are skipped on re-entry.
+6. **Idempotency** of `setMode`, `setActiveWorkspace(samePath)`,
+   `setWorkspaceLoaded`, `destroyWorkspaceView`.
+7. **`destroying` flag suppresses focus ops during shutdown** — alternative impls
+   must respect this or shutdown will reach into freed handles.
+8. **`needsReloadOnAttach` + 15s watchdog + recreate** are WebContents quirks;
+   they stay in the subclass.
+9. **Windows DirectComposition workaround** stays inline in the subclass's
+   `attachView` override; do not promote to the base.
+10. **`KeyboardTarget.id` must equal the underlying handle id** so
+    `shortcut-module`'s map (currently keyed by `handle.id`) keeps de-duplicating
+    correctly across registrations.
+11. **Two-phase init (`new` + `create()`)** remains a contract; `create()` stays
+    on `IViewManager`. `view-module.ts`'s `app-start/init` hook continues to own
+    the timing.

--- a/src/boundaries/platform/logging-types.ts
+++ b/src/boundaries/platform/logging-types.ts
@@ -37,7 +37,7 @@ export type LoggerName =
   | "opencode-server" // OpenCodeServerManager - opencode server lifecycle
   | "api" // IPC handlers
   | "window" // WindowManager
-  | "view" // ViewManager
+  | "view" // WebContentsViewManager
   | "app" // Application lifecycle
   | "ui" // Renderer UI components
   | "binary-download" // Binary download operations

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -142,6 +142,10 @@ export abstract class BaseViewManager implements IViewManager {
     }
   }
 
+  loadUIContent(htmlPath: string): Promise<void> {
+    return this.loadUIContentImpl(htmlPath);
+  }
+
   // ---------------------------------------------------------------------------
   // Workspace lifecycle
   // ---------------------------------------------------------------------------
@@ -641,6 +645,9 @@ export abstract class BaseViewManager implements IViewManager {
   protected abstract isUIViewAvailable(): boolean;
 
   protected abstract sendToUIView(channel: string, args: unknown[]): void;
+
+  /** Load a URL/HTML path into the UI view. */
+  protected abstract loadUIContentImpl(htmlPath: string): Promise<void>;
 
   protected abstract capturePNG(handle: ViewHandle): Promise<Buffer | null>;
 

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -19,7 +19,7 @@ import type { Logger } from "../platform/logging";
 import type { SessionHandle, ViewHandle } from "./types";
 import type { IViewManager, LoadingChangeCallback, Unsubscribe } from "./view-manager.interface";
 import { WORKSPACE_LOADING_TIMEOUT_MS } from "./view-manager.interface";
-import type { Rect, WorkspaceState } from "./view-manager-types";
+import type { DevtoolsTarget, KeyboardTarget, Rect, WorkspaceState } from "./view-manager-types";
 import { computeUIRect, computeWorkspaceRect } from "./view-manager-types";
 import type { WindowManager } from "./window-manager";
 
@@ -108,6 +108,26 @@ export abstract class BaseViewManager implements IViewManager {
 
   getUIViewHandle(): ViewHandle {
     return this.uiViewHandle;
+  }
+
+  getUIDevtoolsTarget(): DevtoolsTarget {
+    return this.makeDevtoolsTarget(this.uiViewHandle);
+  }
+
+  getWorkspaceDevtoolsTarget(workspacePath: string): DevtoolsTarget | undefined {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return undefined;
+    return this.makeDevtoolsTarget(state.handle);
+  }
+
+  getUIKeyboardTarget(): KeyboardTarget {
+    return this.makeKeyboardTarget(this.uiViewHandle);
+  }
+
+  getWorkspaceKeyboardTarget(workspacePath: string): KeyboardTarget | undefined {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return undefined;
+    return this.makeKeyboardTarget(state.handle);
   }
 
   isUIAvailable(): boolean {
@@ -675,4 +695,17 @@ export abstract class BaseViewManager implements IViewManager {
    * use this hook to add watchdog/recovery behavior.
    */
   protected abstract reloadWorkspaceView(state: WorkspaceState): void;
+
+  /**
+   * Build the narrow `DevtoolsTarget` capability for the given view handle.
+   * The returned object's `id` MUST equal `handle.id` so consumers can use
+   * it as a stable map key.
+   */
+  protected abstract makeDevtoolsTarget(handle: ViewHandle): DevtoolsTarget;
+
+  /**
+   * Build the narrow `KeyboardTarget` capability for the given view handle.
+   * The returned object's `id` MUST equal `handle.id`.
+   */
+  protected abstract makeKeyboardTarget(handle: ViewHandle): KeyboardTarget;
 }

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -1,0 +1,678 @@
+/**
+ * Abstract base for IViewManager implementations.
+ *
+ * Owns the entire UI/state-machine layer that every implementation must share:
+ * mode + active-workspace + loading bookkeeping, the attach-before-detach
+ * sequencing, z-order re-raise rules, focus routing, bounds math, event
+ * subscriptions, and the workspace registry. Concrete implementations only
+ * need to fill in the protected primitives below — actual creation, attach/
+ * detach, URL loading, focus calls into their underlying view technology.
+ *
+ * Two-phase init: subclass constructor calls super(deps), then `create()`
+ * is called once before any other method (it creates the UI view via the
+ * subclass primitive and wires the resize listener).
+ */
+
+import { basename } from "node:path";
+import type { UIMode, UIModeChangedEvent } from "../../shared/ipc";
+import type { Logger } from "../platform/logging";
+import type { SessionHandle, ViewHandle } from "./types";
+import type { IViewManager, LoadingChangeCallback, Unsubscribe } from "./view-manager.interface";
+import { WORKSPACE_LOADING_TIMEOUT_MS } from "./view-manager.interface";
+import type { Rect, WorkspaceState } from "./view-manager-types";
+import { computeUIRect, computeWorkspaceRect } from "./view-manager-types";
+import type { WindowManager } from "./window-manager";
+
+/**
+ * Dependencies the base class needs. Concrete implementations extend this
+ * with their own per-implementation dependencies.
+ */
+export interface BaseViewManagerDeps {
+  readonly windowManager: WindowManager;
+  readonly logger: Logger;
+  readonly codeServerPort: number;
+}
+
+/**
+ * Result of creating a workspace view's underlying primitives. Returned by
+ * the `createWorkspaceViewImpl` subclass primitive and stored in the shared
+ * `WorkspaceState`.
+ */
+export interface CreatedWorkspaceView {
+  readonly handle: ViewHandle;
+  readonly sessionHandle: SessionHandle;
+  readonly partitionName: string;
+}
+
+export abstract class BaseViewManager implements IViewManager {
+  protected readonly windowManager: WindowManager;
+  protected readonly logger: Logger;
+  protected codeServerPort: number;
+
+  protected uiViewHandle!: ViewHandle;
+
+  protected readonly workspaceStates: Map<string, WorkspaceState> = new Map();
+  protected activeWorkspacePath: string | null = null;
+  protected attachedWorkspacePath: string | null = null;
+  protected mode: UIMode = "workspace";
+  protected destroying = false;
+  private isChangingWorkspace = false;
+  protected readonly loadingWorkspaces: Map<string, NodeJS.Timeout> = new Map();
+
+  private readonly modeChangeCallbacks: Set<(event: UIModeChangedEvent) => void> = new Set();
+  private readonly workspaceChangeCallbacks: Set<(path: string | null) => void> = new Set();
+  private readonly loadingChangeCallbacks: Set<LoadingChangeCallback> = new Set();
+
+  private unsubscribeResize: Unsubscribe | null = null;
+
+  constructor(deps: BaseViewManagerDeps) {
+    this.windowManager = deps.windowManager;
+    this.logger = deps.logger;
+    this.codeServerPort = deps.codeServerPort;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  create(): void {
+    this.uiViewHandle = this.createUIView();
+    this.unsubscribeResize = this.windowManager.onResize(() => {
+      this.updateBounds();
+    });
+  }
+
+  destroy(): void {
+    this.destroying = true;
+
+    if (this.unsubscribeResize) {
+      this.unsubscribeResize();
+      this.unsubscribeResize = null;
+    }
+
+    // Destroy all workspace views (fire-and-forget - app is shutting down)
+    for (const path of this.workspaceStates.keys()) {
+      void this.destroyWorkspaceView(path);
+    }
+
+    try {
+      this.destroyUIView();
+    } catch {
+      // Ignore errors during cleanup
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // UI view accessors
+  // ---------------------------------------------------------------------------
+
+  getUIViewHandle(): ViewHandle {
+    return this.uiViewHandle;
+  }
+
+  isUIAvailable(): boolean {
+    return this.isUIViewAvailable();
+  }
+
+  sendToUI(channel: string, ...args: unknown[]): void {
+    try {
+      this.sendToUIView(channel, args);
+    } catch {
+      // Ignore errors - view may be destroyed
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace lifecycle
+  // ---------------------------------------------------------------------------
+
+  createWorkspaceView(
+    workspacePath: string,
+    url: string,
+    projectPath: string,
+    isNew = false
+  ): ViewHandle {
+    const { handle, sessionHandle, partitionName } = this.createWorkspaceViewImpl(
+      workspacePath,
+      url,
+      projectPath
+    );
+
+    this.workspaceStates.set(workspacePath, {
+      handle,
+      sessionHandle,
+      url,
+      urlLoaded: false,
+      partitionName,
+      retryCount: 0,
+      retryTimer: null,
+      needsReloadOnAttach: false,
+      reloadWatchdogTimer: null,
+    });
+
+    if (isNew) {
+      const timeout = setTimeout(
+        () => this.setWorkspaceLoaded(workspacePath),
+        WORKSPACE_LOADING_TIMEOUT_MS
+      );
+      this.loadingWorkspaces.set(workspacePath, timeout);
+      this.notifyLoadingChange(workspacePath, true);
+    }
+
+    return handle;
+  }
+
+  async destroyWorkspaceView(workspacePath: string): Promise<void> {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return;
+
+    // Remove from registry FIRST to make this idempotent under concurrent
+    // calls and to prevent re-entry during the async teardown below.
+    this.workspaceStates.delete(workspacePath);
+
+    // Clear loading state
+    const timeout = this.loadingWorkspaces.get(workspacePath);
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      this.loadingWorkspaces.delete(workspacePath);
+      this.notifyLoadingChange(workspacePath, false);
+    }
+
+    // If this was the active workspace, clear it (triggers callbacks via setActiveWorkspace)
+    if (this.activeWorkspacePath === workspacePath) {
+      this.setActiveWorkspace(null);
+    }
+
+    // If this was the attached workspace, clear the tracker
+    if (this.attachedWorkspacePath === workspacePath) {
+      this.attachedWorkspacePath = null;
+    }
+
+    await this.destroyWorkspaceViewImpl(state);
+
+    this.logger.debug("View destroyed", { workspace: basename(workspacePath) });
+  }
+
+  getWorkspaceView(workspacePath: string): ViewHandle | undefined {
+    return this.workspaceStates.get(workspacePath)?.handle;
+  }
+
+  async captureWorkspaceView(workspacePath: string): Promise<Buffer | null> {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return null;
+    return this.capturePNG(state.handle);
+  }
+
+  preloadWorkspaceUrl(workspacePath: string): void {
+    this.logger.debug("Preloading URL", { workspace: basename(workspacePath) });
+    this.loadViewUrl(workspacePath);
+  }
+
+  updateCodeServerPort(port: number): void {
+    this.codeServerPort = port;
+  }
+
+  /**
+   * Default implementation: iterate every workspace whose URL has been loaded
+   * and is not currently in a loading state, and ask the subclass to reload
+   * each one. Subclasses may override to add watchdog/recovery behavior.
+   */
+  reloadAllViews(): void {
+    for (const [workspacePath, state] of this.workspaceStates) {
+      if (!state.urlLoaded) continue;
+      if (this.loadingWorkspaces.has(workspacePath)) continue;
+      this.reloadWorkspaceView(state);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bounds
+  // ---------------------------------------------------------------------------
+
+  updateBounds(): void {
+    if (!this.isWindowAlive()) return;
+
+    const bounds = this.windowManager.getBounds();
+
+    // UI layer: full window (so dialogs can overlay everything)
+    this.applyBounds(this.uiViewHandle, computeUIRect(bounds));
+
+    // Only update active workspace bounds (O(1) - inactive views are detached).
+    // Loading workspaces are also updated: they are detached but setBounds keeps
+    // the renderer viewport in sync so code-server re-layouts at the correct size.
+    if (this.activeWorkspacePath !== null) {
+      const state = this.workspaceStates.get(this.activeWorkspacePath);
+      if (state) {
+        this.applyBounds(state.handle, computeWorkspaceRect(bounds));
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Active workspace
+  // ---------------------------------------------------------------------------
+
+  setActiveWorkspace(workspacePath: string | null, focus: boolean = true): void {
+    if (this.isChangingWorkspace) return;
+
+    // Same workspace is usually a no-op, except when the active path was kept
+    // in place across a destroy + recreate cycle (e.g. hibernate → wake) and
+    // the new view exists but isn't attached yet — in that case we must run
+    // through loadViewUrl + attachView once to bring the view onscreen.
+    if (this.activeWorkspacePath === workspacePath) {
+      if (workspacePath === null) return;
+      const state = this.workspaceStates.get(workspacePath);
+      const needsAttach =
+        state !== undefined &&
+        this.attachedWorkspacePath !== workspacePath &&
+        !this.loadingWorkspaces.has(workspacePath);
+      if (!needsAttach) return;
+      this.loadViewUrl(workspacePath);
+      this.attachView(workspacePath);
+      this.updateBounds();
+      if (focus) this.focus();
+      return;
+    }
+
+    try {
+      this.isChangingWorkspace = true;
+      const previousPath = this.activeWorkspacePath;
+
+      this.activeWorkspacePath = workspacePath;
+
+      // Load URL and attach new view FIRST (visual continuity - no gap)
+      if (workspacePath !== null) {
+        this.loadViewUrl(workspacePath);
+        if (!this.loadingWorkspaces.has(workspacePath)) {
+          this.attachView(workspacePath);
+        }
+        // Loading workspaces stay detached with full-size bounds (set at creation).
+        // Alt+X works via the UI view's before-input-event (focus goes to UI).
+      }
+
+      // Then detach previous
+      if (previousPath !== null && previousPath !== workspacePath) {
+        this.detachView(previousPath);
+      }
+
+      // Maintain z-order: if we're in a mode where the UI should be on top
+      // (dialog/shortcut/hover) we need to raise it back above the new
+      // workspace view. In plain "workspace" mode we still re-attach the UI
+      // at the bottom with the redraw flag set to force Windows to repaint
+      // the transparent sidebar strip.
+      if (this.mode === "dialog" || this.mode === "shortcut" || this.mode === "hover") {
+        try {
+          if (this.isWindowAlive()) {
+            this.bringUIToTop();
+            if (this.mode === "shortcut") {
+              this.focus();
+            } else {
+              this.focusUIView();
+            }
+          }
+        } catch {
+          // Ignore errors during z-order change - window may be closing
+        }
+      } else {
+        try {
+          if (this.isWindowAlive()) {
+            this.bringUIToBottom(true);
+          }
+        } catch {
+          // window may be closing
+        }
+      }
+
+      this.updateBounds();
+
+      if (focus) {
+        this.focus();
+      }
+
+      for (const callback of this.workspaceChangeCallbacks) {
+        try {
+          callback(workspacePath);
+        } catch (error) {
+          this.logger.error(
+            "Error in workspace change callback",
+            {},
+            error instanceof Error ? error : undefined
+          );
+        }
+      }
+    } finally {
+      this.isChangingWorkspace = false;
+    }
+  }
+
+  getActiveWorkspacePath(): string | null {
+    return this.activeWorkspacePath;
+  }
+
+  onWorkspaceChange(callback: (path: string | null) => void): Unsubscribe {
+    this.workspaceChangeCallbacks.add(callback);
+    return () => {
+      this.workspaceChangeCallbacks.delete(callback);
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Focus
+  // ---------------------------------------------------------------------------
+
+  focus(): void {
+    if (this.destroying) return;
+
+    switch (this.mode) {
+      case "dialog":
+      case "hover":
+        // These modes manage their own focus via traps/handlers
+        break;
+      case "shortcut":
+        this.logger.debug("focus", { target: "ui", mode: this.mode });
+        this.focusUIView();
+        break;
+      case "workspace": {
+        const topView = this.getTopView();
+        this.logger.debug("focus", {
+          target: topView === this.uiViewHandle ? "ui" : "workspace",
+          mode: this.mode,
+          attachedWorkspace: this.attachedWorkspacePath
+            ? basename(this.attachedWorkspacePath)
+            : null,
+        });
+        this.focusHandle(topView);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Returns the topmost focusable view handle.
+   * If an active workspace is attached (not loading), returns it.
+   * Otherwise returns the UI view (loading workspaces are detached,
+   * so focus goes to the UI view where Alt+X detection works).
+   */
+  protected getTopView(): ViewHandle {
+    if (
+      this.activeWorkspacePath !== null &&
+      !this.loadingWorkspaces.has(this.activeWorkspacePath)
+    ) {
+      const state = this.workspaceStates.get(this.activeWorkspacePath);
+      if (state) return state.handle;
+    }
+    return this.uiViewHandle;
+  }
+
+  protected focusUIView(): void {
+    this.focusHandle(this.uiViewHandle);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mode
+  // ---------------------------------------------------------------------------
+
+  setMode(newMode: UIMode): void {
+    const previousMode = this.mode;
+    if (newMode === previousMode) return;
+
+    this.mode = newMode;
+
+    try {
+      if (this.isWindowAlive()) {
+        switch (newMode) {
+          case "workspace":
+            this.bringUIToBottom(false);
+            this.focus();
+            break;
+          case "shortcut":
+            this.bringUIToTop();
+            this.focus();
+            break;
+          case "hover":
+          case "dialog":
+            this.bringUIToTop();
+            // Do NOT change focus - hover/dialog component manages its own focus
+            break;
+          default: {
+            const _exhaustive: never = newMode;
+            this.logger.warn("Unhandled UI mode", { mode: _exhaustive });
+          }
+        }
+      }
+    } catch {
+      // Ignore errors during mode change - window may be closing
+    }
+
+    this.logger.debug("Mode changed", { mode: newMode, previous: previousMode });
+
+    const event: UIModeChangedEvent = { mode: newMode, previousMode };
+    for (const callback of this.modeChangeCallbacks) {
+      try {
+        callback(event);
+      } catch (error) {
+        this.logger.error(
+          "Error in mode change callback",
+          { mode: newMode },
+          error instanceof Error ? error : undefined
+        );
+      }
+    }
+  }
+
+  getMode(): UIMode {
+    return this.mode;
+  }
+
+  onModeChange(callback: (event: UIModeChangedEvent) => void): Unsubscribe {
+    this.modeChangeCallbacks.add(callback);
+    return () => {
+      this.modeChangeCallbacks.delete(callback);
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
+
+  isWorkspaceLoading(workspacePath: string): boolean {
+    return this.loadingWorkspaces.has(workspacePath);
+  }
+
+  setWorkspaceLoaded(workspacePath: string): void {
+    if (!this.loadingWorkspaces.has(workspacePath)) return;
+
+    const timeout = this.loadingWorkspaces.get(workspacePath);
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+    this.loadingWorkspaces.delete(workspacePath);
+
+    this.notifyLoadingChange(workspacePath, false);
+
+    if (this.activeWorkspacePath === workspacePath) {
+      this.attachView(workspacePath);
+      this.updateBounds();
+
+      // Maintain z-order: UI must stay in correct position relative to workspace
+      if (this.mode === "dialog" || this.mode === "shortcut" || this.mode === "hover") {
+        try {
+          if (this.isWindowAlive()) {
+            this.bringUIToTop();
+          }
+        } catch {
+          // Ignore errors - window may be closing
+        }
+      } else {
+        try {
+          if (this.isWindowAlive()) {
+            this.bringUIToBottom(true);
+          }
+        } catch {
+          // window may be closing
+        }
+      }
+
+      // In dialog/hover mode, the view re-attachment above may have shifted
+      // focus to the workspace view. Restore focus to the UI view so the
+      // renderer's focus trap continues to work.
+      if (this.mode === "dialog" || this.mode === "hover") {
+        this.focusUIView();
+      } else {
+        this.focus();
+      }
+    }
+    // Inactive: no-op (view stays detached, URL already loaded)
+
+    this.logger.debug("Workspace loaded", { workspace: basename(workspacePath) });
+  }
+
+  onLoadingChange(callback: LoadingChangeCallback): Unsubscribe {
+    this.loadingChangeCallbacks.add(callback);
+
+    // Late-binding replay: catch workspaces whose loading=false events were
+    // lost before this callback was wired (e.g., during startup).
+    for (const workspacePath of this.workspaceStates.keys()) {
+      if (!this.loadingWorkspaces.has(workspacePath)) {
+        try {
+          callback(workspacePath, false);
+        } catch (error) {
+          this.logger.error(
+            "Error in loading change callback (initial emit)",
+            { path: workspacePath, loading: false },
+            error instanceof Error ? error : undefined
+          );
+        }
+      }
+    }
+
+    return () => {
+      this.loadingChangeCallbacks.delete(callback);
+    };
+  }
+
+  protected notifyLoadingChange(path: string, loading: boolean): void {
+    for (const callback of this.loadingChangeCallbacks) {
+      try {
+        callback(path, loading);
+      } catch (error) {
+        this.logger.error(
+          "Error in loading change callback",
+          { path, loading },
+          error instanceof Error ? error : undefined
+        );
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Attach / detach + URL load (shared bookkeeping, primitive does the work)
+  // ---------------------------------------------------------------------------
+
+  protected loadViewUrl(workspacePath: string): void {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return;
+    if (state.urlLoaded) return;
+    state.urlLoaded = true;
+    this.startLoadingUrl(state);
+  }
+
+  protected attachView(workspacePath: string): void {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return;
+    if (!this.isWindowAlive()) return;
+    try {
+      this.attachViewImpl(state);
+      this.attachedWorkspacePath = workspacePath;
+      this.logger.debug("View attached", { workspace: basename(workspacePath) });
+    } catch {
+      // Ignore errors during attach - window may be closing
+    }
+  }
+
+  protected detachView(workspacePath: string): void {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return;
+    try {
+      this.detachViewImpl(state);
+      this.logger.debug("View detached", { workspace: basename(workspacePath) });
+    } catch {
+      // Ignore errors during detach - window may be closing
+    }
+    if (this.attachedWorkspacePath === workspacePath) {
+      this.attachedWorkspacePath = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Abstract primitives (implementation-specific I/O)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create the UI view fully wired (created, security configured, attached
+   * to the window, background colored). Returns the handle that the base
+   * will hold onto for the rest of its lifetime.
+   */
+  protected abstract createUIView(): ViewHandle;
+
+  /** Destroy the UI view. May throw; the base wraps it in try/catch. */
+  protected abstract destroyUIView(): void;
+
+  protected abstract isUIViewAvailable(): boolean;
+
+  protected abstract sendToUIView(channel: string, args: unknown[]): void;
+
+  protected abstract capturePNG(handle: ViewHandle): Promise<Buffer | null>;
+
+  /** True if the underlying window is alive and operations are safe. */
+  protected abstract isWindowAlive(): boolean;
+
+  /**
+   * Create a fresh per-workspace view, wire its handlers, set initial bounds.
+   * Does NOT attach to the window and does NOT load the URL.
+   */
+  protected abstract createWorkspaceViewImpl(
+    workspacePath: string,
+    url: string,
+    projectPath: string
+  ): CreatedWorkspaceView;
+
+  /**
+   * Best-effort teardown of a workspace view: clear impl-private timers,
+   * detach if attached, navigate to about:blank if needed, destroy.
+   */
+  protected abstract destroyWorkspaceViewImpl(state: WorkspaceState): Promise<void>;
+
+  /** Start loading the URL on the underlying view (fire-and-forget). */
+  protected abstract startLoadingUrl(state: WorkspaceState): void;
+
+  /**
+   * Attach the workspace view to the window. Implementations are free to
+   * also perform impl-private cleanup (e.g. reload-on-attach for crashed
+   * renderers).
+   */
+  protected abstract attachViewImpl(state: WorkspaceState): void;
+
+  protected abstract detachViewImpl(state: WorkspaceState): void;
+
+  protected abstract applyBounds(handle: ViewHandle, rect: Rect): void;
+
+  protected abstract focusHandle(handle: ViewHandle): void;
+
+  /** Raise the UI view to the top of the stack. */
+  protected abstract bringUIToTop(): void;
+
+  /**
+   * Lower the UI view to the bottom of the stack. `forceRedraw` is a hint
+   * to force a re-composite (used after active-workspace switches to work
+   * around the Windows DirectComposition transparent-sidebar bug).
+   */
+  protected abstract bringUIToBottom(forceRedraw: boolean): void;
+
+  /**
+   * Reload one workspace view as part of `reloadAllViews`. Default
+   * `reloadAllViews` iterates and calls this per workspace; subclasses may
+   * use this hook to add watchdog/recovery behavior.
+   */
+  protected abstract reloadWorkspaceView(state: WorkspaceState): void;
+}

--- a/src/boundaries/shell/view-manager-types.ts
+++ b/src/boundaries/shell/view-manager-types.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared types and pure helpers for view-manager implementations.
+ *
+ * Anything in this file is implementation-agnostic: no Electron calls, no I/O,
+ * no state. The base class and any concrete implementation may depend on it.
+ */
+
+import type { SessionHandle, ViewHandle } from "./types";
+
+/**
+ * Sidebar minimized width in pixels.
+ * Workspace views start at this offset, with expanded sidebar overlaying them.
+ */
+export const SIDEBAR_MINIMIZED_WIDTH = 20;
+
+/**
+ * Minimum window dimensions.
+ */
+export const MIN_WIDTH = 800;
+export const MIN_HEIGHT = 600;
+
+/**
+ * Z-index for the UI layer when positioned at the bottom of the view stack.
+ * The window's own backgroundColor provides the backdrop, so the UI sits at index 0.
+ */
+export const Z_UI_BOTTOM = 0;
+
+/**
+ * Rectangle in window coordinates.
+ */
+export interface Rect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Per-workspace state shared by all implementations.
+ *
+ * Concrete implementations carry their own private state on the view handle
+ * itself or in a separate side map; the slot here only covers what the
+ * shared coordination layer needs to read.
+ */
+export interface WorkspaceState {
+  /** Handle to the view */
+  handle: ViewHandle;
+  /** Handle to the session */
+  sessionHandle: SessionHandle;
+  /** URL to load (stored for lazy loading) */
+  url: string;
+  /** Whether URL has been loaded */
+  urlLoaded: boolean;
+  /** Partition name for cleanup */
+  partitionName: string;
+  /** Current retry attempt count for load failures */
+  retryCount: number;
+  /** Timer handle for scheduled retry, if any */
+  retryTimer: NodeJS.Timeout | null;
+  /**
+   * When true, the next attach will reload this view's webContents before
+   * returning. Set by the render-process-gone handler so the user gets a
+   * fresh page on next attach instead of a dead renderer.
+   */
+  needsReloadOnAttach: boolean;
+  /**
+   * Watchdog timer armed after a resume-triggered loadURL. Cleared when
+   * did-finish-load fires. If it fires, the view is assumed wedged and is
+   * destroyed + recreated from scratch.
+   */
+  reloadWatchdogTimer: NodeJS.Timeout | null;
+}
+
+/**
+ * Clamps a window size to the configured minimum dimensions.
+ */
+export function clampSize(size: { width: number; height: number }): {
+  width: number;
+  height: number;
+} {
+  return {
+    width: Math.max(size.width, MIN_WIDTH),
+    height: Math.max(size.height, MIN_HEIGHT),
+  };
+}
+
+/**
+ * Rect for the UI layer: full window (so dialogs and overlays can cover
+ * everything).
+ */
+export function computeUIRect(size: { width: number; height: number }): Rect {
+  const { width, height } = clampSize(size);
+  return { x: 0, y: 0, width, height };
+}
+
+/**
+ * Rect for a workspace view: full window minus the minimized sidebar gutter.
+ */
+export function computeWorkspaceRect(size: { width: number; height: number }): Rect {
+  const { width, height } = clampSize(size);
+  return {
+    x: SIDEBAR_MINIMIZED_WIDTH,
+    y: 0,
+    width: width - SIDEBAR_MINIMIZED_WIDTH,
+    height,
+  };
+}

--- a/src/boundaries/shell/view-manager-types.ts
+++ b/src/boundaries/shell/view-manager-types.ts
@@ -6,6 +6,8 @@
  */
 
 import type { SessionHandle, ViewHandle } from "./types";
+import type { KeyboardInput } from "./view";
+import type { Unsubscribe } from "./view-manager.interface";
 
 /**
  * Sidebar minimized width in pixels.
@@ -69,6 +71,35 @@ export interface WorkspaceState {
    * destroyed + recreated from scratch.
    */
   reloadWatchdogTimer: NodeJS.Timeout | null;
+}
+
+/**
+ * Narrow capability handle for opening/closing devtools on a view, without
+ * exposing the underlying ViewHandle to consumers. Returned by
+ * IViewManager.getUIDevtoolsTarget / getWorkspaceDevtoolsTarget.
+ */
+export interface DevtoolsTarget {
+  /** Stable identifier (handle id of the underlying view). */
+  readonly id: string;
+  /** Toggle devtools: open if closed, close if open. */
+  toggle(): void;
+  /** True if devtools are currently open on this view. */
+  isOpen(): boolean;
+}
+
+/**
+ * Narrow capability handle for keyboard input + lifecycle events on a view,
+ * without exposing the underlying ViewHandle. Returned by
+ * IViewManager.getUIKeyboardTarget / getWorkspaceKeyboardTarget.
+ */
+export interface KeyboardTarget {
+  /** Stable identifier (handle id of the underlying view). Used by consumers
+   *  as a map key for de-duplication across registrations. */
+  readonly id: string;
+  /** Subscribe to before-input-event on this view. */
+  onBeforeInput(callback: (input: KeyboardInput, preventDefault: () => void) => void): Unsubscribe;
+  /** Subscribe to the view-destroyed event. */
+  onDestroyed(callback: () => void): Unsubscribe;
 }
 
 /**

--- a/src/boundaries/shell/view-manager.conformance.ts
+++ b/src/boundaries/shell/view-manager.conformance.ts
@@ -1,0 +1,234 @@
+/**
+ * Implementation-agnostic behavioral contract for IViewManager.
+ *
+ * Any IViewManager implementation MUST pass this suite. Concrete impls
+ * (WebContentsViewManager today, others later) wire their own factory
+ * over their own mocks and produce a ConformanceProbe that gives the
+ * suite enough visibility to assert ordering and z-order invariants.
+ *
+ * This suite is intentionally focused on invariants documented in
+ * `view-manager.interface.ts`: attach-before-detach sequencing, late-
+ * binding loading replay, idempotency, z-order re-raise after switches,
+ * focus routing per mode. Implementation-specific behavior (retry
+ * backoff, watchdog, render-process-gone, navigation handlers, the
+ * Windows DC workaround) is verified in each implementation's own
+ * integration test file.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IViewManager } from "./view-manager.interface";
+
+/**
+ * Visibility hook the suite needs into each implementation's underlying
+ * mocks. The probe is built by the impl-specific factory.
+ */
+export interface ConformanceProbe {
+  /**
+   * Workspace paths, in the order their view was attached to the window.
+   * Only workspace-view attaches are recorded — UI-view re-attaches
+   * (z-order shuffles) are excluded.
+   */
+  readonly attachOrder: readonly string[];
+
+  /**
+   * Workspace paths, in the order their view was detached.
+   */
+  readonly detachOrder: readonly string[];
+
+  /**
+   * True iff the UI handle is currently the top-most attached child of
+   * the window. Used to verify that the UI stays on top after active-
+   * workspace switches while in dialog/shortcut/hover modes.
+   */
+  uiIsTop(): boolean;
+
+  /**
+   * Clear the recorded attach/detach order for a fresh scenario.
+   */
+  reset(): void;
+}
+
+export interface ConformanceInstance {
+  readonly manager: IViewManager;
+  readonly probe: ConformanceProbe;
+}
+
+export type ConformanceFactory = () => ConformanceInstance;
+
+/**
+ * Run the impl-agnostic conformance suite against a factory.
+ */
+export function runViewManagerConformance(opts: {
+  readonly name: string;
+  readonly makeFactory: () => ConformanceFactory;
+}): void {
+  describe(`IViewManager conformance: ${opts.name}`, () => {
+    const URL_A = "http://127.0.0.1:8080/?folder=/a";
+    const URL_B = "http://127.0.0.1:8080/?folder=/b";
+    const PROJECT = "/project";
+
+    describe("setActiveWorkspace sequencing", () => {
+      it("attaches new view BEFORE detaching previous (visual continuity)", () => {
+        const { manager, probe } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.createWorkspaceView("/b", URL_B, PROJECT);
+        manager.setActiveWorkspace("/a");
+        probe.reset();
+
+        manager.setActiveWorkspace("/b");
+
+        // The new workspace must appear in attachOrder before the old
+        // appears in detachOrder.
+        expect(probe.attachOrder).toContain("/b");
+        expect(probe.detachOrder).toContain("/a");
+        // Cross-check the ordering via timestamps: attach-of-/b is
+        // observed before detach-of-/a in the recorded streams.
+        const attachIdx = probe.attachOrder.indexOf("/b");
+        const detachIdx = probe.detachOrder.indexOf("/a");
+        expect(attachIdx).toBeGreaterThanOrEqual(0);
+        expect(detachIdx).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    describe("idempotency", () => {
+      it("setMode(sameMode) is a no-op (no event emitted)", () => {
+        const { manager } = opts.makeFactory()();
+        manager.setMode("workspace");
+        let events = 0;
+        manager.onModeChange(() => {
+          events++;
+        });
+        manager.setMode("workspace");
+        expect(events).toBe(0);
+      });
+
+      it("setActiveWorkspace(samePath) does not re-emit workspace change", () => {
+        const { manager } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.setActiveWorkspace("/a");
+        let events = 0;
+        manager.onWorkspaceChange(() => {
+          events++;
+        });
+        manager.setActiveWorkspace("/a");
+        expect(events).toBe(0);
+      });
+
+      it("setWorkspaceLoaded on a non-loading workspace is a no-op", () => {
+        const { manager } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT, /* isNew */ false);
+        // Workspace was created without isNew, so it isn't loading
+        expect(manager.isWorkspaceLoading("/a")).toBe(false);
+        // Should be safe to call repeatedly
+        manager.setWorkspaceLoaded("/a");
+        manager.setWorkspaceLoaded("/a");
+        expect(manager.isWorkspaceLoading("/a")).toBe(false);
+      });
+
+      it("destroyWorkspaceView for an unknown path resolves without throwing", async () => {
+        const { manager } = opts.makeFactory()();
+        await expect(manager.destroyWorkspaceView("/nope")).resolves.toBeUndefined();
+      });
+    });
+
+    describe("z-order after active-workspace switch", () => {
+      it("UI stays on top in shortcut mode after switching workspaces", () => {
+        const { manager, probe } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.createWorkspaceView("/b", URL_B, PROJECT);
+        manager.setActiveWorkspace("/a");
+        manager.setMode("shortcut");
+        expect(probe.uiIsTop()).toBe(true);
+
+        manager.setActiveWorkspace("/b");
+
+        expect(probe.uiIsTop()).toBe(true);
+      });
+
+      it("UI stays on top in dialog mode after switching workspaces", () => {
+        const { manager, probe } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.createWorkspaceView("/b", URL_B, PROJECT);
+        manager.setActiveWorkspace("/a");
+        manager.setMode("dialog");
+        expect(probe.uiIsTop()).toBe(true);
+
+        manager.setActiveWorkspace("/b");
+
+        expect(probe.uiIsTop()).toBe(true);
+      });
+
+      it("UI stays on top in hover mode after switching workspaces", () => {
+        const { manager, probe } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.createWorkspaceView("/b", URL_B, PROJECT);
+        manager.setActiveWorkspace("/a");
+        manager.setMode("hover");
+        expect(probe.uiIsTop()).toBe(true);
+
+        manager.setActiveWorkspace("/b");
+
+        expect(probe.uiIsTop()).toBe(true);
+      });
+    });
+
+    describe("onLoadingChange late-binding replay", () => {
+      it("emits loading=false immediately for workspaces that already finished loading", () => {
+        const { manager } = opts.makeFactory()();
+        // Created without isNew → not in loading state at all
+        manager.createWorkspaceView("/already-loaded", URL_A, PROJECT);
+
+        const events: Array<{ path: string; loading: boolean }> = [];
+        manager.onLoadingChange((path, loading) => {
+          events.push({ path, loading });
+        });
+
+        expect(events).toContainEqual({ path: "/already-loaded", loading: false });
+      });
+
+      it("does not replay for workspaces still loading", () => {
+        const { manager } = opts.makeFactory()();
+        manager.createWorkspaceView("/loading", URL_A, PROJECT, /* isNew */ true);
+
+        const replay: Array<{ path: string; loading: boolean }> = [];
+        manager.onLoadingChange((path, loading) => {
+          if (path === "/loading" && loading === false) {
+            replay.push({ path, loading });
+          }
+        });
+
+        expect(replay).toHaveLength(0);
+      });
+    });
+
+    describe("focus routing", () => {
+      it("focus() in dialog mode is a no-op (mode owns focus)", () => {
+        const { manager } = opts.makeFactory()();
+        manager.setMode("dialog");
+        // Just shouldn't throw — dialog/hover are documented no-ops
+        expect(() => manager.focus()).not.toThrow();
+      });
+
+      it("focus() in hover mode is a no-op", () => {
+        const { manager } = opts.makeFactory()();
+        manager.setMode("hover");
+        expect(() => manager.focus()).not.toThrow();
+      });
+    });
+
+    describe("destroy", () => {
+      it("is idempotent (safe to call twice)", () => {
+        const { manager } = opts.makeFactory()();
+        manager.createWorkspaceView("/a", URL_A, PROJECT);
+        manager.destroy();
+        expect(() => manager.destroy()).not.toThrow();
+      });
+
+      it("after destroy(), focus() is a no-op (does not throw)", () => {
+        const { manager } = opts.makeFactory()();
+        manager.destroy();
+        expect(() => manager.focus()).not.toThrow();
+      });
+    });
+  });
+}

--- a/src/boundaries/shell/view-manager.integration.test.ts
+++ b/src/boundaries/shell/view-manager.integration.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ViewManager, SIDEBAR_MINIMIZED_WIDTH, type ViewManagerDeps } from "./view-manager";
+import { ViewManager, type ViewManagerDeps } from "./view-manager";
+import { SIDEBAR_MINIMIZED_WIDTH } from "./view-manager-types";
 import type { WindowManager } from "./window-manager";
 import { SILENT_LOGGER } from "../platform/logging";
 import { createViewBoundaryMock, type MockViewBoundary } from "./view.state-mock";

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -10,6 +10,7 @@
 
 import type { UIMode, UIModeChangedEvent } from "../../shared/ipc";
 import type { ViewHandle } from "./types";
+import type { DevtoolsTarget, KeyboardTarget } from "./view-manager-types";
 
 /**
  * Timeout for workspace loading in milliseconds.
@@ -62,8 +63,35 @@ export interface IViewManager {
 
   /**
    * Returns the UI layer view handle.
+   *
+   * @deprecated Prefer `getUIDevtoolsTarget()` / `getUIKeyboardTarget()`
+   *   to avoid coupling consumers to the underlying view technology.
    */
   getUIViewHandle(): ViewHandle;
+
+  /**
+   * Returns a narrow capability for toggling devtools on the UI view.
+   */
+  getUIDevtoolsTarget(): DevtoolsTarget;
+
+  /**
+   * Returns a narrow capability for toggling devtools on a workspace view.
+   * Returns undefined if the workspace doesn't exist.
+   */
+  getWorkspaceDevtoolsTarget(workspacePath: string): DevtoolsTarget | undefined;
+
+  /**
+   * Returns a narrow capability for subscribing to keyboard input and the
+   * destroyed lifecycle on the UI view.
+   */
+  getUIKeyboardTarget(): KeyboardTarget;
+
+  /**
+   * Returns a narrow capability for subscribing to keyboard input and the
+   * destroyed lifecycle on a workspace view. Returns undefined if the
+   * workspace doesn't exist.
+   */
+  getWorkspaceKeyboardTarget(workspacePath: string): KeyboardTarget | undefined;
 
   /**
    * Checks if the UI layer view is available (not destroyed).

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -1,6 +1,11 @@
 /**
- * Interface for ViewManager to enable testability.
- * Allows mocking in handler tests.
+ * Interface for ViewManager to enable testability and to allow alternative
+ * implementations (e.g. WebContents-based vs. iframe-based) to coexist behind
+ * a feature flag.
+ *
+ * Implementations MUST honor the invariants documented on each method.
+ * The conformance test suite (`view-manager.conformance.ts`) encodes most
+ * of them.
  */
 
 import type { UIMode, UIModeChangedEvent } from "../../shared/ipc";
@@ -25,10 +30,36 @@ export type Unsubscribe = () => void;
 export type LoadingChangeCallback = (path: string, loading: boolean) => void;
 
 /**
- * Interface for managing WebContentsViews.
- * Used for dependency injection and testability.
+ * Interface for managing per-workspace views and the UI layer.
+ *
+ * Lifecycle invariants:
+ * - Two-phase init: `new Impl(deps)` followed by `await create()` before any
+ *   other call. `create()` creates the UI view and wires resize listeners.
+ * - `destroy()` is idempotent and tears down all per-workspace state.
+ *
+ * Coordination invariants (apply to every implementation):
+ * - `setActiveWorkspace`: the new view MUST be attached BEFORE the previous
+ *   view is detached, so there is never a blank frame.
+ * - Z-order after `setActiveWorkspace`: if the current mode is `dialog`,
+ *   `shortcut`, or `hover`, the UI layer MUST end up on top again.
+ * - Idempotency: re-issuing `setMode(same)`, `setActiveWorkspace(samePath)`,
+ *   `setWorkspaceLoaded(same)`, and `destroyWorkspaceView(unknown)` is a no-op
+ *   and emits no events.
+ * - `onLoadingChange`: a subscriber registered after a workspace has already
+ *   finished loading MUST receive an immediate `(path, false)` replay for
+ *   that workspace, so late-binding consumers don't get stuck.
+ * - `focus()` routing is a function of mode + attachment state only; see the
+ *   method docstring.
+ * - During shutdown (after `destroy()` begins), focus operations are
+ *   suppressed; implementations must not reach into freed view handles.
  */
 export interface IViewManager {
+  /**
+   * Creates UI view and wires event subscriptions.
+   * MUST be called before any other method. Safe to call only once.
+   */
+  create(): void;
+
   /**
    * Returns the UI layer view handle.
    */
@@ -75,7 +106,8 @@ export interface IViewManager {
   ): ViewHandle;
 
   /**
-   * Destroys a workspace view.
+   * Destroys a workspace view. Idempotent: calling for an unknown path is a
+   * no-op.
    *
    * Navigates to about:blank before closing to ensure resources are released.
    * Uses a timeout to ensure destruction completes even if navigation hangs.
@@ -93,7 +125,12 @@ export interface IViewManager {
   getWorkspaceView(workspacePath: string): ViewHandle | undefined;
 
   /**
-   * Updates all view bounds (called on window resize).
+   * Updates view bounds (called on window resize).
+   *
+   * MUST be O(1) in the number of workspaces: only the UI layer and the
+   * active workspace are repositioned. Loading (detached) workspaces still
+   * receive bounds updates so the renderer re-layouts at the correct size
+   * before they are revealed.
    */
   updateBounds(): void;
 
@@ -104,7 +141,11 @@ export interface IViewManager {
    * Other workspaces are detached from contentView entirely (not attached, no GPU usage).
    *
    * On first activation, the workspace's URL is loaded (lazy loading).
-   * Attach happens BEFORE detach of previous view for visual continuity (no gap).
+   * The new view MUST be attached BEFORE the previous view is detached so
+   * there is no visual gap. If the current mode is `dialog`, `shortcut`, or
+   * `hover`, the UI layer MUST be re-raised to the top after the switch.
+   *
+   * Idempotent: calling with the same path twice has no observable effect.
    *
    * By default, focuses the workspace view so it receives keyboard input.
    *
@@ -127,6 +168,8 @@ export interface IViewManager {
    * - workspace mode: focuses workspace view if attached, else UI
    * - shortcut mode: focuses UI (keyboard events go to sidebar)
    * - dialog/hover mode: no-op (these modes manage their own focus)
+   *
+   * Implementations MUST treat focus as a no-op once `destroy()` has begun.
    */
   focus(): void;
 
@@ -135,8 +178,10 @@ export interface IViewManager {
    * - "workspace": UI at z-index 0, focus active workspace
    * - "shortcut": UI on top, focus UI layer
    * - "dialog": UI on top, no focus change
+   * - "hover": UI on top, no focus change
    *
-   * Mode transitions are idempotent - setting the same mode twice does not emit an event.
+   * Idempotent: setting the same mode twice does not emit an event and does
+   * not re-focus.
    *
    * @param mode - The new UI mode
    */
@@ -199,6 +244,11 @@ export interface IViewManager {
    * Subscribe to loading state changes.
    * Called when a workspace starts or finishes loading.
    *
+   * Late-binding guarantee: when a subscriber registers, it MUST receive an
+   * immediate `(path, false)` callback for every workspace that has already
+   * finished loading. This prevents consumers registered after startup
+   * (e.g. the splash-screen coordinator) from waiting forever.
+   *
    * @param callback - Called with (path, loading) when loading state changes
    * @returns Unsubscribe function
    */
@@ -230,7 +280,8 @@ export interface IViewManager {
 
   /**
    * Destroys all views and cleans up resources.
-   * Called during application shutdown.
+   * Called during application shutdown. Idempotent. After this returns,
+   * focus operations are no-ops and view handles must not be touched.
    */
   destroy(): void;
 

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -62,14 +62,6 @@ export interface IViewManager {
   create(): void;
 
   /**
-   * Returns the UI layer view handle.
-   *
-   * @deprecated Prefer `getUIDevtoolsTarget()` / `getUIKeyboardTarget()`
-   *   to avoid coupling consumers to the underlying view technology.
-   */
-  getUIViewHandle(): ViewHandle;
-
-  /**
    * Returns a narrow capability for toggling devtools on the UI view.
    */
   getUIDevtoolsTarget(): DevtoolsTarget;
@@ -143,14 +135,6 @@ export interface IViewManager {
    * @param workspacePath - Absolute path to the workspace directory
    */
   destroyWorkspaceView(workspacePath: string): Promise<void>;
-
-  /**
-   * Gets a workspace view handle by path.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   * @returns The ViewHandle or undefined if not found
-   */
-  getWorkspaceView(workspacePath: string): ViewHandle | undefined;
 
   /**
    * Updates view bounds (called on window resize).

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -93,6 +93,14 @@ export interface IViewManager {
   isUIAvailable(): boolean;
 
   /**
+   * Loads the given HTML (or other) URL into the UI view. Called once by
+   * the composition root after `create()` to point the UI at its bundle.
+   *
+   * @param htmlPath - file:// URL of the UI HTML to load
+   */
+  loadUIContent(htmlPath: string): Promise<void>;
+
+  /**
    * Sends an IPC message to the UI layer.
    *
    * @param channel - IPC channel name

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -1,7 +1,7 @@
 /**
- * Interface for ViewManager to enable testability and to allow alternative
- * implementations (e.g. WebContents-based vs. iframe-based) to coexist behind
- * a feature flag.
+ * Interface for view-manager implementations. Enables testability and allows
+ * alternative implementations (e.g. WebContents-based vs. iframe-based) to
+ * coexist behind a feature flag.
  *
  * Implementations MUST honor the invariants documented on each method.
  * The conformance test suite (`view-manager.conformance.ts`) encodes most

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -19,12 +19,12 @@ import type { ViewBoundary, WindowOpenDetails, FailLoadDetails } from "./view";
 import type { SessionBoundary } from "./session";
 import type { WindowBoundaryInternal } from "./window";
 import type { ViewHandle, SessionHandle, WindowHandle } from "./types";
-
-/**
- * Sidebar minimized width in pixels.
- * Workspace views start at this offset, with expanded sidebar overlaying them.
- */
-export const SIDEBAR_MINIMIZED_WIDTH = 20;
+import {
+  Z_UI_BOTTOM,
+  computeUIRect,
+  computeWorkspaceRect,
+  type WorkspaceState,
+} from "./view-manager-types";
 
 /**
  * Global session partition name shared by all workspaces.
@@ -34,12 +34,6 @@ export const SIDEBAR_MINIMIZED_WIDTH = 20;
  * The `persist:` prefix ensures data survives app restarts.
  */
 const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
-
-/**
- * Minimum window dimensions.
- */
-const MIN_WIDTH = 800;
-const MIN_HEIGHT = 600;
 
 /**
  * Timeout for navigation to about:blank before closing a view.
@@ -63,12 +57,6 @@ const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000];
  * we see on Windows after multiple suspend/resume cycles.
  */
 const RELOAD_WATCHDOG_MS = 15000;
-
-/**
- * Z-index for the UI layer when positioned at the bottom of the view stack.
- * The window's own backgroundColor provides the backdrop, so the UI sits at index 0.
- */
-const Z_UI_BOTTOM = 0;
 
 /**
  * Configuration for creating a ViewManager.
@@ -98,39 +86,6 @@ export interface ViewManagerDeps {
   readonly config: ViewManagerConfig;
   /** Logger */
   readonly logger: Logger;
-}
-
-/**
- * Workspace state tracking.
- */
-interface WorkspaceState {
-  /** Handle to the view */
-  handle: ViewHandle;
-  /** Handle to the session */
-  sessionHandle: SessionHandle;
-  /** URL to load (stored for lazy loading) */
-  url: string;
-  /** Whether URL has been loaded */
-  urlLoaded: boolean;
-  /** Partition name for cleanup */
-  partitionName: string;
-  /** Current retry attempt count for load failures */
-  retryCount: number;
-  /** Timer handle for scheduled retry, if any */
-  retryTimer: NodeJS.Timeout | null;
-  /**
-   * When true, the next attachView() will call viewLayer.reload() on this
-   * view's webContents before returning. Set by the render-process-gone
-   * handler so the user gets a fresh page on next attach instead of a
-   * dead renderer.
-   */
-  needsReloadOnAttach: boolean;
-  /**
-   * Watchdog timer armed after a resume-triggered loadURL. Cleared when
-   * did-finish-load fires. If it fires, the view is assumed wedged and is
-   * destroyed + recreated from scratch.
-   */
-  reloadWatchdogTimer: NodeJS.Timeout | null;
 }
 
 /**
@@ -501,15 +456,7 @@ export class ViewManager implements IViewManager {
 
     // Set workspace bounds on detached view so code-server renders at correct size.
     // Electron respects setBounds on detached WebContentsViews.
-    const windowBounds = this.windowManager.getBounds();
-    const clampedWidth = Math.max(windowBounds.width, MIN_WIDTH);
-    const clampedHeight = Math.max(windowBounds.height, MIN_HEIGHT);
-    this.viewLayer.setBounds(viewHandle, {
-      x: SIDEBAR_MINIMIZED_WIDTH,
-      y: 0,
-      width: clampedWidth - SIDEBAR_MINIMIZED_WIDTH,
-      height: clampedHeight,
-    });
+    this.viewLayer.setBounds(viewHandle, computeWorkspaceRect(this.windowManager.getBounds()));
 
     this.logger.debug("View created", { workspace: workspaceName });
     return viewHandle;
@@ -628,17 +575,8 @@ export class ViewManager implements IViewManager {
 
     const bounds = this.windowManager.getBounds();
 
-    // Clamp to minimum dimensions
-    const width = Math.max(bounds.width, MIN_WIDTH);
-    const height = Math.max(bounds.height, MIN_HEIGHT);
-
     // UI layer: full window (so dialogs can overlay everything)
-    this.viewLayer.setBounds(this.uiViewHandle, {
-      x: 0,
-      y: 0,
-      width,
-      height,
-    });
+    this.viewLayer.setBounds(this.uiViewHandle, computeUIRect(bounds));
 
     // Only update active workspace bounds (O(1) - inactive views are detached).
     // Loading workspaces are also updated: they are detached but setBounds keeps
@@ -646,12 +584,7 @@ export class ViewManager implements IViewManager {
     if (this.activeWorkspacePath !== null) {
       const state = this.workspaceStates.get(this.activeWorkspacePath);
       if (state) {
-        this.viewLayer.setBounds(state.handle, {
-          x: SIDEBAR_MINIMIZED_WIDTH,
-          y: 0,
-          width: width - SIDEBAR_MINIMIZED_WIDTH,
-          height,
-        });
+        this.viewLayer.setBounds(state.handle, computeWorkspaceRect(bounds));
       }
     }
   }

--- a/src/boundaries/shell/webcontents-view-manager.integration.test.ts
+++ b/src/boundaries/shell/webcontents-view-manager.integration.test.ts
@@ -1,9 +1,12 @@
 /**
- * Integration tests for ViewManager using behavioral mocks.
+ * Integration tests for WebContentsViewManager using behavioral mocks.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ViewManager, type ViewManagerDeps } from "./view-manager";
+import {
+  WebContentsViewManager,
+  type WebContentsViewManagerDeps,
+} from "./webcontents-view-manager";
 import { SIDEBAR_MINIMIZED_WIDTH } from "./view-manager-types";
 import type { WindowManager } from "./window-manager";
 import { SILENT_LOGGER } from "../platform/logging";
@@ -20,7 +23,7 @@ import { createMockWindowManager } from "./window-manager.test-utils";
 const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
 
 /**
- * Creates a test window layer with a pre-created window for ViewManager tests.
+ * Creates a test window layer with a pre-created window for WebContentsViewManager tests.
  */
 function createViewManagerWindowBoundary(): MockWindowBoundaryInternal & {
   _createdWindowHandle: WindowHandle;
@@ -41,9 +44,9 @@ function createViewManagerWindowBoundary(): MockWindowBoundaryInternal & {
 }
 
 /**
- * Creates ViewManager deps with behavioral mocks.
+ * Creates WebContentsViewManager deps with behavioral mocks.
  */
-function createViewManagerDeps(): ViewManagerDeps & {
+function createViewManagerDeps(): WebContentsViewManagerDeps & {
   viewLayer: MockViewBoundary;
   windowLayer: MockWindowBoundaryInternal & { _createdWindowHandle: WindowHandle };
   sessionLayer: MockSessionBoundary;
@@ -70,15 +73,15 @@ function createViewManagerDeps(): ViewManagerDeps & {
 }
 
 /**
- * Creates a ViewManager with two-phase init (constructor + create).
+ * Creates a WebContentsViewManager with two-phase init (constructor + create).
  */
-function createViewManager(deps: ViewManagerDeps): ViewManager {
-  const manager = new ViewManager(deps);
+function createViewManager(deps: WebContentsViewManagerDeps): WebContentsViewManager {
+  const manager = new WebContentsViewManager(deps);
   manager.create();
   return manager;
 }
 
-describe("ViewManager", () => {
+describe("WebContentsViewManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -94,11 +97,11 @@ describe("ViewManager", () => {
   });
 
   describe("create", () => {
-    it("creates a ViewManager instance", () => {
+    it("creates a WebContentsViewManager instance", () => {
       const deps = createViewManagerDeps();
       const manager = createViewManager(deps);
 
-      expect(manager).toBeInstanceOf(ViewManager);
+      expect(manager).toBeInstanceOf(WebContentsViewManager);
     });
 
     it("creates UI layer view with security settings", () => {

--- a/src/boundaries/shell/webcontents-view-manager.integration.test.ts
+++ b/src/boundaries/shell/webcontents-view-manager.integration.test.ts
@@ -8,6 +8,11 @@ import {
   type WebContentsViewManagerDeps,
 } from "./webcontents-view-manager";
 import { SIDEBAR_MINIMIZED_WIDTH } from "./view-manager-types";
+import {
+  runViewManagerConformance,
+  type ConformanceFactory,
+  type ConformanceProbe,
+} from "./view-manager.conformance";
 import type { WindowManager } from "./window-manager";
 import { SILENT_LOGGER } from "../platform/logging";
 import { createViewBoundaryMock, type MockViewBoundary } from "./view.state-mock";
@@ -80,6 +85,78 @@ function createViewManager(deps: WebContentsViewManagerDeps): WebContentsViewMan
   manager.create();
   return manager;
 }
+
+/**
+ * Conformance-test factory: builds a WebContentsViewManager plus a probe
+ * that wraps viewLayer.attachToWindow / detachFromWindow to record per-
+ * workspace attach/detach order, and inspects window children to decide
+ * whether the UI is the top-most attached view.
+ */
+function makeWebContentsConformanceFactory(): ConformanceFactory {
+  return () => {
+    const deps = createViewManagerDeps();
+    const uiViewHandleId = { current: "" };
+    const handleToPath = new Map<string, string>();
+    const attachOrder: string[] = [];
+    const detachOrder: string[] = [];
+
+    const originalAttach = deps.viewLayer.attachToWindow.bind(deps.viewLayer);
+    deps.viewLayer.attachToWindow = (handle, windowHandle, index, options) => {
+      const path = handleToPath.get(handle.id);
+      if (path !== undefined && handle.id !== uiViewHandleId.current) {
+        attachOrder.push(path);
+      }
+      return originalAttach(handle, windowHandle, index, options);
+    };
+
+    const originalDetach = deps.viewLayer.detachFromWindow.bind(deps.viewLayer);
+    deps.viewLayer.detachFromWindow = (handle) => {
+      const path = handleToPath.get(handle.id);
+      if (path !== undefined && handle.id !== uiViewHandleId.current) {
+        detachOrder.push(path);
+      }
+      return originalDetach(handle);
+    };
+
+    const manager = new WebContentsViewManager(deps);
+    manager.create();
+    uiViewHandleId.current = manager.getUIViewHandle().id;
+
+    // Wrap createWorkspaceView so the probe can map handle IDs back to paths.
+    const originalCreate = manager.createWorkspaceView.bind(manager);
+    manager.createWorkspaceView = (path, url, projectPath, isNew) => {
+      const handle = originalCreate(path, url, projectPath, isNew);
+      handleToPath.set(handle.id, path);
+      return handle;
+    };
+
+    const windowId = deps.windowLayer._createdWindowHandle.id;
+    const probe: ConformanceProbe = {
+      get attachOrder() {
+        return attachOrder;
+      },
+      get detachOrder() {
+        return detachOrder;
+      },
+      uiIsTop() {
+        const children = deps.viewLayer.$.windowChildren.get(windowId) ?? [];
+        if (children.length === 0) return false;
+        return children[children.length - 1] === uiViewHandleId.current;
+      },
+      reset() {
+        attachOrder.length = 0;
+        detachOrder.length = 0;
+      },
+    };
+
+    return { manager, probe };
+  };
+}
+
+runViewManagerConformance({
+  name: "WebContentsViewManager",
+  makeFactory: () => makeWebContentsConformanceFactory(),
+});
 
 describe("WebContentsViewManager", () => {
   beforeEach(() => {

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -18,7 +18,7 @@ import { getErrorMessage } from "../../shared/error-utils";
 import type { ViewBoundary, WindowOpenDetails, FailLoadDetails } from "./view";
 import type { SessionBoundary } from "./session";
 import type { WindowBoundaryInternal } from "./window";
-import type { ViewHandle, SessionHandle, WindowHandle } from "./types";
+import type { ViewHandle, WindowHandle } from "./types";
 import {
   Z_UI_BOTTOM,
   computeUIRect,
@@ -59,9 +59,9 @@ const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000];
 const RELOAD_WATCHDOG_MS = 15000;
 
 /**
- * Configuration for creating a ViewManager.
+ * Configuration for creating a WebContentsViewManager.
  */
-export interface ViewManagerConfig {
+export interface WebContentsViewManagerConfig {
   /** Path to the UI layer preload script */
   readonly uiPreloadPath: string;
   /** Code-server port number */
@@ -69,9 +69,9 @@ export interface ViewManagerConfig {
 }
 
 /**
- * Dependencies for ViewManager.
+ * Dependencies for WebContentsViewManager.
  */
-export interface ViewManagerDeps {
+export interface WebContentsViewManagerDeps {
   /** Window manager for the main window */
   readonly windowManager: WindowManager;
   /** Window layer for accessing raw window */
@@ -83,7 +83,7 @@ export interface ViewManagerDeps {
   /** App layer for opening URLs/paths externally */
   readonly appLayer: Pick<AppBoundary, "openUrl">;
   /** Configuration */
-  readonly config: ViewManagerConfig;
+  readonly config: WebContentsViewManagerConfig;
   /** Logger */
   readonly logger: Logger;
 }
@@ -92,13 +92,13 @@ export interface ViewManagerDeps {
  * Manages WebContentsViews for the application.
  * Implements the IViewManager interface.
  */
-export class ViewManager implements IViewManager {
+export class WebContentsViewManager implements IViewManager {
   private readonly windowManager: WindowManager;
   private readonly windowLayer: WindowBoundaryInternal;
   private readonly viewLayer: ViewBoundary;
   private readonly sessionLayer: SessionBoundary;
   private readonly appLayer: Pick<AppBoundary, "openUrl">;
-  private readonly config: ViewManagerConfig;
+  private readonly config: WebContentsViewManagerConfig;
   private uiViewHandle!: ViewHandle;
   private codeServerPort: number;
   private windowHandle!: WindowHandle;
@@ -144,7 +144,7 @@ export class ViewManager implements IViewManager {
    */
   private readonly loadingChangeCallbacks: Set<LoadingChangeCallback> = new Set();
 
-  constructor(deps: ViewManagerDeps) {
+  constructor(deps: WebContentsViewManagerDeps) {
     this.windowManager = deps.windowManager;
     this.windowLayer = deps.windowLayer;
     this.viewLayer = deps.viewLayer;
@@ -1279,7 +1279,7 @@ export class ViewManager implements IViewManager {
   }
 
   /**
-   * Destroys the ViewManager and cleans up all views.
+   * Destroys the WebContentsViewManager and cleans up all views.
    * Called on application shutdown.
    */
   destroy(): void {

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -1,30 +1,31 @@
 /**
- * View manager for managing WebContentsViews.
- * Handles UI layer, workspace views, bounds, and focus management.
+ * WebContentsView-based implementation of IViewManager.
  *
- * Uses two-phase initialization:
- * 1. Constructor: stores deps (pure, no Electron calls)
- * 2. create(): creates views and wires event subscriptions
+ * Subclass of BaseViewManager. The base owns the UI/state-machine layer
+ * (mode, active workspace, loading bookkeeping, focus routing, z-order
+ * rules, bounds math). This class supplies all Electron `WebContentsView`-
+ * specific I/O: view creation with security/partition settings, event
+ * handler wiring, URL load + exponential-backoff retry, render-process-gone
+ * recovery, the reload watchdog, and the Windows DirectComposition
+ * re-composite workaround.
  */
 
 import { basename } from "node:path";
-import type { IViewManager, Unsubscribe, LoadingChangeCallback } from "./view-manager.interface";
-import { WORKSPACE_LOADING_TIMEOUT_MS } from "./view-manager.interface";
-import type { UIMode, UIModeChangedEvent } from "../../shared/ipc";
-import type { WindowManager } from "./window-manager";
 import type { AppBoundary } from "./app";
 import type { Logger } from "../platform/logging";
 import { getErrorMessage } from "../../shared/error-utils";
-import type { ViewBoundary, WindowOpenDetails, FailLoadDetails } from "./view";
+import type { FailLoadDetails, ViewBoundary, WindowOpenDetails } from "./view";
 import type { SessionBoundary } from "./session";
 import type { WindowBoundaryInternal } from "./window";
 import type { ViewHandle, WindowHandle } from "./types";
+import { BaseViewManager, type CreatedWorkspaceView } from "./view-manager-base";
 import {
   Z_UI_BOTTOM,
-  computeUIRect,
   computeWorkspaceRect,
+  type Rect,
   type WorkspaceState,
 } from "./view-manager-types";
+import type { WindowManager } from "./window-manager";
 
 /**
  * Global session partition name shared by all workspaces.
@@ -37,7 +38,6 @@ const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
 
 /**
  * Timeout for navigation to about:blank before closing a view.
- * If navigation doesn't complete within this time, we proceed with closing.
  */
 const NAVIGATION_TIMEOUT_MS = 2000;
 
@@ -58,9 +58,6 @@ const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000];
  */
 const RELOAD_WATCHDOG_MS = 15000;
 
-/**
- * Configuration for creating a WebContentsViewManager.
- */
 export interface WebContentsViewManagerConfig {
   /** Path to the UI layer preload script */
   readonly uiPreloadPath: string;
@@ -68,102 +65,45 @@ export interface WebContentsViewManagerConfig {
   readonly codeServerPort: number;
 }
 
-/**
- * Dependencies for WebContentsViewManager.
- */
 export interface WebContentsViewManagerDeps {
-  /** Window manager for the main window */
   readonly windowManager: WindowManager;
-  /** Window layer for accessing raw window */
   readonly windowLayer: WindowBoundaryInternal;
-  /** View layer for view operations */
   readonly viewLayer: ViewBoundary;
-  /** Session layer for session operations */
   readonly sessionLayer: SessionBoundary;
-  /** App layer for opening URLs/paths externally */
   readonly appLayer: Pick<AppBoundary, "openUrl">;
-  /** Configuration */
   readonly config: WebContentsViewManagerConfig;
-  /** Logger */
   readonly logger: Logger;
 }
 
-/**
- * Manages WebContentsViews for the application.
- * Implements the IViewManager interface.
- */
-export class WebContentsViewManager implements IViewManager {
-  private readonly windowManager: WindowManager;
+export class WebContentsViewManager extends BaseViewManager {
   private readonly windowLayer: WindowBoundaryInternal;
   private readonly viewLayer: ViewBoundary;
   private readonly sessionLayer: SessionBoundary;
   private readonly appLayer: Pick<AppBoundary, "openUrl">;
   private readonly config: WebContentsViewManagerConfig;
-  private uiViewHandle!: ViewHandle;
-  private codeServerPort: number;
   private windowHandle!: WindowHandle;
-  /**
-   * Map of workspace paths to their state.
-   */
-  private readonly workspaceStates: Map<string, WorkspaceState> = new Map();
-  private activeWorkspacePath: string | null = null;
-  /**
-   * Tracks which workspace view is currently attached to the contentView.
-   * Used for explicit attachment state tracking (detach optimization).
-   */
-  private attachedWorkspacePath: string | null = null;
-  /**
-   * Current UI mode. Single source of truth for UI state.
-   */
-  private mode: UIMode = "workspace";
-  /**
-   * Callbacks for mode change events.
-   */
-  private readonly modeChangeCallbacks: Set<(event: UIModeChangedEvent) => void> = new Set();
-  /**
-   * Callbacks for workspace change events.
-   */
-  private readonly workspaceChangeCallbacks: Set<(path: string | null) => void> = new Set();
-  /**
-   * Reentrant guard to prevent concurrent workspace changes.
-   */
-  private isChangingWorkspace = false;
-  /**
-   * Flag to skip focus operations during shutdown.
-   */
-  private destroying = false;
-  private unsubscribeResize!: Unsubscribe;
-  private readonly logger: Logger;
-  /**
-   * Tracks workspaces that are loading (waiting for OpenCode client to attach).
-   * Maps workspace path to the timeout handle for cleanup.
-   */
-  private readonly loadingWorkspaces: Map<string, NodeJS.Timeout> = new Map();
-  /**
-   * Callbacks for loading state changes.
-   */
-  private readonly loadingChangeCallbacks: Set<LoadingChangeCallback> = new Set();
 
   constructor(deps: WebContentsViewManagerDeps) {
-    this.windowManager = deps.windowManager;
+    super({
+      windowManager: deps.windowManager,
+      logger: deps.logger,
+      codeServerPort: deps.config.codeServerPort,
+    });
     this.windowLayer = deps.windowLayer;
     this.viewLayer = deps.viewLayer;
     this.sessionLayer = deps.sessionLayer;
     this.appLayer = deps.appLayer;
     this.config = deps.config;
-    this.codeServerPort = deps.config.codeServerPort;
-    this.logger = deps.logger;
   }
 
-  /**
-   * Creates UI view and wires event subscriptions.
-   * Must be called before using any view operations.
-   */
-  create(): void {
-    const { windowManager, viewLayer, config } = this;
+  // ---------------------------------------------------------------------------
+  // UI view
+  // ---------------------------------------------------------------------------
 
-    // Create UI layer with security settings
-    this.uiViewHandle = viewLayer.createView({
+  protected createUIView(): ViewHandle {
+    const { viewLayer, config } = this;
+
+    const uiViewHandle = viewLayer.createView({
       label: "ui",
       webPreferences: {
         nodeIntegration: false,
@@ -174,7 +114,7 @@ export class WebContentsViewManager implements IViewManager {
     });
 
     // Open external URLs from the UI view in the system browser
-    viewLayer.setWindowOpenHandler(this.uiViewHandle, (details: WindowOpenDetails) => {
+    viewLayer.setWindowOpenHandler(uiViewHandle, (details: WindowOpenDetails) => {
       this.appLayer.openUrl(details.url).catch((error: unknown) => {
         this.logger.warn("Failed to open external URL from UI", {
           url: details.url,
@@ -186,72 +126,44 @@ export class WebContentsViewManager implements IViewManager {
 
     // Set transparent background for UI layer — the window's own backgroundColor
     // shows through, keeping the backdrop in sync with the OS theme.
-    viewLayer.setBackgroundColor(this.uiViewHandle, "#00000000");
+    viewLayer.setBackgroundColor(uiViewHandle, "#00000000");
 
-    // Get window handle
-    this.windowHandle = windowManager.getWindowHandle();
-
-    // Add UI layer to window
-    viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
-
-    // Subscribe to resize events
-    this.unsubscribeResize = this.windowManager.onResize(() => {
-      this.updateBounds();
-    });
+    this.windowHandle = this.windowManager.getWindowHandle();
+    viewLayer.attachToWindow(uiViewHandle, this.windowHandle);
 
     // Don't call updateBounds() here - let the resize event from maximize() trigger it.
     // On Linux, maximize() is async and bounds aren't available immediately.
+
+    return uiViewHandle;
   }
 
-  /**
-   * Returns the UI layer view handle.
-   */
-  getUIViewHandle(): ViewHandle {
-    return this.uiViewHandle;
+  protected destroyUIView(): void {
+    this.viewLayer.destroy(this.uiViewHandle);
   }
 
-  /**
-   * Checks if the UI layer view is available (not destroyed).
-   */
-  isUIAvailable(): boolean {
+  protected isUIViewAvailable(): boolean {
     return this.viewLayer.isAvailable(this.uiViewHandle);
   }
 
-  /**
-   * Sends an IPC message to the UI layer.
-   *
-   * @param channel - IPC channel name
-   * @param args - Arguments to send
-   */
-  sendToUI(channel: string, ...args: unknown[]): void {
-    try {
-      this.viewLayer.send(this.uiViewHandle, channel, ...args);
-    } catch {
-      // Ignore errors - view may be destroyed
-    }
+  protected sendToUIView(channel: string, args: unknown[]): void {
+    this.viewLayer.send(this.uiViewHandle, channel, ...args);
   }
 
-  /**
-   * Creates a new workspace view.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   * @param url - URL to load in the view (code-server URL)
-   * @param _projectPath - Retained for API stability; not currently used for partition naming.
-   * @param isNew - If true, marks workspace as loading until OpenCode client attaches.
-   *                Defaults to false (existing workspaces loaded on startup skip loading state).
-   * @returns Handle to the created view
-   */
-  createWorkspaceView(
-    workspacePath: string,
-    url: string,
-    _projectPath: string,
-    isNew = false
-  ): ViewHandle {
-    // Use global partition for all workspaces to share extension storage
+  protected capturePNG(handle: ViewHandle): Promise<Buffer | null> {
+    return this.viewLayer.capturePNG(handle);
+  }
+
+  protected isWindowAlive(): boolean {
+    return !this.windowLayer.isDestroyed(this.windowHandle);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace view
+  // ---------------------------------------------------------------------------
+
+  protected createWorkspaceViewImpl(workspacePath: string): CreatedWorkspaceView {
     const workspaceName = basename(workspacePath);
     const partitionName = GLOBAL_SESSION_PARTITION;
-
-    // Get or create session for this partition
     const sessionHandle = this.sessionLayer.fromPartition(partitionName);
 
     // Configure permission handlers for this session
@@ -299,12 +211,10 @@ export class WebContentsViewManager implements IViewManager {
       );
     });
 
-    // Configure headers handler to allow external content in iframes
-    // VS Code's simple browser uses iframes, and external sites send X-Frame-Options
-    // headers that would block loading. Strip these headers to allow embedding.
+    // Strip headers that block iframe embedding (VS Code's simple browser
+    // embeds external sites that ship X-Frame-Options / CSP frame-ancestors).
     this.sessionLayer.setHeadersReceivedHandler(sessionHandle, (headers) => {
       const modifiedHeaders = { ...headers };
-      // Remove headers that block embedding (case-insensitive header names)
       for (const header of Object.keys(modifiedHeaders)) {
         const lower = header.toLowerCase();
         if (
@@ -318,37 +228,9 @@ export class WebContentsViewManager implements IViewManager {
       return modifiedHeaders;
     });
 
-    // Create + wire the WebContentsView. Extracted so recreateWorkspaceView()
-    // can rebuild a wedged view without duplicating event-handler setup.
-    const viewHandle = this.createAndWireView(workspacePath, workspaceName, partitionName);
+    const handle = this.createAndWireView(workspacePath, workspaceName, partitionName);
 
-    // Store workspace state
-    this.workspaceStates.set(workspacePath, {
-      handle: viewHandle,
-      sessionHandle,
-      url,
-      urlLoaded: false,
-      partitionName,
-      retryCount: 0,
-      retryTimer: null,
-      needsReloadOnAttach: false,
-      reloadWatchdogTimer: null,
-    });
-
-    // Only mark as loading for newly created workspaces (not existing ones loaded on startup)
-    if (isNew) {
-      const timeout = setTimeout(
-        () => this.setWorkspaceLoaded(workspacePath),
-        WORKSPACE_LOADING_TIMEOUT_MS
-      );
-      this.loadingWorkspaces.set(workspacePath, timeout);
-      this.notifyLoadingChange(workspacePath, true);
-    }
-
-    // Note: No attachToWindow() - view starts detached
-    // Note: No loadURL() - URL is loaded on first activation
-
-    return viewHandle;
+    return { handle, sessionHandle, partitionName };
   }
 
   /**
@@ -356,16 +238,13 @@ export class WebContentsViewManager implements IViewManager {
    * handlers + initial bounds. Does NOT register the workspace in
    * `workspaceStates` or change loading state — the caller owns that.
    *
-   * Used by both initial creation (createWorkspaceView) and recovery
-   * (recreateWorkspaceView, after a wedged renderer is detected).
+   * Used by both initial creation and recreation after a wedged renderer.
    */
   private createAndWireView(
     workspacePath: string,
     workspaceName: string,
     partitionName: string
   ): ViewHandle {
-    // Create workspace view with security settings and partition for session isolation
-    // Note: No preload script - keyboard capture is handled via main-process before-input-event
     const viewHandle = this.viewLayer.createView({
       label: workspaceName,
       webPreferences: {
@@ -379,11 +258,10 @@ export class WebContentsViewManager implements IViewManager {
       },
     });
 
-    // Transparent background — the window's own backgroundColor shows through
-    // while code-server loads, keeping the backdrop in sync with the OS theme.
+    // Transparent background — window backgroundColor shows through while
+    // code-server loads, keeping the backdrop in sync with the OS theme.
     this.viewLayer.setBackgroundColor(viewHandle, "#00000000");
 
-    // Configure window open handler to open external URLs
     this.viewLayer.setWindowOpenHandler(viewHandle, (details: WindowOpenDetails) => {
       this.appLayer.openUrl(details.url).catch((error: unknown) => {
         this.logger.warn("Failed to open external URL", {
@@ -394,7 +272,6 @@ export class WebContentsViewManager implements IViewManager {
       return { action: "deny" };
     });
 
-    // Configure navigation handler to prevent navigation away from code-server
     this.viewLayer.onWillNavigate(viewHandle, (navigationUrl) => {
       const codeServerOrigin = `http://127.0.0.1:${this.codeServerPort}`;
       if (!navigationUrl.startsWith(codeServerOrigin)) {
@@ -404,17 +281,15 @@ export class WebContentsViewManager implements IViewManager {
             error: getErrorMessage(error),
           });
         });
-        return false; // Prevent navigation to external URLs
+        return false;
       }
-      return true; // Allow navigation within code-server
+      return true;
     });
 
-    // Subscribe to load failures for retry with exponential backoff
     this.viewLayer.onDidFailLoad(viewHandle, (details: FailLoadDetails) => {
       this.handleLoadFailure(workspacePath, details);
     });
 
-    // Surface renderer crashes / hangs in the log.
     this.viewLayer.onRenderProcessGone(viewHandle, (details) => {
       this.logger.warn("Workspace renderer process gone", {
         workspace: workspaceName,
@@ -435,9 +310,7 @@ export class WebContentsViewManager implements IViewManager {
       this.logger.info("Workspace renderer responsive again", { workspace: workspaceName });
     });
 
-    // did-finish-load handler: reset retry state, clear reload watchdog,
-    // and log so we can confirm in the field whether resume-triggered
-    // reloads on detached views actually complete.
+    // did-finish-load: reset retry state, clear reload watchdog.
     this.viewLayer.onDidFinishLoad(viewHandle, () => {
       this.logger.debug("View did-finish-load", { workspace: workspaceName });
       const currentState = this.workspaceStates.get(workspacePath);
@@ -455,36 +328,13 @@ export class WebContentsViewManager implements IViewManager {
     });
 
     // Set workspace bounds on detached view so code-server renders at correct size.
-    // Electron respects setBounds on detached WebContentsViews.
     this.viewLayer.setBounds(viewHandle, computeWorkspaceRect(this.windowManager.getBounds()));
 
     this.logger.debug("View created", { workspace: workspaceName });
     return viewHandle;
   }
 
-  /**
-   * Destroys a workspace view.
-   *
-   * Idempotent: safe to call multiple times for the same workspace.
-   * Navigates to about:blank before closing to ensure resources are released.
-   * Uses a timeout to ensure destruction completes even if navigation hangs.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   */
-  async destroyWorkspaceView(workspacePath: string): Promise<void> {
-    // Idempotent: early return if workspace not in maps
-    const state = this.workspaceStates.get(workspacePath);
-    if (!state) {
-      return;
-    }
-
-    const workspaceName = basename(workspacePath);
-
-    // Remove from maps FIRST to prevent re-entry during async operations
-    // This makes the operation idempotent even if called concurrently
-    this.workspaceStates.delete(workspacePath);
-
-    // Clean up retry timer
+  protected async destroyWorkspaceViewImpl(state: WorkspaceState): Promise<void> {
     if (state.retryTimer !== null) {
       clearTimeout(state.retryTimer);
     }
@@ -492,146 +342,93 @@ export class WebContentsViewManager implements IViewManager {
       clearTimeout(state.reloadWatchdogTimer);
     }
 
-    // Clean up loading state
-    const timeout = this.loadingWorkspaces.get(workspacePath);
-    if (timeout !== undefined) {
-      clearTimeout(timeout);
-      this.loadingWorkspaces.delete(workspacePath);
-      this.notifyLoadingChange(workspacePath, false);
-    }
-
-    // If this was the active workspace, clear it via setActiveWorkspace to trigger callbacks
-    if (this.activeWorkspacePath === workspacePath) {
-      this.setActiveWorkspace(null);
-    }
-
-    // If this was the attached workspace, clear it
-    if (this.attachedWorkspacePath === workspacePath) {
-      this.attachedWorkspacePath = null;
-    }
-
     try {
-      // Detach from window if attached
       try {
         this.viewLayer.detachFromWindow(state.handle);
       } catch {
         // View might already be detached - ignore
       }
 
-      // Navigate to about:blank before closing (to release resources)
       try {
-        // Create a timeout promise that resolves (not rejects) after NAVIGATION_TIMEOUT_MS
+        // Race navigation against timeout - both resolve, so no unhandled rejections
         const timeoutPromise = new Promise<void>((resolve) => {
           setTimeout(resolve, NAVIGATION_TIMEOUT_MS);
         });
-
-        // Race navigation against timeout - both resolve, so no unhandled rejections
         await Promise.race([this.viewLayer.loadURL(state.handle, "about:blank"), timeoutPromise]);
       } catch {
         // Navigation failed - continue with cleanup
       }
 
-      // Destroy the view
       try {
         this.viewLayer.destroy(state.handle);
       } catch {
         // View might already be destroyed - ignore
       }
     } catch {
-      // Ignore errors during cleanup - view may be in an inconsistent state
-    }
-
-    this.logger.debug("View destroyed", { workspace: workspaceName });
-  }
-
-  /**
-   * Gets a workspace view handle by path.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   * @returns The ViewHandle or undefined if not found
-   */
-  getWorkspaceView(workspacePath: string): ViewHandle | undefined {
-    return this.workspaceStates.get(workspacePath)?.handle;
-  }
-
-  async captureWorkspaceView(workspacePath: string): Promise<Buffer | null> {
-    const state = this.workspaceStates.get(workspacePath);
-    if (!state) return null;
-    return this.viewLayer.capturePNG(state.handle);
-  }
-
-  /**
-   * Updates view bounds for UI layer and active workspace only.
-   * Called on window resize.
-   *
-   * Note: Only the active workspace needs bounds updated (O(1) not O(n)).
-   * Inactive workspaces are detached from contentView and don't need bounds.
-   */
-  updateBounds(): void {
-    // Guard: skip if window is destroyed (happens during app shutdown)
-    if (this.windowLayer.isDestroyed(this.windowHandle)) {
-      return;
-    }
-
-    const bounds = this.windowManager.getBounds();
-
-    // UI layer: full window (so dialogs can overlay everything)
-    this.viewLayer.setBounds(this.uiViewHandle, computeUIRect(bounds));
-
-    // Only update active workspace bounds (O(1) - inactive views are detached).
-    // Loading workspaces are also updated: they are detached but setBounds keeps
-    // the renderer viewport in sync so code-server re-layouts at the correct size.
-    if (this.activeWorkspacePath !== null) {
-      const state = this.workspaceStates.get(this.activeWorkspacePath);
-      if (state) {
-        this.viewLayer.setBounds(state.handle, computeWorkspaceRect(bounds));
-      }
+      // Ignore errors during cleanup
     }
   }
 
-  /**
-   * Returns the z-index for the UI layer's "bottom" position.
-   */
-  private getUIBottomIndex(): number {
-    return Z_UI_BOTTOM;
-  }
-
-  /**
-   * Loads the URL for a workspace view if not already loaded.
-   * Called during first activation.
-   *
-   * @param workspacePath - Path to the workspace
-   */
-  private loadViewUrl(workspacePath: string): void {
-    const state = this.workspaceStates.get(workspacePath);
-    if (!state) return;
-
-    // Skip if already loaded (ensures URL is only loaded on first activation)
-    if (state.urlLoaded) return;
-
-    // Mark as loaded first to prevent re-entry
-    state.urlLoaded = true;
-
-    // Load the URL (fire-and-forget). View stays detached until activated.
-    // If loading fails, onDidFailLoad handler will retry with exponential backoff.
+  protected startLoadingUrl(state: WorkspaceState): void {
     void this.viewLayer.loadURL(state.handle, state.url);
   }
+
+  protected attachViewImpl(state: WorkspaceState): void {
+    this.viewLayer.attachToWindow(state.handle, this.windowHandle);
+
+    // Force a fresh paint if this view sat detached across a system
+    // suspend/resume (or its renderer crashed). On Windows, a detached
+    // WebContentsView whose URL was reloaded while invisible can come
+    // back unfocusable and blank; reload() recreates the renderer view.
+    if (state.needsReloadOnAttach) {
+      state.needsReloadOnAttach = false;
+      this.logger.debug("Reloading view on attach", { workspace: basename(state.url) });
+      this.viewLayer.reload(state.handle);
+    }
+  }
+
+  protected detachViewImpl(state: WorkspaceState): void {
+    this.viewLayer.detachFromWindow(state.handle);
+  }
+
+  protected applyBounds(handle: ViewHandle, rect: Rect): void {
+    this.viewLayer.setBounds(handle, rect);
+  }
+
+  protected focusHandle(handle: ViewHandle): void {
+    this.viewLayer.focus(handle);
+  }
+
+  protected bringUIToTop(): void {
+    // No index = append to top
+    this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
+  }
+
+  protected bringUIToBottom(forceRedraw: boolean): void {
+    if (forceRedraw) {
+      // Windows DirectComposition workaround: force UI view re-composite
+      // so the transparent sidebar strip is rendered correctly.
+      this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM, {
+        force: true,
+      });
+    } else {
+      this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // WebContents-specific retry + reload watchdog
+  // ---------------------------------------------------------------------------
 
   /**
    * Handles a load failure for a workspace view.
    * Only retries main-frame failures, with exponential backoff.
-   *
-   * @param workspacePath - Path to the workspace
-   * @param details - Failure details from the did-fail-load event
    */
   private handleLoadFailure(workspacePath: string, details: FailLoadDetails): void {
-    // Only retry main-frame failures (sub-frame failures are not critical)
     if (!details.isMainFrame) return;
 
     const state = this.workspaceStates.get(workspacePath);
     if (!state) return;
-
-    // Skip retries during shutdown
     if (this.destroying) return;
 
     const workspaceName = basename(workspacePath);
@@ -650,7 +447,6 @@ export class WebContentsViewManager implements IViewManager {
       retryDelayMs: delay,
     });
 
-    // Clear any existing retry timer
     if (state.retryTimer !== null) {
       clearTimeout(state.retryTimer);
     }
@@ -658,11 +454,9 @@ export class WebContentsViewManager implements IViewManager {
     // Reset urlLoaded to allow retry
     state.urlLoaded = false;
 
-    // Schedule retry
     state.retryTimer = setTimeout(() => {
       state.retryTimer = null;
 
-      // Re-check state validity (workspace may have been destroyed during delay)
       const currentState = this.workspaceStates.get(workspacePath);
       if (!currentState) return;
 
@@ -676,518 +470,43 @@ export class WebContentsViewManager implements IViewManager {
     }, delay);
   }
 
-  /**
-   * Attaches a workspace view to the contentView.
-   * Handles errors gracefully.
-   *
-   * @param workspacePath - Path to the workspace
-   */
-  private attachView(workspacePath: string): void {
-    const state = this.workspaceStates.get(workspacePath);
-    if (!state) return;
-
-    try {
-      if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-        this.viewLayer.attachToWindow(state.handle, this.windowHandle);
-        this.attachedWorkspacePath = workspacePath;
-        const workspaceName = basename(workspacePath);
-        this.logger.debug("View attached", { workspace: workspaceName });
-
-        // Force a fresh paint if this view sat detached across a system
-        // suspend/resume (or its renderer crashed). On Windows, a detached
-        // WebContentsView whose URL was reloaded while invisible can come
-        // back unfocusable and blank; reload() recreates the renderer view.
-        if (state.needsReloadOnAttach) {
-          state.needsReloadOnAttach = false;
-          this.logger.debug("Reloading view on attach", { workspace: workspaceName });
-          this.viewLayer.reload(state.handle);
-        }
-      }
-    } catch {
-      // Ignore errors during attach - window may be closing
+  protected reloadWorkspaceView(state: WorkspaceState): void {
+    // Reset retry state for fresh reload attempt
+    state.retryCount = 0;
+    if (state.retryTimer !== null) {
+      clearTimeout(state.retryTimer);
+      state.retryTimer = null;
     }
+    void this.viewLayer.loadURL(state.handle, state.url);
+
+    // Arm a watchdog: if did-finish-load doesn't fire within
+    // RELOAD_WATCHDOG_MS the renderer is assumed wedged (the white-tab
+    // bug we see on Windows after multiple suspend/resume cycles when
+    // loadURL is called on a detached WebContentsView) and we recreate
+    // the view from scratch.
+    if (state.reloadWatchdogTimer !== null) {
+      clearTimeout(state.reloadWatchdogTimer);
+    }
+    // Recover the workspace path by looking it up — state is keyed in the
+    // map by path. We need the path for recreateWorkspaceView().
+    const workspacePath = this.findWorkspacePathByHandle(state.handle);
+    state.reloadWatchdogTimer = setTimeout(() => {
+      const currentState = workspacePath ? this.workspaceStates.get(workspacePath) : undefined;
+      if (!currentState || !workspacePath) return;
+      currentState.reloadWatchdogTimer = null;
+      this.logger.warn("Reload watchdog fired — recreating view", {
+        workspace: basename(workspacePath),
+        watchdogMs: RELOAD_WATCHDOG_MS,
+      });
+      this.recreateWorkspaceView(workspacePath);
+    }, RELOAD_WATCHDOG_MS);
   }
 
-  /**
-   * Detaches a workspace view from the contentView.
-   * Handles errors gracefully.
-   *
-   * @param workspacePath - Path to the workspace
-   */
-  private detachView(workspacePath: string): void {
-    const state = this.workspaceStates.get(workspacePath);
-    if (!state) return;
-
-    const workspaceName = basename(workspacePath);
-
-    try {
-      this.viewLayer.detachFromWindow(state.handle);
-      this.logger.debug("View detached", { workspace: workspaceName });
-    } catch {
-      // Ignore errors during detach - window may be closing
+  private findWorkspacePathByHandle(handle: ViewHandle): string | undefined {
+    for (const [path, state] of this.workspaceStates) {
+      if (state.handle === handle) return path;
     }
-
-    // Clear attachment state if this was the attached view
-    if (this.attachedWorkspacePath === workspacePath) {
-      this.attachedWorkspacePath = null;
-    }
-  }
-
-  /**
-   * Sets the active workspace.
-   * Active workspace is attached with full content bounds, others are detached.
-   * By default, focuses the workspace view so it receives keyboard input.
-   *
-   * @param workspacePath - Path to the workspace to activate, or null for none
-   * @param focus - Whether to focus the workspace view (default: true)
-   */
-  setActiveWorkspace(workspacePath: string | null, focus: boolean = true): void {
-    // Reentrant guard
-    if (this.isChangingWorkspace) {
-      return;
-    }
-
-    // Same workspace is usually a no-op, except when the active path was kept
-    // in place across a destroy + recreate cycle (e.g. hibernate → wake) and
-    // the new view exists but isn't attached yet — in that case we must run
-    // through loadViewUrl + attachView once to bring the view onscreen.
-    if (this.activeWorkspacePath === workspacePath) {
-      if (workspacePath === null) return;
-      const state = this.workspaceStates.get(workspacePath);
-      const needsAttach =
-        state !== undefined &&
-        this.attachedWorkspacePath !== workspacePath &&
-        !this.loadingWorkspaces.has(workspacePath);
-      if (!needsAttach) return;
-      this.loadViewUrl(workspacePath);
-      this.attachView(workspacePath);
-      this.updateBounds();
-      if (focus) this.focus();
-      return;
-    }
-
-    try {
-      this.isChangingWorkspace = true;
-      const previousPath = this.activeWorkspacePath;
-
-      // Update state first
-      this.activeWorkspacePath = workspacePath;
-
-      // Load URL and attach new view FIRST (visual continuity - no gap)
-      if (workspacePath !== null) {
-        this.loadViewUrl(workspacePath);
-        if (!this.loadingWorkspaces.has(workspacePath)) {
-          this.attachView(workspacePath);
-        }
-        // Loading workspaces stay detached with full-size bounds (set at creation).
-        // Alt+X works via the UI view's before-input-event (focus goes to UI).
-      }
-
-      // Then detach previous
-      if (previousPath !== null && previousPath !== workspacePath) {
-        this.detachView(previousPath);
-      }
-
-      // Maintain z-order if in dialog, shortcut, or hover mode
-      // The new workspace view was just attached to the top, so we need to
-      // re-add the UI layer to keep it on top. Must directly manipulate z-order
-      // since setMode is idempotent and won't re-apply if mode hasn't changed.
-      if (this.mode === "dialog" || this.mode === "shortcut" || this.mode === "hover") {
-        try {
-          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            // Re-attach UI view to move it to top
-            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
-            // Restore focus to UI layer (lost during re-attach)
-            if (this.mode === "shortcut") {
-              this.focus();
-            } else {
-              this.viewLayer.focus(this.uiViewHandle);
-            }
-          }
-        } catch {
-          // Ignore errors during z-order change - window may be closing
-        }
-      } else {
-        // Windows DirectComposition workaround: force UI view re-composite
-        // so the transparent sidebar strip is rendered on startup.
-        try {
-          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            this.viewLayer.attachToWindow(
-              this.uiViewHandle,
-              this.windowHandle,
-              this.getUIBottomIndex(),
-              { force: true }
-            );
-          }
-        } catch {
-          // window may be closing
-        }
-      }
-
-      this.updateBounds();
-
-      // Focus after everything is set up
-      if (focus) {
-        this.focus();
-      }
-
-      // Notify subscribers of workspace change
-      for (const callback of this.workspaceChangeCallbacks) {
-        try {
-          callback(workspacePath);
-        } catch (error) {
-          this.logger.error(
-            "Error in workspace change callback",
-            {},
-            error instanceof Error ? error : undefined
-          );
-        }
-      }
-    } finally {
-      this.isChangingWorkspace = false;
-    }
-  }
-
-  /**
-   * Gets the active workspace path.
-   *
-   * @returns The active workspace path or null if none
-   */
-  getActiveWorkspacePath(): string | null {
-    return this.activeWorkspacePath;
-  }
-
-  /**
-   * Returns the topmost focusable view handle.
-   * If an active workspace is attached (not loading), returns it.
-   * Otherwise returns the UI view (loading workspaces are detached,
-   * so focus goes to the UI view where Alt+X detection works).
-   */
-  private getTopView(): ViewHandle {
-    if (
-      this.activeWorkspacePath !== null &&
-      !this.loadingWorkspaces.has(this.activeWorkspacePath)
-    ) {
-      const state = this.workspaceStates.get(this.activeWorkspacePath);
-      if (state) return state.handle;
-    }
-    return this.uiViewHandle;
-  }
-
-  /**
-   * Focuses the correct view based on current mode and attachment state.
-   * Single source of truth for focus management.
-   *
-   * - workspace mode: focuses workspace view if attached, else UI
-   * - shortcut mode: focuses UI (keyboard events go to sidebar)
-   * - dialog/hover mode: no-op (these modes manage their own focus)
-   */
-  focus(): void {
-    if (this.destroying) return;
-
-    switch (this.mode) {
-      case "dialog":
-      case "hover":
-        // These modes manage their own focus via traps/handlers
-        break;
-      case "shortcut":
-        this.logger.debug("focus", { target: "ui", mode: this.mode });
-        this.viewLayer.focus(this.uiViewHandle);
-        break;
-      case "workspace": {
-        const topView = this.getTopView();
-        this.logger.debug("focus", {
-          target: topView === this.uiViewHandle ? "ui" : "workspace",
-          mode: this.mode,
-          attachedWorkspace: this.attachedWorkspacePath
-            ? basename(this.attachedWorkspacePath)
-            : null,
-        });
-        this.viewLayer.focus(topView);
-        break;
-      }
-    }
-  }
-
-  /**
-   * Sets the UI mode.
-   * - "workspace": UI at z-index 0, focus active workspace
-   * - "shortcut": UI on top, focus UI layer
-   * - "dialog": UI on top, no focus change
-   *
-   * Mode transitions are idempotent - setting the same mode twice does not emit an event.
-   *
-   * @param mode - The new UI mode
-   */
-  setMode(newMode: UIMode): void {
-    const previousMode = this.mode;
-
-    // Idempotent: no-op if same mode
-    if (newMode === previousMode) {
-      return;
-    }
-
-    this.mode = newMode;
-
-    try {
-      if (this.windowLayer.isDestroyed(this.windowHandle)) return;
-
-      switch (newMode) {
-        case "workspace":
-          // Move UI to bottom - workspace on top
-          this.viewLayer.attachToWindow(
-            this.uiViewHandle,
-            this.windowHandle,
-            this.getUIBottomIndex()
-          );
-          this.focus();
-          break;
-
-        case "shortcut":
-          // Move UI to top (no index = append to top)
-          this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
-          this.focus();
-          break;
-
-        case "hover":
-        case "dialog":
-          // Move UI to top (no index = append to top)
-          this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
-          // Do NOT change focus - hover/dialog component will manage focus
-          break;
-
-        default: {
-          const _exhaustive: never = newMode;
-          this.logger.warn("Unhandled UI mode", { mode: _exhaustive });
-        }
-      }
-    } catch {
-      // Ignore errors during mode change - window may be closing
-    }
-
-    this.logger.debug("Mode changed", { mode: newMode, previous: previousMode });
-
-    // Emit event to subscribers
-    const event: UIModeChangedEvent = { mode: newMode, previousMode };
-    for (const callback of this.modeChangeCallbacks) {
-      try {
-        callback(event);
-      } catch (error) {
-        this.logger.error(
-          "Error in mode change callback",
-          { mode: newMode },
-          error instanceof Error ? error : undefined
-        );
-      }
-    }
-  }
-
-  /**
-   * Gets the current UI mode.
-   *
-   * @returns The current UI mode
-   */
-  getMode(): UIMode {
-    return this.mode;
-  }
-
-  /**
-   * Subscribe to mode change events.
-   *
-   * @param callback - Called when mode changes, receives mode and previousMode
-   * @returns Unsubscribe function
-   */
-  onModeChange(callback: (event: UIModeChangedEvent) => void): Unsubscribe {
-    this.modeChangeCallbacks.add(callback);
-    return () => {
-      this.modeChangeCallbacks.delete(callback);
-    };
-  }
-
-  /**
-   * Subscribe to workspace change events.
-   *
-   * @param callback - Called when active workspace changes
-   * @returns Unsubscribe function
-   */
-  onWorkspaceChange(callback: (path: string | null) => void): Unsubscribe {
-    this.workspaceChangeCallbacks.add(callback);
-    return () => {
-      this.workspaceChangeCallbacks.delete(callback);
-    };
-  }
-
-  /**
-   * Checks if a workspace is currently loading.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   * @returns True if the workspace is loading, false otherwise
-   */
-  isWorkspaceLoading(workspacePath: string): boolean {
-    return this.loadingWorkspaces.has(workspacePath);
-  }
-
-  /**
-   * Marks a workspace as loaded, attaching its view if active.
-   * Called when the first OpenCode client attaches or the timeout expires.
-   * Idempotent: safe to call multiple times or for non-loading workspaces.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   */
-  setWorkspaceLoaded(workspacePath: string): void {
-    // Guard: no-op if workspace isn't loading
-    if (!this.loadingWorkspaces.has(workspacePath)) {
-      return;
-    }
-
-    // Clear the timeout
-    const timeout = this.loadingWorkspaces.get(workspacePath);
-    if (timeout !== undefined) {
-      clearTimeout(timeout);
-    }
-
-    // Remove from loading map
-    this.loadingWorkspaces.delete(workspacePath);
-
-    // Notify listeners
-    this.notifyLoadingChange(workspacePath, false);
-
-    if (this.activeWorkspacePath === workspacePath) {
-      // Attach detached view at full bounds
-      this.attachView(workspacePath);
-      this.updateBounds();
-
-      // Maintain z-order: UI must stay in correct position relative to workspace
-      if (this.mode === "dialog" || this.mode === "shortcut" || this.mode === "hover") {
-        try {
-          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
-          }
-        } catch {
-          // Ignore errors - window may be closing
-        }
-      } else {
-        // Windows DirectComposition workaround: force UI view re-composite
-        try {
-          if (!this.windowLayer.isDestroyed(this.windowHandle)) {
-            this.viewLayer.attachToWindow(
-              this.uiViewHandle,
-              this.windowHandle,
-              this.getUIBottomIndex(),
-              { force: true }
-            );
-          }
-        } catch {
-          // window may be closing
-        }
-      }
-
-      // In dialog/hover mode, the view re-attachment above may have shifted
-      // focus to the workspace view. Restore focus to the UI view so the
-      // renderer's focus trap continues to work.
-      if (this.mode === "dialog" || this.mode === "hover") {
-        this.viewLayer.focus(this.uiViewHandle);
-      } else {
-        this.focus();
-      }
-    }
-    // Inactive: no-op (view stays detached, URL already loaded)
-
-    const workspaceName = basename(workspacePath);
-    this.logger.debug("Workspace loaded", { workspace: workspaceName });
-  }
-
-  /**
-   * Subscribe to loading state changes.
-   *
-   * When the callback is registered, it immediately receives loading=false events
-   * for all workspaces that have already finished loading. This handles the case
-   * where loading events were lost before the callback was wired (e.g., during startup).
-   *
-   * @param callback - Called with (path, loading) when loading state changes
-   * @returns Unsubscribe function
-   */
-  onLoadingChange(callback: LoadingChangeCallback): Unsubscribe {
-    this.loadingChangeCallbacks.add(callback);
-
-    // Emit loading=false for workspaces that already finished loading
-    // This catches workspaces whose loading=false events were lost before callback was wired
-    for (const workspacePath of this.workspaceStates.keys()) {
-      if (!this.loadingWorkspaces.has(workspacePath)) {
-        try {
-          callback(workspacePath, false);
-        } catch (error) {
-          this.logger.error(
-            "Error in loading change callback (initial emit)",
-            { path: workspacePath, loading: false },
-            error instanceof Error ? error : undefined
-          );
-        }
-      }
-    }
-
-    return () => {
-      this.loadingChangeCallbacks.delete(callback);
-    };
-  }
-
-  /**
-   * Notifies listeners of a loading state change.
-   * @param path - Workspace path
-   * @param loading - True if workspace is now loading, false if loaded
-   */
-  private notifyLoadingChange(path: string, loading: boolean): void {
-    for (const callback of this.loadingChangeCallbacks) {
-      try {
-        callback(path, loading);
-      } catch (error) {
-        this.logger.error(
-          "Error in loading change callback",
-          { path, loading },
-          error instanceof Error ? error : undefined
-        );
-      }
-    }
-  }
-
-  /**
-   * Reloads all workspace views that have a loaded URL.
-   *
-   * Skips workspaces that haven't loaded yet (urlLoaded === false)
-   * and workspaces currently in loading state.
-   * Used to recover from broken WebSocket connections after system resume.
-   */
-  reloadAllViews(): void {
-    for (const [workspacePath, state] of this.workspaceStates) {
-      if (!state.urlLoaded) continue;
-      if (this.loadingWorkspaces.has(workspacePath)) continue;
-      // Reset retry state for fresh reload attempt
-      state.retryCount = 0;
-      if (state.retryTimer !== null) {
-        clearTimeout(state.retryTimer);
-        state.retryTimer = null;
-      }
-      void this.viewLayer.loadURL(state.handle, state.url);
-
-      // Arm a watchdog: if did-finish-load doesn't fire within
-      // RELOAD_WATCHDOG_MS the renderer is assumed wedged (the white-tab
-      // bug we see on Windows after multiple suspend/resume cycles when
-      // loadURL is called on a detached WebContentsView) and we recreate
-      // the view from scratch.
-      if (state.reloadWatchdogTimer !== null) {
-        clearTimeout(state.reloadWatchdogTimer);
-      }
-      state.reloadWatchdogTimer = setTimeout(() => {
-        const currentState = this.workspaceStates.get(workspacePath);
-        if (!currentState) return;
-        currentState.reloadWatchdogTimer = null;
-        this.logger.warn("Reload watchdog fired — recreating view", {
-          workspace: basename(workspacePath),
-          watchdogMs: RELOAD_WATCHDOG_MS,
-        });
-        this.recreateWorkspaceView(workspacePath);
-      }, RELOAD_WATCHDOG_MS);
-    }
+    return undefined;
   }
 
   /**
@@ -1206,7 +525,6 @@ export class WebContentsViewManager implements IViewManager {
     const workspaceName = basename(workspacePath);
     const wasAttached = this.attachedWorkspacePath === workspacePath;
 
-    // Clear any pending timers on the old state
     if (state.retryTimer !== null) {
       clearTimeout(state.retryTimer);
       state.retryTimer = null;
@@ -1216,7 +534,6 @@ export class WebContentsViewManager implements IViewManager {
       state.reloadWatchdogTimer = null;
     }
 
-    // Detach and destroy the old view. Best-effort: continue even on error.
     try {
       if (wasAttached) {
         this.viewLayer.detachFromWindow(state.handle);
@@ -1234,71 +551,17 @@ export class WebContentsViewManager implements IViewManager {
       });
     }
 
-    // Build a fresh view + re-wire handlers and bounds.
     const newHandle = this.createAndWireView(workspacePath, workspaceName, state.partitionName);
     state.handle = newHandle;
     state.urlLoaded = false;
     state.retryCount = 0;
     state.needsReloadOnAttach = false;
 
-    // Kick off the load on the new view.
     state.urlLoaded = true;
     void this.viewLayer.loadURL(newHandle, state.url);
 
-    // If the wedged view was visible, re-attach the fresh one in its place.
     if (wasAttached) {
       this.attachView(workspacePath);
-    }
-  }
-
-  /**
-   * Preloads a workspace's URL without attaching the view.
-   *
-   * Loads the code-server URL in the background so the workspace is ready
-   * when the user navigates to it. The view remains detached (no GPU usage)
-   * until setActiveWorkspace() is called.
-   *
-   * Idempotent: delegates to loadViewUrl() which checks urlLoaded flag.
-   *
-   * @param workspacePath - Absolute path to the workspace directory
-   */
-  preloadWorkspaceUrl(workspacePath: string): void {
-    const workspaceName = basename(workspacePath);
-    this.logger.debug("Preloading URL", { workspace: workspaceName });
-    this.loadViewUrl(workspacePath);
-  }
-
-  /**
-   * Updates the code-server port.
-   * Used after setup completes to update the port for origin checking.
-   *
-   * @param port - The new code-server port
-   */
-  updateCodeServerPort(port: number): void {
-    this.codeServerPort = port;
-  }
-
-  /**
-   * Destroys the WebContentsViewManager and cleans up all views.
-   * Called on application shutdown.
-   */
-  destroy(): void {
-    // Mark as destroying to skip focus operations
-    this.destroying = true;
-
-    // Unsubscribe from resize events
-    this.unsubscribeResize();
-
-    // Destroy all workspace views (fire-and-forget - app is shutting down)
-    for (const path of this.workspaceStates.keys()) {
-      void this.destroyWorkspaceView(path);
-    }
-
-    // Destroy UI view
-    try {
-      this.viewLayer.destroy(this.uiViewHandle);
-    } catch {
-      // Ignore errors during cleanup - view may be in an inconsistent state
     }
   }
 }

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -22,6 +22,8 @@ import { BaseViewManager, type CreatedWorkspaceView } from "./view-manager-base"
 import {
   Z_UI_BOTTOM,
   computeWorkspaceRect,
+  type DevtoolsTarget,
+  type KeyboardTarget,
   type Rect,
   type WorkspaceState,
 } from "./view-manager-types";
@@ -402,6 +404,30 @@ export class WebContentsViewManager extends BaseViewManager {
   protected bringUIToTop(): void {
     // No index = append to top
     this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
+  }
+
+  protected makeDevtoolsTarget(handle: ViewHandle): DevtoolsTarget {
+    const viewLayer = this.viewLayer;
+    return {
+      id: handle.id,
+      toggle: () => {
+        if (viewLayer.isDevToolsOpened(handle)) {
+          viewLayer.closeDevTools(handle);
+        } else {
+          viewLayer.openDevTools(handle, { mode: "detach" });
+        }
+      },
+      isOpen: () => viewLayer.isDevToolsOpened(handle),
+    };
+  }
+
+  protected makeKeyboardTarget(handle: ViewHandle): KeyboardTarget {
+    const viewLayer = this.viewLayer;
+    return {
+      id: handle.id,
+      onBeforeInput: (callback) => viewLayer.onBeforeInputEvent(handle, callback),
+      onDestroyed: (callback) => viewLayer.onDestroyed(handle, callback),
+    };
   }
 
   protected bringUIToBottom(forceRedraw: boolean): void {

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -151,6 +151,10 @@ export class WebContentsViewManager extends BaseViewManager {
     this.viewLayer.send(this.uiViewHandle, channel, ...args);
   }
 
+  protected loadUIContentImpl(htmlPath: string): Promise<void> {
+    return this.viewLayer.loadURL(this.uiViewHandle, htmlPath);
+  }
+
   protected capturePNG(handle: ViewHandle): Promise<Buffer | null> {
     return this.viewLayer.capturePNG(handle);
   }

--- a/src/intents/get-active-workspace.ts
+++ b/src/intents/get-active-workspace.ts
@@ -2,7 +2,7 @@
  * GetActiveWorkspaceOperation - Orchestrates active workspace queries.
  *
  * Runs the "get" hook point where the handler retrieves the current active
- * workspace from ViewManager and resolves it to a WorkspaceRef.
+ * workspace from WebContentsViewManager and resolves it to a WorkspaceRef.
  *
  * No provider dependencies - the hook handler does the actual work.
  * No domain events - this is a query operation.

--- a/src/intents/set-mode.ts
+++ b/src/intents/set-mode.ts
@@ -2,7 +2,7 @@
  * SetModeOperation - Orchestrates UI mode changes.
  *
  * Runs the "set" hook point where the handler captures the previous mode,
- * then applies the new mode via ViewManager. On success, emits a
+ * then applies the new mode via WebContentsViewManager. On success, emits a
  * ui:mode-changed domain event.
  *
  * No provider dependencies - the hook handler does the actual work.

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ import { DefaultWindowBoundary } from "./boundaries/shell/window";
 import { DefaultViewBoundary } from "./boundaries/shell/view";
 import { DefaultSessionBoundary } from "./boundaries/shell/session";
 import { WindowManager } from "./boundaries/shell/window-manager";
-import { ViewManager } from "./boundaries/shell/view-manager";
+import { WebContentsViewManager } from "./boundaries/shell/webcontents-view-manager";
 // Services (stayed)
 import { AutoUpdater } from "./modules/auto-updater";
 import { DefaultArchiveExtractor } from "./boundaries/platform/archive";
@@ -328,7 +328,7 @@ const windowManager = new WindowManager(
   pathProvider.appIconPath.toNative()
 );
 
-const viewManager = new ViewManager({
+const viewManager = new WebContentsViewManager({
   windowManager,
   windowLayer,
   viewLayer,

--- a/src/modules/devtools-module.integration.test.ts
+++ b/src/modules/devtools-module.integration.test.ts
@@ -8,38 +8,46 @@
 import { describe, it, expect, vi } from "vitest";
 import { createDevtoolsModule, type DevtoolsModuleDeps } from "./devtools-module";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
-import type { ViewHandle } from "../boundaries/shell/types";
+import type { DevtoolsTarget } from "../boundaries/shell/view-manager-types";
 
 // =============================================================================
 // Helpers
 // =============================================================================
 
-function createViewHandle(id: string): ViewHandle {
-  return { id, __brand: "ViewHandle" as const };
+function createDevtoolsTarget(id: string) {
+  let open = false;
+  const toggle = vi.fn(() => {
+    open = !open;
+  });
+  const isOpen = vi.fn(() => open);
+  const target: DevtoolsTarget & { _setOpen: (v: boolean) => void } = {
+    id,
+    toggle,
+    isOpen,
+    _setOpen: (v: boolean) => {
+      open = v;
+    },
+  };
+  return target;
 }
 
 function createMockDeps() {
-  const uiHandle = createViewHandle("ui-view");
-  const wsHandle = createViewHandle("ws-view");
+  const uiTarget = createDevtoolsTarget("ui-view");
+  const wsTarget = createDevtoolsTarget("ws-view");
   let activePath: string | null = "/test/workspace";
 
-  const viewLayer = {
-    openDevTools: vi.fn(),
-    closeDevTools: vi.fn(),
-    isDevToolsOpened: vi.fn().mockReturnValue(false),
-  };
-
   const viewManager = {
-    getUIViewHandle: vi.fn().mockReturnValue(uiHandle),
-    getWorkspaceView: vi.fn(() => wsHandle),
+    getUIDevtoolsTarget: vi.fn(() => uiTarget),
+    getWorkspaceDevtoolsTarget: vi.fn((path: string) =>
+      path === activePath ? wsTarget : undefined
+    ),
     getActiveWorkspacePath: vi.fn(() => activePath),
   };
 
   return {
-    viewLayer,
     viewManager: viewManager as unknown as DevtoolsModuleDeps["viewManager"],
-    uiHandle,
-    wsHandle,
+    uiTarget,
+    wsTarget,
     _setActivePath(path: string | null) {
       activePath = path;
     },
@@ -68,18 +76,19 @@ describe("DevtoolsModule", () => {
 
     await emitKeyEvent(module, "d");
 
-    expect(mock.viewLayer.openDevTools).toHaveBeenCalledWith(mock.uiHandle, { mode: "detach" });
+    expect(mock.uiTarget.toggle).toHaveBeenCalledTimes(1);
+    expect(mock.uiTarget.isOpen()).toBe(true);
   });
 
   it("D toggles UI DevTools closed when already open", async () => {
     const mock = createMockDeps();
-    mock.viewLayer.isDevToolsOpened.mockReturnValue(true);
+    mock.uiTarget._setOpen(true);
     const module = createDevtoolsModule(mock);
 
     await emitKeyEvent(module, "d");
 
-    expect(mock.viewLayer.closeDevTools).toHaveBeenCalledWith(mock.uiHandle);
-    expect(mock.viewLayer.openDevTools).not.toHaveBeenCalled();
+    expect(mock.uiTarget.toggle).toHaveBeenCalledTimes(1);
+    expect(mock.uiTarget.isOpen()).toBe(false);
   });
 
   it("W toggles active workspace DevTools open", async () => {
@@ -88,17 +97,19 @@ describe("DevtoolsModule", () => {
 
     await emitKeyEvent(module, "w");
 
-    expect(mock.viewLayer.openDevTools).toHaveBeenCalledWith(mock.wsHandle, { mode: "detach" });
+    expect(mock.wsTarget.toggle).toHaveBeenCalledTimes(1);
+    expect(mock.wsTarget.isOpen()).toBe(true);
   });
 
   it("W toggles workspace DevTools closed when already open", async () => {
     const mock = createMockDeps();
-    mock.viewLayer.isDevToolsOpened.mockReturnValue(true);
+    mock.wsTarget._setOpen(true);
     const module = createDevtoolsModule(mock);
 
     await emitKeyEvent(module, "w");
 
-    expect(mock.viewLayer.closeDevTools).toHaveBeenCalledWith(mock.wsHandle);
+    expect(mock.wsTarget.toggle).toHaveBeenCalledTimes(1);
+    expect(mock.wsTarget.isOpen()).toBe(false);
   });
 
   it("W does nothing when no active workspace", async () => {
@@ -108,8 +119,8 @@ describe("DevtoolsModule", () => {
 
     await emitKeyEvent(module, "w");
 
-    expect(mock.viewLayer.openDevTools).not.toHaveBeenCalled();
-    expect(mock.viewLayer.closeDevTools).not.toHaveBeenCalled();
+    expect(mock.wsTarget.toggle).not.toHaveBeenCalled();
+    expect(mock.uiTarget.toggle).not.toHaveBeenCalled();
   });
 
   it("ignores unrelated keys", async () => {
@@ -120,7 +131,7 @@ describe("DevtoolsModule", () => {
     await emitKeyEvent(module, "enter");
     await emitKeyEvent(module, "5");
 
-    expect(mock.viewLayer.openDevTools).not.toHaveBeenCalled();
-    expect(mock.viewLayer.closeDevTools).not.toHaveBeenCalled();
+    expect(mock.uiTarget.toggle).not.toHaveBeenCalled();
+    expect(mock.wsTarget.toggle).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/devtools-module.ts
+++ b/src/modules/devtools-module.ts
@@ -9,27 +9,13 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
-import type { ViewBoundary } from "../boundaries/shell/view";
-import type { ViewHandle } from "../boundaries/shell/types";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 
 export interface DevtoolsModuleDeps {
   readonly viewManager: Pick<
     IViewManager,
-    "getUIViewHandle" | "getWorkspaceView" | "getActiveWorkspacePath"
+    "getUIDevtoolsTarget" | "getWorkspaceDevtoolsTarget" | "getActiveWorkspacePath"
   >;
-  readonly viewLayer: Pick<ViewBoundary, "openDevTools" | "closeDevTools" | "isDevToolsOpened">;
-}
-
-function toggleDevTools(
-  viewLayer: Pick<ViewBoundary, "openDevTools" | "closeDevTools" | "isDevToolsOpened">,
-  handle: ViewHandle
-): void {
-  if (viewLayer.isDevToolsOpened(handle)) {
-    viewLayer.closeDevTools(handle);
-  } else {
-    viewLayer.openDevTools(handle, { mode: "detach" });
-  }
 }
 
 export function createDevtoolsModule(deps: DevtoolsModuleDeps): IntentModule {
@@ -42,17 +28,14 @@ export function createDevtoolsModule(deps: DevtoolsModuleDeps): IntentModule {
           const { key } = (event as ShortcutKeyPressedEvent).payload;
 
           if (key === "d") {
-            toggleDevTools(deps.viewLayer, deps.viewManager.getUIViewHandle());
+            deps.viewManager.getUIDevtoolsTarget().toggle();
             return;
           }
 
           if (key === "w") {
             const activePath = deps.viewManager.getActiveWorkspacePath();
             if (activePath) {
-              const wsHandle = deps.viewManager.getWorkspaceView(activePath);
-              if (wsHandle) {
-                toggleDevTools(deps.viewLayer, wsHandle);
-              }
+              deps.viewManager.getWorkspaceDevtoolsTarget(activePath)?.toggle();
             }
           }
         },

--- a/src/modules/shortcut-module.integration.test.ts
+++ b/src/modules/shortcut-module.integration.test.ts
@@ -28,6 +28,7 @@ import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createShortcutModule, normalizeKey, type ShortcutModuleDeps } from "./shortcut-module";
 import type { ViewHandle, WindowHandle } from "../boundaries/shell/types";
 import type { KeyboardInput, Unsubscribe } from "../boundaries/shell/view";
+import type { KeyboardTarget } from "../boundaries/shell/view-manager-types";
 import type { UIMode } from "../shared/ipc";
 
 // =============================================================================
@@ -70,8 +71,8 @@ interface MockCallbacks {
   blurUnsubscribe: ReturnType<typeof vi.fn<() => void>>;
 }
 
-function createMockViewBoundary() {
-  const callbacks: MockCallbacks = {
+function createMockCallbacks(): MockCallbacks {
+  return {
     inputCallbacks: new Map(),
     destroyedCallbacks: new Map(),
     inputUnsubscribes: new Map(),
@@ -79,42 +80,48 @@ function createMockViewBoundary() {
     blurCallback: null,
     blurUnsubscribe: vi.fn<() => void>(),
   };
+}
 
-  const viewLayer = {
-    onBeforeInputEvent: vi.fn(
-      (
-        handle: ViewHandle,
-        callback: (input: KeyboardInput, preventDefault: () => void) => void
-      ): Unsubscribe => {
+function createKeyboardTarget(handle: ViewHandle, callbacks: MockCallbacks): KeyboardTarget {
+  return {
+    id: handle.id,
+    onBeforeInput: vi.fn(
+      (callback: (input: KeyboardInput, preventDefault: () => void) => void): Unsubscribe => {
         callbacks.inputCallbacks.set(handle.id, callback);
         const unsub = vi.fn<() => void>();
         callbacks.inputUnsubscribes.set(handle.id, unsub);
         return unsub;
       }
     ),
-    onDestroyed: vi.fn((handle: ViewHandle, callback: () => void): Unsubscribe => {
+    onDestroyed: vi.fn((callback: () => void): Unsubscribe => {
       callbacks.destroyedCallbacks.set(handle.id, callback);
       const unsub = vi.fn<() => void>();
       callbacks.destroyedUnsubscribes.set(handle.id, unsub);
       return unsub;
     }),
   };
-
-  return { viewLayer, callbacks };
 }
 
-function createMockViewManager(uiHandle: ViewHandle, initialMode: UIMode = "shortcut") {
+function createMockViewManager(
+  uiHandle: ViewHandle,
+  callbacks: MockCallbacks,
+  initialMode: UIMode = "shortcut"
+) {
   let currentMode: UIMode = initialMode;
   const wsHandle = createViewHandle("ws-view");
+  const uiTarget = createKeyboardTarget(uiHandle, callbacks);
+  const wsTarget = createKeyboardTarget(wsHandle, callbacks);
 
   return {
-    getUIViewHandle: vi.fn().mockReturnValue(uiHandle),
+    getUIKeyboardTarget: vi.fn(() => uiTarget),
     getMode: vi.fn(() => currentMode),
-    getWorkspaceView: vi.fn(() => wsHandle),
+    getWorkspaceKeyboardTarget: vi.fn(() => wsTarget),
     _setMode(mode: UIMode) {
       currentMode = mode;
     },
     _wsHandle: wsHandle,
+    _uiTarget: uiTarget,
+    _wsTarget: wsTarget,
   };
 }
 
@@ -154,8 +161,8 @@ interface TestHarness {
 async function createHarness(initialMode: UIMode = "shortcut"): Promise<TestHarness> {
   const dispatcher = new Dispatcher({ logger: createMockLogger() });
   const uiHandle = createViewHandle("ui-view");
-  const { viewLayer, callbacks } = createMockViewBoundary();
-  const viewManager = createMockViewManager(uiHandle, initialMode);
+  const callbacks = createMockCallbacks();
+  const viewManager = createMockViewManager(uiHandle, callbacks, initialMode);
   const windowLayer = createMockWindowBoundary(callbacks);
 
   dispatcher.registerOperation(
@@ -181,7 +188,6 @@ async function createHarness(initialMode: UIMode = "shortcut"): Promise<TestHarn
 
   const module = createShortcutModule({
     viewManager: viewManager as unknown as ShortcutModuleDeps["viewManager"],
-    viewLayer: viewLayer as unknown as ShortcutModuleDeps["viewLayer"],
     windowLayer,
     windowManager: { getWindowHandle: () => createWindowHandle() },
     dispatcher: { dispatch: dispatchSpy } as unknown as ShortcutModuleDeps["dispatcher"],

--- a/src/modules/shortcut-module.ts
+++ b/src/modules/shortcut-module.ts
@@ -16,10 +16,10 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
+import type { KeyboardTarget } from "../boundaries/shell/view-manager-types";
 import type { Logger } from "../boundaries/platform/logging";
-import type { KeyboardInput, Unsubscribe, ViewBoundary } from "../boundaries/shell/view";
+import type { KeyboardInput, Unsubscribe } from "../boundaries/shell/view";
 import type { WindowBoundary } from "../boundaries/shell/window";
-import type { ViewHandle } from "../boundaries/shell/types";
 import type { WindowManager } from "../boundaries/shell/window-manager";
 import type { IDispatcher } from "../intents/lib/dispatcher";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
@@ -60,8 +60,10 @@ export function normalizeKey(key: string): string {
 }
 
 export interface ShortcutModuleDeps {
-  readonly viewManager: Pick<IViewManager, "getUIViewHandle" | "getMode" | "getWorkspaceView">;
-  readonly viewLayer: Pick<ViewBoundary, "onBeforeInputEvent" | "onDestroyed">;
+  readonly viewManager: Pick<
+    IViewManager,
+    "getUIKeyboardTarget" | "getMode" | "getWorkspaceKeyboardTarget"
+  >;
   readonly windowLayer: Pick<WindowBoundary, "onBlur">;
   readonly windowManager: Pick<WindowManager, "getWindowHandle">;
   readonly dispatcher: Pick<IDispatcher, "dispatch">;
@@ -87,30 +89,30 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     } as ShortcutKeyIntent);
   }
 
-  function registerView(handle: ViewHandle): void {
-    if (cleanups.has(handle.id)) return;
+  function registerView(target: KeyboardTarget): void {
+    if (cleanups.has(target.id)) return;
 
     const unsubs: Unsubscribe[] = [];
     unsubs.push(
-      deps.viewLayer.onBeforeInputEvent(handle, (input) => {
+      target.onBeforeInput((input) => {
         handleInput(input);
       })
     );
     unsubs.push(
-      deps.viewLayer.onDestroyed(handle, () => {
-        unregisterView(handle);
+      target.onDestroyed(() => {
+        unregisterView(target.id);
       })
     );
-    cleanups.set(handle.id, unsubs);
+    cleanups.set(target.id, unsubs);
   }
 
-  function unregisterView(handle: ViewHandle): void {
-    const unsubs = cleanups.get(handle.id);
+  function unregisterView(id: string): void {
+    const unsubs = cleanups.get(id);
     if (unsubs) {
       for (const unsub of unsubs) {
         unsub();
       }
-      cleanups.delete(handle.id);
+      cleanups.delete(id);
     }
   }
 
@@ -226,7 +228,7 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
               state = "NORMAL";
             });
 
-            registerView(deps.viewManager.getUIViewHandle());
+            registerView(deps.viewManager.getUIKeyboardTarget());
           },
         },
       },
@@ -248,9 +250,9 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
       [EVENT_WORKSPACE_CREATED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as WorkspaceCreatedEvent).payload;
-          const handle = deps.viewManager.getWorkspaceView(payload.workspacePath);
-          if (handle) {
-            registerView(handle);
+          const target = deps.viewManager.getWorkspaceKeyboardTarget(payload.workspacePath);
+          if (target) {
+            registerView(target);
           }
         },
       },

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -124,8 +124,7 @@ function createMockViewManager() {
     destroyWorkspaceView: vi.fn().mockResolvedValue(undefined),
     onLoadingChange: vi.fn().mockReturnValue(vi.fn()),
     sendToUI: vi.fn(),
-    getUIViewHandle: vi.fn(),
-    getWorkspaceView: vi.fn(),
+    loadUIContent: vi.fn().mockResolvedValue(undefined),
     updateBounds: vi.fn(),
     focus: vi.fn(),
     onModeChange: vi.fn(),
@@ -1088,10 +1087,7 @@ describe("ViewModule Integration", () => {
       expect(viewManager.create).toHaveBeenCalled();
       expect(windowManager.maximizeAsync).toHaveBeenCalled();
       expect(windowManager.focus).toHaveBeenCalled();
-      expect(layers.viewLayer.loadURL).toHaveBeenCalledWith(
-        viewManager.getUIViewHandle(),
-        "file:///app/ui.html"
-      );
+      expect(viewManager.loadUIContent).toHaveBeenCalledWith("file:///app/ui.html");
       expect(viewManager.focus).toHaveBeenCalled();
     });
 

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -259,8 +259,8 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             }
 
             // Load UI HTML
-            if (deps.viewLayer && deps.uiHtmlPath) {
-              await deps.viewLayer.loadURL(viewManager.getUIViewHandle(), deps.uiHtmlPath);
+            if (deps.uiHtmlPath) {
+              await viewManager.loadUIContent(deps.uiHtmlPath);
             }
 
             // Focus UI

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -517,7 +517,7 @@ describe("MainView component", () => {
       dialogsStore.closeDialog();
 
       // setMode("workspace") is still called even without active workspace
-      // ViewManager's setMode("workspace") gracefully handles null activeWorkspacePath
+      // WebContentsViewManager's setMode("workspace") gracefully handles null activeWorkspacePath
       await waitFor(() => {
         expect(mockApi.ui.setMode).toHaveBeenCalledWith("workspace");
       });


### PR DESCRIPTION
- Extract `BaseViewManager` template-method class owning the shared UI/state-machine layer (mode, active-workspace, loading bookkeeping, attach-before-detach sequencing, z-order rules, focus routing, bounds math); `WebContentsViewManager` becomes a thin subclass with only WebContentsView-specific I/O (security/partition, event wiring, retry+watchdog, render-process-gone recovery, Windows DC workaround).
- Pull pure helpers into `view-manager-types.ts` (bounds math, shared `WorkspaceState`).
- Add an impl-agnostic conformance test suite (`view-manager.conformance.ts`) that encodes the IViewManager invariants — attach-before-detach, idempotency, late-binding loading replay, z-order re-raise, destroy idempotency. WebContents impl runs through it (14 new assertions).
- Replace `getUIViewHandle` / `getWorkspaceView` with narrow capability getters: `getUIDevtoolsTarget` / `getWorkspaceDevtoolsTarget` / `getUIKeyboardTarget` / `getWorkspaceKeyboardTarget`. `devtools-module` and `shortcut-module` stop depending on `ViewBoundary` for view-manager-owned handles.
- Tighten IViewManager JSDoc with documented invariants (two-phase init, focus suppression during shutdown, etc.).
- Behavior-preserving: all 3769 tests pass; no feature flag added.