### PR TITLE
fix: avoid workspace being stuck in hibernation

### DIFF
--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -416,7 +416,11 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
     if (!(await handle.accepted)) {
       return { started: false };
     }
-    void handle.catch(() => {});
+    // Await full completion (not fire-and-forget): callers — notably the
+    // renderer's wake → reopen sequence in shortcuts.svelte.ts — rely on the
+    // `workspace:metadata-changed` event being processed before reopen runs,
+    // and on wake errors being surfaced rather than swallowed.
+    await handle;
     return { started: true };
   });
 

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -140,7 +140,7 @@ export function addWorkspace(
       ? {
           ...p,
           workspaces: p.workspaces.some((w) => w.path === workspace.path)
-            ? p.workspaces
+            ? p.workspaces.map((w) => (w.path === workspace.path ? workspace : w))
             : [...p.workspaces, workspace],
           // Update defaultBaseBranch if provided (remembers last-used branch for next workspace creation)
           ...(defaultBaseBranch !== undefined ? { defaultBaseBranch } : {}),
@@ -162,13 +162,15 @@ export function updateWorkspaceMetadata(
   workspaceName: WorkspaceName,
   key: string,
   value: string | null
-): void {
+): boolean {
+  let matched = false;
   _projects = _projects.map((p) => {
     if (p.id !== projectId) return p;
     return {
       ...p,
       workspaces: p.workspaces.map((w) => {
         if (w.name !== workspaceName) return w;
+        matched = true;
         const metadata = { ...w.metadata };
         if (value === null) {
           delete metadata[key];
@@ -179,6 +181,7 @@ export function updateWorkspaceMetadata(
       }),
     };
   });
+  return matched;
 }
 
 /**

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Api } from "@shared/electron-api";
 import type { ProjectPath } from "@shared/ipc";
-import type { ProjectId, Workspace } from "@shared/api/types";
+import type { ProjectId, Workspace, WorkspaceName } from "@shared/api/types";
 import { createMockProject, createMockWorkspace } from "$lib/test-fixtures";
 import { createMockApi } from "../test-utils";
 
@@ -26,6 +26,7 @@ import {
   setActiveWorkspace,
   addWorkspace,
   removeWorkspace,
+  updateWorkspaceMetadata,
   reset,
   getAllWorkspaces,
   getAwakeWorkspaceRefByIndex,
@@ -232,6 +233,28 @@ describe("projects store", () => {
       expect(projects.value[0]?.workspaces).toHaveLength(1);
     });
 
+    // Regression: wake clears the `hibernated` flag server-side and emits
+    // workspace:metadata-changed; reopen subsequently emits workspace:created
+    // with clean metadata. If addWorkspace silently dedups (keeping the stale
+    // entry), the renderer is left depending entirely on metadata-changed.
+    // The most recent payload from main must win.
+    it("replaces metadata when re-added for an existing path", () => {
+      const ws = createMockWorkspace({
+        path: "/test/project/.worktrees/ws1",
+        metadata: { hibernated: "true" },
+      });
+      addProject(createMockProject({ path: "/test/project" as ProjectPath, workspaces: [ws] }));
+
+      const refreshed = createMockWorkspace({
+        path: "/test/project/.worktrees/ws1",
+        metadata: {},
+      });
+      addWorkspace("/test/project" as ProjectPath, refreshed);
+
+      expect(projects.value[0]?.workspaces).toHaveLength(1);
+      expect(projects.value[0]?.workspaces[0]?.metadata).not.toHaveProperty("hibernated");
+    });
+
     it("keeps arrow navigation consistent after a wake/reopen re-adds an existing workspace", () => {
       // Reproduce the user-reported sidebar layout:
       //   project A: ws-a
@@ -264,6 +287,61 @@ describe("projects store", () => {
       const nextIndex = wrapIndex(currentIndex + 1, all.length);
       const nextRef = getWorkspaceRefByIndex(nextIndex);
       expect(nextRef?.path).toBe(wsC.path);
+    });
+  });
+
+  describe("updateWorkspaceMetadata", () => {
+    it("clears the key and returns true when the workspace matches", () => {
+      const ws = createMockWorkspace({
+        path: "/test/project/.worktrees/ws1",
+        name: "ws1",
+        metadata: { hibernated: "true" },
+      });
+      const project = createMockProject({
+        path: "/test/project" as ProjectPath,
+        workspaces: [ws],
+      });
+      addProject(project);
+
+      const projectId = projects.value[0]!.id;
+      const matched = updateWorkspaceMetadata(
+        projectId,
+        "ws1" as WorkspaceName,
+        "hibernated",
+        null
+      );
+
+      expect(matched).toBe(true);
+      expect(projects.value[0]?.workspaces[0]?.metadata).not.toHaveProperty("hibernated");
+    });
+
+    it("returns false when projectId does not match any project", () => {
+      const ws = createMockWorkspace({ path: "/test/project/.worktrees/ws1", name: "ws1" });
+      addProject(createMockProject({ path: "/test/project" as ProjectPath, workspaces: [ws] }));
+
+      const matched = updateWorkspaceMetadata(
+        "nonexistent-id" as ProjectId,
+        "ws1" as WorkspaceName,
+        "hibernated",
+        null
+      );
+
+      expect(matched).toBe(false);
+    });
+
+    it("returns false when workspaceName does not match any workspace in the project", () => {
+      const ws = createMockWorkspace({ path: "/test/project/.worktrees/ws1", name: "ws1" });
+      addProject(createMockProject({ path: "/test/project" as ProjectPath, workspaces: [ws] }));
+      const projectId = projects.value[0]!.id;
+
+      const matched = updateWorkspaceMetadata(
+        projectId,
+        "unknown" as WorkspaceName,
+        "hibernated",
+        null
+      );
+
+      expect(matched).toBe(false);
     });
   });
 

--- a/src/renderer/lib/utils/setup-domain-event-bindings.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.ts
@@ -114,7 +114,15 @@ export function setupDomainEventBindings(
         logger.debug("Store updated", { store: "agent-status" });
       },
       updateWorkspaceMetadata: (projectId, workspaceName, key, value) => {
-        updateWorkspaceMetadata(projectId, workspaceName, key, value);
+        const matched = updateWorkspaceMetadata(projectId, workspaceName, key, value);
+        if (!matched) {
+          logger.warn("Metadata update did not match any workspace", {
+            projectId,
+            workspaceName,
+            key,
+          });
+          return;
+        }
         logger.debug("Store updated", { store: "projects", key });
       },
     },


### PR DESCRIPTION
- `addWorkspace` now replaces an existing entry on path match instead of silently deduping, so reopen's `workspace:created` payload self-heals stale metadata when `metadata-changed` is lost or no-ops.
- `updateWorkspaceMetadata` returns whether any workspace matched; the domain-event wrapper logs a warning on no-op so future regressions surface in bug-report logs.
- `WORKSPACE_WAKE` IPC handler now awaits dispatch completion (was fire-and-forget), guaranteeing `metadata-changed` reaches the renderer before reopen runs and surfacing wake errors instead of swallowing them.
- Regression tests for `addWorkspace` metadata-replace and `updateWorkspaceMetadata` no-op signal.