### PR TITLE
feat: reduced process counts per workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,30 +304,30 @@ All settings use dot-separated, kebab-case config keys. The same key works in th
 
 Precedence (highest wins): CLI flag > env var > config.json > computed defaults > static defaults.
 
-| Key                                   | Default   | Description                                                                                                                                                           |
-| ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                               | `null`    | Agent selection: claude\|opencode                                                                                                                                     |
-| `auto-update`                         | `ask`     | Auto-update preference: always\|ask\|never                                                                                                                            |
-| `version.claude`                      | `null`    | Claude agent version override                                                                                                                                         |
-| `version.opencode`                    | `null`    | OpenCode agent version override                                                                                                                                       |
-| `code-server.port`                    | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                                        |
-| `version.code-server`                 | `null`    | Code-server version override (null = built-in)                                                                                                                        |
-| `telemetry.enabled`                   | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                                            |
-| `telemetry.distinct-id`               | —         | Telemetry user ID (auto-generated)                                                                                                                                    |
-| `log.level`                           | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                                               |
-| `log.output`                          | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                                             |
-| `electron.flags`                      | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                                             |
-| `electron.disabled-features`          | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults                     |
-| `experimental.iframes`                | `false`   | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools, fail-load retry, and crash recovery |
-| `experimental.prevent-sleep`          | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline                               |
-| `experimental.load-on-resume`         | `true`    | Reload all workspace views when the system resumes from sleep (gated on code-server being healthy)                                                                    |
-| `experimental.github.query`           | (below)   | GitHub auto-workspace search query (requires `gh` CLI); default: `is:open is:pr review-requested:@me`                                                                 |
-| `experimental.github.template-path`   | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable. Sensitive                                                                                          |
-| `experimental.youtrack.base-url`      | `null`    | YouTrack instance URL (e.g. `https://youtrack.example.com`). Sensitive                                                                                                |
-| `experimental.youtrack.token`         | `null`    | YouTrack API permanent token. Sensitive                                                                                                                               |
-| `experimental.youtrack.query`         | `null`    | YouTrack auto-workspace search query (e.g. `for:me State: {In Progress}`)                                                                                             |
-| `experimental.youtrack.template-path` | `null`    | Path to Liquid template for YouTrack auto-workspaces; set to enable. Sensitive                                                                                        |
-| `help`                                | `false`   | Print config help and exit                                                                                                                                            |
+| Key                                   | Default   | Description                                                                                                                                         |
+| ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`                               | `null`    | Agent selection: claude\|opencode                                                                                                                   |
+| `auto-update`                         | `ask`     | Auto-update preference: always\|ask\|never                                                                                                          |
+| `version.claude`                      | `null`    | Claude agent version override                                                                                                                       |
+| `version.opencode`                    | `null`    | OpenCode agent version override                                                                                                                     |
+| `code-server.port`                    | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                      |
+| `version.code-server`                 | `null`    | Code-server version override (null = built-in)                                                                                                      |
+| `telemetry.enabled`                   | `true`    | Enable telemetry (false in dev/unpackaged)                                                                                                          |
+| `telemetry.distinct-id`               | —         | Telemetry user ID (auto-generated)                                                                                                                  |
+| `log.level`                           | `warn`    | Level spec: `<level>` or `<level>:<filter>` (e.g., `debug:git,process`)                                                                             |
+| `log.output`                          | `file`    | Output destinations: `file`, `console`, or `file,console`                                                                                           |
+| `electron.flags`                      | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                           |
+| `electron.disabled-features`          | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults   |
+| `experimental.iframes`                | `true`    | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools and crash recovery |
+| `experimental.prevent-sleep`          | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline             |
+| `experimental.load-on-resume`         | `true`    | Reload all workspace views when the system resumes from sleep (gated on code-server being healthy)                                                  |
+| `experimental.github.query`           | (below)   | GitHub auto-workspace search query (requires `gh` CLI); default: `is:open is:pr review-requested:@me`                                               |
+| `experimental.github.template-path`   | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable. Sensitive                                                                        |
+| `experimental.youtrack.base-url`      | `null`    | YouTrack instance URL (e.g. `https://youtrack.example.com`). Sensitive                                                                              |
+| `experimental.youtrack.token`         | `null`    | YouTrack API permanent token. Sensitive                                                                                                             |
+| `experimental.youtrack.query`         | `null`    | YouTrack auto-workspace search query (e.g. `for:me State: {In Progress}`)                                                                           |
+| `experimental.youtrack.template-path` | `null`    | Path to Liquid template for YouTrack auto-workspaces; set to enable. Sensitive                                                                      |
+| `help`                                | `false`   | Print config help and exit                                                                                                                          |
 
 Any key can appear in config.json, env vars, or CLI flags.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,11 +224,11 @@ configService.register("help", {
 });
 configService.register("experimental.iframes", {
   name: "experimental.iframes",
-  default: false,
+  default: true,
   description:
     "Render workspaces as iframes inside a single host WebContentsView " +
     "(experimental; requires app restart). Lower memory at the cost of " +
-    "per-workspace devtools, fail-load retry, and crash recovery.",
+    "per-workspace devtools and crash recovery.",
   ...configBoolean(),
 });
 


### PR DESCRIPTION
- Flip `experimental.iframes` default from `false` to `true`, so workspaces render as iframes inside a single shared host WebContentsView instead of one renderer process per workspace
- Cuts memory at scale (spike: −43% at 9 streaming workspaces; ~169 MB saved per workspace)
- WebContentsView-per-workspace remains available via `experimental.iframes=false`
- Trim the config description's cost list to drop the now-implemented fail-load retry (keeps per-workspace devtools + crash recovery as known gaps)
- Update `CLAUDE.md` config table default to `true`

Note: existing users on the default move to iframe mode on their next launch (no migration needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)