### PR TITLE
refactor(intents): surface active flag on resolve result

### DIFF
--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -121,8 +121,9 @@ export abstract class BaseViewManager implements IViewManager {
     return this.makeDevtoolsTarget(this.uiViewHandle);
   }
 
-  getWorkspaceDevtoolsTarget(workspacePath: string): DevtoolsTarget | undefined {
-    const state = this.workspaceStates.get(workspacePath);
+  getActiveWorkspaceDevtoolsTarget(): DevtoolsTarget | undefined {
+    if (this.activeWorkspacePath === null) return undefined;
+    const state = this.workspaceStates.get(this.activeWorkspacePath);
     if (!state) return undefined;
     return this.makeDevtoolsTarget(state.handle);
   }

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -67,10 +67,10 @@ export interface IViewManager {
   getUIDevtoolsTarget(): DevtoolsTarget;
 
   /**
-   * Returns a narrow capability for toggling devtools on a workspace view.
-   * Returns undefined if the workspace doesn't exist.
+   * Returns a narrow capability for toggling devtools on the active
+   * workspace view. Returns undefined if no workspace is active.
    */
-  getWorkspaceDevtoolsTarget(workspacePath: string): DevtoolsTarget | undefined;
+  getActiveWorkspaceDevtoolsTarget(): DevtoolsTarget | undefined;
 
   /**
    * Returns a narrow capability for subscribing to keyboard input and the
@@ -173,13 +173,6 @@ export interface IViewManager {
    * @param focus - Whether to focus the workspace view (default: true)
    */
   setActiveWorkspace(workspacePath: string | null, focus?: boolean): void;
-
-  /**
-   * Gets the active workspace path.
-   *
-   * @returns The active workspace path or null if none
-   */
-  getActiveWorkspacePath(): string | null;
 
   /**
    * Focuses the correct view based on current mode and attachment state.

--- a/src/boundaries/shell/view-manager.test-utils.ts
+++ b/src/boundaries/shell/view-manager.test-utils.ts
@@ -12,27 +12,24 @@ import type { UIMode } from "../../shared/ipc";
 export interface CreateMockViewManagerOptions {
   /** Initial mode. Default: "workspace". */
   initialMode?: UIMode;
-  /** Initial active workspace path. Default: null. */
-  initialActiveWorkspace?: string | null;
   /** Override any subset of the IViewManager API. */
   overrides?: Partial<IViewManager>;
 }
 
 /**
- * Create a mock ViewManager. State is held in closures; mode and active
- * workspace mutate in place when setMode / setActiveWorkspace are called.
+ * Create a mock ViewManager. State is held in closures; mode mutates in
+ * place when setMode is called.
  *
  * The returned object satisfies IViewManager. Pass `overrides` to plug in
  * specific behavior for methods your test exercises.
  */
 export function createMockViewManager(options?: CreateMockViewManagerOptions): IViewManager {
   let currentMode: UIMode = options?.initialMode ?? "workspace";
-  let activePath: string | null = options?.initialActiveWorkspace ?? null;
 
   const base: IViewManager = {
     create: vi.fn(),
     getUIDevtoolsTarget: vi.fn(),
-    getWorkspaceDevtoolsTarget: vi.fn(),
+    getActiveWorkspaceDevtoolsTarget: vi.fn(),
     getUIKeyboardTarget: vi.fn(),
     getWorkspaceKeyboardTarget: vi.fn(),
     isUIAvailable: vi.fn().mockReturnValue(true),
@@ -41,10 +38,7 @@ export function createMockViewManager(options?: CreateMockViewManagerOptions): I
     createWorkspaceView: vi.fn(),
     destroyWorkspaceView: vi.fn().mockResolvedValue(undefined),
     updateBounds: vi.fn(),
-    setActiveWorkspace: vi.fn((path: string | null) => {
-      activePath = path;
-    }),
-    getActiveWorkspacePath: vi.fn(() => activePath),
+    setActiveWorkspace: vi.fn(),
     focus: vi.fn(),
     setMode: vi.fn((mode: UIMode) => {
       currentMode = mode;

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -99,8 +99,8 @@ export class ViewManager implements IViewManager {
   getUIDevtoolsTarget(): DevtoolsTarget {
     return this.vm.getUIDevtoolsTarget();
   }
-  getWorkspaceDevtoolsTarget(path: string): DevtoolsTarget | undefined {
-    return this.vm.getWorkspaceDevtoolsTarget(path);
+  getActiveWorkspaceDevtoolsTarget(): DevtoolsTarget | undefined {
+    return this.vm.getActiveWorkspaceDevtoolsTarget();
   }
   getUIKeyboardTarget(): KeyboardTarget {
     return this.vm.getUIKeyboardTarget();
@@ -129,9 +129,6 @@ export class ViewManager implements IViewManager {
   }
   setActiveWorkspace(path: string | null, focus?: boolean): void {
     this.vm.setActiveWorkspace(path, focus);
-  }
-  getActiveWorkspacePath(): string | null {
-    return this.impl?.getActiveWorkspacePath() ?? null;
   }
   focus(): void {
     this.impl?.focus();

--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -247,7 +247,11 @@ function createTestHarness(options?: {
               const workspace = p.workspaces?.find((w: { path: string }) => w.path === wsPath);
               if (workspace) {
                 const workspaceName = extractWorkspaceName(wsPath);
-                return { projectPath: p.path, workspaceName: workspaceName as WorkspaceName };
+                return {
+                  projectPath: p.path,
+                  workspaceName: workspaceName as WorkspaceName,
+                  active: viewManager.getActiveWorkspacePath() === wsPath,
+                };
               }
             }
             return {};

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -435,7 +435,11 @@ function createTestHarness(options?: {
             const project = appState.findProjectForWorkspace(wsPath);
             if (!project) return {};
             const workspaceName = extractWorkspaceName(wsPath);
-            return { projectPath: project.path, workspaceName: workspaceName as WorkspaceName };
+            return {
+              projectPath: project.path,
+              workspaceName: workspaceName as WorkspaceName,
+              active: viewManager.getActiveWorkspacePath() === wsPath,
+            };
           },
         },
       },
@@ -466,10 +470,8 @@ function createTestHarness(options?: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
-            const { workspacePath } = ctx as DeletePipelineHookInput;
+            const { workspacePath, active: isActive } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
-
-            const isActive = viewManager.getActiveWorkspacePath() === workspacePath;
 
             try {
               await viewManager.destroyWorkspaceView(workspacePath);
@@ -694,10 +696,10 @@ function createTestHarness(options?: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ActivateHookInput;
+            const { workspacePath, active } = ctx as ActivateHookInput;
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
-            if (viewManager.getActiveWorkspacePath() === workspacePath) {
+            if (active) {
               return {};
             }
             const focus = intent.payload.focus ?? true;

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -162,6 +162,7 @@ export interface FlushHookResult {
 export interface DeletePipelineHookInput extends HookContext {
   readonly projectPath: string;
   readonly workspacePath: string;
+  readonly active: boolean;
 }
 
 /** Input for flush hook (enriched with PIDs to kill). */
@@ -383,7 +384,7 @@ export class DeleteWorkspaceOperation implements Operation<
     const { payload } = ctx.intent;
 
     // --- Resolve (workspacePath → projectPath + workspaceName) via dispatch ---
-    const { projectPath, workspaceName } = await ctx.dispatch({
+    const { projectPath, workspaceName, active } = await ctx.dispatch({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath: payload.workspacePath },
     } as ResolveWorkspaceIntent);
@@ -401,6 +402,7 @@ export class DeleteWorkspaceOperation implements Operation<
       intent: ctx.intent,
       projectPath,
       workspacePath: payload.workspacePath,
+      active,
     };
 
     // Safety net: catch unexpected errors after identity resolution to ensure

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -88,6 +88,7 @@ export interface HibernatePipelineHookInput extends HookContext {
   readonly workspacePath: string;
   readonly projectId: ProjectId;
   readonly workspaceName: WorkspaceName;
+  readonly active: boolean;
 }
 
 /** Per-handler result for the "capture" hook point. */
@@ -124,7 +125,7 @@ export class HibernateWorkspaceOperation implements Operation<
 
     try {
       // Resolve workspace + project identity
-      const { projectPath, workspaceName } = await ctx.dispatch({
+      const { projectPath, workspaceName, active } = await ctx.dispatch({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: payload.workspacePath },
       } as ResolveWorkspaceIntent);
@@ -140,6 +141,7 @@ export class HibernateWorkspaceOperation implements Operation<
         workspacePath: payload.workspacePath,
         projectId,
         workspaceName,
+        active,
       };
 
       // Capture screenshot (best-effort, errors logged but not propagated)

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -630,6 +630,7 @@ function createTestHarness(options?: {
                 return {
                   projectPath: project.path,
                   workspaceName: workspaceName as WorkspaceName,
+                  active: viewManager.getActiveWorkspacePath() === wsPath,
                 };
               }
             }
@@ -661,10 +662,10 @@ function createTestHarness(options?: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ActivateHookInput;
+            const { workspacePath, active } = ctx as ActivateHookInput;
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
-            if (viewManager.getActiveWorkspacePath() === workspacePath) {
+            if (active) {
               return {};
             }
 

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -102,12 +102,17 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
   // -- resolve-workspace --
   if (config.workspaces) {
     const workspaces = config.workspaces;
+    const vm = config.viewManager;
     hooks[RESOLVE_WORKSPACE_OPERATION_ID] = {
       resolve: {
         handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
           const intent = ctx.intent as { payload: { workspacePath: string } };
           const entry = workspaces[intent.payload.workspacePath];
-          return entry ?? {};
+          if (!entry) return {};
+          return {
+            ...entry,
+            active: vm ? vm.getActiveWorkspacePath() === intent.payload.workspacePath : false,
+          };
         },
       },
     };
@@ -148,9 +153,9 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
     hooks[SWITCH_WORKSPACE_OPERATION_ID] = {
       activate: {
         handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-          const { workspacePath } = ctx as ActivateHookInput;
+          const { workspacePath, active } = ctx as ActivateHookInput;
           const intent = ctx.intent as SwitchWorkspaceIntent;
-          if (vm.getActiveWorkspacePath() === workspacePath) {
+          if (active) {
             return {};
           }
           const focus = intent.payload.focus ?? true;

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -85,6 +85,7 @@ describe("ResolveWorkspaceOperation Integration", () => {
       expect(result).toEqual({
         projectPath: PROJECT_PATH,
         workspaceName: WORKSPACE_NAME,
+        active: false,
       });
     });
   });

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -26,6 +26,7 @@ export interface ResolveWorkspacePayload {
 export interface ResolveWorkspaceResult {
   readonly projectPath: string;
   readonly workspaceName: WorkspaceName;
+  readonly active: boolean;
 }
 
 export interface ResolveWorkspaceIntent extends Intent<ResolveWorkspaceResult> {
@@ -50,6 +51,7 @@ export interface ResolveHookInput extends HookContext {
 export interface ResolveHookResult {
   readonly projectPath?: string;
   readonly workspaceName?: WorkspaceName;
+  readonly active?: boolean;
 }
 
 // =============================================================================
@@ -79,15 +81,17 @@ export class ResolveWorkspaceOperation implements Operation<
 
     let projectPath: string | undefined;
     let workspaceName: WorkspaceName | undefined;
+    let active = false;
     for (const r of results) {
       if (r.projectPath !== undefined) projectPath = r.projectPath;
       if (r.workspaceName !== undefined) workspaceName = r.workspaceName;
+      if (r.active === true) active = true;
     }
 
     if (!projectPath || !workspaceName) {
       throw new Error(`Workspace not found: ${payload.workspacePath}`);
     }
 
-    return { projectPath, workspaceName };
+    return { projectPath, workspaceName, active };
   }
 }

--- a/src/intents/switch-workspace.integration.test.ts
+++ b/src/intents/switch-workspace.integration.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { createMockDispatcher } from "./lib/dispatcher.test-utils";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 import type { IntentInterceptor } from "./lib/dispatcher";
 
@@ -148,6 +148,7 @@ interface TestSetup {
   dispatcher: Dispatcher;
   viewManager: IViewManager;
   appState: MockAppState;
+  getActivePath: () => string | null;
 }
 
 function createTestSetup(opts?: {
@@ -156,8 +157,12 @@ function createTestSetup(opts?: {
   projects?: ProjectEntry[];
 }): TestSetup {
   const projects = opts?.projects ?? [createTestProject()];
+  let activePath: string | null = opts?.initialActive ?? null;
+  const setActiveWorkspace = vi.fn((path: string | null) => {
+    activePath = path;
+  });
   const viewManager = createMockViewManager({
-    initialActiveWorkspace: opts?.initialActive ?? null,
+    overrides: { setActiveWorkspace },
   });
   const appState = createMockAppState(projects);
 
@@ -167,7 +172,7 @@ function createTestSetup(opts?: {
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
 
-  // ResolveModule: "resolve" hook -- resolves workspacePath → projectPath + workspaceName
+  // ResolveModule: "resolve" hook -- resolves workspacePath → projectPath + workspaceName + active
   const resolveModule: IntentModule = {
     name: "test",
     hooks: {
@@ -179,7 +184,11 @@ function createTestSetup(opts?: {
             for (const project of appState.projects) {
               const workspace = project.workspaces.find((w) => w.path === wsPath);
               if (workspace) {
-                return { projectPath: project.path, workspaceName: extractWorkspaceName(wsPath) };
+                return {
+                  projectPath: project.path,
+                  workspaceName: extractWorkspaceName(wsPath),
+                  active: activePath === wsPath,
+                };
               }
             }
             return {};
@@ -214,10 +223,10 @@ function createTestSetup(opts?: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ActivateHookInput;
+            const { workspacePath, active } = ctx as ActivateHookInput;
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
-            if (viewManager.getActiveWorkspacePath() === workspacePath) {
+            if (active) {
               return {};
             }
 
@@ -294,6 +303,7 @@ function createTestSetup(opts?: {
     dispatcher,
     viewManager,
     appState,
+    getActivePath: () => activePath,
   };
 }
 
@@ -329,11 +339,11 @@ describe("SwitchWorkspace Operation", () => {
     });
 
     it("sets viewManager activeWorkspacePath to resolved path", async () => {
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       await dispatcher.dispatch(switchIntent());
 
-      expect(viewManager.getActiveWorkspacePath()).toBe(TEST_WORKSPACE_PATH);
+      expect(getActivePath()).toBe(TEST_WORKSPACE_PATH);
     });
   });
 
@@ -387,31 +397,31 @@ describe("SwitchWorkspace Operation", () => {
   describe("throws when workspace not found (#5)", () => {
     it("rejects with error and leaves activeWorkspacePath unchanged", async () => {
       const setup = createTestSetup();
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       await expect(
         dispatcher.dispatch(switchIntent("/projects/my-app/workspaces/nonexistent"))
       ).rejects.toThrow("Workspace not found: /projects/my-app/workspaces/nonexistent");
 
-      expect(viewManager.getActiveWorkspacePath()).toBeNull();
+      expect(getActivePath()).toBeNull();
     });
 
     it("rejects when project not found", async () => {
       const setup = createTestSetup();
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       await expect(
         dispatcher.dispatch(switchIntent("/nonexistent/workspaces/feature-login"))
       ).rejects.toThrow("Workspace not found: /nonexistent/workspaces/feature-login");
 
-      expect(viewManager.getActiveWorkspacePath()).toBeNull();
+      expect(getActivePath()).toBeNull();
     });
   });
 
   describe("no-op when switching to already-active workspace (#6)", () => {
     it("does not emit event and leaves activeWorkspacePath unchanged", async () => {
       const setup = createTestSetup({ initialActive: TEST_WORKSPACE_PATH });
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       const receivedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
@@ -420,7 +430,7 @@ describe("SwitchWorkspace Operation", () => {
 
       await dispatcher.dispatch(switchIntent());
 
-      expect(viewManager.getActiveWorkspacePath()).toBe(TEST_WORKSPACE_PATH);
+      expect(getActivePath()).toBe(TEST_WORKSPACE_PATH);
       expect(receivedEvents).toHaveLength(0);
     });
   });
@@ -428,7 +438,7 @@ describe("SwitchWorkspace Operation", () => {
   describe("bridge handler defaults focus (#7)", () => {
     it("dispatches with focus defaulting to true when omitted", async () => {
       const setup = createTestSetup();
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, viewManager, getActivePath } = setup;
 
       // Simulate what the bridge handler does: no focus field in payload
       const intent: SwitchWorkspaceIntent = {
@@ -439,7 +449,7 @@ describe("SwitchWorkspace Operation", () => {
       };
       await dispatcher.dispatch(intent);
 
-      expect(viewManager.getActiveWorkspacePath()).toBe(TEST_WORKSPACE_PATH);
+      expect(getActivePath()).toBe(TEST_WORKSPACE_PATH);
       expect(viewManager.setActiveWorkspace).toHaveBeenLastCalledWith(TEST_WORKSPACE_PATH, true);
     });
   });
@@ -447,7 +457,7 @@ describe("SwitchWorkspace Operation", () => {
   describe("interceptor cancellation prevents operation and event (#11)", () => {
     it("does not run operation and does not emit event", async () => {
       const setup = createTestSetup();
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       const receivedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
@@ -465,7 +475,7 @@ describe("SwitchWorkspace Operation", () => {
       const result = await dispatcher.dispatch(switchIntent());
 
       expect(result).toBeUndefined();
-      expect(viewManager.getActiveWorkspacePath()).toBeNull();
+      expect(getActivePath()).toBeNull();
       expect(receivedEvents).toHaveLength(0);
     });
   });
@@ -476,7 +486,7 @@ describe("SwitchWorkspace Operation", () => {
         withAutoSelect: true,
         projects: [createMultiWorkspaceProject()],
       });
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
@@ -484,7 +494,7 @@ describe("SwitchWorkspace Operation", () => {
       };
       await dispatcher.dispatch(autoIntent);
 
-      expect(viewManager.getActiveWorkspacePath()).toBe(TEST_WORKSPACE_PATH_B);
+      expect(getActivePath()).toBe(TEST_WORKSPACE_PATH_B);
     });
   });
 
@@ -494,7 +504,7 @@ describe("SwitchWorkspace Operation", () => {
         withAutoSelect: true,
         projects: [createTestProject()], // only one workspace (the current one)
       });
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       const receivedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
@@ -507,7 +517,7 @@ describe("SwitchWorkspace Operation", () => {
       };
       await dispatcher.dispatch(autoIntent);
 
-      expect(viewManager.getActiveWorkspacePath()).toBeNull();
+      expect(getActivePath()).toBeNull();
       expect(receivedEvents).toHaveLength(1);
       expect((receivedEvents[0] as WorkspaceSwitchedEvent).payload).toBeNull();
     });
@@ -519,7 +529,7 @@ describe("SwitchWorkspace Operation", () => {
         withAutoSelect: true,
         projects: [], // no projects at all
       });
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       const receivedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
@@ -532,7 +542,7 @@ describe("SwitchWorkspace Operation", () => {
       };
       await dispatcher.dispatch(autoIntent);
 
-      expect(viewManager.getActiveWorkspacePath()).toBeNull();
+      expect(getActivePath()).toBeNull();
       expect(receivedEvents).toHaveLength(1);
       expect((receivedEvents[0] as WorkspaceSwitchedEvent).payload).toBeNull();
     });
@@ -544,7 +554,7 @@ describe("SwitchWorkspace Operation", () => {
         withAutoSelect: true,
         projects: [createMultiWorkspaceProject()],
       });
-      const { dispatcher, viewManager } = setup;
+      const { dispatcher, getActivePath } = setup;
 
       // currentPath doesn't match any candidate (workspace already de-registered)
       const autoIntent: SwitchWorkspaceIntent = {
@@ -554,7 +564,7 @@ describe("SwitchWorkspace Operation", () => {
       await dispatcher.dispatch(autoIntent);
 
       // Should still switch to a valid workspace instead of null
-      expect(viewManager.getActiveWorkspacePath()).not.toBeNull();
+      expect(getActivePath()).not.toBeNull();
     });
   });
 });

--- a/src/intents/switch-workspace.ts
+++ b/src/intents/switch-workspace.ts
@@ -92,6 +92,7 @@ export const SWITCH_WORKSPACE_OPERATION_ID = "switch-workspace";
 /** Input context for the "activate" hook point. */
 export interface ActivateHookInput extends HookContext {
   readonly workspacePath: string;
+  readonly active: boolean;
 }
 
 /**
@@ -240,7 +241,7 @@ export class SwitchWorkspaceOperation implements Operation<SwitchWorkspaceIntent
     payload: SwitchWorkspaceTargetPayload
   ): Promise<void> {
     // 1. Dispatch shared workspace resolution
-    const { projectPath, workspaceName } = await ctx.dispatch({
+    const { projectPath, workspaceName, active } = await ctx.dispatch({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath: payload.workspacePath },
     } as ResolveWorkspaceIntent);
@@ -255,6 +256,7 @@ export class SwitchWorkspaceOperation implements Operation<SwitchWorkspaceIntent
     const activateCtx: ActivateHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
+      active,
     };
     const { results: activateResults, errors: activateErrors } =
       await ctx.hooks.collect<SwitchWorkspaceHookResult>("activate", activateCtx);

--- a/src/intents/update-agent-status.integration.test.ts
+++ b/src/intents/update-agent-status.integration.test.ts
@@ -126,9 +126,10 @@ describe("UpdateAgentStatus Operation", () => {
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
       expect(event.type).toBe(EVENT_AGENT_STATUS_UPDATED);
-      expect(event.payload.workspacePath).toBe("/workspace/test");
-      expect(event.payload.projectId).toBe(TEST_PROJECT_ID);
-      expect(event.payload.workspaceName).toBe(TEST_WORKSPACE_NAME);
+      expect(event.payload.workspace.path).toBe("/workspace/test");
+      expect(event.payload.workspace.projectId).toBe(TEST_PROJECT_ID);
+      expect(event.payload.workspace.name).toBe(TEST_WORKSPACE_NAME);
+      expect(event.payload.workspace.active).toBe(false);
       expect(event.payload.status).toEqual(status);
     });
 
@@ -144,7 +145,7 @@ describe("UpdateAgentStatus Operation", () => {
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
-      expect(event.payload.workspacePath).toBe("/workspace/idle-test");
+      expect(event.payload.workspace.path).toBe("/workspace/idle-test");
       expect(event.payload.status).toEqual(status);
     });
 

--- a/src/intents/update-agent-status.ts
+++ b/src/intents/update-agent-status.ts
@@ -35,10 +35,15 @@ export const INTENT_UPDATE_AGENT_STATUS = "agent:update-status" as const;
 // Event Types
 // =============================================================================
 
-export interface AgentStatusUpdatedPayload {
-  readonly workspacePath: WorkspacePath;
+export interface AgentStatusUpdatedWorkspaceRef {
+  readonly path: WorkspacePath;
   readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
+  readonly name: WorkspaceName;
+  readonly active: boolean;
+}
+
+export interface AgentStatusUpdatedPayload {
+  readonly workspace: AgentStatusUpdatedWorkspaceRef;
   readonly status: AggregatedAgentStatus;
 }
 
@@ -65,8 +70,9 @@ export class UpdateAgentStatusOperation implements Operation<UpdateAgentStatusIn
     let projectPath: string;
     let workspaceName: WorkspaceName;
     let projectId: ProjectId;
+    let active: boolean;
     try {
-      ({ projectPath, workspaceName } = await ctx.dispatch({
+      ({ projectPath, workspaceName, active } = await ctx.dispatch({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: payload.workspacePath },
       } as ResolveWorkspaceIntent));
@@ -82,9 +88,12 @@ export class UpdateAgentStatusOperation implements Operation<UpdateAgentStatusIn
     const event: AgentStatusUpdatedEvent = {
       type: EVENT_AGENT_STATUS_UPDATED,
       payload: {
-        workspacePath: payload.workspacePath,
-        projectId,
-        workspaceName,
+        workspace: {
+          path: payload.workspacePath,
+          projectId,
+          name: workspaceName,
+          active,
+        },
         status: payload.status,
       },
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -718,10 +718,10 @@ const focusTerminal = (workspacePath: string): void => {
 
 dispatcher.subscribe(EVENT_AGENT_STATUS_UPDATED, (event) => {
   const payload = (event as AgentStatusUpdatedEvent).payload;
-  if (firstFocused.has(payload.workspacePath)) return;
+  if (firstFocused.has(payload.workspace.path)) return;
   if (payload.status.status !== "idle") return;
-  if (viewManager.getActiveWorkspacePath() !== payload.workspacePath) return;
-  focusTerminal(payload.workspacePath);
+  if (!payload.workspace.active) return;
+  focusTerminal(payload.workspace.path);
 });
 
 dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -290,6 +290,7 @@ class MinimalShutdownOperation implements Operation<
       intent: ctx.intent,
       projectPath: "/test/project",
       workspacePath: payload.workspacePath ?? "/test/workspace",
+      active: false,
       ...(this.agentCapability !== null && {
         capabilities: { agent: this.agentCapability },
       }),

--- a/src/modules/badge-module.ts
+++ b/src/modules/badge-module.ts
@@ -425,8 +425,8 @@ export function createBadgeModule(deps: BadgeModuleDeps): IntentModule {
     events: {
       [EVENT_AGENT_STATUS_UPDATED]: {
         handler: async (event: DomainEvent): Promise<void> => {
-          const { workspacePath, status } = (event as AgentStatusUpdatedEvent).payload;
-          workspaceStatuses.set(workspacePath, status);
+          const { workspace, status } = (event as AgentStatusUpdatedEvent).payload;
+          workspaceStatuses.set(workspace.path, status);
           updateBadge();
         },
       },

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -183,6 +183,7 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteH
       intent: ctx.intent,
       projectPath: "/projects/test",
       workspacePath: payload.workspacePath ?? "",
+      active: false,
     };
     const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);
     if (errors.length > 0) throw errors[0]!;

--- a/src/modules/devtools-module.integration.test.ts
+++ b/src/modules/devtools-module.integration.test.ts
@@ -34,14 +34,11 @@ function createDevtoolsTarget(id: string) {
 function createMockDeps() {
   const uiTarget = createDevtoolsTarget("ui-view");
   const wsTarget = createDevtoolsTarget("ws-view");
-  let activePath: string | null = "/test/workspace";
+  let hasActive = true;
 
   const viewManager = {
     getUIDevtoolsTarget: vi.fn(() => uiTarget),
-    getWorkspaceDevtoolsTarget: vi.fn((path: string) =>
-      path === activePath ? wsTarget : undefined
-    ),
-    getActiveWorkspacePath: vi.fn(() => activePath),
+    getActiveWorkspaceDevtoolsTarget: vi.fn(() => (hasActive ? wsTarget : undefined)),
   };
 
   return {
@@ -49,7 +46,7 @@ function createMockDeps() {
     uiTarget,
     wsTarget,
     _setActivePath(path: string | null) {
-      activePath = path;
+      hasActive = path !== null;
     },
   };
 }

--- a/src/modules/devtools-module.ts
+++ b/src/modules/devtools-module.ts
@@ -14,7 +14,7 @@ import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../int
 export interface DevtoolsModuleDeps {
   readonly viewManager: Pick<
     IViewManager,
-    "getUIDevtoolsTarget" | "getWorkspaceDevtoolsTarget" | "getActiveWorkspacePath"
+    "getUIDevtoolsTarget" | "getActiveWorkspaceDevtoolsTarget"
   >;
 }
 
@@ -33,10 +33,7 @@ export function createDevtoolsModule(deps: DevtoolsModuleDeps): IntentModule {
           }
 
           if (key === "w") {
-            const activePath = deps.viewManager.getActiveWorkspacePath();
-            if (activePath) {
-              deps.viewManager.getWorkspaceDevtoolsTarget(activePath)?.toggle();
-            }
+            deps.viewManager.getActiveWorkspaceDevtoolsTarget()?.toggle();
           }
         },
       },

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -139,6 +139,7 @@ class MinimalPreflightOperation implements Operation<DeleteWorkspaceIntent, Pref
       intent: ctx.intent,
       projectPath: resolvedProjectPath,
       workspacePath: payload.workspacePath,
+      active: false,
     };
     const { results, errors } = await ctx.hooks.collect<PreflightHookResult>(
       "preflight",
@@ -180,6 +181,7 @@ class MinimalDeleteWorkspaceOperation implements Operation<DeleteWorkspaceIntent
       intent: ctx.intent,
       projectPath: resolvedProjectPath,
       workspacePath: payload.workspacePath,
+      active: false,
     };
     const { results: deleteResults, errors: deleteErrors } =
       await ctx.hooks.collect<DeleteHookResult>("delete", deleteInput);

--- a/src/modules/plugin-server-module.integration.test.ts
+++ b/src/modules/plugin-server-module.integration.test.ts
@@ -75,6 +75,7 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteH
       intent: ctx.intent,
       projectPath: "/projects/test",
       workspacePath: payload.workspacePath ?? "",
+      active: false,
     };
     const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);
     if (errors.length > 0) throw errors[0]!;

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -290,12 +290,8 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
     },
     [EVENT_AGENT_STATUS_UPDATED]: {
       handler: async (event: DomainEvent): Promise<void> => {
-        const {
-          workspacePath,
-          projectId,
-          workspaceName,
-          status: aggregatedStatus,
-        } = (event as AgentStatusUpdatedEvent).payload;
+        const { workspace, status: aggregatedStatus } = (event as AgentStatusUpdatedEvent).payload;
+        const { path: workspacePath, projectId, name: workspaceName } = workspace;
 
         const status: WorkspaceStatus =
           aggregatedStatus.status === "none"

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -172,11 +172,13 @@ class MinimalAgentSelectionOperation implements Operation<SetupIntent, AgentSele
 /** Runs "activate" hook point + emits workspace:switched event. */
 class MinimalSwitchOperation implements Operation<SwitchWorkspaceIntent, void> {
   readonly id = SWITCH_WORKSPACE_OPERATION_ID;
+  constructor(private readonly active: boolean = false) {}
   async execute(ctx: OperationContext<SwitchWorkspaceIntent>): Promise<void> {
     const workspacePath = (ctx.intent.payload as { workspacePath: string }).workspacePath;
     const activateCtx: ActivateHookInput = {
       intent: ctx.intent,
       workspacePath,
+      active: this.active,
     };
     const { results, errors } = await ctx.hooks.collect<SwitchWorkspaceHookResult>(
       "activate",
@@ -208,12 +210,14 @@ class MinimalSwitchOperation implements Operation<SwitchWorkspaceIntent, void> {
 /** Runs "shutdown" hook point only. */
 class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, ShutdownHookResult> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
+  constructor(private readonly active: boolean = false) {}
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<ShutdownHookResult> {
     const { payload } = ctx.intent;
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
       projectPath: "/projects/test",
       workspacePath: payload.workspacePath,
+      active: this.active,
     };
     const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", hookCtx);
     if (errors.length > 0) throw errors[0]!;
@@ -513,11 +517,8 @@ describe("ViewModule Integration", () => {
     it("destroys workspace view and returns wasActive", async () => {
       const { dispatcher, viewManager } = createTestSetup({
         intentType: INTENT_DELETE_WORKSPACE,
-        operation: new MinimalDeleteOperation(),
+        operation: new MinimalDeleteOperation(true),
       });
-
-      // Mark workspace as active
-      viewManager.setActiveWorkspace("/workspaces/ws1", false);
 
       const result = await dispatcher.dispatch({
         type: INTENT_DELETE_WORKSPACE,
@@ -586,12 +587,8 @@ describe("ViewModule Integration", () => {
     it("does not call setActiveWorkspace when already active", async () => {
       const { dispatcher, viewManager } = createTestSetup({
         intentType: INTENT_SWITCH_WORKSPACE,
-        operation: new MinimalSwitchOperation(),
+        operation: new MinimalSwitchOperation(true),
       });
-
-      // Set workspace as already active, then clear the spy's call history
-      viewManager.setActiveWorkspace("/workspaces/ws1", false);
-      (viewManager.setActiveWorkspace as ReturnType<typeof vi.fn>).mockClear();
 
       await dispatcher.dispatch({
         type: INTENT_SWITCH_WORKSPACE,
@@ -771,9 +768,12 @@ describe("ViewModule Integration", () => {
           const event: AgentStatusUpdatedEvent = {
             type: EVENT_AGENT_STATUS_UPDATED,
             payload: {
-              workspacePath: "/workspaces/ws1" as WorkspacePath,
-              projectId: "test-project" as ProjectId,
-              workspaceName: "ws1" as WorkspaceName,
+              workspace: {
+                path: "/workspaces/ws1" as WorkspacePath,
+                projectId: "test-project" as ProjectId,
+                name: "ws1" as WorkspaceName,
+                active: false,
+              },
               status: { status: "idle" } as AggregatedAgentStatus,
             },
           };

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -71,6 +71,11 @@ import { GET_ACTIVE_WORKSPACE_OPERATION_ID } from "../intents/get-active-workspa
 import { SWITCH_WORKSPACE_OPERATION_ID } from "../intents/switch-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
 import {
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  type ResolveHookInput,
+  type ResolveHookResult,
+} from "../intents/resolve-workspace";
+import {
   EVENT_WORKSPACE_CREATED,
   EVENT_WORKSPACE_LOADING,
   EVENT_WORKSPACE_CREATE_FAILED,
@@ -154,21 +159,20 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
 
   /**
    * Shared shutdown logic for workspace teardown (used by delete + hibernate).
-   * Returns { wasActive, error } and never throws. Callers decide whether to
-   * propagate the error (delete in non-force mode does; hibernate doesn't).
+   * Returns { error } and never throws. Callers decide whether to propagate
+   * the error (delete in non-force mode does; hibernate doesn't).
    */
   async function tearDownWorkspaceView(
     workspacePath: string,
     logTag: string
-  ): Promise<{ wasActive: boolean; error?: string }> {
-    const wasActive = viewManager.getActiveWorkspacePath() === workspacePath;
+  ): Promise<{ error?: string }> {
     try {
       await viewManager.destroyWorkspaceView(workspacePath);
-      return { wasActive };
+      return {};
     } catch (error) {
       const message = getErrorMessage(error);
       logger.warn(`ViewModule: ${logTag} error`, { error: message });
-      return { wasActive, error: message };
+      return { error: message };
     }
   }
 
@@ -538,6 +542,18 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       },
 
       // -------------------------------------------------------------------
+      // resolve-workspace → resolve: contribute `active` snapshot
+      // -------------------------------------------------------------------
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+            const { workspacePath } = ctx as ResolveHookInput;
+            return { active: cachedActiveRef?.path === workspacePath };
+          },
+        },
+      },
+
+      // -------------------------------------------------------------------
       // get-active-workspace → get: return cached active ref
       // -------------------------------------------------------------------
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
@@ -554,10 +570,10 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ActivateHookInput;
+            const { workspacePath, active } = ctx as ActivateHookInput;
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
-            if (viewManager.getActiveWorkspacePath() === workspacePath) {
+            if (active) {
               return {};
             }
 
@@ -574,14 +590,14 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
-            const { workspacePath } = ctx as DeletePipelineHookInput;
+            const { workspacePath, active } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             const result = await tearDownWorkspaceView(workspacePath, "delete shutdown");
             if (result.error && !payload.force) {
               throw new Error(result.error);
             }
             return {
-              ...(result.wasActive && { wasActive: true }),
+              ...(active && { wasActive: true }),
               ...(result.error && { error: result.error }),
             };
           },
@@ -596,9 +612,9 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<HibernateShutdownHookResult> => {
-            const { workspacePath } = ctx as HibernatePipelineHookInput;
-            const result = await tearDownWorkspaceView(workspacePath, "hibernate shutdown");
-            return result.wasActive ? { wasActive: true } : {};
+            const { workspacePath, active } = ctx as HibernatePipelineHookInput;
+            await tearDownWorkspaceView(workspacePath, "hibernate shutdown");
+            return active ? { wasActive: true } : {};
           },
         },
       },
@@ -890,7 +906,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [EVENT_AGENT_STATUS_UPDATED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as AgentStatusUpdatedEvent).payload;
-          viewManager.setWorkspaceLoaded(payload.workspacePath);
+          viewManager.setWorkspaceLoaded(payload.workspace.path);
           closeStartupSplash();
         },
       },

--- a/src/modules/windows-file-lock-module.integration.test.ts
+++ b/src/modules/windows-file-lock-module.integration.test.ts
@@ -115,6 +115,7 @@ class FlushOperation implements Operation<Intent, FlushHookResult> {
       intent: ctx.intent,
       projectPath: "/projects/my-app",
       workspacePath: "/workspaces/feature-1",
+      active: false,
       blockingPids: this.blockingPids,
     };
     const { results, errors } = await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);

--- a/src/modules/workspace-selection-module.integration.test.ts
+++ b/src/modules/workspace-selection-module.integration.test.ts
@@ -223,9 +223,12 @@ describe("WorkspaceSelectionModule", () => {
         const event: AgentStatusUpdatedEvent = {
           type: EVENT_AGENT_STATUS_UPDATED,
           payload: {
-            workspacePath: wsPath as WorkspacePath,
-            projectId,
-            workspaceName: extractWorkspaceName(wsPath) as WorkspaceName,
+            workspace: {
+              path: wsPath as WorkspacePath,
+              projectId,
+              name: extractWorkspaceName(wsPath) as WorkspaceName,
+              active: false,
+            },
             status,
           },
         };

--- a/src/modules/workspace-selection-module.ts
+++ b/src/modules/workspace-selection-module.ts
@@ -55,8 +55,8 @@ export function createWorkspaceSelectionModule(): IntentModule {
     events: {
       [EVENT_AGENT_STATUS_UPDATED]: {
         handler: async (event: DomainEvent) => {
-          const { workspacePath, status } = (event as AgentStatusUpdatedEvent).payload;
-          workspaceStatuses.set(workspacePath, status);
+          const { workspace, status } = (event as AgentStatusUpdatedEvent).payload;
+          workspaceStatuses.set(workspace.path, status);
         },
       },
       [EVENT_WORKSPACE_DELETED]: {


### PR DESCRIPTION
- Add `active: boolean` to `ResolveWorkspaceResult`, contributed by a new view-module resolve hook
- Thread `active` through switch/delete/hibernate pipeline ctx; view-module handlers no longer query `viewManager.getActiveWorkspacePath()`
- Reshape `AgentStatusUpdatedPayload` to `{ workspace: { path, projectId, name, active }, status }` so the agent-status subscriber gates on `active` without an extra dispatch (IPC contract unchanged)
- Replace `getWorkspaceDevtoolsTarget(path)` with `getActiveWorkspaceDevtoolsTarget()` and remove `getActiveWorkspacePath` from `IViewManager`