### PR TITLE
feat: faster workspace hibernation

### DIFF
--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -2,9 +2,10 @@
  * Smoke integration tests for HibernateWorkspaceOperation and
  * WakeWorkspaceOperation.
  *
- * Verifies the orchestration: resolve → capture → shutdown → set-metadata for
- * hibernate; resolve → set-metadata → cleanup for wake. Uses minimal stub
- * modules that record interactions; no provider boundaries are exercised.
+ * Hibernate splits foreground (resolve → capture → set-metadata → optional
+ * switch) from background (shutdown → release → emit hibernated). Uses
+ * minimal stub modules that record interactions; no provider boundaries
+ * are exercised.
  */
 
 import { createMockDispatcher } from "./lib/dispatcher.test-utils";
@@ -54,6 +55,11 @@ import {
   EVENT_METADATA_CHANGED,
   type MetadataChangedEvent,
 } from "./set-metadata";
+import {
+  SwitchWorkspaceOperation,
+  INTENT_SWITCH_WORKSPACE,
+  SWITCH_WORKSPACE_OPERATION_ID,
+} from "./switch-workspace";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
 const PROJECT_PATH = "/test/project";
@@ -66,6 +72,7 @@ interface Recorder {
   shutdownCalled: boolean;
   releaseCalled: boolean;
   cleanupCalled: boolean;
+  switchCalled: boolean;
   callOrder: string[];
   metadataWrites: Array<{ key: string; value: string | null }>;
   events: DomainEvent[];
@@ -77,13 +84,14 @@ function createRecorder(): Recorder {
     shutdownCalled: false,
     releaseCalled: false,
     cleanupCalled: false,
+    switchCalled: false,
     callOrder: [],
     metadataWrites: [],
     events: [],
   };
 }
 
-function createResolveModule(): IntentModule {
+function createResolveModule(active: boolean): IntentModule {
   return {
     name: "test-resolve",
     hooks: {
@@ -92,6 +100,7 @@ function createResolveModule(): IntentModule {
           handler: async (): Promise<ResolveWorkspaceHookResult> => ({
             projectPath: PROJECT_PATH,
             workspaceName: WORKSPACE_NAME,
+            active,
           }),
         },
       },
@@ -119,6 +128,24 @@ function createMetadataModule(recorder: Recorder): IntentModule {
               key: intent.payload.key,
               value: intent.payload.value,
             });
+            recorder.callOrder.push(`set-metadata:${intent.payload.value ?? "null"}`);
+          },
+        },
+      },
+    },
+  };
+}
+
+function createSwitchModule(recorder: Recorder): IntentModule {
+  return {
+    name: "test-switch",
+    hooks: {
+      [SWITCH_WORKSPACE_OPERATION_ID]: {
+        activate: {
+          handler: async (): Promise<Record<string, never>> => {
+            recorder.switchCalled = true;
+            recorder.callOrder.push("switch");
+            return {};
           },
         },
       },
@@ -128,7 +155,10 @@ function createMetadataModule(recorder: Recorder): IntentModule {
 
 function createHibernateHookModule(
   recorder: Recorder,
-  opts: { wasActive?: boolean; releaseThrows?: boolean } = {}
+  opts: {
+    releaseThrows?: boolean;
+    shutdownGate?: Promise<void>;
+  } = {}
 ): IntentModule {
   return {
     name: "test-hibernate-hooks",
@@ -146,9 +176,12 @@ function createHibernateHookModule(
         },
         shutdown: {
           handler: async (): Promise<HibernateShutdownHookResult> => {
+            if (opts.shutdownGate) {
+              await opts.shutdownGate;
+            }
             recorder.shutdownCalled = true;
             recorder.callOrder.push("shutdown");
-            return opts.wasActive ? { wasActive: true } : {};
+            return {};
           },
         },
         release: {
@@ -186,9 +219,17 @@ function createWakeHookModule(recorder: Recorder): IntentModule {
   };
 }
 
-function buildHarness(buildHookModules: (recorder: Recorder) => IntentModule[]): {
+interface HarnessOpts {
+  active?: boolean;
+}
+
+function buildHarness(
+  buildHookModules: (recorder: Recorder) => IntentModule[],
+  opts: HarnessOpts = {}
+): {
   dispatcher: Dispatcher;
   recorder: Recorder;
+  waitForBackground: () => Promise<void>;
 } {
   const recorder = createRecorder();
   const dispatcher = createMockDispatcher();
@@ -196,11 +237,13 @@ function buildHarness(buildHookModules: (recorder: Recorder) => IntentModule[]):
   dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
   dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
+  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
   dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());
   dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, new WakeWorkspaceOperation());
 
-  dispatcher.registerModule(createResolveModule());
+  dispatcher.registerModule(createResolveModule(opts.active ?? false));
   dispatcher.registerModule(createMetadataModule(recorder));
+  dispatcher.registerModule(createSwitchModule(recorder));
   for (const m of buildHookModules(recorder)) dispatcher.registerModule(m);
 
   for (const t of [
@@ -214,23 +257,35 @@ function buildHarness(buildHookModules: (recorder: Recorder) => IntentModule[]):
     });
   }
 
-  return { dispatcher, recorder };
+  // Register the backgroundDone resolver AFTER the recorder subscriber so it
+  // fires last in the collect loop — guarantees recorder.events has the
+  // hibernated event by the time waitForBackground() resolves.
+  const backgroundDone = new Promise<void>((resolve) => {
+    dispatcher.subscribe(EVENT_WORKSPACE_HIBERNATED, () => resolve());
+  });
+
+  return { dispatcher, recorder, waitForBackground: () => backgroundDone };
 }
 
 describe("workspace:hibernate", () => {
-  it("runs capture + shutdown + release, persists hibernated metadata, emits hibernated event", async () => {
-    const { dispatcher, recorder } = buildHarness((r) => [createHibernateHookModule(r)]);
+  it("runs full pipeline, persists hibernated metadata, emits hibernated event", async () => {
+    const { dispatcher, recorder, waitForBackground } = buildHarness((r) => [
+      createHibernateHookModule(r),
+    ]);
 
     const intent: HibernateWorkspaceIntent = {
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
     };
     await dispatcher.dispatch(intent);
+    await waitForBackground();
 
     expect(recorder.captureCalled).toBe(true);
     expect(recorder.shutdownCalled).toBe(true);
     expect(recorder.releaseCalled).toBe(true);
-    expect(recorder.callOrder).toEqual(["capture", "shutdown", "release"]);
+    expect(recorder.switchCalled).toBe(false);
+    // Foreground: capture → set-metadata. Background: shutdown → release.
+    expect(recorder.callOrder).toEqual(["capture", "set-metadata:true", "shutdown", "release"]);
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
 
     const hibernated = recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED);
@@ -246,8 +301,59 @@ describe("workspace:hibernate", () => {
     expect(metadataChanged?.payload.value).toBe("true");
   });
 
-  it("tolerates shutdown errors (silent-on-busy semantics)", async () => {
-    const { dispatcher, recorder } = buildHarness(() => [
+  it("dispatches switch in foreground when the workspace was active", async () => {
+    const { dispatcher, recorder, waitForBackground } = buildHarness(
+      (r) => [createHibernateHookModule(r)],
+      { active: true }
+    );
+
+    await dispatcher.dispatch({
+      type: INTENT_HIBERNATE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    } as HibernateWorkspaceIntent);
+    await waitForBackground();
+
+    // Switch happened in foreground, between set-metadata and shutdown.
+    expect(recorder.callOrder).toEqual([
+      "capture",
+      "set-metadata:true",
+      "switch",
+      "shutdown",
+      "release",
+    ]);
+  });
+
+  it("flips hibernated metadata before background shutdown runs", async () => {
+    let releaseShutdown: () => void = () => {};
+    const shutdownGate = new Promise<void>((resolve) => {
+      releaseShutdown = resolve;
+    });
+
+    const { dispatcher, recorder, waitForBackground } = buildHarness((r) => [
+      createHibernateHookModule(r, { shutdownGate }),
+    ]);
+
+    await dispatcher.dispatch({
+      type: INTENT_HIBERNATE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    } as HibernateWorkspaceIntent);
+
+    // Foreground done: metadata flipped, no shutdown yet.
+    expect(recorder.callOrder).toEqual(["capture", "set-metadata:true"]);
+    expect(recorder.shutdownCalled).toBe(false);
+    expect(recorder.releaseCalled).toBe(false);
+    expect(recorder.events.find((e) => e.type === EVENT_METADATA_CHANGED)).toBeDefined();
+    expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeUndefined();
+
+    releaseShutdown();
+    await waitForBackground();
+
+    expect(recorder.callOrder).toEqual(["capture", "set-metadata:true", "shutdown", "release"]);
+    expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
+  });
+
+  it("tolerates shutdown handlers that return empty", async () => {
+    const { dispatcher, recorder, waitForBackground } = buildHarness(() => [
       {
         name: "tolerant-hibernate-hooks",
         hooks: {
@@ -256,8 +362,6 @@ describe("workspace:hibernate", () => {
               handler: async (): Promise<CaptureHookResult> => ({ captured: false }),
             },
             shutdown: {
-              // Real shutdown handlers swallow errors and return wasActive only;
-              // simulate that here to confirm the operation still completes.
               handler: async (): Promise<HibernateShutdownHookResult> => ({}),
             },
           },
@@ -265,11 +369,11 @@ describe("workspace:hibernate", () => {
       },
     ]);
 
-    const intent: HibernateWorkspaceIntent = {
+    await dispatcher.dispatch({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    };
-    await dispatcher.dispatch(intent);
+    } as HibernateWorkspaceIntent);
+    await waitForBackground();
 
     expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
     expect(
@@ -279,18 +383,21 @@ describe("workspace:hibernate", () => {
   });
 
   it("hibernate completes when release throws (best-effort)", async () => {
-    const { dispatcher, recorder } = buildHarness((r) => [
+    const { dispatcher, recorder, waitForBackground } = buildHarness((r) => [
       createHibernateHookModule(r, { releaseThrows: true }),
     ]);
 
-    const intent: HibernateWorkspaceIntent = {
+    await dispatcher.dispatch({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    };
-    await dispatcher.dispatch(intent);
+    } as HibernateWorkspaceIntent);
+    await waitForBackground();
 
     expect(recorder.releaseCalled).toBe(true);
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
+    // Background failures no longer surface as hibernate-failed — the user
+    // already saw the overlay flip in the foreground. workspace:hibernated
+    // still fires so the dispatcher's idempotency lock is released.
     expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
     expect(
       recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATE_FAILED)

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -2,15 +2,33 @@
  * HibernateWorkspaceOperation - Tears down a workspace's view + agent server
  * while preserving the worktree, branch, and uncommitted changes.
  *
- * Steps:
- * 1. Dispatch workspace:resolve — workspacePath → projectPath + workspaceName
+ * Pipeline is split so the renderer flips to a pending hibernation overlay as
+ * soon as the screenshot is on disk; the slow teardown runs in the background:
+ *
+ * Foreground (awaited by callers, ~500 ms):
+ * 1. Dispatch workspace:resolve — yields projectPath, workspaceName, active
  * 2. Dispatch project:resolve — projectPath → projectId
- * 3. "capture" hook — best-effort screenshot capture (view-module + screenshot persistence)
- * 4. "shutdown" hook — same handlers as workspace:delete shutdown:
- *    view-module destroys the view, agent-module stops the agent server.
- * 5. Dispatch workspace:set-metadata to persist `hibernated="true"`
- * 6. Emit workspace:hibernated (NOT workspace:deleted — workspace stays in
- *    sidebar/state).
+ * 3. "capture" hook — best-effort screenshot capture
+ * 4. Dispatch workspace:set-metadata to persist `hibernated="true"` (this is
+ *    what makes the renderer show HibernatedOverlay; switch-workspace's
+ *    `c.hibernated` filter also begins excluding the workspace immediately)
+ * 5. If active, dispatch workspace:switch so the user is moved to an awake
+ *    sibling without waiting for the background teardown
+ *
+ * Background (fire-and-forget):
+ * 6. "shutdown" hook — view-module destroys the view, agent-module stops the
+ *    agent server
+ * 7. "release" hook — best-effort kill of CWD-rooted processes (Windows
+ *    file-lock cleanup; multi-second PowerShell scan)
+ * 8. Emit workspace:hibernated (always, via finally) so the dispatcher's
+ *    idempotency interceptor releases the per-workspace lock and the renderer
+ *    clears its pending entry
+ *
+ * Background failures are logged only — the user already saw the overlay
+ * flip and re-emitting workspace:hibernate-failed at this point would be
+ * misleading. The renderer's wake button is hidden while pending, so the
+ * teardown does not race a wake intent (only entry point for wake is the
+ * renderer's WORKSPACE_WAKE IPC).
  *
  * Intentionally does NOT emit workspace:deleted — consumers (sidebar,
  * workspace-selection-module, badge-module, etc.) should not evict the
@@ -32,8 +50,6 @@ import { getErrorMessage } from "../shared/error-utils";
 
 export interface HibernateWorkspacePayload {
   readonly workspacePath: string;
-  /** If true, do not auto-switch to another workspace when hibernating the active one. */
-  readonly skipSwitch?: boolean;
 }
 
 export interface HibernateWorkspaceIntent extends Intent<{ started: true }> {
@@ -82,7 +98,7 @@ export const EVENT_WORKSPACE_HIBERNATE_FAILED = "workspace:hibernate-failed" as 
 // Hook Types
 // =============================================================================
 
-/** Input for capture/shutdown hook handlers. */
+/** Input for capture/shutdown/release hook handlers. */
 export interface HibernatePipelineHookInput extends HookContext {
   readonly projectPath: string;
   readonly workspacePath: string;
@@ -98,13 +114,11 @@ export interface CaptureHookResult {
 }
 
 /** Per-handler result for the "shutdown" hook point. */
-export interface HibernateShutdownHookResult {
-  readonly wasActive?: boolean;
-}
+export type HibernateShutdownHookResult = Record<string, never>;
 
 /**
  * Per-handler result for the "release" hook point.
- * Best-effort CWD-rooted process kill before metadata persists.
+ * Best-effort CWD-rooted process kill.
  */
 export interface HibernateReleaseHookResult {
   readonly error?: string;
@@ -123,19 +137,25 @@ export class HibernateWorkspaceOperation implements Operation<
   async execute(ctx: OperationContext<HibernateWorkspaceIntent>): Promise<{ started: true }> {
     const { payload } = ctx.intent;
 
+    let hookCtx: HibernatePipelineHookInput;
+    let projectId: ProjectId;
+    let projectPath: string;
+    let workspaceName: WorkspaceName;
+
     try {
-      // Resolve workspace + project identity
-      const { projectPath, workspaceName, active } = await ctx.dispatch({
+      // ─── Foreground ──────────────────────────────────────────────────────
+      let active: boolean;
+      ({ projectPath, workspaceName, active } = await ctx.dispatch({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: payload.workspacePath },
-      } as ResolveWorkspaceIntent);
+      } as ResolveWorkspaceIntent));
 
-      const { projectId } = await ctx.dispatch({
+      ({ projectId } = await ctx.dispatch({
         type: INTENT_RESOLVE_PROJECT,
         payload: { projectPath },
-      } as ResolveProjectIntent);
+      } as ResolveProjectIntent));
 
-      const hookCtx: HibernatePipelineHookInput = {
+      hookCtx = {
         intent: ctx.intent,
         projectPath,
         workspacePath: payload.workspacePath,
@@ -144,35 +164,15 @@ export class HibernateWorkspaceOperation implements Operation<
         active,
       };
 
-      // Capture screenshot (best-effort, errors logged but not propagated)
+      // Capture screenshot (best-effort, errors logged but not propagated).
+      // Must complete in the foreground so the overlay has a file:// URL to
+      // load when the metadata flip below triggers the renderer.
       await ctx.hooks.collect<CaptureHookResult>("capture", hookCtx);
 
-      // Shutdown view + agent (reuses the handlers registered by view-module
-      // and agent-module; same semantics as workspace:delete shutdown).
-      const { results: shutdownResults } = await ctx.hooks.collect<HibernateShutdownHookResult>(
-        "shutdown",
-        hookCtx
-      );
-
-      let wasActive = false;
-      for (const r of shutdownResults) {
-        if (r.wasActive) wasActive = true;
-      }
-
-      // Best-effort: kill processes whose CWD is rooted under the workspace.
-      // Errors here never block hibernation — the worktree stays on disk
-      // either way, so a stuck cleanup must not fail the operation.
-      const { results: releaseResults, errors: releaseCollectErrors } =
-        await ctx.hooks.collect<HibernateReleaseHookResult>("release", hookCtx);
-      for (const e of releaseCollectErrors) {
-        // collect errors are already logged by the dispatcher; nothing to do.
-        void e;
-      }
-      for (const r of releaseResults) {
-        void r;
-      }
-
-      // Persist hibernated flag via existing set-metadata pipeline
+      // Persist hibernated flag via existing set-metadata pipeline. This is
+      // what makes the renderer swap in HibernatedOverlay via the
+      // workspace:metadata-changed → WORKSPACE_METADATA_CHANGED IPC, and
+      // makes switch-workspace's `c.hibernated` filter exclude us.
       await ctx.dispatch({
         type: INTENT_SET_METADATA,
         payload: {
@@ -182,10 +182,12 @@ export class HibernateWorkspaceOperation implements Operation<
         },
       } as SetMetadataIntent);
 
-      // If the hibernated workspace was active, auto-switch to an awake
-      // sibling; if none exist, fallbackToCurrent keeps the hibernated
-      // workspace as active so the renderer shows the hibernation overlay.
-      if (wasActive && !payload.skipSwitch) {
+      // If the hibernated workspace was active, switch to an awake sibling
+      // immediately so the user is moved away while the teardown runs in the
+      // background. fallbackToCurrent keeps the hibernated workspace as
+      // active when no awake sibling exists; the renderer then shows the
+      // pending hibernation overlay over it.
+      if (active) {
         try {
           await ctx.dispatch({
             type: INTENT_SWITCH_WORKSPACE,
@@ -197,22 +199,9 @@ export class HibernateWorkspaceOperation implements Operation<
             },
           } as SwitchWorkspaceIntent);
         } catch {
-          // Best-effort: switch failure doesn't fail hibernation
+          // Best-effort: switch failure doesn't fail hibernation.
         }
       }
-
-      const event: WorkspaceHibernatedEvent = {
-        type: EVENT_WORKSPACE_HIBERNATED,
-        payload: {
-          projectId,
-          workspaceName,
-          workspacePath: payload.workspacePath,
-          projectPath,
-        },
-      };
-      ctx.emit(event);
-
-      return { started: true };
     } catch (error) {
       const failedEvent: WorkspaceHibernateFailedEvent = {
         type: EVENT_WORKSPACE_HIBERNATE_FAILED,
@@ -224,5 +213,31 @@ export class HibernateWorkspaceOperation implements Operation<
       ctx.emit(failedEvent);
       throw error;
     }
+
+    // ─── Background ────────────────────────────────────────────────────────
+    // Fire-and-forget; failures are logged by the dispatcher's hook runner.
+    // The renderer's wake button is hidden until workspace:hibernated fires,
+    // so no wake intent can race the teardown.
+    void (async () => {
+      try {
+        await ctx.hooks.collect<HibernateShutdownHookResult>("shutdown", hookCtx);
+        await ctx.hooks.collect<HibernateReleaseHookResult>("release", hookCtx);
+      } finally {
+        // Always emit so the dispatcher's idempotency interceptor releases
+        // the per-workspace lock and the renderer clears its pending entry.
+        const event: WorkspaceHibernatedEvent = {
+          type: EVENT_WORKSPACE_HIBERNATED,
+          payload: {
+            projectId,
+            workspaceName,
+            workspacePath: payload.workspacePath,
+            projectPath,
+          },
+        };
+        void ctx.emit(event);
+      }
+    })();
+
+    return { started: true };
   }
 }

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -386,12 +386,11 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
   });
 
   registerIpc(ApiIpcChannels.WORKSPACE_HIBERNATE, async (payload) => {
-    const p = payload as { workspacePath: string; skipSwitch?: boolean };
+    const p = payload as { workspacePath: string };
     const intent: HibernateWorkspaceIntent = {
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: {
         workspacePath: p.workspacePath,
-        ...(p.skipSwitch !== undefined && { skipSwitch: p.skipSwitch }),
       },
     };
     const handle = dispatcher.dispatch(intent);

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -612,9 +612,9 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<HibernateShutdownHookResult> => {
-            const { workspacePath, active } = ctx as HibernatePipelineHookInput;
+            const { workspacePath } = ctx as HibernatePipelineHookInput;
             await tearDownWorkspaceView(workspacePath, "hibernate shutdown");
-            return active ? { wasActive: true } : {};
+            return {};
           },
         },
       },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -80,8 +80,8 @@ contextBridge.exposeInMainWorld("api", {
         workspacePath,
         ...(options?.refresh !== undefined && { refresh: options.refresh }),
       }),
-    hibernate: (workspacePath: string, options?: { skipSwitch?: boolean }) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_HIBERNATE, { workspacePath, ...options }),
+    hibernate: (workspacePath: string) =>
+      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_HIBERNATE, { workspacePath }),
     wake: (workspacePath: string) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_WAKE, { workspacePath }),
     reopen: (

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -75,10 +75,7 @@ export interface Api {
      * and emits workspace:hibernated. Returns { started: false } if blocked
      * by idempotency.
      */
-    hibernate(
-      workspacePath: string,
-      options?: { skipSwitch?: boolean }
-    ): Promise<{ started: boolean }>;
+    hibernate(workspacePath: string): Promise<{ started: boolean }>;
     /**
      * Wake a hibernated workspace (fire-and-forget).
      * Clears the `hibernated` metadata flag and deletes the saved screenshot.


### PR DESCRIPTION
- Split `workspace:hibernate` into a foreground phase (resolve → capture → set-metadata → optional switch) and a background phase (shutdown → release → emit hibernated). Intent now resolves in ~500 ms instead of 2–6 s, so the HibernatedOverlay flips immediately on Windows where the PowerShell-driven file-lock cleanup dominates wall time.
- Auto-switch moves into the foreground using the `active` flag from `workspace:resolve`, so the user is moved off the hibernating workspace without waiting for shutdown.
- Drop the unused `skipSwitch` hibernate option from the IPC, preload, and shared API. Simplify `HibernateShutdownHookResult` (wasActive no longer needed).
- Background failures are log-only — the user already saw the overlay flip, so re-emitting `hibernate-failed` would be misleading.

Renderer-side spinner/wake-hiding to follow in a separate change.