### PR TITLE
docs(claude-md): sync experimental config table with source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,25 +304,30 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                                 | Default   | Description                                                                                                                                                           |
-| ----------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                             | `null`    | Agent selection: claude\|opencode                                                                                                                                     |
-| `auto-update`                       | `ask`     | Auto-update preference: always\|ask\|never                                                                                                                            |
-| `version.claude`                    | `null`    | Claude agent version override                                                                                                                                         |
-| `version.opencode`                  | `null`    | OpenCode agent version override                                                                                                                                       |
-| `code-server.port`                  | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                                        |
-| `version.code-server`               | `null`    | Code-server version override (null = built-in)                                                                                                                        |
-| `telemetry.enabled`                 | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                                            |
-| `telemetry.distinct-id`             | —         | Telemetry user ID (auto-generated)                                                                                                                                    |
-| `log.level`                         | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                                               |
-| `log.output`                        | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                                             |
-| `electron.flags`                    | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                                             |
-| `electron.disabled-features`        | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults                     |
-| `experimental.github.query`         | (below)   | GitHub search query; default: `is:open is:pr review-requested:@me`                                                                                                    |
-| `experimental.github.template-path` | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable (requires `gh` CLI)                                                                                 |
-| `experimental.iframes`              | `false`   | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools, fail-load retry, and crash recovery |
-| `experimental.prevent-sleep`        | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline                               |
-| `help`                              | `false`   | Print config help and exit                                                                                                                                            |
+| Key                                   | Default   | Description                                                                                                                                                           |
+| ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                               | `null`    | Agent selection: claude\|opencode                                                                                                                                     |
+| `auto-update`                         | `ask`     | Auto-update preference: always\|ask\|never                                                                                                                            |
+| `version.claude`                      | `null`    | Claude agent version override                                                                                                                                         |
+| `version.opencode`                    | `null`    | OpenCode agent version override                                                                                                                                       |
+| `code-server.port`                    | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                                        |
+| `version.code-server`                 | `null`    | Code-server version override (null = built-in)                                                                                                                        |
+| `telemetry.enabled`                   | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                                            |
+| `telemetry.distinct-id`               | —         | Telemetry user ID (auto-generated)                                                                                                                                    |
+| `log.level`                           | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                                               |
+| `log.output`                          | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                                             |
+| `electron.flags`                      | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                                             |
+| `electron.disabled-features`          | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults                     |
+| `experimental.iframes`                | `false`   | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools, fail-load retry, and crash recovery |
+| `experimental.prevent-sleep`          | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline                               |
+| `experimental.load-on-resume`         | `false`   | Reload all workspace views when the system resumes from sleep (gated on code-server being healthy)                                                                    |
+| `experimental.github.query`           | (below)   | GitHub auto-workspace search query (requires `gh` CLI); default: `is:open is:pr review-requested:@me`                                                                 |
+| `experimental.github.template-path`   | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable. Sensitive                                                                                          |
+| `experimental.youtrack.base-url`      | `null`    | YouTrack instance URL (e.g. `https://youtrack.example.com`). Sensitive                                                                                                |
+| `experimental.youtrack.token`         | `null`    | YouTrack API permanent token. Sensitive                                                                                                                               |
+| `experimental.youtrack.query`         | `null`    | YouTrack auto-workspace search query (e.g. `for:me State: {In Progress}`)                                                                                             |
+| `experimental.youtrack.template-path` | `null`    | Path to Liquid template for YouTrack auto-workspaces; set to enable. Sensitive                                                                                        |
+| `help`                                | `false`   | Print config help and exit                                                                                                                                            |
 
 Any key can appear in config.json, env vars, or CLI flags.
 


### PR DESCRIPTION
- Add `experimental.load-on-resume` to the config table
- Add the YouTrack auto-workspace keys (`base-url`, `token`, `query`, `template-path`)
- Document that `template-path` is registered per auto-workspace source (GitHub + YouTrack)
- Move the `gh` CLI requirement note onto the GitHub query row
- Mark sensitive keys accordingly