### PR TITLE
feat: system sleep is prevented while agents are busy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,6 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | `electron.flags`                      | —         | Electron switches (e.g., `--disable-gpu`)                                                                                                           |
 | `electron.disabled-features`          | (curated) | Comma-separated Chromium features for `--disable-features`. `null` = curated defaults; `""` = nothing disabled; any value fully replaces defaults   |
 | `experimental.iframes`                | `true`    | Render workspaces as iframes inside a single host WebContentsView (requires restart). Lower memory; stubs per-workspace devtools and crash recovery |
-| `experimental.prevent-sleep`          | `true`    | Prevent the OS from sleeping (display-sleep blocker) while any workspace's agent is busy. Releases when all workspaces are idle/offline             |
 | `experimental.load-on-resume`         | `true`    | Reload all workspace views when the system resumes from sleep (gated on code-server being healthy)                                                  |
 | `experimental.github.query`           | (below)   | GitHub auto-workspace search query (requires `gh` CLI); default: `is:open is:pr review-requested:@me`                                               |
 | `experimental.github.template-path`   | `null`    | Path to Liquid template for GitHub auto-workspaces; set to enable. Sensitive                                                                        |

--- a/src/main.ts
+++ b/src/main.ts
@@ -552,7 +552,6 @@ const badgeModule = createBadgeModule({
 });
 const powerModule = createPowerModule({
   appLayer,
-  configService,
   logger: loggingService.createLogger("power"),
 });
 const deletionDialogModule = createDeletionDialogModule({

--- a/src/modules/power-module.integration.test.ts
+++ b/src/modules/power-module.integration.test.ts
@@ -7,7 +7,6 @@
  * - The OS sleep blocker engages while any workspace is busy/mixed.
  * - It releases when all workspaces are idle/none, deleted, or hibernated.
  * - Repeated busy updates don't thrash the blocker (idempotency).
- * - The `experimental.prevent-sleep` config gates the behavior.
  * - The blocker is released on app shutdown.
  */
 
@@ -45,7 +44,6 @@ import type { IntentModule } from "../intents/lib/module";
 import { createPowerModule } from "./power-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createAppBoundaryMock, type MockAppBoundary } from "../boundaries/shell/app.state-mock";
-import { createMockConfig } from "../boundaries/platform/config.test-utils";
 import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
@@ -111,7 +109,7 @@ interface ModuleTestSetup {
   appLayer: MockAppBoundary;
 }
 
-function createModuleTestSetup(options?: { enabled?: boolean }): ModuleTestSetup {
+function createModuleTestSetup(): ModuleTestSetup {
   const appLayer = createAppBoundaryMock();
   const dispatcher = createMockDispatcher();
 
@@ -120,12 +118,7 @@ function createModuleTestSetup(options?: { enabled?: boolean }): ModuleTestSetup
   dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
   dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  const configService =
-    options?.enabled === false
-      ? createMockConfig({ defaults: { "experimental.prevent-sleep": false } })
-      : createMockConfig();
-
-  const powerModule = createPowerModule({ appLayer, configService, logger: SILENT_LOGGER });
+  const powerModule = createPowerModule({ appLayer, logger: SILENT_LOGGER });
   dispatcher.registerModule(powerModule);
   dispatcher.registerModule(createMockResolveModule());
 
@@ -255,16 +248,6 @@ describe("PowerModule Integration", () => {
 
       expect(appLayer).toBePreventingSleep();
       expect(appLayer).toHaveSleepBlockerStartCount(1);
-    });
-  });
-
-  describe("config gating", () => {
-    it("never engages the blocker when experimental.prevent-sleep is false", async () => {
-      const { dispatcher, appLayer } = createModuleTestSetup({ enabled: false });
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
-
-      expect(appLayer).not.toBePreventingSleep();
-      expect(appLayer).toHaveSleepBlockerStartCount(0);
     });
   });
 

--- a/src/modules/power-module.ts
+++ b/src/modules/power-module.ts
@@ -19,11 +19,6 @@
  *
  * Hooks:
  * - app-shutdown/stop: releases the blocker (allowPowerSaving(true)).
- *
- * Gating: the feature is controlled by the `experimental.prevent-sleep` config key
- * (default true). When disabled, the module still tracks state but never toggles
- * the blocker — matching the always-register + internal-check pattern used by
- * debug-module / electron-lifecycle-module.
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -35,15 +30,7 @@ import { EVENT_WORKSPACE_DELETED } from "../intents/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
 import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
 import type { AppBoundary } from "../boundaries/shell/app";
-import type { Config } from "../boundaries/platform/config";
-import { configBoolean } from "../boundaries/platform/config-definition";
 import type { Logger } from "../boundaries/platform/logging";
-
-// =============================================================================
-// Config
-// =============================================================================
-
-export const PREVENT_SLEEP_CONFIG_KEY = "experimental.prevent-sleep";
 
 // =============================================================================
 // Aggregation (pure function)
@@ -76,7 +63,6 @@ export function shouldPreventSleep(
 
 export interface PowerModuleDeps {
   readonly appLayer: AppBoundary;
-  readonly configService: Config;
   readonly logger: Logger;
 }
 
@@ -87,27 +73,15 @@ export interface PowerModuleDeps {
 /**
  * Create a power module that prevents OS sleep while any workspace is busy.
  *
- * @param deps - AppBoundary (sleep blocker), config service, logger
+ * @param deps - AppBoundary (sleep blocker), logger
  * @returns IntentModule with event subscriptions and a shutdown hook
  */
 export function createPowerModule(deps: PowerModuleDeps): IntentModule {
-  const { appLayer, configService, logger } = deps;
-
-  configService.register(PREVENT_SLEEP_CONFIG_KEY, {
-    name: PREVENT_SLEEP_CONFIG_KEY,
-    default: true,
-    description: "Prevent the OS from sleeping while any workspace's agent is busy",
-    ...configBoolean(),
-  });
+  const { appLayer, logger } = deps;
 
   const workspaceStatuses = new Map<WorkspacePath, AggregatedAgentStatus>();
 
-  function isEnabled(): boolean {
-    return configService.get(PREVENT_SLEEP_CONFIG_KEY) === true;
-  }
-
   function applyBlocker(): void {
-    if (!isEnabled()) return;
     const prevent = shouldPreventSleep(workspaceStatuses);
     appLayer.allowPowerSaving(!prevent);
   }


### PR DESCRIPTION
- OS sleep prevention is now unconditional: the display-sleep blocker engages whenever any workspace's agent is busy/mixed and releases when all are idle/offline.
- Removed the `experimental.prevent-sleep` config flag (and its registration, gate, and config dependency in the power module).
- Updated tests and CLAUDE.md accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)