### PR TITLE
feat: prevents sleep while agents are busy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ All external access MUST use abstraction interfaces:
 | Electron Dialog  | `DialogBoundary`                      | `dialog`                |
 | Electron Image   | `ImageBoundary`                       | `nativeImage`           |
 | Electron App     | `AppBoundary`                         | `app`                   |
+| Electron Power   | `AppBoundary.allowPowerSaving`        | `powerSaveBlocker`      |
 | Electron Menu    | `MenuBoundary`                        | `Menu`                  |
 
 **Acceptable exceptions**: Third-party libraries that encapsulate their own I/O (like `ignore`, `posthog-node`) do not need abstraction layers. We abstract our own I/O, not the internals of external libraries.
@@ -320,6 +321,7 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | `experimental.github.query`         | (below)   | GitHub search query; default: `is:open is:pr review-requested:@me`                                                                                                    |
 | `experimental.github.template-path` | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI)                                                                                 |
 | `experimental.iframes`              | `false`   | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools, fail-load retry, and crash recovery |
+| `experimental.prevent-sleep`        | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline                               |
 | `help`                              | `false`   | Print config help and exit                                                                                                                                            |
 
 Any key can appear in config.json, env vars, or CLI flags.
@@ -354,5 +356,6 @@ CH_LOG__LEVEL=debug CH_LOG__OUTPUT=console pnpm dev
 | `[window]`          | WindowManager           |
 | `[view]`            | ViewManager             |
 | `[badge]`           | BadgeManager            |
+| `[power]`           | Sleep prevention        |
 | `[app]`             | Application lifecycle   |
 | `[ui]`              | Renderer UI components  |

--- a/src/boundaries/shell/app.state-mock.ts
+++ b/src/boundaries/shell/app.state-mock.ts
@@ -39,6 +39,12 @@ class AppBoundaryMockStateImpl implements MockState {
   badgeCount = 0;
   dockBadge = "";
   shouldUseDarkColors = true;
+  /** True when a sleep blocker is currently active (OS prevented from sleeping). */
+  preventingSleep = false;
+  /** Number of times a blocker transitioned from inactive → active. */
+  sleepBlockerStarts = 0;
+  /** Number of times a blocker transitioned from active → inactive. */
+  sleepBlockerStops = 0;
   readonly commandLineSwitches: CommandLineSwitch[] = [];
   readonly themeUpdatedCallbacks: Set<() => void> = new Set();
 
@@ -59,7 +65,7 @@ class AppBoundaryMockStateImpl implements MockState {
     const switches = this.commandLineSwitches
       .map((s) => (s.value !== undefined ? `${s.key}=${s.value}` : s.key))
       .join(", ");
-    return `AppBoundaryMockState { badgeCount: ${this.badgeCount}, dockBadge: "${this.dockBadge}", switches: [${switches}] }`;
+    return `AppBoundaryMockState { badgeCount: ${this.badgeCount}, dockBadge: "${this.dockBadge}", preventingSleep: ${this.preventingSleep}, switches: [${switches}] }`;
   }
 }
 
@@ -198,6 +204,21 @@ export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): Moc
       state.commandLineSwitches.push({ key, value });
     },
 
+    allowPowerSaving(allow: boolean): void {
+      // Mirror the real boundary's idempotent single-blocker semantics.
+      if (allow) {
+        if (state.preventingSleep) {
+          state.sleepBlockerStops += 1;
+        }
+        state.preventingSleep = false;
+      } else {
+        if (!state.preventingSleep) {
+          state.sleepBlockerStarts += 1;
+        }
+        state.preventingSleep = true;
+      }
+    },
+
     async openUrl(): Promise<void> {},
     async openPath(): Promise<void> {},
 
@@ -243,6 +264,19 @@ export interface AppBoundaryMatchers {
    * @param value - Optional expected value (if provided, checks exact match)
    */
   toHaveCommandLineSwitch(key: string, value?: string): void;
+
+  /**
+   * Assert that the OS is currently being prevented from sleeping
+   * (a sleep blocker is active). Use `.not` to assert sleep is allowed.
+   */
+  toBePreventingSleep(): void;
+
+  /**
+   * Assert how many times a sleep blocker has been started
+   * (inactive → active transitions). Useful for verifying idempotency.
+   * @param count - Expected number of blocker starts
+   */
+  toHaveSleepBlockerStartCount(count: number): void;
 }
 
 // Extend vitest's assertion interface
@@ -280,6 +314,29 @@ const appBoundaryMatchers: MatcherImplementationsFor<
         pass
           ? `Expected badge count NOT to be ${count}`
           : `Expected badge count to be ${count}, but got ${actual}`,
+    };
+  },
+
+  toBePreventingSleep(received) {
+    const actual = received.$.preventingSleep;
+    return {
+      pass: actual,
+      message: () =>
+        actual
+          ? `Expected OS NOT to be prevented from sleeping, but a sleep blocker is active`
+          : `Expected OS to be prevented from sleeping, but no sleep blocker is active`,
+    };
+  },
+
+  toHaveSleepBlockerStartCount(received, count) {
+    const actual = received.$.sleepBlockerStarts;
+    const pass = actual === count;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected sleep blocker start count NOT to be ${count}`
+          : `Expected sleep blocker start count to be ${count}, but got ${actual}`,
     };
   },
 

--- a/src/boundaries/shell/app.ts
+++ b/src/boundaries/shell/app.ts
@@ -108,6 +108,21 @@ export interface AppBoundary {
   openPath(filePath: string): Promise<void>;
 
   /**
+   * Control whether the OS is allowed to enter power-saving / sleep.
+   *
+   * Wraps Electron's `powerSaveBlocker`, owning a single blocker internally:
+   * - `allow = false` starts a `prevent-display-sleep` blocker (if not already active),
+   *   keeping the system and display awake.
+   * - `allow = true` stops the active blocker (if any), letting the OS sleep normally.
+   *
+   * Idempotent: repeated calls with the same value are no-ops (never start a
+   * second blocker, never double-stop).
+   *
+   * @param allow - true to permit OS sleep, false to prevent it
+   */
+  allowPowerSaving(allow: boolean): void;
+
+  /**
    * Whether the OS is currently using a dark color scheme.
    */
   shouldUseDarkColors(): boolean;
@@ -125,13 +140,16 @@ export interface AppBoundary {
 // Default Implementation
 // ============================================================================
 
-import { app, shell, nativeTheme } from "electron";
+import { app, shell, nativeTheme, powerSaveBlocker } from "electron";
 
 /**
  * Default implementation of AppBoundary using Electron's app module.
  */
 export class DefaultAppBoundary implements AppBoundary {
   readonly dock: AppDock | undefined;
+
+  /** Id of the active power-save blocker, or null when sleep is allowed. */
+  private powerBlockerId: number | null = null;
 
   constructor(private readonly logger: Logger) {
     // app.dock is only available on macOS
@@ -171,6 +189,29 @@ export class DefaultAppBoundary implements AppBoundary {
 
   async openPath(filePath: string): Promise<void> {
     await shell.openExternal(pathToFileURL(filePath).href);
+  }
+
+  allowPowerSaving(allow: boolean): void {
+    if (allow) {
+      if (this.powerBlockerId !== null) {
+        if (powerSaveBlocker.isStarted(this.powerBlockerId)) {
+          powerSaveBlocker.stop(this.powerBlockerId);
+        }
+        this.logger.debug("Power saving allowed (sleep blocker released)", {
+          id: this.powerBlockerId,
+        });
+        this.powerBlockerId = null;
+      }
+      return;
+    }
+
+    if (this.powerBlockerId !== null && powerSaveBlocker.isStarted(this.powerBlockerId)) {
+      return; // Already preventing sleep
+    }
+    this.powerBlockerId = powerSaveBlocker.start("prevent-display-sleep");
+    this.logger.debug("Power saving prevented (display-sleep blocker started)", {
+      id: this.powerBlockerId,
+    });
   }
 
   shouldUseDarkColors(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,7 @@ import { createLocalProjectModule } from "./modules/local-project-module";
 import { createRemoteProjectModule } from "./modules/remote-project-module";
 import { createGitWorktreeWorkspaceModule } from "./modules/git-worktree-workspace-module";
 import { createBadgeModule } from "./modules/badge-module";
+import { createPowerModule } from "./modules/power-module";
 import { createMcpModule } from "./modules/mcp-module";
 import { createElectronLifecycleModule } from "./modules/electron-lifecycle-module";
 import { createLoggingModule } from "./modules/logging-module";
@@ -549,6 +550,11 @@ const badgeModule = createBadgeModule({
   windowManager,
   logger: loggingService.createLogger("badge"),
 });
+const powerModule = createPowerModule({
+  appLayer,
+  configService,
+  logger: loggingService.createLogger("power"),
+});
 const deletionDialogModule = createDeletionDialogModule({
   dialogManager,
   dispatcher,
@@ -772,6 +778,7 @@ dispatcher.registerModule(workspaceAgentResolverModule);
 dispatcher.registerModule(claudeAgentModule);
 dispatcher.registerModule(opencodeAgentModule);
 dispatcher.registerModule(badgeModule);
+dispatcher.registerModule(powerModule);
 dispatcher.registerModule(deletionDialogModule);
 dispatcher.registerModule(workspaceSelectionModule);
 dispatcher.registerModule(metadataModule);

--- a/src/modules/power-module.integration.test.ts
+++ b/src/modules/power-module.integration.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment node
+/**
+ * Integration tests for PowerModule.
+ *
+ * Tests verify, through the full dispatcher pipeline
+ * (UpdateAgentStatusOperation -> domain event -> PowerModule):
+ * - The OS sleep blocker engages while any workspace is busy/mixed.
+ * - It releases when all workspaces are idle/none, deleted, or hibernated.
+ * - Repeated busy updates don't thrash the blocker (idempotency).
+ * - The `experimental.prevent-sleep` config gates the behavior.
+ * - The blocker is released on app shutdown.
+ */
+
+import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
+import { describe, it, expect } from "vitest";
+import { Dispatcher } from "../intents/lib/dispatcher";
+
+import {
+  UpdateAgentStatusOperation,
+  INTENT_UPDATE_AGENT_STATUS,
+} from "../intents/update-agent-status";
+import type { UpdateAgentStatusIntent } from "../intents/update-agent-status";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "../intents/resolve-workspace";
+import type {
+  ResolveHookResult as ResolveWorkspaceHookResult,
+  ResolveHookInput as ResolveWorkspaceHookInput,
+} from "../intents/resolve-workspace";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "../intents/resolve-project";
+import type { ResolveHookResult as ResolveProjectHookResult } from "../intents/resolve-project";
+import { EVENT_WORKSPACE_DELETED, INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../intents/delete-workspace";
+import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
+import type { AppShutdownIntent } from "../intents/app-shutdown";
+import type { Operation, OperationContext, HookContext } from "../intents/lib/operation";
+import { createMinimalOperation } from "../intents/lib/operation.test-utils";
+import type { IntentModule } from "../intents/lib/module";
+import { createPowerModule } from "./power-module";
+import { SILENT_LOGGER } from "../boundaries/platform/logging";
+import { createAppBoundaryMock, type MockAppBoundary } from "../boundaries/shell/app.state-mock";
+import { createMockConfig } from "../boundaries/platform/config.test-utils";
+import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { ProjectId, WorkspaceName } from "../shared/api/types";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Minimal delete operation that only emits EVENT_WORKSPACE_DELETED, so tests can
+ * trigger workspace:deleted through the public dispatcher API without the full
+ * DeleteWorkspaceOperation pipeline.
+ */
+class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { started: true }> {
+  readonly id = "delete-workspace";
+
+  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+    const event: WorkspaceDeletedEvent = {
+      type: EVENT_WORKSPACE_DELETED,
+      payload: {
+        projectId: "test-12345678" as ProjectId,
+        workspaceName: "ws" as WorkspaceName,
+        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        projectPath: "/projects/test",
+      },
+    };
+    ctx.emit(event);
+    return { started: true };
+  }
+}
+
+/**
+ * Mock resolve module providing workspace/project resolution for the
+ * update-agent-status operation.
+ */
+function createMockResolveModule(): IntentModule {
+  return {
+    name: "test-resolve",
+    hooks: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
+        resolve: {
+          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
+            const { workspacePath } = ctx as ResolveWorkspaceHookInput;
+            return {
+              projectPath: "/projects/test",
+              workspaceName: workspacePath.split("/").pop() as WorkspaceName,
+            };
+          },
+        },
+      },
+      [RESOLVE_PROJECT_OPERATION_ID]: {
+        resolve: {
+          handler: async (): Promise<ResolveProjectHookResult> => {
+            return { projectId: "test-project" as ProjectId };
+          },
+        },
+      },
+    },
+  };
+}
+
+interface ModuleTestSetup {
+  dispatcher: Dispatcher;
+  appLayer: MockAppBoundary;
+}
+
+function createModuleTestSetup(options?: { enabled?: boolean }): ModuleTestSetup {
+  const appLayer = createAppBoundaryMock();
+  const dispatcher = createMockDispatcher();
+
+  dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new MinimalDeleteOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+
+  const configService =
+    options?.enabled === false
+      ? createMockConfig({ defaults: { "experimental.prevent-sleep": false } })
+      : createMockConfig();
+
+  const powerModule = createPowerModule({ appLayer, configService, logger: SILENT_LOGGER });
+  dispatcher.registerModule(powerModule);
+  dispatcher.registerModule(createMockResolveModule());
+
+  return { dispatcher, appLayer };
+}
+
+function updateStatusIntent(
+  workspacePath: string,
+  status: AggregatedAgentStatus
+): UpdateAgentStatusIntent {
+  return {
+    type: INTENT_UPDATE_AGENT_STATUS,
+    payload: { workspacePath: workspacePath as WorkspacePath, status },
+  };
+}
+
+const busy = (n = 1): AggregatedAgentStatus => ({ status: "busy", counts: { idle: 0, busy: n } });
+const idle = (n = 1): AggregatedAgentStatus => ({ status: "idle", counts: { idle: n, busy: 0 } });
+const mixed = (): AggregatedAgentStatus => ({ status: "mixed", counts: { idle: 1, busy: 1 } });
+const none = (): AggregatedAgentStatus => ({ status: "none", counts: { idle: 0, busy: 0 } });
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("PowerModule Integration", () => {
+  describe("blocks sleep while a workspace is busy", () => {
+    it("does not prevent sleep when a workspace is idle", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      expect(appLayer).not.toBePreventingSleep();
+    });
+
+    it("prevents sleep when a workspace becomes busy", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy(2)));
+      expect(appLayer).toBePreventingSleep();
+    });
+
+    it("prevents sleep for a mixed workspace", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", mixed()));
+      expect(appLayer).toBePreventingSleep();
+    });
+
+    it("releases the blocker when the busy workspace becomes idle", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      expect(appLayer).toBePreventingSleep();
+
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      expect(appLayer).not.toBePreventingSleep();
+    });
+
+    it("keeps blocking while at least one of several workspaces is busy", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent("/workspace/2", busy()));
+      expect(appLayer).toBePreventingSleep();
+
+      // One goes idle - the other is still busy.
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      expect(appLayer).toBePreventingSleep();
+
+      // Both idle now - release.
+      await dispatcher.dispatch(updateStatusIntent("/workspace/2", idle()));
+      expect(appLayer).not.toBePreventingSleep();
+    });
+  });
+
+  describe("offline workspaces allow sleep", () => {
+    it("releases when the only busy workspace goes to status none (hibernation teardown)", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      expect(appLayer).toBePreventingSleep();
+
+      // Hibernation stops the agent server, which fires status "none".
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", none()));
+      expect(appLayer).not.toBePreventingSleep();
+    });
+
+    it("releases when the only busy workspace is deleted", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      expect(appLayer).toBePreventingSleep();
+
+      const deleteIntent: DeleteWorkspaceIntent = {
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath: "/workspace/1",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      };
+      await dispatcher.dispatch(deleteIntent);
+      expect(appLayer).not.toBePreventingSleep();
+    });
+
+    it("keeps blocking when a busy workspace remains after another is deleted", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent("/workspace/2", idle()));
+      expect(appLayer).toBePreventingSleep();
+
+      // Delete the idle one - the busy one remains.
+      const deleteIntent: DeleteWorkspaceIntent = {
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath: "/workspace/2",
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      };
+      await dispatcher.dispatch(deleteIntent);
+      expect(appLayer).toBePreventingSleep();
+    });
+  });
+
+  describe("idempotency", () => {
+    it("does not start a second blocker on repeated busy updates", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy(3)));
+      await dispatcher.dispatch(updateStatusIntent("/workspace/2", busy()));
+
+      expect(appLayer).toBePreventingSleep();
+      expect(appLayer).toHaveSleepBlockerStartCount(1);
+    });
+  });
+
+  describe("config gating", () => {
+    it("never engages the blocker when experimental.prevent-sleep is false", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup({ enabled: false });
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+
+      expect(appLayer).not.toBePreventingSleep();
+      expect(appLayer).toHaveSleepBlockerStartCount(0);
+    });
+  });
+
+  describe("shutdown", () => {
+    it("releases the blocker on app shutdown", async () => {
+      const { dispatcher, appLayer } = createModuleTestSetup();
+      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      expect(appLayer).toBePreventingSleep();
+
+      dispatcher.registerOperation(
+        INTENT_APP_SHUTDOWN,
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+      );
+      await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
+
+      expect(appLayer).not.toBePreventingSleep();
+    });
+  });
+});

--- a/src/modules/power-module.ts
+++ b/src/modules/power-module.ts
@@ -1,0 +1,146 @@
+/**
+ * PowerModule - Prevents the OS from sleeping while any workspace is busy.
+ *
+ * Mirrors the badge module: it keeps a per-workspace status map, aggregates an
+ * app-wide "is anything working?" signal, and drives a single sink — here, the
+ * OS sleep blocker via AppBoundary.allowPowerSaving().
+ *
+ * Behavior: while at least one workspace's agent is "busy" or "mixed", the OS is
+ * kept awake (display-sleep blocker). When all workspaces are "idle"/"none" or
+ * offline (hibernated/deleted), the OS may sleep normally.
+ *
+ * Subscribes to:
+ * - agent:status-updated: updates internal map, re-aggregates, toggles the blocker.
+ *   (Hibernation tears down the agent server, which fires status "none" before
+ *   the workspace:hibernated event, so a hibernating busy workspace releases the
+ *   blocker without any extra handling here.)
+ * - workspace:deleted: evicts the workspace from the map, re-aggregates. Covers
+ *   both full deletion and project:close runtime teardown, which both emit it.
+ *
+ * Hooks:
+ * - app-shutdown/stop: releases the blocker (allowPowerSaving(true)).
+ *
+ * Gating: the feature is controlled by the `experimental.prevent-sleep` config key
+ * (default true). When disabled, the module still tracks state but never toggles
+ * the blocker — matching the always-register + internal-check pattern used by
+ * debug-module / electron-lifecycle-module.
+ */
+
+import type { IntentModule } from "../intents/lib/module";
+import type { DomainEvent } from "../intents/lib/types";
+import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
+import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
+import type { WorkspaceDeletedEvent } from "../intents/delete-workspace";
+import { EVENT_WORKSPACE_DELETED } from "../intents/delete-workspace";
+import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { AppBoundary } from "../boundaries/shell/app";
+import type { Config } from "../boundaries/platform/config";
+import { configBoolean } from "../boundaries/platform/config-definition";
+import type { Logger } from "../boundaries/platform/logging";
+
+// =============================================================================
+// Config
+// =============================================================================
+
+export const PREVENT_SLEEP_CONFIG_KEY = "experimental.prevent-sleep";
+
+// =============================================================================
+// Aggregation (pure function)
+// =============================================================================
+
+/**
+ * Determines whether the OS should be prevented from sleeping.
+ *
+ * Returns true when at least one workspace has active work in progress, i.e. a
+ * "busy" or "mixed" status. "idle" and "none" do not count, so workspaces that
+ * are waiting for input, have no agent, or have gone offline allow the OS to sleep.
+ *
+ * @param statuses - Map of workspace paths to their aggregated statuses
+ * @returns true if sleep should be prevented
+ */
+export function shouldPreventSleep(
+  statuses: ReadonlyMap<WorkspacePath, AggregatedAgentStatus>
+): boolean {
+  for (const status of statuses.values()) {
+    if (status.status === "busy" || status.status === "mixed") {
+      return true;
+    }
+  }
+  return false;
+}
+
+// =============================================================================
+// Dependencies
+// =============================================================================
+
+export interface PowerModuleDeps {
+  readonly appLayer: AppBoundary;
+  readonly configService: Config;
+  readonly logger: Logger;
+}
+
+// =============================================================================
+// Module Factory
+// =============================================================================
+
+/**
+ * Create a power module that prevents OS sleep while any workspace is busy.
+ *
+ * @param deps - AppBoundary (sleep blocker), config service, logger
+ * @returns IntentModule with event subscriptions and a shutdown hook
+ */
+export function createPowerModule(deps: PowerModuleDeps): IntentModule {
+  const { appLayer, configService, logger } = deps;
+
+  configService.register(PREVENT_SLEEP_CONFIG_KEY, {
+    name: PREVENT_SLEEP_CONFIG_KEY,
+    default: true,
+    description: "Prevent the OS from sleeping while any workspace's agent is busy",
+    ...configBoolean(),
+  });
+
+  const workspaceStatuses = new Map<WorkspacePath, AggregatedAgentStatus>();
+
+  function isEnabled(): boolean {
+    return configService.get(PREVENT_SLEEP_CONFIG_KEY) === true;
+  }
+
+  function applyBlocker(): void {
+    if (!isEnabled()) return;
+    const prevent = shouldPreventSleep(workspaceStatuses);
+    appLayer.allowPowerSaving(!prevent);
+  }
+
+  return {
+    name: "power",
+    events: {
+      [EVENT_AGENT_STATUS_UPDATED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { workspace, status } = (event as AgentStatusUpdatedEvent).payload;
+          workspaceStatuses.set(workspace.path, status);
+          applyBlocker();
+        },
+      },
+      [EVENT_WORKSPACE_DELETED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { workspacePath } = (event as WorkspaceDeletedEvent).payload;
+          workspaceStatuses.delete(workspacePath as WorkspacePath);
+          applyBlocker();
+        },
+      },
+    },
+    hooks: {
+      [APP_SHUTDOWN_OPERATION_ID]: {
+        stop: {
+          handler: async () => {
+            // Always release on shutdown, regardless of config, so a slow/hanging
+            // shutdown never leaves the OS pinned awake.
+            appLayer.allowPowerSaving(true);
+            logger.debug("Released sleep blocker on shutdown");
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Keeps the OS awake while at least one workspace's agent is busy, and lets it sleep normally once all workspaces are idle, offline (hibernated), or deleted — similar to how a browser inhibits sleep while playing a video.

- New `power-module` mirrors the badge module: subscribes to `agent:status-updated` + `workspace:deleted`, keeps a per-workspace status map, and toggles a single OS sleep blocker when any workspace is `busy`/`mixed`.
- New idempotent `AppBoundary.allowPowerSaving(allow)` wraps Electron's `powerSaveBlocker` (`prevent-display-sleep`), owning one blocker internally.
- Gated by the `experimental.prevent-sleep` config key (default `true`); blocker is released on `app:shutdown`.
- Hibernation/offline transitions release the blocker for free (agent teardown fires status `none`).
- Adds the `Electron Power` row to the External System Access Rules table, config + logger table entries, and integration tests.