### PR TITLE
feat(view-manager): add iframe backend behind experimental.iframes flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,23 +303,24 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                                 | Default   | Description                                                                                                                                       |
-| ----------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                             | `null`    | Agent selection: claude\|opencode                                                                                                                 |
-| `auto-update`                       | `ask`     | Auto-update preference: always\|ask\|never                                                                                                        |
-| `version.claude`                    | `null`    | Claude agent version override                                                                                                                     |
-| `version.opencode`                  | `null`    | OpenCode agent version override                                                                                                                   |
-| `code-server.port`                  | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                    |
-| `version.code-server`               | `null`    | Code-server version override (null = built-in)                                                                                                    |
-| `telemetry.enabled`                 | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                        |
-| `telemetry.distinct-id`             | —         | Telemetry user ID (auto-generated)                                                                                                                |
-| `log.level`                         | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                           |
-| `log.output`                        | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                         |
-| `electron.flags`                    | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                         |
-| `electron.disabled-features`        | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults |
-| `experimental.github.query`         | (below)   | GitHub search query; default: `is:open is:pr review-requested:@me`                                                                                |
-| `experimental.github.template-path` | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI)                                                             |
-| `help`                              | `false`   | Print config help and exit                                                                                                                        |
+| Key                                 | Default   | Description                                                                                                                                                           |
+| ----------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                             | `null`    | Agent selection: claude\|opencode                                                                                                                                     |
+| `auto-update`                       | `ask`     | Auto-update preference: always\|ask\|never                                                                                                                            |
+| `version.claude`                    | `null`    | Claude agent version override                                                                                                                                         |
+| `version.opencode`                  | `null`    | OpenCode agent version override                                                                                                                                       |
+| `code-server.port`                  | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                                        |
+| `version.code-server`               | `null`    | Code-server version override (null = built-in)                                                                                                                        |
+| `telemetry.enabled`                 | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                                            |
+| `telemetry.distinct-id`             | —         | Telemetry user ID (auto-generated)                                                                                                                                    |
+| `log.level`                         | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                                               |
+| `log.output`                        | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                                             |
+| `electron.flags`                    | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                                             |
+| `electron.disabled-features`        | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults                     |
+| `experimental.github.query`         | (below)   | GitHub search query; default: `is:open is:pr review-requested:@me`                                                                                                    |
+| `experimental.github.template-path` | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI)                                                                                 |
+| `experimental.iframes`              | `false`   | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools, fail-load retry, and crash recovery |
+| `help`                              | `false`   | Print config help and exit                                                                                                                                            |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/renderer/index.html"),
+          "workspace-host": resolve(__dirname, "src/renderer/workspace-host.html"),
         },
       },
     },

--- a/planning/view-manager-refactor.md
+++ b/planning/view-manager-refactor.md
@@ -409,3 +409,64 @@ preserves.
 11. **Two-phase init (`new` + `create()`)** remains a contract; `create()` stays
     on `IViewManager`. `view-module.ts`'s `app-start/init` hook continues to own
     the timing.
+
+---
+
+## Phase 2: iframe integration
+
+The seam this refactor created is used by a second `IViewManager` implementation,
+`IframeViewManager` (`src/boundaries/shell/iframe-view-manager.ts`), gated behind
+the `experimental.iframes` config flag (default `false`, requires app restart).
+
+### Shape
+
+- One shared `WebContentsView` (`workspace-host`) loads `workspace-host.html`,
+  which holds one `<iframe>` per workspace keyed by path.
+- All workspaces share a single renderer process — the memory win.
+- Per-workspace state still flows through `BaseViewManager`; every state's
+  `handle` is the host view handle, and `attachViewImpl` / `detachViewImpl`
+  toggle `display: block` / `none` on the right iframe via injected JS
+  (`window.__host.show/hide/add/remove`).
+
+### One base hook added
+
+`BaseViewManager.shouldAttachWhileLoading(): boolean` (default `false`).
+`IframeViewManager` overrides it to `true` because iframes that are
+`display: none` don't lay out — VS Code's workbench needs to be visible so it
+renders, otherwise `terminal.focus` lands on an unmounted terminal at
+agent-idle time.
+
+### Composition
+
+`main.ts` reads the flag once at startup and picks the implementation:
+
+```ts
+const useIframes = configService.get("experimental.iframes") as boolean;
+const viewManager: IViewManager = useIframes
+  ? new IframeViewManager({ ... })
+  : new WebContentsViewManager({ ... });
+```
+
+### Stubbed in the iframe impl (matches "experimental" label)
+
+- Per-workspace `did-fail-load` retry — failures show as broken iframes.
+- Per-workspace `render-process-gone` recovery — host-renderer-wide.
+- Reload watchdog.
+- Per-workspace DevTools — routed to the host (all workspaces share).
+- Per-workspace keyboard input target — routed to the host.
+
+### Initial terminal focus
+
+`main.ts` subscribes to `agent:status-updated` (focuses terminal when the
+active workspace's agent becomes idle, once per session) and
+`workspace:switched` (queries status; if idle, focuses terminal). Tracked via
+a `firstFocused` set so subsequent switches let Chromium's native focus
+restoration take over. These subscriptions are registered unconditionally —
+harmless in WebContentsView mode (event fires, dispatch runs, no observable
+side effect).
+
+### Tests
+
+`src/boundaries/shell/iframe-view-manager.integration.test.ts` runs the
+same conformance suite as the WebContentsView impl, plus iframe-specific
+tests (host lifecycle, `shouldAttachWhileLoading`, hostExec queue draining).

--- a/src/boundaries/shell/iframe-view-manager.integration.test.ts
+++ b/src/boundaries/shell/iframe-view-manager.integration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Integration tests for IframeViewManager using behavioral mocks.
+ *
+ * Runs the shared IViewManager conformance suite against the iframe impl,
+ * then adds iframe-specific tests for behavior not covered by the suite
+ * (host-iframe lifecycle, shouldAttachWhileLoading semantics, child-frame
+ * focus tracker installation).
+ */
+
+import { describe, it, expect } from "vitest";
+import { IframeViewManager, type IframeViewManagerDeps } from "./iframe-view-manager";
+import {
+  runViewManagerConformance,
+  type ConformanceFactory,
+  type ConformanceProbe,
+} from "./view-manager.conformance";
+import type { WindowManager } from "./window-manager";
+import { SILENT_LOGGER } from "../platform/logging";
+import { createViewBoundaryMock, type MockViewBoundary } from "./view.state-mock";
+import { createSessionBoundaryMock, type MockSessionBoundary } from "./session.state-mock";
+import {
+  createWindowBoundaryInternalMock,
+  type MockWindowBoundaryInternal,
+} from "./window.state-mock";
+import type { ViewHandle, WindowHandle } from "./types";
+import { createMockWindowManager } from "./window-manager.test-utils";
+
+function createViewManagerWindowBoundary(): MockWindowBoundaryInternal & {
+  _createdWindowHandle: WindowHandle;
+} {
+  const behavioralLayer = createWindowBoundaryInternalMock();
+  const windowHandle = behavioralLayer.createWindow({
+    width: 1200,
+    height: 800,
+    title: "Test Window",
+    show: false,
+  });
+  return Object.assign(behavioralLayer, {
+    _createdWindowHandle: windowHandle,
+  }) as unknown as MockWindowBoundaryInternal & { _createdWindowHandle: WindowHandle };
+}
+
+function createIframeDeps(): IframeViewManagerDeps & {
+  viewLayer: MockViewBoundary;
+  windowLayer: MockWindowBoundaryInternal & { _createdWindowHandle: WindowHandle };
+  sessionLayer: MockSessionBoundary;
+} {
+  const windowLayer = createViewManagerWindowBoundary();
+  const viewLayer = createViewBoundaryMock();
+  const sessionLayer = createSessionBoundaryMock();
+  const windowManager = createMockWindowManager({
+    windowHandle: windowLayer._createdWindowHandle,
+  }) as unknown as WindowManager;
+
+  return {
+    windowManager,
+    windowLayer,
+    viewLayer,
+    sessionLayer,
+    appLayer: { openUrl: () => Promise.resolve() },
+    config: {
+      uiPreloadPath: "/path/to/preload.js",
+      codeServerPort: 8080,
+      workspaceHostHtmlPath: "/path/to/workspace-host.html",
+    },
+    logger: SILENT_LOGGER,
+  };
+}
+
+/**
+ * Parses `window.__host.show('/path')` / `window.__host.hide('/path')`
+ * from an injected JS string, returning the kind and path. Returns null
+ * if the script isn't a show/hide call.
+ */
+function parseHostCall(code: string): { kind: "show" | "hide"; path: string } | null {
+  const m = code.match(/window\.__host\.(show|hide)\('((?:\\.|[^'\\])*)'\)/);
+  if (!m) return null;
+  const path = m[2]!.replace(/\\\\/g, "\\").replace(/\\'/g, "'");
+  return { kind: m[1] as "show" | "hide", path };
+}
+
+/**
+ * Fires the host view's did-finish-load callbacks so the iframe view
+ * manager's pending hostExec queue drains synchronously. Must be called
+ * AFTER manager.create() but before any setActiveWorkspace.
+ */
+function flushHostReady(viewLayer: MockViewBoundary, hostHandle: ViewHandle): void {
+  viewLayer.$.triggerDidFinishLoad(hostHandle);
+}
+
+function makeIframeConformanceFactory(): ConformanceFactory {
+  return () => {
+    const deps = createIframeDeps();
+    const attachOrder: string[] = [];
+    const detachOrder: string[] = [];
+
+    const manager = new IframeViewManager(deps);
+    manager.create();
+
+    const hostHandle = manager.getWorkspaceHostHandle();
+    const uiViewHandleId = manager.getUIViewHandle().id;
+
+    // Intercept executeJavaScript on the host handle to record show/hide
+    // calls into the probe's attach/detach order. The interception runs
+    // synchronously before the (mock-resolved) promise — hostExec is
+    // synchronous through to this call once the host is ready.
+    const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+    deps.viewLayer.executeJavaScript = (handle, code) => {
+      if (handle.id === hostHandle.id) {
+        const call = parseHostCall(code);
+        if (call?.kind === "show") attachOrder.push(call.path);
+        else if (call?.kind === "hide") detachOrder.push(call.path);
+      }
+      return originalExec(handle, code);
+    };
+
+    // Drain queued hostExec calls synchronously so subsequent test
+    // actions hit the executeJavaScript interceptor without microtask
+    // delay.
+    flushHostReady(deps.viewLayer, hostHandle);
+
+    const windowId = deps.windowLayer._createdWindowHandle.id;
+    const probe: ConformanceProbe = {
+      get attachOrder() {
+        return attachOrder;
+      },
+      get detachOrder() {
+        return detachOrder;
+      },
+      uiIsTop() {
+        const children = deps.viewLayer.$.windowChildren.get(windowId) ?? [];
+        if (children.length === 0) return false;
+        return children[children.length - 1] === uiViewHandleId;
+      },
+      reset() {
+        attachOrder.length = 0;
+        detachOrder.length = 0;
+      },
+    };
+
+    return { manager, probe };
+  };
+}
+
+runViewManagerConformance({
+  name: "IframeViewManager",
+  makeFactory: () => makeIframeConformanceFactory(),
+});
+
+describe("IframeViewManager", () => {
+  describe("host view lifecycle", () => {
+    it("creates a single workspace-host view and reuses its handle for every workspace", () => {
+      const deps = createIframeDeps();
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+
+      // Track distinct view handles attached to the window across workspaces.
+      const seenHandles = new Set<string>([host.id]);
+      const originalAttach = deps.viewLayer.attachToWindow.bind(deps.viewLayer);
+      deps.viewLayer.attachToWindow = (handle, win, idx, opts) => {
+        seenHandles.add(handle.id);
+        return originalAttach(handle, win, idx, opts);
+      };
+
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.createWorkspaceView("/b", "http://127.0.0.1/?b", "/p");
+      manager.createWorkspaceView("/c", "http://127.0.0.1/?c", "/p");
+
+      // Only host + UI view should ever be attached — workspaces are iframes
+      // inside the host, not separate WebContentsViews.
+      expect(seenHandles.size).toBeLessThanOrEqual(2);
+      expect(seenHandles.has(host.id)).toBe(true);
+    });
+
+    it("installs the child-frame focus tracker on the host view", () => {
+      const deps = createIframeDeps();
+      let installedOn: string | null = null;
+      let installedScript: string | null = null;
+      const originalInstall = deps.viewLayer.installChildFrameScript.bind(deps.viewLayer);
+      deps.viewLayer.installChildFrameScript = (handle, script) => {
+        installedOn = handle.id;
+        installedScript = script;
+        return originalInstall(handle, script);
+      };
+
+      const manager = new IframeViewManager(deps);
+      manager.create();
+
+      const host = manager.getWorkspaceHostHandle();
+      expect(installedOn).toBe(host.id);
+      expect(installedScript).toContain("__chFocusTracker");
+      expect(installedScript).toContain("focusin");
+    });
+  });
+
+  describe("shouldAttachWhileLoading", () => {
+    it("attaches new workspaces immediately even while they are loading", () => {
+      const deps = createIframeDeps();
+      const showCalls: string[] = [];
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+
+      const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+      deps.viewLayer.executeJavaScript = (handle, code) => {
+        if (handle.id === host.id) {
+          const call = parseHostCall(code);
+          if (call?.kind === "show") showCalls.push(call.path);
+        }
+        return originalExec(handle, code);
+      };
+
+      manager.createWorkspaceView("/loading", "http://127.0.0.1/?l", "/p", /* isNew */ true);
+      expect(manager.isWorkspaceLoading("/loading")).toBe(true);
+
+      manager.setActiveWorkspace("/loading");
+
+      // Despite being in the loading set, the iframe was shown.
+      expect(showCalls).toContain("/loading");
+    });
+  });
+
+  describe("hostExec queue", () => {
+    it("queues calls made before host did-finish-load and drains them in order on ready", () => {
+      const deps = createIframeDeps();
+      const execCalls: string[] = [];
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+
+      const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+      deps.viewLayer.executeJavaScript = (handle, code) => {
+        if (handle.id === host.id) execCalls.push(code);
+        return originalExec(handle, code);
+      };
+
+      // Host hasn't fired did-finish-load yet — calls should queue.
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.setActiveWorkspace("/a");
+      expect(execCalls).toHaveLength(0);
+
+      // Fire did-finish-load → queue drains in order.
+      flushHostReady(deps.viewLayer, host);
+      expect(execCalls.length).toBeGreaterThan(0);
+      // First two queued calls should be add + show for /a (in that order).
+      const firstAdd = execCalls.findIndex((c) => c.includes("__host.add") && c.includes("/a"));
+      const firstShow = execCalls.findIndex((c) => c.includes("__host.show") && c.includes("/a"));
+      expect(firstAdd).toBeGreaterThanOrEqual(0);
+      expect(firstShow).toBeGreaterThan(firstAdd);
+    });
+  });
+});

--- a/src/boundaries/shell/iframe-view-manager.ts
+++ b/src/boundaries/shell/iframe-view-manager.ts
@@ -1,0 +1,446 @@
+/**
+ * Iframe-based implementation of IViewManager.
+ *
+ * One shared host `WebContentsView` (`workspace-host.html`) holds one
+ * `<iframe>` per workspace, keyed by workspace path. All workspaces share
+ * a single renderer process — the main memory win over per-view rendering.
+ *
+ * Trade-offs vs `WebContentsViewManager`:
+ *   - Per-workspace `did-fail-load` retry, `render-process-gone` recovery,
+ *     and the reload watchdog are not implemented. Failures show as broken
+ *     iframes; recovery is host-renderer-wide.
+ *   - DevTools and keyboard input are routed to the host view; workspaces
+ *     share both.
+ *
+ * Loading semantics mirror per-view backends: when the active workspace
+ * is in the loading set, the host view is detached from the window so the
+ * UI's loading overlay is visible. The iframe inside is still
+ * `display: block` (set during `swapActiveSurface`) so workbench can lay
+ * out while we wait — otherwise `terminal.focus` would land on an
+ * unrendered terminal at agent-idle time.
+ */
+
+import { basename } from "node:path";
+import type { AppBoundary } from "./app";
+import type { Logger } from "../platform/logging";
+import { getErrorMessage } from "../../shared/error-utils";
+import type { ViewBoundary, WindowOpenDetails } from "./view";
+import type { SessionBoundary } from "./session";
+import type { WindowBoundaryInternal } from "./window";
+import type { SessionHandle, ViewHandle, WindowHandle } from "./types";
+import { BaseViewManager, type CreatedWorkspaceView } from "./view-manager-base";
+import {
+  Z_UI_BOTTOM,
+  computeWorkspaceRect,
+  type DevtoolsTarget,
+  type KeyboardTarget,
+  type Rect,
+  type WorkspaceState,
+} from "./view-manager-types";
+import type { WindowManager } from "./window-manager";
+
+const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
+
+const VIEW_BACKGROUND_COLOR = "#1e1e1e";
+
+/**
+ * Script injected into every workspace iframe to preserve focus across
+ * show/hide cycles. Records the last-focused element via `focusin` and
+ * re-focuses it whenever the iframe's window receives focus (which the
+ * host triggers via `iframe.contentWindow.focus()` when showing).
+ *
+ * Runs inside the iframe's same-origin page context — bypasses cross-origin
+ * focus restrictions that would block any host-side equivalent.
+ */
+const CHILD_FRAME_FOCUS_TRACKER = `
+  (function(){
+    if (window.__chFocusTracker) return;
+    window.__chFocusTracker = true;
+    let last = null;
+    document.addEventListener('focusin', function(e){ last = e.target; }, true);
+    window.addEventListener('focus', function(){
+      if (last && document.contains(last)) {
+        try { last.focus(); } catch(e) {}
+      }
+    });
+  })();
+`;
+
+const ALLOWED_PERMISSIONS = new Set([
+  "clipboard-read",
+  "clipboard-sanitized-write",
+  "clipboard-write",
+  "media",
+  "fullscreen",
+  "notifications",
+  "openExternal",
+  "fileSystem",
+  "hid",
+  "serial",
+  "usb",
+]);
+
+export interface IframeViewManagerConfig {
+  /** Path to the UI layer preload script */
+  readonly uiPreloadPath: string;
+  /** Code-server port number */
+  readonly codeServerPort: number;
+  /** Path to the workspace host HTML page that holds per-workspace iframes */
+  readonly workspaceHostHtmlPath: string;
+}
+
+export interface IframeViewManagerDeps {
+  readonly windowManager: WindowManager;
+  readonly windowLayer: WindowBoundaryInternal;
+  readonly viewLayer: ViewBoundary;
+  readonly sessionLayer: SessionBoundary;
+  readonly appLayer: Pick<AppBoundary, "openUrl">;
+  readonly config: IframeViewManagerConfig;
+  readonly logger: Logger;
+}
+
+export class IframeViewManager extends BaseViewManager {
+  private readonly windowLayer: WindowBoundaryInternal;
+  private readonly viewLayer: ViewBoundary;
+  private readonly sessionLayer: SessionBoundary;
+  private readonly appLayer: Pick<AppBoundary, "openUrl">;
+  private readonly config: IframeViewManagerConfig;
+  private windowHandle!: WindowHandle;
+
+  private workspaceHostHandle!: ViewHandle;
+  private hostReady = false;
+  private hostAttachedToWindow = false;
+  private readonly pendingHostScripts: string[] = [];
+  private sharedSessionHandle!: SessionHandle;
+
+  constructor(deps: IframeViewManagerDeps) {
+    super({
+      windowManager: deps.windowManager,
+      logger: deps.logger,
+      codeServerPort: deps.config.codeServerPort,
+    });
+    this.windowLayer = deps.windowLayer;
+    this.viewLayer = deps.viewLayer;
+    this.sessionLayer = deps.sessionLayer;
+    this.appLayer = deps.appLayer;
+    this.config = deps.config;
+  }
+
+  /**
+   * Returns the handle for the shared workspace-host view. Exposed for
+   * tests that need to drive `did-finish-load` or inspect the host.
+   */
+  getWorkspaceHostHandle(): ViewHandle {
+    return this.workspaceHostHandle;
+  }
+
+  // ---------------------------------------------------------------------------
+  // UI view
+  // ---------------------------------------------------------------------------
+
+  protected createUIView(): ViewHandle {
+    const { viewLayer, config } = this;
+
+    const uiViewHandle = viewLayer.createView({
+      label: "ui",
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        preload: config.uiPreloadPath,
+      },
+    });
+
+    viewLayer.setWindowOpenHandler(uiViewHandle, (details: WindowOpenDetails) => {
+      this.appLayer.openUrl(details.url).catch((error: unknown) => {
+        this.logger.warn("Failed to open external URL from UI", {
+          url: details.url,
+          error: getErrorMessage(error),
+        });
+      });
+      return { action: "deny" };
+    });
+
+    viewLayer.setBackgroundColor(uiViewHandle, "#00000000");
+
+    this.windowHandle = this.windowManager.getWindowHandle();
+
+    this.createWorkspaceHost();
+
+    viewLayer.attachToWindow(uiViewHandle, this.windowHandle);
+
+    return uiViewHandle;
+  }
+
+  /**
+   * Creates the single workspace-host WebContentsView that holds all
+   * workspace iframes. Wires session-level header/permission handlers,
+   * loads `workspace-host.html`, and installs the in-frame focus tracker.
+   */
+  private createWorkspaceHost(): void {
+    const { viewLayer, sessionLayer, config } = this;
+
+    this.workspaceHostHandle = viewLayer.createView({
+      label: "workspace-host",
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        partition: GLOBAL_SESSION_PARTITION,
+        focusOnNavigation: false,
+        backgroundThrottling: false,
+      },
+    });
+    viewLayer.setBackgroundColor(this.workspaceHostHandle, VIEW_BACKGROUND_COLOR);
+
+    this.sharedSessionHandle = sessionLayer.fromPartition(GLOBAL_SESSION_PARTITION);
+
+    // Strip frame-blocking headers so code-server loads inside iframes.
+    sessionLayer.setHeadersReceivedHandler(this.sharedSessionHandle, (headers) => {
+      const modified = { ...headers };
+      for (const header of Object.keys(modified)) {
+        const lower = header.toLowerCase();
+        if (
+          lower === "x-frame-options" ||
+          lower === "content-security-policy" ||
+          lower === "content-security-policy-report-only"
+        ) {
+          delete modified[header];
+        }
+      }
+      return modified;
+    });
+
+    sessionLayer.setPermissionRequestHandler(this.sharedSessionHandle, (permission) =>
+      ALLOWED_PERMISSIONS.has(permission)
+    );
+    sessionLayer.setPermissionCheckHandler(this.sharedSessionHandle, (permission) =>
+      ALLOWED_PERMISSIONS.has(permission)
+    );
+
+    viewLayer.setWindowOpenHandler(this.workspaceHostHandle, (details: WindowOpenDetails) => {
+      this.appLayer.openUrl(details.url).catch((error: unknown) => {
+        this.logger.warn("Failed to open external URL from host", {
+          url: details.url,
+          error: getErrorMessage(error),
+        });
+      });
+      return { action: "deny" };
+    });
+
+    // Host starts detached. attachViewImpl attaches it when the active
+    // workspace has finished loading, mirroring the per-WCV pattern.
+    // Set initial bounds on the detached host so workbench inside the
+    // iframes still has a viewport and can lay out while loading.
+    viewLayer.setBounds(
+      this.workspaceHostHandle,
+      computeWorkspaceRect(this.windowManager.getBounds())
+    );
+    viewLayer.installChildFrameScript(this.workspaceHostHandle, CHILD_FRAME_FOCUS_TRACKER);
+
+    const off = viewLayer.onDidFinishLoad(this.workspaceHostHandle, () => {
+      off();
+      this.hostReady = true;
+      const pending = this.pendingHostScripts.splice(0);
+      for (const code of pending) this.hostExec(code);
+    });
+    void viewLayer.loadURL(this.workspaceHostHandle, `file://${config.workspaceHostHtmlPath}`);
+  }
+
+  protected destroyUIView(): void {
+    this.viewLayer.destroy(this.uiViewHandle);
+    try {
+      this.viewLayer.destroy(this.workspaceHostHandle);
+    } catch {
+      // host may already be destroyed
+    }
+  }
+
+  protected isUIViewAvailable(): boolean {
+    return this.viewLayer.isAvailable(this.uiViewHandle);
+  }
+
+  protected sendToUIView(channel: string, args: unknown[]): void {
+    this.viewLayer.send(this.uiViewHandle, channel, ...args);
+  }
+
+  protected loadUIContentImpl(htmlPath: string): Promise<void> {
+    return this.viewLayer.loadURL(this.uiViewHandle, htmlPath);
+  }
+
+  protected capturePNG(handle: ViewHandle): Promise<Buffer | null> {
+    // For per-workspace capture, the host view shows only the active
+    // iframe; capture returns the active workspace's pixels regardless of
+    // which handle is asked for. Inactive workspaces are invisible.
+    return this.viewLayer.capturePNG(handle);
+  }
+
+  protected isWindowAlive(): boolean {
+    return !this.windowLayer.isDestroyed(this.windowHandle);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace view (iframe inside the host)
+  // ---------------------------------------------------------------------------
+
+  protected createWorkspaceViewImpl(workspacePath: string): CreatedWorkspaceView {
+    const workspaceName = basename(workspacePath);
+    this.logger.debug("Workspace iframe registered", { workspace: workspaceName });
+    // All workspaces share the host view's handle and session — the only
+    // per-workspace identity is the iframe inside the host page (keyed by
+    // path), created lazily on first `startLoadingUrl` (= loadViewUrl).
+    return {
+      handle: this.workspaceHostHandle,
+      sessionHandle: this.sharedSessionHandle,
+      partitionName: GLOBAL_SESSION_PARTITION,
+    };
+  }
+
+  protected async destroyWorkspaceViewImpl(state: WorkspaceState): Promise<void> {
+    // Remove the iframe from the host page. The host view itself is
+    // shared and stays alive until UI shutdown.
+    const path = this.findWorkspacePathByState(state);
+    if (path !== undefined) {
+      this.hostExec(`window.__host.remove(${jsStr(path)})`);
+    }
+  }
+
+  protected startLoadingUrl(state: WorkspaceState): void {
+    const path = this.findWorkspacePathByState(state);
+    if (path === undefined) return;
+    this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)})`);
+  }
+
+  protected swapActiveSurface(prev: WorkspaceState | null, next: WorkspaceState | null): void {
+    // Shared-surface backend: hide the outgoing iframe and reveal the
+    // incoming one. Host attachment is left as-is — attach/detachSurface
+    // own that based on the new workspace's loading state.
+    if (prev) {
+      const prevPath = this.findWorkspacePathByState(prev);
+      if (prevPath !== undefined) {
+        this.hostExec(`window.__host.hide(${jsStr(prevPath)})`);
+      }
+    }
+    if (next) {
+      const nextPath = this.findWorkspacePathByState(next);
+      if (nextPath !== undefined) {
+        this.hostExec(`window.__host.show(${jsStr(nextPath)})`);
+      }
+    }
+  }
+
+  protected attachSurface(): void {
+    if (this.hostAttachedToWindow) return;
+    this.viewLayer.attachToWindow(this.workspaceHostHandle, this.windowHandle);
+    this.hostAttachedToWindow = true;
+  }
+
+  protected detachSurface(): void {
+    if (!this.hostAttachedToWindow) return;
+    this.viewLayer.detachFromWindow(this.workspaceHostHandle);
+    this.hostAttachedToWindow = false;
+  }
+
+  protected applyBounds(handle: ViewHandle, rect: Rect): void {
+    // Single host view holds all workspace iframes; size it once. The base
+    // calls applyBounds per workspace; collapsing to one setBounds call on
+    // the host is harmless because every state.handle === workspaceHostHandle.
+    this.viewLayer.setBounds(handle, rect);
+  }
+
+  protected focusHandle(handle: ViewHandle): void {
+    this.viewLayer.focus(handle);
+    if (handle === this.workspaceHostHandle) {
+      // After focusing the host webContents, focus the active iframe
+      // element inside it so VS Code receives keystrokes. The in-frame
+      // tracker installed via installChildFrameScript restores the
+      // iframe's last-focused element on its window's focus event.
+      this.hostExec(`window.__host.focusActive()`);
+    }
+  }
+
+  protected bringUIToTop(): void {
+    this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle);
+  }
+
+  protected bringUIToBottom(forceRedraw: boolean): void {
+    if (forceRedraw) {
+      this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM, {
+        force: true,
+      });
+    } else {
+      this.viewLayer.attachToWindow(this.uiViewHandle, this.windowHandle, Z_UI_BOTTOM);
+    }
+  }
+
+  protected reloadWorkspaceView(state: WorkspaceState): void {
+    // No per-iframe reload primitive — reload the entire host renderer.
+    // Cheap because all workspaces share it, but coarse (affects all).
+    const path = this.findWorkspacePathByState(state);
+    if (path !== undefined) {
+      this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)})`);
+    }
+  }
+
+  protected makeDevtoolsTarget(handle: ViewHandle): DevtoolsTarget {
+    // All workspace iframes share the host's webContents devtools.
+    const viewLayer = this.viewLayer;
+    return {
+      id: handle.id,
+      toggle: () => {
+        if (viewLayer.isDevToolsOpened(handle)) {
+          viewLayer.closeDevTools(handle);
+        } else {
+          viewLayer.openDevTools(handle, { mode: "detach" });
+        }
+      },
+      isOpen: () => viewLayer.isDevToolsOpened(handle),
+    };
+  }
+
+  protected makeKeyboardTarget(handle: ViewHandle): KeyboardTarget {
+    const viewLayer = this.viewLayer;
+    return {
+      id: handle.id,
+      onBeforeInput: (callback) => viewLayer.onBeforeInputEvent(handle, callback),
+      onDestroyed: (callback) => viewLayer.onDestroyed(handle, callback),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Iframe host helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run a script inside the workspace-host page. When the host page hasn't
+   * finished loading yet (window.__host not defined), the call is queued
+   * and drained in order when did-finish-load fires.
+   *
+   * Synchronous through to `viewLayer.executeJavaScript` once ready, so
+   * tests can observe the call without awaiting microtasks.
+   */
+  private hostExec(code: string): void {
+    if (this.destroying) return;
+    if (!this.hostReady) {
+      this.pendingHostScripts.push(code);
+      return;
+    }
+    if (!this.viewLayer.isAvailable(this.workspaceHostHandle)) return;
+    this.viewLayer.executeJavaScript(this.workspaceHostHandle, code).catch((error: unknown) => {
+      this.logger.warn("hostExec failed", { error: getErrorMessage(error) });
+    });
+  }
+
+  /** Reverse-lookup a workspace path from its state object. */
+  private findWorkspacePathByState(state: WorkspaceState): string | undefined {
+    for (const [path, candidate] of this.workspaceStates) {
+      if (candidate === state) return path;
+    }
+    return undefined;
+  }
+}
+
+/** Escapes a string for safe embedding in single-quoted JS string. */
+function jsStr(s: string): string {
+  return "'" + s.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
+}

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -301,22 +301,32 @@ export abstract class BaseViewManager implements IViewManager {
     try {
       this.isChangingWorkspace = true;
       const previousPath = this.activeWorkspacePath;
+      const previousState =
+        previousPath !== null ? (this.workspaceStates.get(previousPath) ?? null) : null;
 
       this.activeWorkspacePath = workspacePath;
 
-      // Load URL and attach new view FIRST (visual continuity - no gap)
-      if (workspacePath !== null) {
-        this.loadViewUrl(workspacePath);
-        if (!this.loadingWorkspaces.has(workspacePath)) {
-          this.attachView(workspacePath);
-        }
-        // Loading workspaces stay detached with full-size bounds (set at creation).
-        // Alt+X works via the UI view's before-input-event (focus goes to UI).
-      }
+      // Load URL FIRST so the new workspace's render target exists before
+      // we try to make it the active surface (shared-surface backends
+      // need the child slot to exist before they can reveal it).
+      if (workspacePath !== null) this.loadViewUrl(workspacePath);
 
-      // Then detach previous
-      if (previousPath !== null && previousPath !== workspacePath) {
-        this.detachView(previousPath);
+      // Swap which workspace's content is the active surface. For per-view
+      // backends this hides the previous view; for shared-surface backends
+      // (iframe) this flips display:block on the matching child iframe.
+      // Does NOT change window attachment.
+      const newState = workspacePath !== null ? this.workspaceStates.get(workspacePath) : null;
+      this.swapActiveSurface(previousState, newState ?? null);
+
+      // Visibility (= window attachment of the surface) is gated on
+      // loading state. While loading, the surface is detached and the
+      // UI's loading overlay is visible underneath.
+      if (workspacePath !== null && !this.loadingWorkspaces.has(workspacePath)) {
+        this.attachView(workspacePath);
+      } else {
+        // Either no active workspace, or the new one is loading. Either
+        // way the previously-attached surface must come down.
+        if (previousPath !== null) this.detachView(previousPath);
       }
 
       // Maintain z-order: if we're in a mode where the UI should be on top
@@ -601,12 +611,16 @@ export abstract class BaseViewManager implements IViewManager {
     this.startLoadingUrl(state);
   }
 
+  /**
+   * Make the workspace's surface visible. Called when activating a loaded
+   * workspace, or when an active workspace transitions to loaded.
+   */
   protected attachView(workspacePath: string): void {
     const state = this.workspaceStates.get(workspacePath);
     if (!state) return;
     if (!this.isWindowAlive()) return;
     try {
-      this.attachViewImpl(state);
+      this.attachSurface(state);
       this.attachedWorkspacePath = workspacePath;
       this.logger.debug("View attached", { workspace: basename(workspacePath) });
     } catch {
@@ -614,11 +628,15 @@ export abstract class BaseViewManager implements IViewManager {
     }
   }
 
+  /**
+   * Hide the workspace's surface. Called when the active workspace is in
+   * the loading set so the UI's loading overlay is visible underneath.
+   */
   protected detachView(workspacePath: string): void {
     const state = this.workspaceStates.get(workspacePath);
     if (!state) return;
     try {
-      this.detachViewImpl(state);
+      this.detachSurface(state);
       this.logger.debug("View detached", { workspace: basename(workspacePath) });
     } catch {
       // Ignore errors during detach - window may be closing
@@ -674,13 +692,37 @@ export abstract class BaseViewManager implements IViewManager {
   protected abstract startLoadingUrl(state: WorkspaceState): void;
 
   /**
-   * Attach the workspace view to the window. Implementations are free to
-   * also perform impl-private cleanup (e.g. reload-on-attach for crashed
-   * renderers).
+   * Swap which workspace's content occupies the active surface position.
+   *
+   * For per-view backends this means detaching `prev`'s view from the
+   * window (its WCV IS the surface). For shared-surface backends (iframe)
+   * this hides `prev`'s child slot and reveals `new`'s — without touching
+   * the surface's window attachment. Either argument may be null.
+   *
+   * Called by the base on every active-workspace change BEFORE deciding
+   * whether to attach the surface to the window. Independent of loading
+   * state.
    */
-  protected abstract attachViewImpl(state: WorkspaceState): void;
+  protected abstract swapActiveSurface(
+    prev: WorkspaceState | null,
+    next: WorkspaceState | null
+  ): void;
 
-  protected abstract detachViewImpl(state: WorkspaceState): void;
+  /**
+   * Attach the active workspace's surface to the window so it becomes
+   * visible. The base calls this once the active workspace has finished
+   * loading (or immediately, if it wasn't loading to begin with).
+   * Implementations are free to also perform impl-private cleanup here
+   * (e.g. reload-on-attach for crashed renderers).
+   */
+  protected abstract attachSurface(state: WorkspaceState): void;
+
+  /**
+   * Detach the active workspace's surface from the window so the UI's
+   * loading overlay is visible. Called when the active workspace is in
+   * the loading set.
+   */
+  protected abstract detachSurface(state: WorkspaceState): void;
 
   protected abstract applyBounds(handle: ViewHandle, rect: Rect): void;
 

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -1,0 +1,175 @@
+/**
+ * ViewManager — composition-root facade that picks its backend at `create()`
+ * time based on `experimental.iframes`.
+ *
+ * Construction is cheap (just captures deps). The backend choice happens in
+ * `create()`, which is called from the `app-start/init` hook — AFTER
+ * `configService.load()` has resolved CLI/env/file overrides. This lets the
+ * flag flow through the normal config system without re-ordering the rest of
+ * main.ts (modules can still register their own keys lazily in their
+ * factories).
+ *
+ * The two concrete implementations (`WebContentsViewManager` and
+ * `IframeViewManager`) remain as-is — both extend `BaseViewManager` and are
+ * unit-tested directly via the conformance suite. This class is a thin
+ * delegating wrapper; production code always constructs `ViewManager`, never
+ * the concrete subclasses.
+ */
+
+import type { Config } from "./../platform/config";
+import type { Logger } from "../platform/logging";
+import type { AppBoundary } from "./app";
+import type { SessionBoundary } from "./session";
+import type { ViewBoundary } from "./view";
+import type { ViewHandle } from "./types";
+import type { WindowBoundaryInternal } from "./window";
+import type { WindowManager } from "./window-manager";
+import { IframeViewManager } from "./iframe-view-manager";
+import { WebContentsViewManager } from "./webcontents-view-manager";
+import type { IViewManager, LoadingChangeCallback, Unsubscribe } from "./view-manager.interface";
+import type { UIMode, UIModeChangedEvent } from "../../shared/ipc";
+import type { DevtoolsTarget, KeyboardTarget } from "./view-manager-types";
+
+export interface ViewManagerConfig {
+  /** Path to the UI layer preload script */
+  readonly uiPreloadPath: string;
+  /** Code-server port number */
+  readonly codeServerPort: number;
+  /** Path to the workspace host HTML page (used in iframe mode) */
+  readonly workspaceHostHtmlPath: string;
+}
+
+export interface ViewManagerDeps {
+  readonly windowManager: WindowManager;
+  readonly windowLayer: WindowBoundaryInternal;
+  readonly viewLayer: ViewBoundary;
+  readonly sessionLayer: SessionBoundary;
+  readonly appLayer: Pick<AppBoundary, "openUrl">;
+  readonly configService: Config;
+  readonly config: ViewManagerConfig;
+  readonly logger: Logger;
+}
+
+export class ViewManager implements IViewManager {
+  private impl: IViewManager | null = null;
+
+  constructor(private readonly deps: ViewManagerDeps) {}
+
+  create(): void {
+    if (this.impl) return; // idempotent
+    const useIframes = this.deps.configService.get("experimental.iframes") as boolean;
+    this.impl = useIframes
+      ? new IframeViewManager({
+          windowManager: this.deps.windowManager,
+          windowLayer: this.deps.windowLayer,
+          viewLayer: this.deps.viewLayer,
+          sessionLayer: this.deps.sessionLayer,
+          appLayer: this.deps.appLayer,
+          config: {
+            uiPreloadPath: this.deps.config.uiPreloadPath,
+            codeServerPort: this.deps.config.codeServerPort,
+            workspaceHostHtmlPath: this.deps.config.workspaceHostHtmlPath,
+          },
+          logger: this.deps.logger,
+        })
+      : new WebContentsViewManager({
+          windowManager: this.deps.windowManager,
+          windowLayer: this.deps.windowLayer,
+          viewLayer: this.deps.viewLayer,
+          sessionLayer: this.deps.sessionLayer,
+          appLayer: this.deps.appLayer,
+          config: {
+            uiPreloadPath: this.deps.config.uiPreloadPath,
+            codeServerPort: this.deps.config.codeServerPort,
+          },
+          logger: this.deps.logger,
+        });
+    this.impl.create();
+  }
+
+  private get vm(): IViewManager {
+    if (!this.impl) throw new Error("ViewManager.create() has not been called yet");
+    return this.impl;
+  }
+
+  // ---------------------------------------------------------------------------
+  // IViewManager — full delegation
+  // ---------------------------------------------------------------------------
+
+  getUIDevtoolsTarget(): DevtoolsTarget {
+    return this.vm.getUIDevtoolsTarget();
+  }
+  getWorkspaceDevtoolsTarget(path: string): DevtoolsTarget | undefined {
+    return this.vm.getWorkspaceDevtoolsTarget(path);
+  }
+  getUIKeyboardTarget(): KeyboardTarget {
+    return this.vm.getUIKeyboardTarget();
+  }
+  getWorkspaceKeyboardTarget(path: string): KeyboardTarget | undefined {
+    return this.vm.getWorkspaceKeyboardTarget(path);
+  }
+  isUIAvailable(): boolean {
+    return this.impl?.isUIAvailable() ?? false;
+  }
+  loadUIContent(htmlPath: string): Promise<void> {
+    return this.vm.loadUIContent(htmlPath);
+  }
+  sendToUI(channel: string, ...args: unknown[]): void {
+    // Pre-create sends are dropped silently — UI doesn't exist yet.
+    this.impl?.sendToUI(channel, ...args);
+  }
+  createWorkspaceView(path: string, url: string, projectPath: string, isNew?: boolean): ViewHandle {
+    return this.vm.createWorkspaceView(path, url, projectPath, isNew);
+  }
+  destroyWorkspaceView(path: string): Promise<void> {
+    return this.impl ? this.impl.destroyWorkspaceView(path) : Promise.resolve();
+  }
+  updateBounds(): void {
+    this.impl?.updateBounds();
+  }
+  setActiveWorkspace(path: string | null, focus?: boolean): void {
+    this.vm.setActiveWorkspace(path, focus);
+  }
+  getActiveWorkspacePath(): string | null {
+    return this.impl?.getActiveWorkspacePath() ?? null;
+  }
+  focus(): void {
+    this.impl?.focus();
+  }
+  setMode(mode: UIMode): void {
+    this.vm.setMode(mode);
+  }
+  getMode(): UIMode {
+    return this.impl?.getMode() ?? "workspace";
+  }
+  onModeChange(cb: (e: UIModeChangedEvent) => void): Unsubscribe {
+    return this.vm.onModeChange(cb);
+  }
+  onWorkspaceChange(cb: (path: string | null) => void): Unsubscribe {
+    return this.vm.onWorkspaceChange(cb);
+  }
+  updateCodeServerPort(port: number): void {
+    this.impl?.updateCodeServerPort(port);
+  }
+  isWorkspaceLoading(path: string): boolean {
+    return this.impl?.isWorkspaceLoading(path) ?? false;
+  }
+  setWorkspaceLoaded(path: string): void {
+    this.impl?.setWorkspaceLoaded(path);
+  }
+  onLoadingChange(cb: LoadingChangeCallback): Unsubscribe {
+    return this.vm.onLoadingChange(cb);
+  }
+  reloadAllViews(): void {
+    this.impl?.reloadAllViews();
+  }
+  preloadWorkspaceUrl(path: string): void {
+    this.impl?.preloadWorkspaceUrl(path);
+  }
+  destroy(): void {
+    this.impl?.destroy();
+  }
+  captureWorkspaceView(path: string): Promise<Buffer | null> {
+    return this.impl ? this.impl.captureWorkspaceView(path) : Promise.resolve(null);
+  }
+}

--- a/src/boundaries/shell/view.state-mock.ts
+++ b/src/boundaries/shell/view.state-mock.ts
@@ -612,6 +612,11 @@ export function createViewBoundaryMock(): MockViewBoundary {
       return undefined;
     },
 
+    installChildFrameScript(_handle: ViewHandle, _script: string): void {
+      getView(_handle); // Validate handle exists
+      // No-op in mock - did-frame-finish-load is not simulated
+    },
+
     send(_handle: ViewHandle, _channel: string, ..._args: unknown[]): void {
       getView(_handle); // Validate handle exists
       // No-op in mock - IPC is not simulated

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -391,6 +391,23 @@ export interface ViewBoundary {
    */
   isDevToolsOpened(handle: ViewHandle): boolean;
 
+  /**
+   * Install a script in every child frame (non-top) that finishes loading
+   * inside this view. The script runs same-origin inside each child frame.
+   *
+   * Used to inject in-frame helpers that can't be installed from the host
+   * document due to cross-origin restrictions (e.g., focus trackers that
+   * need to observe and call focus on elements inside the iframe).
+   *
+   * The subscription is established immediately and applies to every future
+   * frame load — call once during view setup.
+   *
+   * @param handle - Handle to the host view
+   * @param script - JavaScript source to execute in each child frame
+   * @throws ShellError with code VIEW_NOT_FOUND if handle is invalid
+   */
+  installChildFrameScript(handle: ViewHandle, script: string): void;
+
   // Cleanup
   /**
    * Dispose of all resources.
@@ -746,7 +763,9 @@ export class DefaultViewBoundary implements ViewBoundary {
 
   executeJavaScript(handle: ViewHandle, code: string): Promise<unknown> {
     const state = this.getView(handle);
-    return state.view.webContents.executeJavaScript(code);
+    // userGesture=true so scripted cross-origin iframe focus
+    // (iframe.contentWindow.focus()) isn't silently blocked by Chromium.
+    return state.view.webContents.executeJavaScript(code, true);
   }
 
   send(handle: ViewHandle, channel: string, ...args: unknown[]): void {
@@ -857,6 +876,19 @@ export class DefaultViewBoundary implements ViewBoundary {
 
   async dispose(): Promise<void> {
     this.destroyAll();
+  }
+
+  installChildFrameScript(handle: ViewHandle, script: string): void {
+    const state = this.getView(handle);
+    const wc = state.view.webContents;
+    wc.on("did-frame-finish-load", (_event, isMainFrame, frameProcessId, frameRoutingId) => {
+      if (isMainFrame) return;
+      const frame = wc.mainFrame.framesInSubtree.find(
+        (f) => f.processId === frameProcessId && f.routingId === frameRoutingId
+      );
+      if (!frame) return;
+      void frame.executeJavaScript(script);
+    });
   }
 
   private getView(handle: ViewHandle): ViewState {

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -379,7 +379,20 @@ export class WebContentsViewManager extends BaseViewManager {
     void this.viewLayer.loadURL(state.handle, state.url);
   }
 
-  protected attachViewImpl(state: WorkspaceState): void {
+  protected swapActiveSurface(prev: WorkspaceState | null): void {
+    // Per-view backend: each workspace owns its own WebContentsView, so
+    // "swapping" means removing the previous one from the window. The
+    // incoming workspace's view is attached separately via attachSurface.
+    if (prev) {
+      try {
+        this.viewLayer.detachFromWindow(prev.handle);
+      } catch {
+        // Window may be closing
+      }
+    }
+  }
+
+  protected attachSurface(state: WorkspaceState): void {
     this.viewLayer.attachToWindow(state.handle, this.windowHandle);
 
     // Force a fresh paint if this view sat detached across a system
@@ -393,7 +406,7 @@ export class WebContentsViewManager extends BaseViewManager {
     }
   }
 
-  protected detachViewImpl(state: WorkspaceState): void {
+  protected detachSurface(state: WorkspaceState): void {
     this.viewLayer.detachFromWindow(state.handle);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ import { DefaultWindowBoundary } from "./boundaries/shell/window";
 import { DefaultViewBoundary } from "./boundaries/shell/view";
 import { DefaultSessionBoundary } from "./boundaries/shell/session";
 import { WindowManager } from "./boundaries/shell/window-manager";
-import { WebContentsViewManager } from "./boundaries/shell/webcontents-view-manager";
+import { ViewManager } from "./boundaries/shell/view-manager";
 // Services (stayed)
 import { AutoUpdater } from "./modules/auto-updater";
 import { DefaultArchiveExtractor } from "./boundaries/platform/archive";
@@ -118,11 +118,19 @@ import {
 } from "./intents/open-project";
 import type { OpenProjectPayload } from "./intents/open-project";
 import { CloseProjectOperation, INTENT_CLOSE_PROJECT } from "./intents/close-project";
-import { SwitchWorkspaceOperation, INTENT_SWITCH_WORKSPACE } from "./intents/switch-workspace";
+import {
+  SwitchWorkspaceOperation,
+  INTENT_SWITCH_WORKSPACE,
+  EVENT_WORKSPACE_SWITCHED,
+} from "./intents/switch-workspace";
+import type { WorkspaceSwitchedEvent } from "./intents/switch-workspace";
+import type { GetWorkspaceStatusIntent } from "./intents/get-workspace-status";
 import {
   UpdateAgentStatusOperation,
   INTENT_UPDATE_AGENT_STATUS,
+  EVENT_AGENT_STATUS_UPDATED,
 } from "./intents/update-agent-status";
+import type { AgentStatusUpdatedEvent } from "./intents/update-agent-status";
 import { ShortcutKeyOperation, INTENT_SHORTCUT_KEY } from "./intents/shortcut-key";
 import { SubmitBugReportOperation, INTENT_SUBMIT_BUG_REPORT } from "./intents/submit-bug-report";
 import {
@@ -211,6 +219,15 @@ configService.register("help", {
   name: "help",
   default: false,
   description: "Print config help and exit",
+  ...configBoolean(),
+});
+configService.register("experimental.iframes", {
+  name: "experimental.iframes",
+  default: false,
+  description:
+    "Render workspaces as iframes inside a single host WebContentsView " +
+    "(experimental; requires app restart). Lower memory at the cost of " +
+    "per-workspace devtools, fail-load retry, and crash recovery.",
   ...configBoolean(),
 });
 
@@ -328,15 +345,20 @@ const windowManager = new WindowManager(
   pathProvider.appIconPath.toNative()
 );
 
-const viewManager = new WebContentsViewManager({
+// ViewManager construction is cheap (no backend yet). The backend is
+// chosen inside ViewManager.create() based on `experimental.iframes` —
+// which runs later, from the app-start/init hook, AFTER configService.load().
+const viewManager = new ViewManager({
   windowManager,
   windowLayer,
   viewLayer,
   sessionLayer,
   appLayer,
+  configService,
   config: {
     uiPreloadPath: nodePath.join(__dirname, "../preload/index.cjs"),
     codeServerPort: 0,
+    workspaceHostHtmlPath: nodePath.join(__dirname, "../renderer/workspace-host.html"),
   },
   logger: loggingService.createLogger("view"),
 });
@@ -659,6 +681,67 @@ dispatcher.registerOperation(INTENT_SHORTCUT_KEY, new ShortcutKeyOperation());
 dispatcher.registerOperation(INTENT_SUBMIT_BUG_REPORT, new SubmitBugReportOperation());
 dispatcher.registerOperation(INTENT_VSCODE_SHOW_MESSAGE, new VscodeShowMessageOperation());
 dispatcher.registerOperation(INTENT_VSCODE_COMMAND, new VscodeCommandOperation());
+
+// Initial terminal focus for a workspace, fired exactly once per session
+// per workspace (tracked in firstFocused). After the first focus, the
+// in-frame focus tracker (installed by view-manager via the boundary's
+// installChildFrameScript) preserves wherever the user left off (search
+// input, editor, terminal, file explorer, etc.) across subsequent switches.
+//
+// Triggers:
+//   1. agent:status-updated → "idle" for the active workspace (most common
+//      path: agent boots, becomes idle while its workspace is on screen).
+//   2. workspace:switched to a workspace not yet initially-focused, when
+//      its current status is idle (covers auto-switch after delete and
+//      switch-to-already-idle-workspace cases).
+//
+// Dispatches workbench.action.terminal.focus via sidekick, then refreshes
+// OS window focus and the in-window focus chain so keystrokes reach xterm.
+const firstFocused = new Set<string>();
+
+const focusTerminal = (workspacePath: string): void => {
+  void dispatcher
+    .dispatch({
+      type: INTENT_VSCODE_COMMAND,
+      payload: {
+        workspacePath,
+        command: "workbench.action.terminal.focus",
+      },
+    })
+    .then(() => {
+      firstFocused.add(workspacePath);
+      viewManager.focus();
+    })
+    .catch(() => {
+      /* sidekick not connected yet; will retry on next trigger */
+    });
+};
+
+dispatcher.subscribe(EVENT_AGENT_STATUS_UPDATED, (event) => {
+  const payload = (event as AgentStatusUpdatedEvent).payload;
+  if (firstFocused.has(payload.workspacePath)) return;
+  if (payload.status.status !== "idle") return;
+  if (viewManager.getActiveWorkspacePath() !== payload.workspacePath) return;
+  focusTerminal(payload.workspacePath);
+});
+
+dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
+  const payload = (event as WorkspaceSwitchedEvent).payload;
+  if (!payload) return;
+  const path = payload.path;
+  if (firstFocused.has(path)) return;
+  void dispatcher
+    .dispatch({
+      type: INTENT_GET_WORKSPACE_STATUS,
+      payload: { workspacePath: path },
+    } as GetWorkspaceStatusIntent)
+    .then((status) => {
+      if (status.agent.type === "idle") focusTerminal(path);
+    })
+    .catch(() => {
+      /* status query failed; agent-idle event will handle it later */
+    });
+});
 
 // Create UI IPC module (handles all bidirectional IPC between main and renderer)
 const uiIpcModule = createUiIpcModule({

--- a/src/renderer/workspace-host.html
+++ b/src/renderer/workspace-host.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Workspace Host</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #1e1e1e;
+      }
+      /* Inactive iframes are hidden via display:none so Chromium suspends
+         their paint/layout. visibility:hidden would seem equivalent but
+         makes elements non-focusable, breaking restoration on switch-back.
+         display:block is async — see __host.show() which defers focus
+         past layout via requestAnimationFrame. */
+      iframe {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: #1e1e1e;
+        display: none;
+      }
+      iframe.active {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      // One host view, N iframes, one visible at a time. Each workspace
+      // gets its own iframe keyed by workspace path.
+      //
+      // Focus chain on switch:
+      //   1. Host toggles display:none → display:block on the .active iframe.
+      //   2. iframe.focus() + contentWindow.focus() (deferred via rAF so
+      //      layout has flushed) put the iframe element in the host doc's
+      //      focus chain and fire a `focus` event on the iframe's window.
+      //   3. The in-frame focus tracker (installed by the view boundary via
+      //      installChildFrameScript) reacts to that `focus` event and
+      //      restores the last-focused element inside the iframe.
+      const frames = new Map(); // path -> HTMLIFrameElement
+
+      window.__host = {
+        add(path, url) {
+          if (frames.has(path)) {
+            const existing = frames.get(path);
+            if (existing.src !== url) existing.src = url;
+            return;
+          }
+          const f = document.createElement("iframe");
+          f.dataset.path = path;
+          f.allow =
+            "clipboard-read; clipboard-write; fullscreen; cross-origin-isolated; autoplay; camera; microphone; display-capture";
+          f.setAttribute("allowfullscreen", "");
+          f.setAttribute("tabindex", "0");
+          f.src = url;
+          document.body.appendChild(f);
+          frames.set(path, f);
+        },
+        remove(path) {
+          const f = frames.get(path);
+          if (!f) return;
+          try {
+            f.src = "about:blank";
+          } catch (e) {}
+          f.remove();
+          frames.delete(path);
+        },
+        show(path) {
+          let target = null;
+          for (const [p, f] of frames) {
+            const active = p === path;
+            f.classList.toggle("active", active);
+            if (active) target = f;
+          }
+          if (target) {
+            // display:none → block is async; defer focus past layout. The
+            // contentWindow.focus() fires a window 'focus' event inside the
+            // iframe, which the per-iframe tracker uses to restore the
+            // last-focused element.
+            requestAnimationFrame(() => {
+              try {
+                target.focus();
+                target.contentWindow?.focus();
+              } catch (e) {}
+            });
+          }
+        },
+        hide(path) {
+          const f = frames.get(path);
+          if (f) f.classList.remove("active");
+        },
+        focusActive() {
+          for (const f of frames.values()) {
+            if (f.classList.contains("active")) {
+              requestAnimationFrame(() => {
+                try {
+                  f.focus();
+                  f.contentWindow?.focus();
+                } catch (e) {}
+              });
+              return;
+            }
+          }
+        },
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- New `IframeViewManager` renders all workspaces as iframes inside a single shared host `WebContentsView`, cutting renderer process count from N → 1.
- Wired behind `experimental.iframes` boolean config (default `false`, requires app restart). Read inside `ViewManager.create()` after `configService.load()` — flows through the normal CLI > env > config.json precedence.
- New `ViewManager` facade picks between `WebContentsViewManager` and `IframeViewManager` at create time.
- Refactored `BaseViewManager` backend protocol: `swapActiveSurface(prev, next)` + `attachSurface(state)` / `detachSurface(state)`. Base owns the "attached only when not loading" decision; both backends just describe their surface ops.
- Iframe focus restoration via in-frame tracker injected by new `ViewBoundary.installChildFrameScript`. Initial terminal focus driven from main via `agent:status-updated` and `workspace:switched`, once per workspace per session.
- Iframe-mode stubs (acceptable for experimental): per-workspace did-fail-load retry, render-process-gone recovery, reload watchdog, per-workspace DevTools/keyboard targets.
- Conformance suite runs against both backends; new iframe-specific tests cover host lifecycle, swap/attach/detach semantics, hostExec queue draining.