### PR TITLE
fix(iframe-host): make workspace-host transparent so window theme shows through

### DIFF
--- a/src/boundaries/shell/iframe-view-manager.ts
+++ b/src/boundaries/shell/iframe-view-manager.ts
@@ -41,8 +41,6 @@ import type { WindowManager } from "./window-manager";
 
 const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
 
-const VIEW_BACKGROUND_COLOR = "#1e1e1e";
-
 /**
  * Script injected into every workspace iframe to preserve focus across
  * show/hide cycles. Records the last-focused element via `focusin` and
@@ -191,7 +189,7 @@ export class IframeViewManager extends BaseViewManager {
         backgroundThrottling: false,
       },
     });
-    viewLayer.setBackgroundColor(this.workspaceHostHandle, VIEW_BACKGROUND_COLOR);
+    viewLayer.setBackgroundColor(this.workspaceHostHandle, "#00000000");
 
     this.sharedSessionHandle = sessionLayer.fromPartition(GLOBAL_SESSION_PARTITION);
 

--- a/src/renderer/workspace-host.html
+++ b/src/renderer/workspace-host.html
@@ -11,7 +11,7 @@
         width: 100%;
         height: 100%;
         overflow: hidden;
-        background: #1e1e1e;
+        background: transparent;
       }
       /* Inactive iframes are hidden via display:none so Chromium suspends
          their paint/layout. visibility:hidden would seem equivalent but
@@ -24,7 +24,7 @@
         width: 100%;
         height: 100%;
         border: 0;
-        background: #1e1e1e;
+        background: transparent;
         display: none;
       }
       iframe.active {


### PR DESCRIPTION
- Replace hardcoded `#1e1e1e` on the iframe-host view and `workspace-host.html` (html/body + iframe) with transparent backgrounds
- Window's existing theme-aware backdrop (`colorForTheme()`) now shows through, matching the non-iframe path
- Fixes dark flash on light theme while code-server loads