### PR TITLE
feat: MCP support for workspace hibernation

### DIFF
--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -60,12 +60,27 @@ import {
   INTENT_SWITCH_WORKSPACE,
   SWITCH_WORKSPACE_OPERATION_ID,
 } from "./switch-workspace";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "./get-metadata";
+import {
+  INTENT_OPEN_WORKSPACE,
+  OPEN_WORKSPACE_OPERATION_ID,
+  type OpenWorkspacePayload,
+} from "./open-workspace";
+import type { ProjectId, WorkspaceName, Workspace } from "../shared/api/types";
 
 const PROJECT_PATH = "/test/project";
 const PROJECT_ID = Buffer.from(PROJECT_PATH).toString("base64url") as ProjectId;
 const WORKSPACE_PATH = "/test/project/workspaces/feature-a";
 const WORKSPACE_NAME = "feature-a" as WorkspaceName;
+const BRANCH = "feature-a-branch";
+const CLEAN_METADATA: Readonly<Record<string, string>> = { base: "main" };
+const REOPENED_WORKSPACE: Workspace = {
+  projectId: PROJECT_ID,
+  name: WORKSPACE_NAME,
+  branch: BRANCH,
+  metadata: CLEAN_METADATA,
+  path: WORKSPACE_PATH,
+};
 
 interface Recorder {
   captureCalled: boolean;
@@ -76,6 +91,7 @@ interface Recorder {
   callOrder: string[];
   metadataWrites: Array<{ key: string; value: string | null }>;
   events: DomainEvent[];
+  openPayload?: OpenWorkspacePayload;
 }
 
 function createRecorder(): Recorder {
@@ -101,6 +117,7 @@ function createResolveModule(active: boolean): IntentModule {
             projectPath: PROJECT_PATH,
             workspaceName: WORKSPACE_NAME,
             active,
+            branch: BRANCH,
           }),
         },
       },
@@ -240,6 +257,22 @@ function buildHarness(
   dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
   dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());
   dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, new WakeWorkspaceOperation());
+
+  // Mock the get-metadata + open-workspace operations that wake now dispatches
+  // internally to bring the workspace back online. (Hibernate never dispatches
+  // these, so registering them is harmless for those tests.)
+  dispatcher.registerOperation(INTENT_GET_METADATA, {
+    id: GET_METADATA_OPERATION_ID,
+    execute: async () => CLEAN_METADATA,
+  });
+  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, {
+    id: OPEN_WORKSPACE_OPERATION_ID,
+    execute: async (ctx) => {
+      recorder.openPayload = (ctx.intent as { payload: OpenWorkspacePayload }).payload;
+      recorder.callOrder.push("open");
+      return REOPENED_WORKSPACE;
+    },
+  });
 
   dispatcher.registerModule(createResolveModule(opts.active ?? false));
   dispatcher.registerModule(createMetadataModule(recorder));
@@ -406,19 +439,61 @@ describe("workspace:hibernate", () => {
 });
 
 describe("workspace:wake", () => {
-  it("clears hibernated metadata, runs cleanup, emits woken event", async () => {
+  it("clears hibernated metadata, runs cleanup, reopens, emits woken event", async () => {
     const { dispatcher, recorder } = buildHarness((r) => [createWakeHookModule(r)]);
 
     const intent: WakeWorkspaceIntent = {
       type: INTENT_WAKE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
     };
-    await dispatcher.dispatch(intent);
+    const result = await dispatcher.dispatch(intent);
 
     expect(recorder.cleanupCalled).toBe(true);
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: null }]);
 
+    // Reopen dispatched with the resolved branch and the clean (post-clear)
+    // metadata, via the existingWorkspace branch of workspace:open.
+    expect(recorder.openPayload).toBeDefined();
+    expect(recorder.openPayload?.projectPath).toBe(PROJECT_PATH);
+    expect(recorder.openPayload?.workspaceName).toBe(WORKSPACE_NAME);
+    expect(recorder.openPayload?.existingWorkspace).toEqual({
+      path: WORKSPACE_PATH,
+      name: WORKSPACE_NAME,
+      branch: BRANCH,
+      metadata: CLEAN_METADATA,
+    });
+    // Metadata is cleared before reopen runs.
+    expect(recorder.callOrder).toEqual(["set-metadata:null", "open"]);
+
+    // Returns the reopened workspace.
+    expect(result).toEqual(REOPENED_WORKSPACE);
+
     const woken = recorder.events.find((e) => e.type === EVENT_WORKSPACE_WOKEN);
     expect(woken).toBeDefined();
+  });
+
+  it("forwards stealFocus and source to the internal open", async () => {
+    const { dispatcher, recorder } = buildHarness((r) => [createWakeHookModule(r)]);
+
+    await dispatcher.dispatch({
+      type: INTENT_WAKE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH, stealFocus: false, source: "mcp" },
+    } as WakeWorkspaceIntent);
+
+    expect(recorder.openPayload?.stealFocus).toBe(false);
+    expect(recorder.openPayload?.source).toBe("mcp");
+  });
+
+  it("omits stealFocus/source when the caller does not set them", async () => {
+    const { dispatcher, recorder } = buildHarness((r) => [createWakeHookModule(r)]);
+
+    await dispatcher.dispatch({
+      type: INTENT_WAKE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    } as WakeWorkspaceIntent);
+
+    expect(recorder.openPayload).toBeDefined();
+    expect(recorder.openPayload).not.toHaveProperty("stealFocus");
+    expect(recorder.openPayload).not.toHaveProperty("source");
   });
 });

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -86,7 +86,23 @@ describe("ResolveWorkspaceOperation Integration", () => {
         projectPath: PROJECT_PATH,
         workspaceName: WORKSPACE_NAME,
         active: false,
+        // Defaults to null when no handler provides a branch.
+        branch: null,
       });
+    });
+
+    it("returns the branch when a handler provides it", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<ResolveHookResult> => ({
+          projectPath: PROJECT_PATH,
+          workspaceName: WORKSPACE_NAME,
+          branch: "feature-x",
+        })
+      );
+
+      const result = await dispatcher.dispatch(resolveIntent(WORKSPACE_PATH));
+
+      expect(result.branch).toBe("feature-x");
     });
   });
 

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -27,6 +27,8 @@ export interface ResolveWorkspaceResult {
   readonly projectPath: string;
   readonly workspaceName: WorkspaceName;
   readonly active: boolean;
+  /** Current branch name, or null for detached HEAD. */
+  readonly branch: string | null;
 }
 
 export interface ResolveWorkspaceIntent extends Intent<ResolveWorkspaceResult> {
@@ -52,6 +54,7 @@ export interface ResolveHookResult {
   readonly projectPath?: string;
   readonly workspaceName?: WorkspaceName;
   readonly active?: boolean;
+  readonly branch?: string | null;
 }
 
 // =============================================================================
@@ -82,16 +85,20 @@ export class ResolveWorkspaceOperation implements Operation<
     let projectPath: string | undefined;
     let workspaceName: WorkspaceName | undefined;
     let active = false;
+    // branch can legitimately be null (detached HEAD), so track "provided"
+    // separately from the null value.
+    let branch: string | null = null;
     for (const r of results) {
       if (r.projectPath !== undefined) projectPath = r.projectPath;
       if (r.workspaceName !== undefined) workspaceName = r.workspaceName;
       if (r.active === true) active = true;
+      if (r.branch !== undefined) branch = r.branch;
     }
 
     if (!projectPath || !workspaceName) {
       throw new Error(`Workspace not found: ${payload.workspacePath}`);
     }
 
-    return { projectPath, workspaceName, active };
+    return { projectPath, workspaceName, active, branch };
   }
 }

--- a/src/intents/wake-workspace.ts
+++ b/src/intents/wake-workspace.ts
@@ -1,25 +1,37 @@
 /**
- * WakeWorkspaceOperation - Marks a hibernated workspace as awake.
+ * WakeWorkspaceOperation - Wakes a hibernated workspace and brings it online.
  *
  * Steps:
- * 1. Dispatch workspace:resolve — workspacePath → projectPath + workspaceName
+ * 1. Dispatch workspace:resolve — workspacePath → projectPath + workspaceName + branch
  * 2. Dispatch project:resolve — projectPath → projectId
- * 3. Dispatch workspace:set-metadata — clear `hibernated` metadata
+ * 3. Dispatch workspace:set-metadata — clear `hibernated` metadata (emits
+ *    workspace:metadata-changed, which clears the renderer overlay)
  * 4. "cleanup" hook — delete the on-disk screenshot file (best-effort)
- * 5. Emit workspace:woken
+ * 5. Dispatch workspace:get-metadata — read back the now-clean metadata
+ * 6. Dispatch workspace:open (existingWorkspace branch) — re-run the canonical
+ *    open pipeline against the already-existing worktree to restart the agent
+ *    server, rebuild the workspace URL, and emit workspace:created (which mounts
+ *    the view). stealFocus/source are forwarded so callers control focus and
+ *    error-notification behavior, exactly like workspace_create.
+ * 7. Emit workspace:woken (releases the per-workspace wake idempotency lock)
  *
- * The operation intentionally does NOT recreate views or start the agent
- * server — the caller (typically the renderer) should follow up with a
- * workspace:open intent (using the existingWorkspace branch) to bring the
- * workspace fully online.
+ * Returns the reopened Workspace. The metadata-changed event (step 3) is
+ * emitted before workspace:created (step 6), so the overlay clears before the
+ * new view appears.
  */
 
 import type { Intent, DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import type { ProjectId, WorkspaceName, Workspace } from "../shared/api/types";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "./set-metadata";
+import { INTENT_GET_METADATA, type GetMetadataIntent } from "./get-metadata";
+import {
+  INTENT_OPEN_WORKSPACE,
+  type OpenWorkspaceIntent,
+  type WorkspaceOpenSource,
+} from "./open-workspace";
 import { HIBERNATED_METADATA_KEY } from "./hibernate-workspace";
 import { getErrorMessage } from "../shared/error-utils";
 
@@ -29,9 +41,16 @@ import { getErrorMessage } from "../shared/error-utils";
 
 export interface WakeWorkspacePayload {
   readonly workspacePath: string;
+  /** Forwarded to the internal workspace:open. If true, switch to the woken
+   *  workspace; if false, bring it online in the background. Default
+   *  (undefined): switch — matching the pre-fold renderer behavior. */
+  readonly stealFocus?: boolean;
+  /** Forwarded to the internal workspace:open. Identifies the originating
+   *  surface so error-notification can skip non-interactive sources (e.g. mcp). */
+  readonly source?: WorkspaceOpenSource;
 }
 
-export interface WakeWorkspaceIntent extends Intent<{ started: true }> {
+export interface WakeWorkspaceIntent extends Intent<Workspace> {
   readonly type: "workspace:wake";
   readonly payload: WakeWorkspacePayload;
 }
@@ -86,14 +105,14 @@ export type CleanupHookResult = Record<string, never>;
 // Operation
 // =============================================================================
 
-export class WakeWorkspaceOperation implements Operation<WakeWorkspaceIntent, { started: true }> {
+export class WakeWorkspaceOperation implements Operation<WakeWorkspaceIntent, Workspace> {
   readonly id = WAKE_WORKSPACE_OPERATION_ID;
 
-  async execute(ctx: OperationContext<WakeWorkspaceIntent>): Promise<{ started: true }> {
+  async execute(ctx: OperationContext<WakeWorkspaceIntent>): Promise<Workspace> {
     const { payload } = ctx.intent;
 
     try {
-      const { projectPath, workspaceName } = await ctx.dispatch({
+      const { projectPath, workspaceName, branch } = await ctx.dispatch({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: payload.workspacePath },
       } as ResolveWorkspaceIntent);
@@ -125,6 +144,32 @@ export class WakeWorkspaceOperation implements Operation<WakeWorkspaceIntent, { 
       // Best-effort screenshot file cleanup.
       await ctx.hooks.collect<CleanupHookResult>("cleanup", hookCtx);
 
+      // Read back the now-clean metadata (hibernated flag removed above) so the
+      // reopen — and the workspace:created event it emits — carry accurate
+      // metadata rather than reintroducing the stale flag.
+      const metadata = await ctx.dispatch({
+        type: INTENT_GET_METADATA,
+        payload: { workspacePath: payload.workspacePath },
+      } as GetMetadataIntent);
+
+      // Re-run the canonical open pipeline against the existing worktree to
+      // bring the workspace back online (agent server, workspace URL, view).
+      const workspace = await ctx.dispatch({
+        type: INTENT_OPEN_WORKSPACE,
+        payload: {
+          projectPath,
+          workspaceName,
+          existingWorkspace: {
+            path: payload.workspacePath,
+            name: workspaceName,
+            branch,
+            metadata,
+          },
+          ...(payload.stealFocus !== undefined && { stealFocus: payload.stealFocus }),
+          ...(payload.source !== undefined && { source: payload.source }),
+        },
+      } as OpenWorkspaceIntent);
+
       const event: WorkspaceWokenEvent = {
         type: EVENT_WORKSPACE_WOKEN,
         payload: {
@@ -136,7 +181,7 @@ export class WakeWorkspaceOperation implements Operation<WakeWorkspaceIntent, { 
       };
       ctx.emit(event);
 
-      return { started: true };
+      return workspace;
     } catch (error) {
       const failedEvent: WorkspaceWakeFailedEvent = {
         type: EVENT_WORKSPACE_WAKE_FAILED,

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -114,6 +114,7 @@ export function createGitWorktreeWorkspaceModule(
     | {
         projectPath: string;
         workspaceName: WorkspaceName;
+        branch: string | null;
       }
     | undefined {
     const normalizedPath = new Path(workspacePath).toString();
@@ -124,6 +125,7 @@ export function createGitWorktreeWorkspaceModule(
           return {
             projectPath: projectKey,
             workspaceName: extractWorkspaceName(ws.path.toString()),
+            branch: ws.branch,
           };
         }
       }

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -52,6 +52,10 @@ import { INTENT_GET_AGENT_SESSION } from "../intents/get-agent-session";
 import type { GetAgentSessionIntent } from "../intents/get-agent-session";
 import { INTENT_RESTART_AGENT } from "../intents/restart-agent";
 import type { RestartAgentIntent } from "../intents/restart-agent";
+import { INTENT_HIBERNATE_WORKSPACE } from "../intents/hibernate-workspace";
+import type { HibernateWorkspaceIntent } from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE } from "../intents/wake-workspace";
+import type { WakeWorkspaceIntent } from "../intents/wake-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import type { OpenWorkspaceIntent } from "../intents/open-workspace";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
@@ -62,6 +66,20 @@ import { INTENT_VSCODE_SHOW_MESSAGE } from "../intents/vscode-show-message";
 import type { VscodeShowMessageIntent } from "../intents/vscode-show-message";
 import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import type { VscodeCommandIntent } from "../intents/vscode-command";
+
+/**
+ * Optional target workspace path for tools that can act on a workspace other
+ * than the session's own (hibernate/wake). Omit to target the current
+ * workspace; use project_list to discover other workspaces' paths.
+ */
+const targetWorkspacePathSchema = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    "Path of the workspace to act on. Omit to target the current workspace. " +
+      "Use project_list to discover other workspaces' paths."
+  );
 
 // =============================================================================
 // MCP Type Definitions
@@ -574,6 +592,67 @@ export class McpServer implements IMcpServer {
         if (result === undefined) throw new Error("Restart agent dispatch returned no result");
         return result;
       })
+    );
+
+    // workspace_hibernate
+    mcpServer.registerTool(
+      "workspace_hibernate",
+      {
+        description:
+          "Hibernate a workspace: tears down its view and agent server to free " +
+          "resources, while keeping the git worktree on disk. The workspace stays listed and " +
+          "can be brought back online with workspace_wake. Returns { started: true } once " +
+          "hibernation has begun — teardown completes in the background. " +
+          "Omit workspacePath to hibernate the current workspace.",
+        inputSchema: z.object({
+          workspacePath: targetWorkspacePathSchema,
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (sessionWorkspacePath, args: { workspacePath?: string | undefined }) => {
+          const workspacePath = args.workspacePath ?? sessionWorkspacePath;
+          const intent: HibernateWorkspaceIntent = {
+            type: INTENT_HIBERNATE_WORKSPACE,
+            payload: { workspacePath },
+          };
+          const handle = this.dispatcher.dispatch(intent);
+          if (!(await handle.accepted)) {
+            return { started: false };
+          }
+          await handle;
+          return { started: true };
+        }
+      )
+    );
+
+    // workspace_wake
+    mcpServer.registerTool(
+      "workspace_wake",
+      {
+        description:
+          "Wake a hibernated workspace: clears the hibernated flag and brings " +
+          "the workspace back online (recreates its view and restarts its agent server). " +
+          "Returns the reopened workspace. Does not steal focus. " +
+          "Omit workspacePath to wake the current workspace.",
+        inputSchema: z.object({
+          workspacePath: targetWorkspacePathSchema,
+        }),
+      },
+      this.createWorkspaceHandler(
+        async (sessionWorkspacePath, args: { workspacePath?: string | undefined }) => {
+          const workspacePath = args.workspacePath ?? sessionWorkspacePath;
+          // The wake operation clears the hibernated flag AND reopens the
+          // workspace (restarts the agent server, rebuilds the view) in one step.
+          // stealFocus:false keeps it in the background for API callers; source
+          // "mcp" suppresses interactive error notifications.
+          const result = await this.dispatcher.dispatch({
+            type: INTENT_WAKE_WORKSPACE,
+            payload: { workspacePath, stealFocus: false, source: "mcp" },
+          } as WakeWorkspaceIntent);
+          if (!result) throw new Error("Wake workspace dispatch returned no result");
+          return result as Workspace;
+        }
+      )
     );
 
     // project_list

--- a/src/modules/mcp-server.boundary.test.ts
+++ b/src/modules/mcp-server.boundary.test.ts
@@ -24,6 +24,15 @@ import {
   GET_AGENT_SESSION_OPERATION_ID,
 } from "../intents/get-agent-session";
 import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../intents/restart-agent";
+import {
+  INTENT_RESOLVE_WORKSPACE,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+} from "../intents/resolve-workspace";
+import {
+  INTENT_HIBERNATE_WORKSPACE,
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+} from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE, WAKE_WORKSPACE_OPERATION_ID } from "../intents/wake-workspace";
 import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../intents/list-projects";
 import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import {
@@ -118,6 +127,27 @@ function createMockDispatcher(): { dispatcher: Dispatcher; capturedIntents: Inte
   dispatcher.registerOperation(
     INTENT_DELETE_WORKSPACE,
     createCapturingOperation(DELETE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
+  );
+  dispatcher.registerOperation(
+    INTENT_RESOLVE_WORKSPACE,
+    createCapturingOperation(RESOLVE_WORKSPACE_OPERATION_ID, capturedIntents, {
+      projectPath: "/home/user/projects/my-app",
+      workspaceName: "feature-branch",
+      active: false,
+    })
+  );
+  dispatcher.registerOperation(
+    INTENT_HIBERNATE_WORKSPACE,
+    createCapturingOperation(HIBERNATE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
+  );
+  dispatcher.registerOperation(
+    INTENT_WAKE_WORKSPACE,
+    createCapturingOperation(WAKE_WORKSPACE_OPERATION_ID, capturedIntents, {
+      name: "test",
+      path: "/path",
+      branch: "main",
+      metadata: {},
+    })
   );
   dispatcher.registerOperation(
     INTENT_VSCODE_COMMAND,
@@ -414,6 +444,65 @@ describe("McpServer Boundary Tests", () => {
       for (const response of responses) {
         expect(response.status).toBeLessThan(500);
       }
+    });
+  });
+
+  describe("hibernation tools", () => {
+    /** Initialize a session, send the initialized notification, and call a tool. */
+    async function callTool(workspacePath: string, toolName: string): Promise<{ status: number }> {
+      const { sessionId } = await initializeClient(port, workspacePath);
+      const sessionHeaders = {
+        ...mcpHeaders,
+        "Mcp-Session-Id": sessionId,
+        "Mcp-Protocol-Version": "2025-03-26",
+      };
+      await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: "POST",
+        headers: sessionHeaders,
+        body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      });
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: "POST",
+        headers: sessionHeaders,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: toolName, arguments: {} },
+          id: 30,
+        }),
+      });
+      return { status: response.status };
+    }
+
+    it("workspace_hibernate dispatches the hibernate intent for the session workspace", async () => {
+      const { status } = await callTool(workspacePathA, "workspace_hibernate");
+      expect(status).toBe(200);
+
+      const hibernateIntents = capturedIntents.filter((i) => i.type === INTENT_HIBERNATE_WORKSPACE);
+      expect(hibernateIntents).toHaveLength(1);
+      expect((hibernateIntents[0]!.payload as { workspacePath: string }).workspacePath).toBe(
+        workspacePathA
+      );
+    });
+
+    it("workspace_wake dispatches a single wake intent for the session workspace", async () => {
+      const { status } = await callTool(workspacePathB, "workspace_wake");
+      expect(status).toBe(200);
+
+      const wakeIntents = capturedIntents.filter((i) => i.type === INTENT_WAKE_WORKSPACE);
+      expect(wakeIntents).toHaveLength(1);
+      const payload = wakeIntents[0]!.payload as {
+        workspacePath: string;
+        stealFocus?: boolean;
+        source?: string;
+      };
+      expect(payload.workspacePath).toBe(workspacePathB);
+      expect(payload.stealFocus).toBe(false);
+      expect(payload.source).toBe("mcp");
+
+      // The tool no longer dispatches open itself — wake reopens internally.
+      const openIntents = capturedIntents.filter((i) => i.type === INTENT_OPEN_WORKSPACE);
+      expect(openIntents).toHaveLength(0);
     });
   });
 

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -27,6 +27,15 @@ import {
   GET_AGENT_SESSION_OPERATION_ID,
 } from "../intents/get-agent-session";
 import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../intents/restart-agent";
+import {
+  INTENT_RESOLVE_WORKSPACE,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+} from "../intents/resolve-workspace";
+import {
+  INTENT_HIBERNATE_WORKSPACE,
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+} from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE, WAKE_WORKSPACE_OPERATION_ID } from "../intents/wake-workspace";
 import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../intents/list-projects";
 import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import {
@@ -103,6 +112,19 @@ function createMockDispatcher(): {
   const deleteWorkspaceOp = createMockOperation(DELETE_WORKSPACE_OPERATION_ID, { started: true });
   const executeCommandOp = createMockOperation(VSCODE_COMMAND_OPERATION_ID, undefined);
   const showMessageOp = createMockOperation(VSCODE_SHOW_MESSAGE_OPERATION_ID, null);
+  const resolveWorkspaceOp = createMockOperation(RESOLVE_WORKSPACE_OPERATION_ID, {
+    projectPath: "/home/user/projects/my-app",
+    workspaceName: "feature-branch",
+    active: false,
+  });
+  const hibernateOp = createMockOperation(HIBERNATE_WORKSPACE_OPERATION_ID, { started: true });
+  const wakeOp = createMockOperation(WAKE_WORKSPACE_OPERATION_ID, {
+    name: "test",
+    path: "/path",
+    branch: "main",
+    metadata: { base: "main" },
+    projectId: "test-12345678" as ProjectId,
+  });
 
   dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, getStatusOp);
   dispatcher.registerOperation(INTENT_GET_METADATA, getMetadataOp);
@@ -114,6 +136,9 @@ function createMockDispatcher(): {
   dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteWorkspaceOp);
   dispatcher.registerOperation(INTENT_VSCODE_COMMAND, executeCommandOp);
   dispatcher.registerOperation(INTENT_VSCODE_SHOW_MESSAGE, showMessageOp);
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, resolveWorkspaceOp);
+  dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, hibernateOp);
+  dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, wakeOp);
 
   return {
     dispatcher,
@@ -128,6 +153,9 @@ function createMockDispatcher(): {
       deleteWorkspace: deleteWorkspaceOp.execute as ReturnType<typeof vi.fn>,
       executeCommand: executeCommandOp.execute as ReturnType<typeof vi.fn>,
       showMessage: showMessageOp.execute as ReturnType<typeof vi.fn>,
+      resolveWorkspace: resolveWorkspaceOp.execute as ReturnType<typeof vi.fn>,
+      hibernate: hibernateOp.execute as ReturnType<typeof vi.fn>,
+      wake: wakeOp.execute as ReturnType<typeof vi.fn>,
     },
   };
 }
@@ -246,13 +274,104 @@ describe("McpServer", () => {
       expect(toolNames).toContain("workspace_set_metadata");
       expect(toolNames).toContain("workspace_get_agent_session");
       expect(toolNames).toContain("workspace_restart_agent_server");
+      expect(toolNames).toContain("workspace_hibernate");
+      expect(toolNames).toContain("workspace_wake");
       expect(toolNames).toContain("workspace_delete");
       expect(toolNames).toContain("workspace_execute_command");
       expect(toolNames).toContain("project_list");
       expect(toolNames).toContain("workspace_create");
       expect(toolNames).toContain("ui_show_message");
       expect(toolNames).toContain("log");
-      expect(tools.length).toBe(11);
+      expect(tools.length).toBe(13);
+    });
+
+    it("workspace_hibernate tool dispatches the hibernate intent", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const hibernateTool = tools.find((t) => t.name === "workspace_hibernate");
+      expect(hibernateTool).toBeDefined();
+
+      const result = await hibernateTool!.handler(
+        {},
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      expect(mockDispatcher.operations.hibernate).toHaveBeenCalled();
+      const intent = mockDispatcher.operations.hibernate!.mock.calls[0]![0].intent as Intent;
+      expect(intent.type).toBe(INTENT_HIBERNATE_WORKSPACE);
+      expect((intent.payload as { workspacePath: string }).workspacePath).toBe(testWorkspacePath);
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ started: true }) }],
+      });
+    });
+
+    it("workspace_wake tool dispatches a single wake intent and returns the workspace", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const wakeTool = tools.find((t) => t.name === "workspace_wake");
+      expect(wakeTool).toBeDefined();
+
+      const result = await wakeTool!.handler(
+        {},
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      // Single dispatch: wake now reopens internally, so the tool does not
+      // dispatch resolve/get-metadata/open itself.
+      expect(mockDispatcher.operations.wake).toHaveBeenCalled();
+      expect(mockDispatcher.operations.openWorkspace).not.toHaveBeenCalled();
+      expect(mockDispatcher.operations.resolveWorkspace).not.toHaveBeenCalled();
+
+      const wakeIntent = mockDispatcher.operations.wake!.mock.calls[0]![0].intent as Intent;
+      expect(wakeIntent.type).toBe(INTENT_WAKE_WORKSPACE);
+      const payload = wakeIntent.payload as {
+        workspacePath: string;
+        stealFocus?: boolean;
+        source?: string;
+      };
+      expect(payload.workspacePath).toBe(testWorkspacePath);
+      expect(payload.stealFocus).toBe(false);
+      expect(payload.source).toBe("mcp");
+
+      // Returns the reopened workspace.
+      const parsed = JSON.parse(
+        (result as { content: Array<{ text: string }> }).content[0]!.text
+      ) as { name: string };
+      expect(parsed.name).toBe("test");
+    });
+
+    it("workspace_hibernate targets an explicit workspacePath argument", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const hibernateTool = tools.find((t) => t.name === "workspace_hibernate");
+      const otherWorkspacePath = "/home/user/projects/my-app/.worktrees/other-branch";
+
+      await hibernateTool!.handler(
+        { workspacePath: otherWorkspacePath },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.hibernate!.mock.calls[0]![0].intent as Intent;
+      expect((intent.payload as { workspacePath: string }).workspacePath).toBe(otherWorkspacePath);
+    });
+
+    it("workspace_wake targets an explicit workspacePath argument", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const wakeTool = tools.find((t) => t.name === "workspace_wake");
+      const otherWorkspacePath = "/home/user/projects/my-app/.worktrees/other-branch";
+
+      await wakeTool!.handler(
+        { workspacePath: otherWorkspacePath },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.wake!.mock.calls[0]![0].intent as Intent;
+      expect((intent.payload as { workspacePath: string }).workspacePath).toBe(otherWorkspacePath);
     });
 
     it("workspace_restart_agent_server tool calls handler and returns port", async () => {

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -403,49 +403,18 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
 
   registerIpc(ApiIpcChannels.WORKSPACE_WAKE, async (payload) => {
     const p = payload as { workspacePath: string };
+    // wake now clears the hibernated flag AND reopens the workspace (restarts
+    // the agent server, rebuilds the view) by dispatching workspace:open
+    // internally. source "ui-ipc" makes open's failures surface as UI
+    // notifications; stealFocus is omitted so the woken workspace is focused.
     const intent: WakeWorkspaceIntent = {
       type: INTENT_WAKE_WORKSPACE,
-      payload: { workspacePath: p.workspacePath },
+      payload: { workspacePath: p.workspacePath, source: "ui-ipc" },
     };
-    const handle = dispatcher.dispatch(intent);
-    if (!(await handle.accepted)) {
-      return { started: false };
-    }
-    // Await full completion (not fire-and-forget): callers — notably the
-    // renderer's wake → reopen sequence in shortcuts.svelte.ts — rely on the
-    // `workspace:metadata-changed` event being processed before reopen runs,
-    // and on wake errors being surfaced rather than swallowed.
-    await handle;
-    return { started: true };
-  });
-
-  registerIpc(ApiIpcChannels.WORKSPACE_REOPEN, async (payload) => {
-    const p = payload as {
-      projectPath: string;
-      workspacePath: string;
-      workspaceName: string;
-      branch: string | null;
-      metadata: Readonly<Record<string, string>>;
-    };
-    const intent: OpenWorkspaceIntent = {
-      type: INTENT_OPEN_WORKSPACE,
-      payload: {
-        projectPath: p.projectPath,
-        workspaceName: p.workspaceName,
-        existingWorkspace: {
-          path: p.workspacePath,
-          name: p.workspaceName,
-          branch: p.branch,
-          metadata: p.metadata,
-        },
-        source: "ui-ipc",
-      },
-    };
+    // result is undefined only when a concurrent wake for the same workspace
+    // was deduped by the idempotency interceptor.
     const result = await dispatcher.dispatch(intent);
-    if (!result) {
-      throw new Error("Reopen workspace dispatch returned no result");
-    }
-    return result as Workspace;
+    return (result ?? null) as Workspace | null;
   });
 
   registerIpc(ApiIpcChannels.WORKSPACE_GET_SCREENSHOT, async (payload) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,20 +84,6 @@ contextBridge.exposeInMainWorld("api", {
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_HIBERNATE, { workspacePath }),
     wake: (workspacePath: string) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_WAKE, { workspacePath }),
-    reopen: (
-      projectPath: string,
-      workspacePath: string,
-      workspaceName: string,
-      branch: string | null,
-      metadata: Readonly<Record<string, string>>
-    ) =>
-      ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_REOPEN, {
-        projectPath,
-        workspacePath,
-        workspaceName,
-        branch,
-        metadata,
-      }),
     getScreenshot: (projectId: string, workspaceName: string) =>
       ipcRenderer.invoke(ApiIpcChannels.WORKSPACE_GET_SCREENSHOT, { projectId, workspaceName }),
   },

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -287,21 +287,9 @@ export async function handleHibernateToggle(): Promise<void> {
   const isHibernated = workspace.metadata?.["hibernated"] === "true";
   try {
     if (isHibernated) {
-      if (!project) return;
-      // Snapshot the reactive metadata into a plain object — Svelte 5 $state
-      // proxies can't traverse Electron's structured-clone boundary. Drop the
-      // hibernated flag here: wake clears it server-side, and shipping a stale
-      // "true" through reopen would resurface it in the workspace:created event.
-      const metadataSnapshot: Record<string, string> = { ...(workspace.metadata ?? {}) };
-      delete metadataSnapshot["hibernated"];
+      // wake clears the hibernated flag AND brings the workspace back online
+      // (the operation reopens it internally), so a single call suffices.
       await api.workspaces.wake(ref.path);
-      await api.workspaces.reopen(
-        project.path,
-        workspace.path,
-        workspace.name,
-        workspace.branch,
-        metadataSnapshot
-      );
     } else {
       await api.workspaces.hibernate(ref.path);
     }

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -42,8 +42,7 @@ export function createMockApi(): Api {
       remove: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.removeResult),
       getStatus: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.status),
       hibernate: vi.fn().mockResolvedValue({ started: true }),
-      wake: vi.fn().mockResolvedValue({ started: true }),
-      reopen: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.workspace),
+      wake: vi.fn().mockResolvedValue(MOCK_WORKSPACE_API_DEFAULTS.workspace),
       getScreenshot: vi.fn().mockResolvedValue({ url: null }),
     },
     ui: {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -77,23 +77,12 @@ export interface Api {
      */
     hibernate(workspacePath: string): Promise<{ started: boolean }>;
     /**
-     * Wake a hibernated workspace (fire-and-forget).
-     * Clears the `hibernated` metadata flag and deletes the saved screenshot.
-     * The caller is responsible for re-opening the workspace afterwards.
+     * Wake a hibernated workspace and bring it back online.
+     * Clears the `hibernated` metadata flag, deletes the saved screenshot, and
+     * re-runs the open pipeline (restarts the agent server, rebuilds the view).
+     * Returns the reopened Workspace, or null if a concurrent wake was deduped.
      */
-    wake(workspacePath: string): Promise<{ started: boolean }>;
-    /**
-     * Re-open a previously-existing workspace (e.g., after wake) without
-     * re-creating the worktree. Goes through the workspace:open flow with
-     * existingWorkspace populated.
-     */
-    reopen(
-      projectPath: string,
-      workspacePath: string,
-      workspaceName: string,
-      branch: string | null,
-      metadata: Readonly<Record<string, string>>
-    ): Promise<Workspace>;
+    wake(workspacePath: string): Promise<Workspace | null>;
     /**
      * Get a file:// URL pointing at the saved hibernation screenshot for a
      * workspace. The returned URL may not exist on disk; consumers should

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -163,7 +163,6 @@ export const ApiIpcChannels = {
   WORKSPACE_REMOVE: "api:workspace:remove",
   WORKSPACE_HIBERNATE: "api:workspace:hibernate",
   WORKSPACE_WAKE: "api:workspace:wake",
-  WORKSPACE_REOPEN: "api:workspace:reopen",
   WORKSPACE_GET_SCREENSHOT: "api:workspace:get-screenshot",
   WORKSPACE_GET_STATUS: "api:workspace:get-status",
   // UI commands


### PR DESCRIPTION
- Add `workspace_hibernate` and `workspace_wake` MCP tools so agents/orchestrators can hibernate and wake workspaces over the MCP server (parity with in-app Alt+X H).
- Both tools accept an optional `workspacePath` to target any workspace (discovered via `project_list`); omitting it acts on the caller's own session workspace.
- Fold the bring-online step into the `workspace:wake` operation: it now clears the hibernated flag AND re-runs the open pipeline (agent server, view, `workspace:created`) internally, returning the reopened `Workspace`. The renderer collapses to a single `wake()` call and the now-unused `workspace:reopen` IPC/API is removed.
- `workspace:resolve` now returns `branch` (from the git-worktree map) so wake can rebuild `existingWorkspace` without the renderer's store.
- `workspace:wake` payload gains `stealFocus`/`source`, forwarded to the internal open (same semantics as `workspace_create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)