### PR TITLE
fix(view): recover workspace iframes from blank/black state on Windows

### DIFF
--- a/src/boundaries/shell/iframe-view-manager.integration.test.ts
+++ b/src/boundaries/shell/iframe-view-manager.integration.test.ts
@@ -7,7 +7,7 @@
  * focus tracker installation).
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { IframeViewManager, type IframeViewManagerDeps } from "./iframe-view-manager";
 import {
   runViewManagerConformance,
@@ -220,6 +220,175 @@ describe("IframeViewManager", () => {
 
       // Despite being in the loading set, the iframe was shown.
       expect(showCalls).toContain("/loading");
+    });
+  });
+
+  describe("host detach when no iframes remain", () => {
+    it("detaches the workspace-host view after destroying the last workspace so the UI overlay is visible", async () => {
+      const deps = createIframeDeps();
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
+
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.setActiveWorkspace("/a");
+
+      // Host is attached while a workspace is active.
+      expect(deps.viewLayer.$.windowChildren.get(windowId)).toContain(host.id);
+
+      await manager.destroyWorkspaceView("/a");
+
+      // Host must be detached so the UI view (at z-bottom) is no longer
+      // covered by the host's dark body. This is the symptom from PostHog
+      // issue 019e3bd1: HibernatedOverlay invisible behind the host.
+      expect(deps.viewLayer.$.windowChildren.get(windowId)).not.toContain(host.id);
+    });
+
+    it("keeps the workspace-host view attached when other workspaces remain", async () => {
+      const deps = createIframeDeps();
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+      const windowId = deps.windowLayer._createdWindowHandle.id;
+
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.createWorkspaceView("/b", "http://127.0.0.1/?b", "/p");
+      manager.setActiveWorkspace("/a");
+      expect(deps.viewLayer.$.windowChildren.get(windowId)).toContain(host.id);
+
+      // Destroying one of two workspaces must NOT detach the host — there
+      // is still another iframe to show.
+      await manager.destroyWorkspaceView("/a");
+      expect(deps.viewLayer.$.windowChildren.get(windowId)).toContain(host.id);
+    });
+  });
+
+  describe("DirectComposition re-composite on workspace switch", () => {
+    it("force-re-attaches the workspace-host view when swapping the active iframe", () => {
+      const deps = createIframeDeps();
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.createWorkspaceView("/b", "http://127.0.0.1/?b", "/p");
+      manager.setActiveWorkspace("/a");
+
+      // Record host attachments with `force: true` after switching workspaces.
+      const forceAttachCalls: ViewHandle[] = [];
+      const originalAttach = deps.viewLayer.attachToWindow.bind(deps.viewLayer);
+      deps.viewLayer.attachToWindow = (handle, win, idx, opts) => {
+        if (opts?.force === true && handle.id === host.id) {
+          forceAttachCalls.push(handle);
+        }
+        return originalAttach(handle, win, idx, opts);
+      };
+
+      manager.setActiveWorkspace("/b");
+
+      // The host must be re-attached with `{ force: true }` after the swap
+      // to force a DirectComposition re-composite. Without this the newly-
+      // revealed iframe can come back blank on Windows.
+      expect(forceAttachCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("did-fail-load retry on subframe failure", () => {
+    it("schedules an exponential-backoff retry when an iframe URL fails to load", () => {
+      vi.useFakeTimers();
+      try {
+        const deps = createIframeDeps();
+        const manager = new IframeViewManager(deps);
+        manager.create();
+        const host = manager.getWorkspaceHostHandle();
+        flushHostReady(deps.viewLayer, host);
+
+        manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+        manager.setActiveWorkspace("/a");
+
+        // Capture `__host.add(..., { force: true })` retry calls.
+        const retryAddCalls: string[] = [];
+        const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+        deps.viewLayer.executeJavaScript = (handle, code) => {
+          if (
+            handle.id === host.id &&
+            code.includes("__host.add") &&
+            code.includes("force: true")
+          ) {
+            retryAddCalls.push(code);
+          }
+          return originalExec(handle, code);
+        };
+
+        // Simulate a subframe load failure for /a's URL.
+        deps.viewLayer.$.triggerDidFailLoad(host, {
+          errorCode: -21,
+          errorDescription: "ERR_NETWORK_CHANGED",
+          isMainFrame: false,
+          validatedURL: "http://127.0.0.1/?a",
+        });
+
+        // No retry should have fired yet (delay is 1s).
+        expect(retryAddCalls).toHaveLength(0);
+
+        // After 1s the first retry fires with `force: true`.
+        vi.advanceTimersByTime(1000);
+        expect(retryAddCalls).toHaveLength(1);
+        expect(retryAddCalls[0]).toContain("/a");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("ignores main-frame failures (the host page itself) and unknown URLs", () => {
+      vi.useFakeTimers();
+      try {
+        const deps = createIframeDeps();
+        const manager = new IframeViewManager(deps);
+        manager.create();
+        const host = manager.getWorkspaceHostHandle();
+        flushHostReady(deps.viewLayer, host);
+
+        manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+        manager.setActiveWorkspace("/a");
+
+        const retryCalls: string[] = [];
+        const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+        deps.viewLayer.executeJavaScript = (handle, code) => {
+          if (
+            handle.id === host.id &&
+            code.includes("__host.add") &&
+            code.includes("force: true")
+          ) {
+            retryCalls.push(code);
+          }
+          return originalExec(handle, code);
+        };
+
+        // Main-frame failure: ignored.
+        deps.viewLayer.$.triggerDidFailLoad(host, {
+          errorCode: -21,
+          errorDescription: "ERR_NETWORK_CHANGED",
+          isMainFrame: true,
+          validatedURL: "file:///path/to/workspace-host.html",
+        });
+        // Subframe failure for a URL we don't recognize: ignored.
+        deps.viewLayer.$.triggerDidFailLoad(host, {
+          errorCode: -21,
+          errorDescription: "ERR_NETWORK_CHANGED",
+          isMainFrame: false,
+          validatedURL: "http://example.test/unknown",
+        });
+
+        vi.advanceTimersByTime(20000);
+        expect(retryCalls).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/boundaries/shell/iframe-view-manager.ts
+++ b/src/boundaries/shell/iframe-view-manager.ts
@@ -6,9 +6,10 @@
  * a single renderer process — the main memory win over per-view rendering.
  *
  * Trade-offs vs `WebContentsViewManager`:
- *   - Per-workspace `did-fail-load` retry, `render-process-gone` recovery,
- *     and the reload watchdog are not implemented. Failures show as broken
- *     iframes; recovery is host-renderer-wide.
+ *   - Per-iframe `did-fail-load` retry uses the host's webContents event
+ *     (filtered to subframes, mapped back to a workspace by URL). There
+ *     is no per-iframe `render-process-gone` — all iframes share the host
+ *     renderer.
  *   - DevTools and keyboard input are routed to the host view; workspaces
  *     share both.
  *
@@ -24,7 +25,7 @@ import { basename } from "node:path";
 import type { AppBoundary } from "./app";
 import type { Logger } from "../platform/logging";
 import { getErrorMessage } from "../../shared/error-utils";
-import type { ViewBoundary, WindowOpenDetails } from "./view";
+import type { FailLoadDetails, ViewBoundary, WindowOpenDetails } from "./view";
 import type { SessionBoundary } from "./session";
 import type { WindowBoundaryInternal } from "./window";
 import type { SessionHandle, ViewHandle, WindowHandle } from "./types";
@@ -242,6 +243,19 @@ export class IframeViewManager extends BaseViewManager {
       const pending = this.pendingHostScripts.splice(0);
       for (const code of pending) this.hostExec(code);
     });
+
+    // Subframe load failures: Electron's `did-fail-load` fires on the host's
+    // webContents for both the host page (isMainFrame=true) and any iframe
+    // inside it (isMainFrame=false). For subframes we map the failing URL
+    // back to a workspace and delegate to the shared backoff scheduler
+    // (`scheduleLoadRetry` in `BaseViewManager`).
+    viewLayer.onDidFailLoad(this.workspaceHostHandle, (details: FailLoadDetails) => {
+      if (details.isMainFrame) return;
+      const failingPath = this.findWorkspacePathByUrl(details.validatedURL);
+      if (failingPath === undefined) return;
+      this.scheduleLoadRetry(failingPath, details);
+    });
+
     void viewLayer.loadURL(this.workspaceHostHandle, `file://${config.workspaceHostHtmlPath}`);
   }
 
@@ -301,6 +315,27 @@ export class IframeViewManager extends BaseViewManager {
     if (path !== undefined) {
       this.hostExec(`window.__host.remove(${jsStr(path)})`);
     }
+
+    // Clear any pending retry timer for this iframe.
+    if (state.retryTimer !== null) {
+      clearTimeout(state.retryTimer);
+      state.retryTimer = null;
+    }
+
+    // If no workspaces remain (e.g. hibernating the last awake workspace),
+    // detach the host view so the UI overlay (HibernatedOverlay, empty
+    // backdrop) is visible. The base class deletes from `workspaceStates`
+    // BEFORE calling this, so an empty map means "no iframes left to show".
+    // Without this detach the host's dark `#1e1e1e` body would cover the
+    // UI view sitting at z-bottom — the symptom in PostHog issue 019e3bd1.
+    if (this.workspaceStates.size === 0 && this.hostAttachedToWindow) {
+      try {
+        this.viewLayer.detachFromWindow(this.workspaceHostHandle);
+      } catch {
+        // window may be closing
+      }
+      this.hostAttachedToWindow = false;
+    }
   }
 
   protected startLoadingUrl(state: WorkspaceState): void {
@@ -323,6 +358,18 @@ export class IframeViewManager extends BaseViewManager {
       const nextPath = this.findWorkspacePathByState(next);
       if (nextPath !== undefined) {
         this.hostExec(`window.__host.show(${jsStr(nextPath)})`);
+      }
+      // Force a host re-composite so the now-visible iframe repaints
+      // correctly on Windows — the same DirectComposition trick the UI
+      // view uses via `bringUIToBottom(true)`.
+      if (this.hostAttachedToWindow) {
+        try {
+          this.viewLayer.attachToWindow(this.workspaceHostHandle, this.windowHandle, undefined, {
+            force: true,
+          });
+        } catch {
+          // window may be closing
+        }
       }
     }
   }
@@ -435,6 +482,26 @@ export class IframeViewManager extends BaseViewManager {
       if (candidate === state) return path;
     }
     return undefined;
+  }
+
+  /** Reverse-lookup a workspace path from its iframe URL. */
+  private findWorkspacePathByUrl(url: string): string | undefined {
+    for (const [path, state] of this.workspaceStates) {
+      if (state.url === url) return path;
+    }
+    return undefined;
+  }
+
+  /**
+   * Re-issue the iframe's `src` via the host page. `__host.add` with
+   * `force: true` bounces through `about:blank` so Chromium actually
+   * re-requests the URL even when it matches the previous (failed)
+   * navigation.
+   */
+  protected retryLoad(state: WorkspaceState): void {
+    const path = this.findWorkspacePathByState(state);
+    if (path === undefined) return;
+    this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)}, { force: true })`);
   }
 }
 

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -34,6 +34,13 @@ export interface BaseViewManagerDeps {
 }
 
 /**
+ * Exponential-backoff schedule for retrying a failed workspace load:
+ * 1s, 2s, 5s, then 10s forever. Shared across backends so behavior is
+ * uniform regardless of which view manager owns the surface.
+ */
+const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000];
+
+/**
  * Result of creating a workspace view's underlying primitives. Returned by
  * the `createWorkspaceViewImpl` subclass primitive and stored in the shared
  * `WorkspaceState`.
@@ -748,6 +755,70 @@ export abstract class BaseViewManager implements IViewManager {
    * use this hook to add watchdog/recovery behavior.
    */
   protected abstract reloadWorkspaceView(state: WorkspaceState): void;
+
+  /**
+   * Re-issue the underlying load for a workspace whose previous load
+   * failed. Called by `scheduleLoadRetry` after the backoff delay.
+   * Implementations decide HOW to re-load (per-view `loadURL` vs
+   * shared-surface iframe `src` bump).
+   */
+  protected abstract retryLoad(state: WorkspaceState): void;
+
+  // ---------------------------------------------------------------------------
+  // Shared retry scheduling
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Schedule an exponential-backoff retry for a workspace whose load
+   * failed. Delay schedule: 1s, 2s, 5s, then 10s forever. Per-workspace
+   * state (`retryCount`, `retryTimer`) lives on the shared
+   * `WorkspaceState`, so both backends keep independent retry chains.
+   *
+   * The actual re-load happens via `retryLoad(state)` inside the timer
+   * callback. Callers should perform any subscriber-specific gating
+   * (e.g. main-frame-only filter for WCV) BEFORE invoking this.
+   */
+  protected scheduleLoadRetry(
+    workspacePath: string,
+    context: { readonly errorCode: number; readonly errorDescription: string }
+  ): void {
+    const state = this.workspaceStates.get(workspacePath);
+    if (!state) return;
+    if (this.destroying) return;
+
+    const workspaceName = basename(workspacePath);
+    const delayIndex = Math.min(state.retryCount, RETRY_DELAYS_MS.length - 1);
+    // RETRY_DELAYS_MS is non-empty and delayIndex is clamped to valid range
+    const delay = RETRY_DELAYS_MS[delayIndex]!;
+    state.retryCount++;
+
+    this.logger.warn("Workspace load failed, scheduling retry", {
+      workspace: workspaceName,
+      errorCode: context.errorCode,
+      errorDescription: context.errorDescription,
+      retryAttempt: state.retryCount,
+      retryDelayMs: delay,
+    });
+
+    if (state.retryTimer !== null) {
+      clearTimeout(state.retryTimer);
+    }
+
+    state.retryTimer = setTimeout(() => {
+      state.retryTimer = null;
+
+      const currentState = this.workspaceStates.get(workspacePath);
+      if (!currentState) return;
+      if (this.destroying) return;
+
+      this.logger.debug("Retrying workspace load", {
+        workspace: workspaceName,
+        retryAttempt: currentState.retryCount,
+      });
+
+      this.retryLoad(currentState);
+    }, delay);
+  }
 
   /**
    * Build the narrow `DevtoolsTarget` capability for the given view handle.

--- a/src/boundaries/shell/view.integration.test.ts
+++ b/src/boundaries/shell/view.integration.test.ts
@@ -254,12 +254,14 @@ describe("ViewBoundary (integration)", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://example.test/",
       });
 
       expect(callback).toHaveBeenCalledWith({
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://example.test/",
       });
     });
 
@@ -273,6 +275,7 @@ describe("ViewBoundary (integration)", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://example.test/",
       });
 
       expect(callback).not.toHaveBeenCalled();
@@ -289,6 +292,7 @@ describe("ViewBoundary (integration)", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://example.test/",
       });
 
       expect(callback1).toHaveBeenCalled();

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -64,6 +64,12 @@ export interface FailLoadDetails {
   readonly errorCode: number;
   readonly errorDescription: string;
   readonly isMainFrame: boolean;
+  /**
+   * The URL whose load failed. For subframe failures, the iframe's `src`.
+   * Used by shared-surface backends (iframe-view-manager) to map a
+   * subframe failure back to a workspace by URL.
+   */
+  readonly validatedURL: string;
 }
 
 /**
@@ -703,10 +709,10 @@ export class DefaultViewBoundary implements ViewBoundary {
       _event: Electron.Event,
       errorCode: number,
       errorDescription: string,
-      _validatedURL: string,
+      validatedURL: string,
       isMainFrame: boolean
     ) => {
-      callback({ errorCode, errorDescription, isMainFrame });
+      callback({ errorCode, errorDescription, isMainFrame, validatedURL });
     };
     state.view.webContents.on("did-fail-load", handler);
     return () => {

--- a/src/boundaries/shell/webcontents-view-manager.integration.test.ts
+++ b/src/boundaries/shell/webcontents-view-manager.integration.test.ts
@@ -1526,6 +1526,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       // Advance past first retry delay (1s)
@@ -1558,6 +1559,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: false,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(5000);
@@ -1590,6 +1592,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(999);
@@ -1603,6 +1606,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(1999);
@@ -1616,6 +1620,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(4999);
@@ -1650,6 +1655,7 @@ describe("WebContentsViewManager", () => {
           errorCode: -21,
           errorDescription: "ERR_NETWORK_CHANGED",
           isMainFrame: true,
+          validatedURL: "http://127.0.0.1:8080/?folder=/path",
         });
         await vi.advanceTimersByTimeAsync(delay);
         expect(loadURLSpy).toHaveBeenCalledTimes(1);
@@ -1662,6 +1668,7 @@ describe("WebContentsViewManager", () => {
           errorCode: -21,
           errorDescription: "ERR_NETWORK_CHANGED",
           isMainFrame: true,
+          validatedURL: "http://127.0.0.1:8080/?folder=/path",
         });
         await vi.advanceTimersByTimeAsync(9999);
         expect(loadURLSpy).not.toHaveBeenCalled();
@@ -1693,6 +1700,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
       await vi.advanceTimersByTimeAsync(1000);
 
@@ -1705,6 +1713,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(999);
@@ -1736,6 +1745,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       // Destroy before retry fires
@@ -1770,12 +1780,14 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
       await vi.advanceTimersByTimeAsync(1000);
       deps.viewLayer.$.triggerDidFailLoad(wsHandle, {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
       await vi.advanceTimersByTimeAsync(2000);
 
@@ -1790,6 +1802,7 @@ describe("WebContentsViewManager", () => {
         errorCode: -21,
         errorDescription: "ERR_NETWORK_CHANGED",
         isMainFrame: true,
+        validatedURL: "http://127.0.0.1:8080/?folder=/path",
       });
 
       await vi.advanceTimersByTimeAsync(999);

--- a/src/boundaries/shell/webcontents-view-manager.ts
+++ b/src/boundaries/shell/webcontents-view-manager.ts
@@ -44,12 +44,6 @@ const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
 const NAVIGATION_TIMEOUT_MS = 2000;
 
 /**
- * Retry delays for failed URL loads (in milliseconds).
- * Backs off to 10s then retries indefinitely at that interval.
- */
-const RETRY_DELAYS_MS = [1000, 2000, 5000, 10000];
-
-/**
  * How long to wait for did-finish-load after a resume-triggered reload
  * before assuming the renderer is wedged and recreating the view.
  *
@@ -464,53 +458,24 @@ export class WebContentsViewManager extends BaseViewManager {
   // ---------------------------------------------------------------------------
 
   /**
-   * Handles a load failure for a workspace view.
-   * Only retries main-frame failures, with exponential backoff.
+   * Handles a load failure for a workspace view. Subframe failures are
+   * ignored — they're sub-resources (extensions, web workers) that
+   * Chromium will retry on its own. Main-frame failures schedule a
+   * backoff retry via the shared `scheduleLoadRetry` in the base class.
    */
   private handleLoadFailure(workspacePath: string, details: FailLoadDetails): void {
     if (!details.isMainFrame) return;
-
+    // Pre-emptively mark the URL as not-loaded so any concurrent attach/
+    // loadViewUrl path doesn't think it's still in flight while we wait
+    // for the retry. `retryLoad` re-sets it to true before re-issuing.
     const state = this.workspaceStates.get(workspacePath);
-    if (!state) return;
-    if (this.destroying) return;
+    if (state) state.urlLoaded = false;
+    this.scheduleLoadRetry(workspacePath, details);
+  }
 
-    const workspaceName = basename(workspacePath);
-
-    // Delay schedule: 1s, 2s, 5s, then 10s forever
-    const delayIndex = Math.min(state.retryCount, RETRY_DELAYS_MS.length - 1);
-    // RETRY_DELAYS_MS is non-empty and delayIndex is clamped to valid range
-    const delay = RETRY_DELAYS_MS[delayIndex]!;
-    state.retryCount++;
-
-    this.logger.warn("URL load failed, scheduling retry", {
-      workspace: workspaceName,
-      errorCode: details.errorCode,
-      errorDescription: details.errorDescription,
-      retryAttempt: state.retryCount,
-      retryDelayMs: delay,
-    });
-
-    if (state.retryTimer !== null) {
-      clearTimeout(state.retryTimer);
-    }
-
-    // Reset urlLoaded to allow retry
-    state.urlLoaded = false;
-
-    state.retryTimer = setTimeout(() => {
-      state.retryTimer = null;
-
-      const currentState = this.workspaceStates.get(workspacePath);
-      if (!currentState) return;
-
-      this.logger.debug("Retrying URL load", {
-        workspace: workspaceName,
-        retryAttempt: currentState.retryCount,
-      });
-
-      currentState.urlLoaded = true;
-      void this.viewLayer.loadURL(currentState.handle, currentState.url);
-    }, delay);
+  protected retryLoad(state: WorkspaceState): void {
+    state.urlLoaded = true;
+    void this.viewLayer.loadURL(state.handle, state.url);
   }
 
   protected reloadWorkspaceView(state: WorkspaceState): void {

--- a/src/renderer/workspace-host.html
+++ b/src/renderer/workspace-host.html
@@ -48,10 +48,22 @@
       const frames = new Map(); // path -> HTMLIFrameElement
 
       window.__host = {
-        add(path, url) {
+        add(path, url, options) {
+          const force = options && options.force === true;
           if (frames.has(path)) {
             const existing = frames.get(path);
-            if (existing.src !== url) existing.src = url;
+            if (force) {
+              // Force a fresh navigation by bouncing through about:blank.
+              // Used by the manager's load-failure retry path: the URL
+              // hasn't changed, but the previous load ended in an error
+              // page and we need Chromium to actually re-request it.
+              try {
+                existing.src = "about:blank";
+              } catch (e) {}
+              existing.src = url;
+            } else if (existing.src !== url) {
+              existing.src = url;
+            }
             return;
           }
           const f = document.createElement("iframe");
@@ -81,12 +93,21 @@
             if (active) target = f;
           }
           if (target) {
+            // Force a paint-tree refresh of the now-visible iframe to work
+            // around Windows DirectComposition surfaces that can come back
+            // blank after a display:none → display:block toggle (the
+            // symptom in PostHog issue 019e3bd1). Reading `offsetHeight`
+            // flushes layout; the transient transform forces a compositor
+            // layer rebuild, which is cleared on the next frame.
+            void target.offsetHeight;
+            target.style.transform = "translateZ(0)";
             // display:none → block is async; defer focus past layout. The
             // contentWindow.focus() fires a window 'focus' event inside the
             // iframe, which the per-iframe tracker uses to restore the
             // last-focused element.
             requestAnimationFrame(() => {
               try {
+                target.style.transform = "";
                 target.focus();
                 target.contentWindow?.focus();
               } catch (e) {}


### PR DESCRIPTION
- Detach the shared workspace-host WebContentsView when no iframes remain, so the UI view's HibernatedOverlay / empty backdrop becomes visible instead of the host's dark body covering them.
- Force a DirectComposition re-composite on workspace switch by re-attaching the host view with `{ force: true }`, plus a paint-tree refresh inside the iframe via `__host.show` (`offsetHeight` + transient `translateZ(0)`).
- Wire `did-fail-load` on the host's webContents to per-iframe retry. Subframe failures are mapped back to a workspace by URL via the new `FailLoadDetails.validatedURL`, and run the same exponential-backoff schedule as the per-view backend.
- Refactor the retry scheduler into `BaseViewManager.scheduleLoadRetry` + a per-backend `retryLoad` primitive so both managers share one source of truth (was duplicated across `WebContentsViewManager` and the new iframe path).