### PR TITLE
fix: bug report dialog lost focus

### DIFF
--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -142,7 +142,7 @@ describe("BugReportModule", () => {
     const config = (deps.dialogManager.open as ReturnType<typeof vi.fn>).mock
       .calls[0]![0] as DialogConfig;
     const initial = getDescriptionInitialValue(config);
-    expect(initial).toBe("# describe your issue\n\n");
+    expect(initial).toBe("# describe your issue");
     expect(initial).not.toContain("config -----");
     expect(initial).not.toContain("{");
   });

--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -147,7 +147,7 @@ describe("BugReportModule", () => {
     expect(initial).not.toContain("{");
   });
 
-  it("places cursor on the empty line after the hint", async () => {
+  it("pre-selects the seed text so typing replaces it", async () => {
     const { deps } = createMockDeps();
     const module = createBugReportModule(deps);
 
@@ -158,7 +158,8 @@ describe("BugReportModule", () => {
     const input = config.sections.find(
       (s: DialogSection): s is DialogSection & { type: "input" } => s.type === "input"
     );
-    expect(input?.cursorOffset).toBe("# describe your issue\n".length);
+    expect(input?.selectInitialValue).toBe(true);
+    expect(input?.cursorOffset).toBeUndefined();
   });
 
   it("sends description verbatim on 'send'", async () => {

--- a/src/modules/bug-report-module.ts
+++ b/src/modules/bug-report-module.ts
@@ -24,8 +24,7 @@ import { INTENT_SUBMIT_BUG_REPORT, type SubmitBugReportIntent } from "../intents
 /** Maximum raw log bytes captured per bug report (compressed before send). */
 const MAX_LOG_SIZE = 20 * 1024 * 1024;
 
-const DESCRIPTION_HEADER = "# describe your issue\n";
-const DESCRIPTION_INITIAL = `${DESCRIPTION_HEADER}\n`;
+const DESCRIPTION_INITIAL = "# describe your issue";
 
 export interface BugReportModuleDeps {
   readonly dialogManager: DialogManager;
@@ -45,7 +44,7 @@ function buildDialogConfig(): DialogConfig {
         placeholder: "Describe the issue...",
         multiline: true,
         initialValue: DESCRIPTION_INITIAL,
-        cursorOffset: DESCRIPTION_HEADER.length,
+        selectInitialValue: true,
       },
       {
         type: "text",

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -76,18 +76,51 @@
     }, 0);
   });
 
-  /** Place the caret at `cursorOffset` and focus, once, after the textarea seeds itself. */
+  /**
+   * Focus the textarea and either select the seeded text or place the caret
+   * at `cursorOffset`. Also re-focuses the textarea when Alt is released:
+   * Chromium's default Alt-up handler activates the window menu and pulls
+   * focus out of the WebContents, which after Alt+X+B would otherwise leave
+   * the dialog with no caret. (Electron #37336 prevents us from suppressing
+   * Alt at the keyDown layer.)
+   */
   function seedCursor(
     node: HTMLTextAreaElement,
-    params: { initialValue: string | undefined; cursorOffset: number | undefined }
-  ): void {
-    if (params.initialValue === undefined || params.cursorOffset === undefined) return;
-    const offset = Math.max(0, Math.min(params.cursorOffset, params.initialValue.length));
+    params: {
+      initialValue: string | undefined;
+      cursorOffset: number | undefined;
+      selectInitialValue: boolean | undefined;
+    }
+  ): { destroy: () => void } | void {
+    if (params.initialValue === undefined) return;
+    const length = params.initialValue.length;
     queueMicrotask(() => {
       node.focus();
-      node.setSelectionRange(offset, offset);
+      if (params.selectInitialValue) {
+        node.setSelectionRange(0, length);
+      } else if (params.cursorOffset !== undefined) {
+        const offset = Math.max(0, Math.min(params.cursorOffset, length));
+        node.setSelectionRange(offset, offset);
+      }
       node.scrollTop = 0;
     });
+
+    const onKeyUp = (e: KeyboardEvent): void => {
+      if (e.key !== "Alt") return;
+      // Re-focus only if focus was stolen (active element is body / null).
+      const active = document.activeElement;
+      if (active === node) return;
+      if (active && active !== document.body) return;
+      queueMicrotask(() => {
+        node.focus();
+      });
+    };
+    window.addEventListener("keyup", onKeyUp, true);
+    return {
+      destroy(): void {
+        window.removeEventListener("keyup", onKeyUp, true);
+      },
+    };
   }
 
   /** Get the current selection data to include in events.
@@ -335,6 +368,7 @@
             use:seedCursor={{
               initialValue: s.initialValue,
               cursorOffset: s.cursorOffset,
+              selectInitialValue: s.selectInitialValue,
             }}
             oninput={(e) => {
               inputState = { ...inputState, [s.id]: e.currentTarget.value };

--- a/src/renderer/lib/components/DialogView.test.ts
+++ b/src/renderer/lib/components/DialogView.test.ts
@@ -385,6 +385,86 @@ describe("DialogView component", () => {
     });
   });
 
+  // ---- Input sections ----
+
+  describe("input sections", () => {
+    it("selects the seeded text when selectInitialValue is true", async () => {
+      const config: DialogConfig = {
+        sections: [
+          {
+            type: "input",
+            id: "desc",
+            multiline: true,
+            initialValue: "hello world",
+            selectInitialValue: true,
+          },
+        ],
+      };
+
+      renderDialog(config);
+
+      const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+      expect(textarea).toBeInTheDocument();
+      await waitFor(() => {
+        expect(textarea.selectionStart).toBe(0);
+        expect(textarea.selectionEnd).toBe("hello world".length);
+      });
+    });
+
+    it("places caret at cursorOffset when selectInitialValue is not set", async () => {
+      const config: DialogConfig = {
+        sections: [
+          {
+            type: "input",
+            id: "desc",
+            multiline: true,
+            initialValue: "hello world",
+            cursorOffset: 5,
+          },
+        ],
+      };
+
+      renderDialog(config);
+
+      const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+      await waitFor(() => {
+        expect(textarea.selectionStart).toBe(5);
+        expect(textarea.selectionEnd).toBe(5);
+      });
+    });
+
+    it("re-focuses the textarea on Alt keyup when focus was lost to body", async () => {
+      const config: DialogConfig = {
+        sections: [
+          {
+            type: "input",
+            id: "desc",
+            multiline: true,
+            initialValue: "hello",
+            selectInitialValue: true,
+          },
+        ],
+      };
+
+      renderDialog(config);
+
+      const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+      await waitFor(() => {
+        expect(document.activeElement).toBe(textarea);
+      });
+
+      // Simulate Chromium's Alt-up stealing focus back to the document body
+      textarea.blur();
+      expect(document.activeElement).toBe(document.body);
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "Alt" }));
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(textarea);
+      });
+    });
+  });
+
   // ---- Accessibility ----
 
   describe("accessibility", () => {

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -67,6 +67,8 @@ interface TableSection {
  * - initialValue seeds the field on first render only; later edits are preserved
  * - cursorOffset places the caret at this character offset after seeding
  *   (only applied when initialValue is set)
+ * - selectInitialValue selects the seeded text instead of placing a caret, so
+ *   the first keystroke replaces it (overrides cursorOffset)
  * - Input values are included in DialogUserEvent.data.inputs when actions fire
  */
 interface InputSection {
@@ -76,6 +78,7 @@ interface InputSection {
   readonly multiline?: boolean;
   readonly initialValue?: string;
   readonly cursorOffset?: number;
+  readonly selectInitialValue?: boolean;
 }
 
 export type DialogSection =


### PR DESCRIPTION
- Re-focus the Report Bug textarea on Alt keyup so Chromium's default menu-activation handler can't strand the dialog without a caret after Alt+X+B
- Add `selectInitialValue` to input sections and use it on the bug-report dialog so the seed comment is pre-selected and the first keystroke replaces it