### PR TITLE
fix: Restore woken workspaces in iframe mode

### DIFF
--- a/src/boundaries/shell/iframe-view-manager.integration.test.ts
+++ b/src/boundaries/shell/iframe-view-manager.integration.test.ts
@@ -246,6 +246,40 @@ describe("IframeViewManager", () => {
       expect(deps.viewLayer.$.windowChildren.get(windowId)).not.toContain(host.id);
     });
 
+    it("removes the iframe from the host page on destroy, so wake re-adds a fresh iframe", async () => {
+      const deps = createIframeDeps();
+      const manager = new IframeViewManager(deps);
+      manager.create();
+      const host = manager.getWorkspaceHostHandle();
+      flushHostReady(deps.viewLayer, host);
+
+      const hostCalls: string[] = [];
+      const originalExec = deps.viewLayer.executeJavaScript.bind(deps.viewLayer);
+      deps.viewLayer.executeJavaScript = (handle, code) => {
+        if (handle.id === host.id) hostCalls.push(code);
+        return originalExec(handle, code);
+      };
+
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.setActiveWorkspace("/a");
+
+      // Hibernation calls destroyWorkspaceView — the iframe must actually be
+      // removed from the host page (regression: previously the reverse-
+      // lookup failed because the base deleted the state from the map
+      // first, so __host.remove silently no-op'd and the iframe survived).
+      hostCalls.length = 0;
+      await manager.destroyWorkspaceView("/a");
+      expect(hostCalls.some((c) => c.includes("window.__host.remove('/a')"))).toBe(true);
+
+      // Wake: re-create + re-load — must add the iframe back via __host.add.
+      hostCalls.length = 0;
+      manager.createWorkspaceView("/a", "http://127.0.0.1/?a", "/p");
+      manager.setActiveWorkspace("/a");
+      expect(
+        hostCalls.some((c) => c.includes("window.__host.add('/a', 'http://127.0.0.1/?a')"))
+      ).toBe(true);
+    });
+
     it("keeps the workspace-host view attached when other workspaces remain", async () => {
       const deps = createIframeDeps();
       const manager = new IframeViewManager(deps);

--- a/src/boundaries/shell/iframe-view-manager.ts
+++ b/src/boundaries/shell/iframe-view-manager.ts
@@ -311,10 +311,7 @@ export class IframeViewManager extends BaseViewManager {
   protected async destroyWorkspaceViewImpl(state: WorkspaceState): Promise<void> {
     // Remove the iframe from the host page. The host view itself is
     // shared and stays alive until UI shutdown.
-    const path = this.findWorkspacePathByState(state);
-    if (path !== undefined) {
-      this.hostExec(`window.__host.remove(${jsStr(path)})`);
-    }
+    this.hostExec(`window.__host.remove(${jsStr(state.workspacePath)})`);
 
     // Clear any pending retry timer for this iframe.
     if (state.retryTimer !== null) {
@@ -339,9 +336,7 @@ export class IframeViewManager extends BaseViewManager {
   }
 
   protected startLoadingUrl(state: WorkspaceState): void {
-    const path = this.findWorkspacePathByState(state);
-    if (path === undefined) return;
-    this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)})`);
+    this.hostExec(`window.__host.add(${jsStr(state.workspacePath)}, ${jsStr(state.url)})`);
   }
 
   protected swapActiveSurface(prev: WorkspaceState | null, next: WorkspaceState | null): void {
@@ -349,16 +344,10 @@ export class IframeViewManager extends BaseViewManager {
     // incoming one. Host attachment is left as-is — attach/detachSurface
     // own that based on the new workspace's loading state.
     if (prev) {
-      const prevPath = this.findWorkspacePathByState(prev);
-      if (prevPath !== undefined) {
-        this.hostExec(`window.__host.hide(${jsStr(prevPath)})`);
-      }
+      this.hostExec(`window.__host.hide(${jsStr(prev.workspacePath)})`);
     }
     if (next) {
-      const nextPath = this.findWorkspacePathByState(next);
-      if (nextPath !== undefined) {
-        this.hostExec(`window.__host.show(${jsStr(nextPath)})`);
-      }
+      this.hostExec(`window.__host.show(${jsStr(next.workspacePath)})`);
       // Force a host re-composite so the now-visible iframe repaints
       // correctly on Windows — the same DirectComposition trick the UI
       // view uses via `bringUIToBottom(true)`.
@@ -374,7 +363,16 @@ export class IframeViewManager extends BaseViewManager {
     }
   }
 
-  protected attachSurface(): void {
+  protected attachSurface(state: WorkspaceState): void {
+    // Ensure the iframe for this workspace is the `.active` child in the host
+    // page. Normally swapActiveSurface has already done this; the defensive
+    // call here covers the case where the workspace's active path was set
+    // before its iframe existed (e.g. user navigated to a hibernated
+    // workspace via shortcut, then woke it — swap could only hide the
+    // outgoing iframe, and the resolve hook's later `active=true` made the
+    // wake's switch a no-op that never re-issued a show).
+    this.hostExec(`window.__host.show(${jsStr(state.workspacePath)})`);
+
     if (this.hostAttachedToWindow) return;
     this.viewLayer.attachToWindow(this.workspaceHostHandle, this.windowHandle);
     this.hostAttachedToWindow = true;
@@ -421,10 +419,7 @@ export class IframeViewManager extends BaseViewManager {
   protected reloadWorkspaceView(state: WorkspaceState): void {
     // No per-iframe reload primitive — reload the entire host renderer.
     // Cheap because all workspaces share it, but coarse (affects all).
-    const path = this.findWorkspacePathByState(state);
-    if (path !== undefined) {
-      this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)})`);
-    }
+    this.hostExec(`window.__host.add(${jsStr(state.workspacePath)}, ${jsStr(state.url)})`);
   }
 
   protected makeDevtoolsTarget(handle: ViewHandle): DevtoolsTarget {
@@ -476,14 +471,6 @@ export class IframeViewManager extends BaseViewManager {
     });
   }
 
-  /** Reverse-lookup a workspace path from its state object. */
-  private findWorkspacePathByState(state: WorkspaceState): string | undefined {
-    for (const [path, candidate] of this.workspaceStates) {
-      if (candidate === state) return path;
-    }
-    return undefined;
-  }
-
   /** Reverse-lookup a workspace path from its iframe URL. */
   private findWorkspacePathByUrl(url: string): string | undefined {
     for (const [path, state] of this.workspaceStates) {
@@ -499,9 +486,9 @@ export class IframeViewManager extends BaseViewManager {
    * navigation.
    */
   protected retryLoad(state: WorkspaceState): void {
-    const path = this.findWorkspacePathByState(state);
-    if (path === undefined) return;
-    this.hostExec(`window.__host.add(${jsStr(path)}, ${jsStr(state.url)}, { force: true })`);
+    this.hostExec(
+      `window.__host.add(${jsStr(state.workspacePath)}, ${jsStr(state.url)}, { force: true })`
+    );
   }
 }
 

--- a/src/boundaries/shell/view-manager-base.ts
+++ b/src/boundaries/shell/view-manager-base.ts
@@ -171,6 +171,7 @@ export abstract class BaseViewManager implements IViewManager {
     );
 
     this.workspaceStates.set(workspacePath, {
+      workspacePath,
       handle,
       sessionHandle,
       url,

--- a/src/boundaries/shell/view-manager-types.ts
+++ b/src/boundaries/shell/view-manager-types.ts
@@ -45,6 +45,8 @@ export interface Rect {
  * shared coordination layer needs to read.
  */
 export interface WorkspaceState {
+  /** Workspace path (POSIX-normalized) this state belongs to */
+  workspacePath: string;
   /** Handle to the view */
   handle: ViewHandle;
   /** Handle to the session */

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -175,6 +175,17 @@ export interface IViewManager {
   setActiveWorkspace(workspacePath: string | null, focus?: boolean): void;
 
   /**
+   * Returns the workspace path that is currently the active surface (the one
+   * attached to or about to be attached to the window), or null if there is
+   * no active workspace.
+   *
+   * Reflects the live attachment state, not any higher-level UI cache. Callers
+   * that need a stable UI-level ref (e.g. for overlays that should remain
+   * visible while teardown runs) should track their own cached snapshot.
+   */
+  getActiveWorkspacePath(): string | null;
+
+  /**
    * Focuses the correct view based on current mode and attachment state.
    * Single source of truth for focus management.
    *

--- a/src/boundaries/shell/view-manager.test-utils.ts
+++ b/src/boundaries/shell/view-manager.test-utils.ts
@@ -39,6 +39,7 @@ export function createMockViewManager(options?: CreateMockViewManagerOptions): I
     destroyWorkspaceView: vi.fn().mockResolvedValue(undefined),
     updateBounds: vi.fn(),
     setActiveWorkspace: vi.fn(),
+    getActiveWorkspacePath: vi.fn().mockReturnValue(null),
     focus: vi.fn(),
     setMode: vi.fn((mode: UIMode) => {
       currentMode = mode;

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -130,6 +130,9 @@ export class ViewManager implements IViewManager {
   setActiveWorkspace(path: string | null, focus?: boolean): void {
     this.vm.setActiveWorkspace(path, focus);
   }
+  getActiveWorkspacePath(): string | null {
+    return this.impl?.getActiveWorkspacePath() ?? null;
+  }
   focus(): void {
     this.impl?.focus();
   }

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -543,12 +543,20 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
 
       // -------------------------------------------------------------------
       // resolve-workspace → resolve: contribute `active` snapshot
+      //
+      // Sourced from the view-manager (the actual active surface), not from
+      // `cachedActiveRef` (which is a UI-level cache that intentionally
+      // sticks to the hibernating workspace during the fallbackToCurrent
+      // overlay window — see hibernate-workspace.ts). The switch operation
+      // uses this flag to decide whether to short-circuit; that decision
+      // must reflect what's actually attached, otherwise wake never calls
+      // setActiveWorkspace and the woken iframe stays detached.
       // -------------------------------------------------------------------
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
           handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
             const { workspacePath } = ctx as ResolveHookInput;
-            return { active: cachedActiveRef?.path === workspacePath };
+            return { active: viewManager.getActiveWorkspacePath() === workspacePath };
           },
         },
       },


### PR DESCRIPTION
Three related bugs prevented a hibernated workspace from appearing after wake under `experimental.iframes=true`:

- Iframe was never removed at hibernate: `destroyWorkspaceViewImpl` did a reverse state-identity lookup on `workspaceStates`, but the base deletes the entry before calling the impl. Store the path on `WorkspaceState` itself and read it directly.
- Resolve hook's `active` flag drifted: it was sourced from a UI-level cache that intentionally lingers during hibernation, while the view-manager's real active path was cleared by an internal `setActiveWorkspace(null)`. After wake, the cached match made the switch a no-op and the host view never re-attached. Read from `viewManager.getActiveWorkspacePath()` instead.
- Wake-after-navigate-to-hibernated left the iframe `display:none`: when the user Alt+arrowed over the hibernated workspace before waking, no `__host.show` was ever issued for the target. Defensively re-issue `__host.show(state.workspacePath)` from `IframeViewManager.attachSurface`.

Adds `getActiveWorkspacePath()` to `IViewManager` and a hibernate→wake integration test for the iframe backend.