### PR TITLE
feat: faster project loading on startup

### DIFF
--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -163,6 +163,41 @@ describe("AppReady Operation", () => {
     });
   });
 
+  describe("parallel dispatch", () => {
+    it("dispatches project:open in parallel rather than sequentially", async () => {
+      // Each stub execute blocks on a shared latch until all have started.
+      // If dispatch were sequential, only one would ever start and the test
+      // would deadlock (the latch resolves only after all N start).
+      const paths = ["/p1", "/p2", "/p3", "/p4", "/p5"];
+      const started: string[] = [];
+      let resolveLatch!: () => void;
+      const latch = new Promise<void>((r) => {
+        resolveLatch = r;
+      });
+      const stub: Operation<OpenProjectIntent, Project> = {
+        id: "open-project",
+        async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project> {
+          const p = ctx.intent.payload.path?.toString() ?? "";
+          started.push(p);
+          if (started.length === paths.length) resolveLatch();
+          await latch;
+          return {
+            id: `id-${p}`,
+            path: p,
+            name: "test",
+            workspaces: [],
+          } as unknown as Project;
+        },
+      };
+      const { dispatcher } = createTestSetup([createProjectModule(paths)], stub);
+
+      await dispatcher.dispatch(appReadyIntent());
+
+      expect(started).toHaveLength(paths.length);
+      expect(new Set(started)).toEqual(new Set(paths));
+    });
+  });
+
   describe("app:started event", () => {
     it("emits app:started after project:open dispatches complete", async () => {
       const state = createTestState();

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -114,18 +114,18 @@ export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResu
       if (result.projectPaths) projectPaths.push(...result.projectPaths);
     }
 
-    // Dispatch project:open for each saved project (best-effort).
+    // Dispatch project:open for each saved project (best-effort, in parallel).
     // Each project:open dispatches workspace:create + workspace:switch internally.
-    for (const projectPath of projectPaths) {
-      try {
-        await ctx.dispatch({
+    // allSettled keeps best-effort semantics: invalid projects (no longer exist,
+    // not git repos, etc.) are silently dropped without aborting the rest.
+    await Promise.allSettled(
+      projectPaths.map((projectPath) =>
+        ctx.dispatch({
           type: INTENT_OPEN_PROJECT,
           payload: { path: new Path(projectPath) },
-        } as OpenProjectIntent);
-      } catch {
-        // Skip invalid projects (no longer exist, not git repos, etc.)
-      }
-    }
+        } as OpenProjectIntent)
+      )
+    );
 
     // Signal that initial project:open dispatches are complete.
     ctx.emit({ type: EVENT_APP_STARTED, payload: {} });


### PR DESCRIPTION
- Parallelize initial `project:open` dispatches in `AppReadyOperation` using `Promise.allSettled`; a profile with 20 saved projects drops from ~22 s to ~1–2 s time-to-interactive.
- The 10 s startup splash now comfortably outlasts loading instead of disappearing mid-load.
- Added integration test asserting all `project:open` dispatches start before any settle.