### PR TITLE
fix(view): detach shared host when switching to hibernated workspace

### DIFF
--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -319,13 +319,17 @@ export abstract class BaseViewManager implements IViewManager {
       this.swapActiveSurface(previousState, newState ?? null);
 
       // Visibility (= window attachment of the surface) is gated on
-      // loading state. While loading, the surface is detached and the
-      // UI's loading overlay is visible underneath.
-      if (workspacePath !== null && !this.loadingWorkspaces.has(workspacePath)) {
+      // loading state and on whether a backing view exists. Hibernated
+      // workspaces have no state (view-module skips createWorkspaceView
+      // for them); in shared-surface backends the host would otherwise
+      // stay attached over the UI's HibernatedOverlay.
+      const hasState = workspacePath !== null && this.workspaceStates.has(workspacePath);
+      if (hasState && !this.loadingWorkspaces.has(workspacePath)) {
         this.attachView(workspacePath);
       } else {
-        // Either no active workspace, or the new one is loading. Either
-        // way the previously-attached surface must come down.
+        // No active workspace, the new one is still loading, or it has
+        // no backing view (hibernated). The previously-attached surface
+        // must come down so the UI layer is visible underneath.
         if (previousPath !== null) this.detachView(previousPath);
       }
 


### PR DESCRIPTION
- Treat absent `workspaceStates` entry the same as "loading" in the base `switchWorkspace` decision so the previously-attached surface is detached when switching to a hibernated workspace.
- Without this, the shared iframe host (`#1e1e1e` background) stayed attached over the UI's `HibernatedOverlay`, hiding the screenshot — visible only while shortcut mode raised the UI to top. Once re-attached, no switch path could detach it again.
- WCV mode is unaffected (no-op).

Fixes PostHog issue 019e39ff-5471-73c3-93a1-eeb11cb74e82.