### PR TITLE
refactor(config): return typed accessors from register(), drop string get/set

### DIFF
--- a/src/boundaries/platform/config-definition.ts
+++ b/src/boundaries/platform/config-definition.ts
@@ -33,8 +33,6 @@ export interface ComputedDefaultContext {
  * their config keys, defaults, and parsing/validation logic.
  */
 export interface ConfigKeyDefinition<T> {
-  /** Config key name (dot-separated, kebab-case). */
-  readonly name: string;
   /** Static default value. */
   readonly default: T;
   /** Parse a raw CLI/env string into a typed value. undefined = invalid. */
@@ -72,6 +70,50 @@ type ConfigTypeBuilder<T> = Pick<ConfigKeyDefinition<T>, "parse" | "validate"> &
 };
 
 // =============================================================================
+// Config Accessors
+// =============================================================================
+
+/**
+ * Typed handle to a single config key, returned by `Config.register()`.
+ *
+ * The accessor carries the key's value type, so reads need no casts and writes
+ * are checked against the registered type. It closes over the owning Config
+ * instance; `get()` reflects the effective value (after `load()`), `set()`
+ * persists, and `reset()` reverts to the default.
+ */
+export interface ConfigAccessor<T> {
+  /** The config key name (dot-separated, kebab-case). */
+  readonly name: string;
+  /** The resolved default (static or computed) for this key. */
+  readonly default: T;
+  /** Get the effective value. */
+  get(): T;
+  /**
+   * Set a value at runtime. Validates against the registered definition.
+   * Always persists the given value (including `null` when `T` allows it)
+   * unless `persist: false`. Use `reset()` to revert to the default.
+   */
+  set(value: T, options?: { persist?: boolean }): Promise<void>;
+  /** Revert to the default value and delete the key from config.json. */
+  reset(options?: { persist?: boolean }): Promise<void>;
+  /** True when the effective value equals the resolved default. */
+  isDefault(): boolean;
+}
+
+/**
+ * Accessor returned for keys registered with `deprecated: true`. The key is
+ * recognized (its config.json entry is preserved) but unusable: `get()`/`set()`
+ * are typed `never`, so calling them is a compile error, with a runtime throw
+ * as a backstop.
+ */
+export interface DeprecatedConfigAccessor {
+  /** The config key name. */
+  readonly name: string;
+  get(): never;
+  set(value: never): never;
+}
+
+// =============================================================================
 // Type Builders
 // =============================================================================
 
@@ -91,12 +133,12 @@ export function configBoolean(): ConfigTypeBuilder<boolean> {
  * Builder for enum config values.
  * Parses/validates against a fixed set of allowed string values.
  */
-export function configEnum<T extends string>(values: readonly T[]): ConfigTypeBuilder<T>;
-export function configEnum<T extends string>(
+export function configEnum<const T extends string>(values: readonly T[]): ConfigTypeBuilder<T>;
+export function configEnum<const T extends string>(
   values: readonly T[],
   options: { nullable: true }
 ): ConfigTypeBuilder<T | null>;
-export function configEnum<T extends string>(
+export function configEnum<const T extends string>(
   values: readonly T[],
   options?: { nullable: true }
 ): ConfigTypeBuilder<T | null> {

--- a/src/boundaries/platform/config.integration.test.ts
+++ b/src/boundaries/platform/config.integration.test.ts
@@ -24,32 +24,33 @@ import { parseBool, ConfigValidationError } from "./config-definition";
 // Test Config Definitions
 // =============================================================================
 
-function stringDef(name: string, defaultValue = "default"): ConfigKeyDefinition<unknown> {
+/**
+ * Non-deprecated definition shape accepted by `register()`'s first overload.
+ * Helpers return this so the values flow through to a `ConfigAccessor`; the
+ * deprecated tests spread one of these and override `deprecated: true` to hit
+ * the second overload.
+ */
+type TestDef = Omit<ConfigKeyDefinition<unknown>, "deprecated">;
+
+function stringDef(_name: string, defaultValue = "default"): TestDef {
   return {
-    name,
     default: defaultValue,
     parse: (s: string) => (s === "" ? undefined : s),
     validate: (v: unknown) => (typeof v === "string" ? v : undefined),
   };
 }
 
-function boolDef(name: string, defaultValue = false): ConfigKeyDefinition<unknown> {
+function boolDef(_name: string, defaultValue = false): TestDef {
   return {
-    name,
     default: defaultValue,
     parse: parseBool,
     validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
   };
 }
 
-function enumDef(
-  name: string,
-  values: string[],
-  defaultValue: string | null = null
-): ConfigKeyDefinition<unknown> {
+function enumDef(_name: string, values: string[], defaultValue: string | null = null): TestDef {
   const set = new Set(values);
   return {
-    name,
     default: defaultValue,
     parse: (s: string) => (set.has(s) ? s : s === "" ? null : undefined),
     validate: (v: unknown) =>
@@ -134,21 +135,21 @@ describe("Config", () => {
   describe("register + load + get", () => {
     it("returns static defaults when no other sources exist", () => {
       const svc = createService();
-      svc.register("test.key", stringDef("test.key", "hello"));
+      const key = svc.register("test.key", stringDef("test.key", "hello"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("hello");
+      expect(key.get()).toBe("hello");
     });
 
     it("applies computed defaults over static defaults", () => {
       const svc = createService({ isDevelopment: true });
-      svc.register("test.key", {
+      const key = svc.register("test.key", {
         ...stringDef("test.key", "prod-default"),
         computedDefault: (ctx) => (ctx.isDevelopment ? "dev-default" : undefined),
       });
       svc.load();
 
-      expect(svc.get("test.key")).toBe("dev-default");
+      expect(key.get()).toBe("dev-default");
     });
 
     it("reads values from config.json", () => {
@@ -158,10 +159,10 @@ describe("Config", () => {
           "/app/config.json": file(JSON.stringify({ "test.key": "from-file" })),
         },
       });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("from-file");
+      expect(key.get()).toBe("from-file");
     });
 
     it("env vars override file values", () => {
@@ -172,10 +173,10 @@ describe("Config", () => {
         },
         env: { CH_TEST__KEY: "from-env" },
       });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("from-env");
+      expect(key.get()).toBe("from-env");
     });
 
     it("CLI flags override env vars", () => {
@@ -183,10 +184,10 @@ describe("Config", () => {
         env: { CH_TEST__KEY: "from-env" },
         argv: ["--test.key=from-cli"],
       });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("from-cli");
+      expect(key.get()).toBe("from-cli");
     });
 
     it("full precedence chain: CLI > env > file > computed > static", () => {
@@ -207,45 +208,45 @@ describe("Config", () => {
         argv: ["--test.c=cli-c"],
       });
 
-      const computedDef: ConfigKeyDefinition<unknown> = {
+      const computedDef: TestDef = {
         ...stringDef("test.d", "static-d"),
         computedDefault: () => "computed-d",
       };
 
-      svc.register("test.a", stringDef("test.a", "static-a"));
-      svc.register("test.b", stringDef("test.b", "static-b"));
-      svc.register("test.c", stringDef("test.c", "static-c"));
-      svc.register("test.d", computedDef);
+      const a = svc.register("test.a", stringDef("test.a", "static-a"));
+      const b = svc.register("test.b", stringDef("test.b", "static-b"));
+      const c = svc.register("test.c", stringDef("test.c", "static-c"));
+      const d = svc.register("test.d", computedDef);
       svc.load();
 
-      expect(svc.get("test.a")).toBe("file-a"); // file wins over static
-      expect(svc.get("test.b")).toBe("env-b"); // env wins over file
-      expect(svc.get("test.c")).toBe("cli-c"); // CLI wins over env
-      expect(svc.get("test.d")).toBe("file-d"); // file wins over computed
+      expect(a.get()).toBe("file-a"); // file wins over static
+      expect(b.get()).toBe("env-b"); // env wins over file
+      expect(c.get()).toBe("cli-c"); // CLI wins over env
+      expect(d.get()).toBe("file-d"); // file wins over computed
     });
 
     it("handles missing config.json gracefully", () => {
       const svc = createService(); // no file in mock fs
-      svc.register("test.key", stringDef("test.key", "fallback"));
+      const key = svc.register("test.key", stringDef("test.key", "fallback"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("fallback");
+      expect(key.get()).toBe("fallback");
     });
 
     it("supports boolean CLI flags without value", () => {
       const svc = createService({ argv: ["--test.flag"] });
-      svc.register("test.flag", boolDef("test.flag"));
+      const flag = svc.register("test.flag", boolDef("test.flag"));
       svc.load();
 
-      expect(svc.get("test.flag")).toBe(true);
+      expect(flag.get()).toBe(true);
     });
 
     it("supports --key value CLI format", () => {
       const svc = createService({ argv: ["--test.key", "value"] });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("value");
+      expect(key.get()).toBe("value");
     });
   });
 
@@ -263,11 +264,11 @@ describe("Config", () => {
           writes.push({ path, content });
         },
       });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
 
       svc.load();
 
-      expect(svc.get("test.key")).toBe("kept");
+      expect(key.get()).toBe("kept");
       expect(logger.warn).toHaveBeenCalledWith("Unknown config key in config.json (stripped)", {
         key: "unknown.key",
       });
@@ -311,14 +312,6 @@ describe("Config", () => {
       expect(() => svc.load()).toThrow(ConfigValidationError);
     });
 
-    it("throws on get() with unregistered key", () => {
-      const svc = createService();
-      svc.register("test.key", stringDef("test.key"));
-      svc.load();
-
-      expect(() => svc.get("unknown.key")).toThrow('Unknown config key: "unknown.key"');
-    });
-
     it("throws on duplicate register()", () => {
       const svc = createService();
       svc.register("test.key", stringDef("test.key"));
@@ -348,11 +341,11 @@ describe("Config", () => {
   describe("set()", () => {
     it("updates effective value", async () => {
       const svc = createService();
-      svc.register("test.key", stringDef("test.key", "initial"));
+      const key = svc.register("test.key", stringDef("test.key", "initial"));
       svc.load();
 
-      await svc.set("test.key", "updated");
-      expect(svc.get("test.key")).toBe("updated");
+      await key.set("updated");
+      expect(key.get()).toBe("updated");
     });
 
     it("persists to config.json by default", async () => {
@@ -360,10 +353,10 @@ describe("Config", () => {
         entries: { "/app": directory() },
       });
       const svc = createService({ fileSystem: fs });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      await svc.set("test.key", "persisted");
+      await key.set("persisted");
 
       const content = await fs.readFile(CONFIG_PATH);
       expect(JSON.parse(content)).toEqual({ "test.key": "persisted" });
@@ -374,11 +367,11 @@ describe("Config", () => {
         entries: { "/app": directory() },
       });
       const svc = createService({ fileSystem: fs });
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      await svc.set("test.key", "memory-only", { persist: false });
-      expect(svc.get("test.key")).toBe("memory-only");
+      await key.set("memory-only", { persist: false });
+      expect(key.get()).toBe("memory-only");
 
       // Config file should not exist
       await expect(fs.readFile(CONFIG_PATH)).rejects.toThrow();
@@ -397,16 +390,16 @@ describe("Config", () => {
         })
       );
       svc.register("test.a", stringDef("test.a"));
-      svc.register("test.b", stringDef("test.b"));
+      const b = svc.register("test.b", stringDef("test.b"));
       svc.load();
 
-      await svc.set("test.b", "new-value");
+      await b.set("new-value");
 
       const content = await fs.readFile(CONFIG_PATH);
       expect(JSON.parse(content)).toEqual({ "test.a": "existing", "test.b": "new-value" });
     });
 
-    it("removes key from file when set to null", async () => {
+    it("persists null to file when set to null", async () => {
       const entries = {
         "/app": directory(),
         "/app/config.json": file(JSON.stringify({ "test.key": "value" })),
@@ -418,29 +411,44 @@ describe("Config", () => {
           readFileSync: createSyncReader(entries),
         })
       );
-      svc.register("test.key", enumDef("test.key", ["value"], null));
+      const key = svc.register("test.key", enumDef("test.key", ["value"], null));
       svc.load();
 
-      await svc.set("test.key", null);
+      await key.set(null);
 
+      expect(key.get()).toBeNull();
+      const content = await fs.readFile(CONFIG_PATH);
+      expect(JSON.parse(content)).toEqual({ "test.key": null });
+    });
+
+    it("reset() reverts to default and removes key from file", async () => {
+      const entries = {
+        "/app": directory(),
+        "/app/config.json": file(JSON.stringify({ "test.key": "value" })),
+      };
+      const fs = createFileSystemMock({ entries });
+      const svc = new DefaultConfig(
+        createDeps({
+          fileSystem: fs,
+          readFileSync: createSyncReader(entries),
+        })
+      );
+      const key = svc.register("test.key", enumDef("test.key", ["value"], null));
+      svc.load();
+
+      await key.reset();
+
+      expect(key.get()).toBeNull();
       const content = await fs.readFile(CONFIG_PATH);
       expect(JSON.parse(content)).toEqual({});
     });
 
-    it("throws on unknown key", async () => {
-      const svc = createService();
-      svc.register("test.key", stringDef("test.key"));
-      svc.load();
-
-      await expect(svc.set("unknown.key", "value")).rejects.toThrow(ConfigValidationError);
-    });
-
     it("throws on invalid value", async () => {
       const svc = createService();
-      svc.register("test.flag", boolDef("test.flag"));
+      const flag = svc.register("test.flag", boolDef("test.flag"));
       svc.load();
 
-      await expect(svc.set("test.flag", "not-bool")).rejects.toThrow(ConfigValidationError);
+      await expect(flag.set("not-bool")).rejects.toThrow(ConfigValidationError);
     });
   });
 
@@ -458,10 +466,10 @@ describe("Config", () => {
           renames.push({ from, to });
         },
       });
-      svc.register("test.key", stringDef("test.key", "fallback"));
+      const key = svc.register("test.key", stringDef("test.key", "fallback"));
       svc.load();
 
-      expect(svc.get("test.key")).toBe("fallback");
+      expect(key.get()).toBe("fallback");
       const backupPath = new Path(CONFIG_PATH.dirname, "config.json.broken");
       expect(renames).toEqual([{ from: CONFIG_PATH.toNative(), to: backupPath.toNative() }]);
       expect(logger.warn).toHaveBeenCalledWith(
@@ -504,10 +512,10 @@ describe("Config", () => {
           },
         })
       );
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      await svc.set("test.key", "fresh");
+      await key.set("fresh");
 
       const content = await fs.readFile(CONFIG_PATH);
       expect(JSON.parse(content)).toEqual({ "test.key": "fresh" });
@@ -534,10 +542,10 @@ describe("Config", () => {
           },
         })
       );
-      svc.register("test.key", stringDef("test.key"));
+      const key = svc.register("test.key", stringDef("test.key"));
       svc.load();
 
-      await expect(svc.set("test.key", "fresh")).rejects.toThrow("EACCES: cannot rename");
+      await expect(key.set("fresh")).rejects.toThrow("EACCES: cannot rename");
 
       const content = await fs.readFile(CONFIG_PATH);
       expect(content).toBe("{{ still broken");
@@ -562,18 +570,19 @@ describe("Config", () => {
       expect(writes).toHaveLength(0);
     });
 
-    it("get() and set() throw with reason 'deprecated'", async () => {
+    it("accessor get() and set() throw with reason 'deprecated'", () => {
       const svc = createService();
-      svc.register("test.old", { ...stringDef("test.old"), deprecated: true });
+      const old = svc.register("test.old", { ...stringDef("test.old"), deprecated: true });
       svc.load();
 
-      expect(() => svc.get("test.old")).toThrow(ConfigValidationError);
+      expect(() => old.get()).toThrow(ConfigValidationError);
       try {
-        svc.get("test.old");
+        old.get();
       } catch (e) {
         expect((e as ConfigValidationError).detail.reason).toBe("deprecated");
       }
-      await expect(svc.set("test.old", "x")).rejects.toThrow(ConfigValidationError);
+      const setDeprecated = old.set as () => never;
+      expect(() => setDeprecated()).toThrow(ConfigValidationError);
     });
 
     it("is hidden from help text and overrides", () => {
@@ -594,9 +603,9 @@ describe("Config", () => {
   });
 
   describe("legacy names", () => {
-    function defWithLegacy(name: string): ConfigKeyDefinition<unknown> {
+    function defWithLegacy(name: string): TestDef {
       return {
-        ...stringDef(name, "default"),
+        ...stringDef(name),
         legacyNames: {
           "legacy.old-name": (v: unknown) => (typeof v === "string" ? `migrated:${v}` : undefined),
         },
@@ -610,10 +619,10 @@ describe("Config", () => {
           "/app/config.json": file(JSON.stringify({ "legacy.old-name": "raw" })),
         },
       });
-      svc.register("test.new", defWithLegacy("test.new"));
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
       svc.load();
 
-      expect(svc.get("test.new")).toBe("migrated:raw");
+      expect(newKey.get()).toBe("migrated:raw");
     });
 
     it("preserves the legacy entry in config.json (no rewrite)", () => {
@@ -644,10 +653,10 @@ describe("Config", () => {
         },
         logger,
       });
-      svc.register("test.new", defWithLegacy("test.new"));
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
       svc.load();
 
-      expect(svc.get("test.new")).toBe("explicit");
+      expect(newKey.get()).toBe("explicit");
       expect(logger.warn).toHaveBeenCalledWith(
         "Legacy config key shadowed by new key (legacy ignored)",
         { legacy: "legacy.old-name", newKey: "test.new" }
@@ -663,10 +672,10 @@ describe("Config", () => {
         },
         logger,
       });
-      svc.register("test.new", defWithLegacy("test.new"));
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
       svc.load();
 
-      expect(svc.get("test.new")).toBe("default");
+      expect(newKey.get()).toBe("default");
       expect(logger.warn).toHaveBeenCalledWith(
         "Legacy config key could not be translated (using default)",
         { legacy: "legacy.old-name", newKey: "test.new", value: "42" }

--- a/src/boundaries/platform/config.test-utils.ts
+++ b/src/boundaries/platform/config.test-utils.ts
@@ -1,16 +1,17 @@
 /**
  * Test utilities for Config.
  *
- * Provides a stateful Map-backed mock that mirrors get/set/getEffective
- * and lets callers seed both the in-memory store and the getOverrides()
- * snapshot independently.
+ * Provides a stateful Map-backed mock whose register() returns working,
+ * store-backed accessors (mirroring production), plus a standalone
+ * createMockAccessor() for injecting cross-module accessors into deps.
  */
 import type { Config } from "./config";
+import type { ConfigAccessor, DeprecatedConfigAccessor } from "./config-definition";
 
 export interface CreateMockConfigOptions {
   /**
-   * Seed the in-memory store. Mirrored by get(), set() (mutates),
-   * and getEffective().
+   * Seed the in-memory store. Mirrored by accessor get()/set() and
+   * getEffective().
    */
   defaults?: Record<string, unknown> | undefined;
   /**
@@ -22,40 +23,93 @@ export interface CreateMockConfigOptions {
 }
 
 /**
- * Create a stateful mock Config for tests.
+ * Create a stateful mock Config for tests. register() returns an accessor
+ * backed by the shared store, so a module under test reads/writes through it
+ * exactly as it would in production.
  *
  * @example
  * const config = createMockConfig({ defaults: { agent: "claude" } });
- * await config.set("agent", "opencode");
- * expect(config.get("agent")).toBe("opencode");
- *
- * @example
- * const config = createMockConfig({
- *   defaults: { "telemetry.enabled": true },
- *   overrides: { agent: "claude", "log.level": "debug" },
- * });
- * expect(config.getOverrides()).toEqual({ agent: "claude", "log.level": "debug" });
+ * const agent = config.register("agent", { default: null, ... });
+ * await agent.set("opencode");
+ * expect(agent.get()).toBe("opencode");
  */
 export function createMockConfig(options?: CreateMockConfigOptions): Config {
   const store = new Map<string, unknown>(Object.entries(options?.defaults ?? {}));
   const overrides = { ...(options?.overrides ?? {}) };
+  const defaultsByKey = new Map<string, unknown>();
+
+  function makeAccessor(key: string): ConfigAccessor<unknown> {
+    return {
+      name: key,
+      get default() {
+        return defaultsByKey.get(key);
+      },
+      get: () => store.get(key),
+      set: async (value: unknown) => {
+        store.set(key, value);
+      },
+      reset: async () => {
+        store.set(key, defaultsByKey.get(key));
+      },
+      isDefault: () => store.get(key) === defaultsByKey.get(key),
+    };
+  }
+
+  const register = ((
+    key: string,
+    definition: { default?: unknown; deprecated?: true }
+  ): ConfigAccessor<unknown> | DeprecatedConfigAccessor => {
+    defaultsByKey.set(key, definition.default);
+    // Mirror production: registered defaults seed the store for unset keys,
+    // but never overwrite values pre-populated via the `defaults` option.
+    if (!store.has(key) && definition.default !== undefined) {
+      store.set(key, definition.default);
+    }
+    if (definition.deprecated) {
+      const throwDeprecated = (): never => {
+        throw new Error(`Deprecated config key "${key}"`);
+      };
+      return { name: key, get: throwDeprecated, set: throwDeprecated };
+    }
+    return makeAccessor(key);
+  }) as Config["register"];
+
   return {
-    register: (key: string, definition: { default?: unknown }) => {
-      // Mirror production: registered defaults seed get() for unset keys,
-      // but never overwrite values pre-populated via the `defaults` option.
-      if (!store.has(key) && definition.default !== undefined) {
-        store.set(key, definition.default);
-      }
-    },
+    register,
     load: () => {},
-    get: (key: string) => store.get(key),
-    set: async (key: string, value: unknown) => {
-      store.set(key, value);
-    },
     getDefinitions: () => new Map(),
     getEffective: () => Object.fromEntries(store),
     getDefaults: () => ({}),
     getOverrides: () => ({ ...overrides }),
     getHelpText: () => "",
+  };
+}
+
+/**
+ * Create a standalone, store-backed ConfigAccessor for tests that inject a
+ * cross-module accessor (e.g. `agent`, `experimental.iframes`) into a module's
+ * deps without constructing a full Config.
+ *
+ * @example
+ * const agentConfig = createMockAccessor<ConfigAgentType>("agent", "claude");
+ * const module = createPosthogModule({ ...deps, agentConfig });
+ */
+export function createMockAccessor<T>(
+  name: string,
+  initial: T,
+  defaultValue: T = initial
+): ConfigAccessor<T> {
+  let value = initial;
+  return {
+    name,
+    default: defaultValue,
+    get: () => value,
+    set: async (next: T) => {
+      value = next;
+    },
+    reset: async () => {
+      value = defaultValue;
+    },
+    isDefault: () => value === defaultValue,
   };
 }

--- a/src/boundaries/platform/config.ts
+++ b/src/boundaries/platform/config.ts
@@ -1,11 +1,12 @@
 /**
  * Config - Plain service for application configuration.
  *
- * Replaces the intent-based config module with a simple register/get/set API.
+ * register() returns a typed ConfigAccessor for each key; reads and writes go
+ * through that accessor (there is no string-keyed get/set on the service).
  * Config is fully resolved before any hooks run:
- *   1. Modules call register() to declare their keys
+ *   1. Modules call register() to declare their keys and capture an accessor
  *   2. load() reads config.json (sync), env vars, CLI args, and merges
- *   3. Modules call get() to read values, set() to persist changes
+ *   3. Modules call accessor.get() to read, accessor.set()/reset() to persist
  *
  * Precedence (highest wins): CLI flags > env vars > config.json > computed defaults > static defaults
  *
@@ -13,12 +14,17 @@
  * run before Electron app.ready, and the FileSystemBoundary interface is async-only.
  * The sync write fires only when unknown (no-longer-registered) keys are stripped from
  * config.json on load; the sync rename fires only when config.json contains invalid JSON
- * and is moved aside to config.json.broken. This is a documented exception. set() uses the
- * async FileSystemBoundary for writes (all callers are post-ready).
+ * and is moved aside to config.json.broken. This is a documented exception. accessor.set()
+ * uses the async FileSystemBoundary for writes (all callers are post-ready).
  */
 
 import { readFileSync, renameSync, writeFileSync } from "node:fs";
-import type { ConfigKeyDefinition, ComputedDefaultContext } from "./config-definition";
+import type {
+  ConfigKeyDefinition,
+  ComputedDefaultContext,
+  ConfigAccessor,
+  DeprecatedConfigAccessor,
+} from "./config-definition";
 import { ConfigValidationError } from "./config-definition";
 import type { FileSystemBoundary } from "./filesystem";
 import { Path } from "../../utils/path/path";
@@ -97,8 +103,22 @@ export function generateHelpText(
 // =============================================================================
 
 export interface Config {
-  /** Register a config key definition. Must be called before load(). */
-  register(key: string, definition: ConfigKeyDefinition<unknown>): void;
+  /**
+   * Register a config key definition and return a typed accessor for it.
+   * Must be called before load(). Keys with `deprecated: true` return a
+   * DeprecatedConfigAccessor whose get()/set() are typed `never`.
+   */
+  register<T>(
+    key: string,
+    definition: Omit<ConfigKeyDefinition<T>, "default"> & {
+      default: NoInfer<T>;
+      deprecated?: undefined;
+    }
+  ): ConfigAccessor<T>;
+  register(
+    key: string,
+    definition: ConfigKeyDefinition<unknown> & { deprecated: true }
+  ): DeprecatedConfigAccessor;
 
   /**
    * Load config from all sources and merge with precedence:
@@ -108,15 +128,6 @@ export interface Config {
    * Throws on validation errors or duplicate keys.
    */
   load(): void;
-
-  /** Get the effective value for a registered config key. Throws if key is not registered. */
-  get(key: string): unknown;
-
-  /**
-   * Set a value at runtime. Validates against the registered definition.
-   * When persist is true (default), writes to config.json via FileSystemBoundary.
-   */
-  set(key: string, value: unknown, options?: { persist?: boolean }): Promise<void>;
 
   /** Get the full definition map (for help text generation). */
   getDefinitions(): ReadonlyMap<string, ConfigKeyDefinition<unknown>>;
@@ -412,7 +423,21 @@ export class DefaultConfig implements Config {
 
   constructor(private readonly deps: ConfigDeps) {}
 
-  register(key: string, definition: ConfigKeyDefinition<unknown>): void {
+  register<T>(
+    key: string,
+    definition: Omit<ConfigKeyDefinition<T>, "default"> & {
+      default: NoInfer<T>;
+      deprecated?: undefined;
+    }
+  ): ConfigAccessor<T>;
+  register(
+    key: string,
+    definition: ConfigKeyDefinition<unknown> & { deprecated: true }
+  ): DeprecatedConfigAccessor;
+  register(
+    key: string,
+    definition: ConfigKeyDefinition<unknown>
+  ): ConfigAccessor<unknown> | DeprecatedConfigAccessor {
     if (this.loaded) {
       throw new Error(`Cannot register config key "${key}" after load()`);
     }
@@ -433,6 +458,39 @@ export class DefaultConfig implements Config {
       }
     }
     this.definitions.set(key, definition);
+    return definition.deprecated ? this.createDeprecatedAccessor(key) : this.createAccessor(key);
+  }
+
+  private createAccessor(key: string): ConfigAccessor<unknown> {
+    // Arrow functions close over the DefaultConfig `this` directly (no aliasing).
+    const readDefault = (): unknown => this.defaults[key];
+    return {
+      name: key,
+      get default(): unknown {
+        return readDefault();
+      },
+      get: (): unknown => this.readValue(key),
+      set: (value: unknown, options?: { persist?: boolean }): Promise<void> =>
+        this.writeValue(key, value, options),
+      reset: (options?: { persist?: boolean }): Promise<void> => this.resetValue(key, options),
+      isDefault: (): boolean => this.isDefaultValue(key),
+    };
+  }
+
+  private createDeprecatedAccessor(key: string): DeprecatedConfigAccessor {
+    const throwDeprecated = (): never => {
+      throw new ConfigValidationError({
+        key,
+        value: undefined,
+        reason: "deprecated",
+        source: "accessor",
+      });
+    };
+    return {
+      name: key,
+      get: throwDeprecated,
+      set: throwDeprecated,
+    };
   }
 
   load(): void {
@@ -534,102 +592,107 @@ export class DefaultConfig implements Config {
     }
   }
 
-  get(key: string): unknown {
-    const def = this.definitions.get(key);
-    if (!def) {
-      throw new Error(`Unknown config key: "${key}"`);
-    }
-    if (def.deprecated) {
-      throw new ConfigValidationError({
-        key,
-        value: undefined,
-        reason: "deprecated",
-        source: "get",
-      });
-    }
+  /** Backs ConfigAccessor.get(). The accessor exists only for registered keys. */
+  private readValue(key: string): unknown {
     return this.effective[key];
   }
 
-  async set(key: string, value: unknown, options?: { persist?: boolean }): Promise<void> {
+  /** Backs ConfigAccessor.set(): validate, update effective, persist the value. */
+  private async writeValue(
+    key: string,
+    value: unknown,
+    options?: { persist?: boolean }
+  ): Promise<void> {
     const def = this.definitions.get(key);
     if (!def) {
+      throw new ConfigValidationError({ key, value, reason: "unknown", source: "set" });
+    }
+
+    const validated = def.validate(value);
+    if (validated === undefined) {
       throw new ConfigValidationError({
         key,
         value,
-        reason: "unknown",
+        reason: "invalid",
         source: "set",
+        ...(def.description !== undefined && { description: def.description }),
+        ...(def.validValues !== undefined && { validValues: def.validValues }),
       });
     }
-    if (def.deprecated) {
-      throw new ConfigValidationError({ key, value, reason: "deprecated", source: "set" });
+    this.effective[key] = validated;
+
+    if (options?.persist !== false) {
+      await this.persistMutation((fileContent) => {
+        fileContent[key] = validated;
+      });
     }
+  }
 
-    // Validate
-    if (value !== null) {
-      const validated = def.validate(value);
-      if (validated === undefined) {
-        throw new ConfigValidationError({
-          key,
-          value,
-          reason: "invalid",
-          source: "set",
-          ...(def.description !== undefined && { description: def.description }),
-          ...(def.validValues !== undefined && { validValues: def.validValues }),
-        });
-      }
-      this.effective[key] = validated;
-    } else {
-      // null means revert to default
-      this.effective[key] = value;
+  /** Backs ConfigAccessor.reset(): revert to default, delete the key from disk. */
+  private async resetValue(key: string, options?: { persist?: boolean }): Promise<void> {
+    if (!this.definitions.has(key)) {
+      throw new ConfigValidationError({
+        key,
+        value: undefined,
+        reason: "unknown",
+        source: "reset",
+      });
     }
+    this.effective[key] = this.defaults[key];
 
-    const persist = options?.persist !== false;
-    if (persist) {
-      const { configPath, fileSystem, logger } = this.deps;
-
-      // Read-modify-write config file
-      let fileContent: Record<string, unknown> = {};
-      let raw: string | null = null;
-      try {
-        raw = await fileSystem.readFile(configPath);
-      } catch (error) {
-        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-          // File doesn't exist yet — start fresh.
-        } else {
-          throw error;
-        }
-      }
-      if (raw !== null) {
-        try {
-          fileContent = JSON.parse(raw) as Record<string, unknown>;
-        } catch (error) {
-          // Invalid JSON: move config.json aside, then write a fresh file with
-          // just the new key. If the rename fails, throw — silently overwriting
-          // would destroy the broken-but-recoverable file.
-          const backupPath = new Path(configPath.dirname, BROKEN_CONFIG_FILENAME);
-          await fileSystem.rename(configPath, backupPath);
-          logger.warn(
-            "Invalid JSON in config.json, backed up to config.json.broken; writing fresh",
-            {
-              path: configPath.toString(),
-              backup: backupPath.toString(),
-              error: error instanceof Error ? error.message : String(error),
-            }
-          );
-          fileContent = {};
-        }
-      }
-
-      if (value === null) {
+    if (options?.persist !== false) {
+      await this.persistMutation((fileContent) => {
         delete fileContent[key];
-      } else {
-        fileContent[key] = this.effective[key];
-      }
-
-      await fileSystem.mkdir(configPath.dirname);
-      await fileSystem.writeFile(configPath, JSON.stringify(fileContent, null, 2));
-      logger.debug("Config persisted", { path: configPath.toString() });
+      });
     }
+  }
+
+  /** Backs ConfigAccessor.isDefault(). */
+  private isDefaultValue(key: string): boolean {
+    return overrideEquals(this.effective[key], this.defaults[key]);
+  }
+
+  /**
+   * Read-modify-write config.json with the given mutator. Handles a missing
+   * file (start fresh) and invalid JSON (back up to config.json.broken, then
+   * write fresh — if the rename fails, throw rather than destroy the file).
+   */
+  private async persistMutation(
+    mutator: (fileContent: Record<string, unknown>) => void
+  ): Promise<void> {
+    const { configPath, fileSystem, logger } = this.deps;
+
+    let fileContent: Record<string, unknown> = {};
+    let raw: string | null = null;
+    try {
+      raw = await fileSystem.readFile(configPath);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        // File doesn't exist yet — start fresh.
+      } else {
+        throw error;
+      }
+    }
+    if (raw !== null) {
+      try {
+        fileContent = JSON.parse(raw) as Record<string, unknown>;
+      } catch (error) {
+        const backupPath = new Path(configPath.dirname, BROKEN_CONFIG_FILENAME);
+        await fileSystem.rename(configPath, backupPath);
+        logger.warn("Invalid JSON in config.json, backed up to config.json.broken; writing fresh", {
+          path: configPath.toString(),
+          backup: backupPath.toString(),
+          error: error instanceof Error ? error.message : String(error),
+        });
+        fileContent = {};
+      }
+    }
+
+    mutator(fileContent);
+
+    await fileSystem.mkdir(configPath.dirname);
+    await fileSystem.writeFile(configPath, JSON.stringify(fileContent, null, 2));
+    logger.debug("Config persisted", { path: configPath.toString() });
   }
 
   getDefinitions(): ReadonlyMap<string, ConfigKeyDefinition<unknown>> {

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -16,7 +16,7 @@
  * the concrete subclasses.
  */
 
-import type { Config } from "./../platform/config";
+import type { ConfigAccessor } from "../platform/config-definition";
 import type { Logger } from "../platform/logging";
 import type { AppBoundary } from "./app";
 import type { SessionBoundary } from "./session";
@@ -45,7 +45,8 @@ export interface ViewManagerDeps {
   readonly viewLayer: ViewBoundary;
   readonly sessionLayer: SessionBoundary;
   readonly appLayer: Pick<AppBoundary, "openUrl">;
-  readonly configService: Config;
+  /** Accessor for the iframe-rendering flag (registered in the composition root). */
+  readonly iframesConfig: ConfigAccessor<boolean>;
   readonly config: ViewManagerConfig;
   readonly logger: Logger;
 }
@@ -57,7 +58,7 @@ export class ViewManager implements IViewManager {
 
   create(): void {
     if (this.impl) return; // idempotent
-    const useIframes = this.deps.configService.get("experimental.iframes") as boolean;
+    const useIframes = this.deps.iframesConfig.get();
     this.impl = useIframes
       ? new IframeViewManager({
           windowManager: this.deps.windowManager,

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -23,7 +23,8 @@ import type { OpenProjectIntent } from "./open-project";
 import type { IntentModule } from "./lib/module";
 import type { Operation, OperationContext } from "./lib/operation";
 import type { Project } from "../shared/api/types";
-import { createMockConfig } from "../boundaries/platform/config.test-utils";
+import { createMockAccessor } from "../boundaries/platform/config.test-utils";
+import type { ConfigAgentType } from "../boundaries/platform/config-definition";
 
 // =============================================================================
 // Test Helpers
@@ -85,7 +86,10 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(createMockConfig()));
+  dispatcher.registerOperation(
+    INTENT_APP_READY,
+    new AppReadyOperation(createMockAccessor<ConfigAgentType>("agent", null))
+  );
   dispatcher.registerOperation(INTENT_OPEN_PROJECT, stub);
 
   for (const m of modules) dispatcher.registerModule(m);

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -17,7 +17,7 @@ import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
 import { Path } from "../utils/path/path";
 import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
-import type { Config } from "../boundaries/platform/config";
+import type { ConfigAccessor, ConfigAgentType } from "../boundaries/platform/config-definition";
 
 // =============================================================================
 // Intent Types
@@ -86,7 +86,7 @@ export interface AvailableAgentsResult {
 export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResult> {
   readonly id = APP_READY_OPERATION_ID;
 
-  constructor(private readonly configService: Config) {}
+  constructor(private readonly agentConfig: ConfigAccessor<ConfigAgentType>) {}
 
   async execute(ctx: OperationContext<AppReadyIntent>): Promise<AppReadyResult> {
     const hookCtx: HookContext = { intent: ctx.intent };
@@ -105,7 +105,7 @@ export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResu
       if (result.agent) availableAgents.push(result.agent);
     }
 
-    const defaultAgentRaw = this.configService.get("agent") as string | null;
+    const defaultAgentRaw = this.agentConfig.get();
     const defaultAgent: LifecycleAgentType | null =
       defaultAgentRaw === "claude" || defaultAgentRaw === "opencode" ? defaultAgentRaw : null;
 

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -51,12 +51,14 @@ import {
 } from "./lib/operation";
 import type { ConfigAgentType } from "../shared/api/types";
 import type { BinaryType } from "./app-start";
-import { createMockConfig as createBaseMockConfig } from "../boundaries/platform/config.test-utils";
-import type { Config } from "../boundaries/platform/config";
+import { createMockAccessor } from "../boundaries/platform/config.test-utils";
+import type { ConfigAccessor } from "../boundaries/platform/config-definition";
 
-/** Mock that seeds the configured agent. Pass null to leave it unset. */
-function createMockConfig(agent: ConfigAgentType | null = "opencode"): Config {
-  return createBaseMockConfig({ defaults: { agent } });
+/** Mock accessor that seeds the configured agent. Pass null to leave it unset. */
+function createMockAgentAccessor(
+  agent: ConfigAgentType | null = "opencode"
+): ConfigAccessor<ConfigAgentType | null> {
+  return createMockAccessor<ConfigAgentType | null>("agent", agent);
 }
 
 // =============================================================================
@@ -225,7 +227,7 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(createMockConfig()));
+  dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(createMockAgentAccessor()));
 
   const allModules = options?.skipDefaultChecks ? modules : [...defaultCheckModules(), ...modules];
   for (const m of allModules) dispatcher.registerModule(m);
@@ -442,7 +444,7 @@ describe("AppStart Operation", () => {
       const agent = options?.configuredAgent !== undefined ? options.configuredAgent : "opencode";
       dispatcher.registerOperation(
         INTENT_APP_START,
-        new AppStartOperation(createMockConfig(agent))
+        new AppStartOperation(createMockAgentAccessor(agent))
       );
       if (options?.setupStub) {
         dispatcher.registerOperation(INTENT_SETUP, options.setupStub);

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -35,8 +35,8 @@
 import type { Intent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { ConfigAgentType } from "../shared/api/types";
+import type { ConfigAccessor } from "../boundaries/platform/config-definition";
 import type { BinaryType } from "../utils/binary-resolution/types";
-import type { Config } from "../boundaries/platform/config";
 
 /** Re-exported for use by operation integration tests (avoids direct service import). */
 export type { BinaryType } from "../utils/binary-resolution/types";
@@ -143,7 +143,7 @@ interface CheckResult {
 export class AppStartOperation implements Operation<AppStartIntent, void> {
   readonly id = APP_START_OPERATION_ID;
 
-  constructor(private readonly configService: Config) {}
+  constructor(private readonly agentConfig: ConfigAccessor<ConfigAgentType | null>) {}
 
   async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
     const hookCtx: HookContext = {
@@ -175,7 +175,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     }
 
     // configuredAgent comes from Config (loaded before app:start)
-    const configuredAgent = this.configService.get("agent") as ConfigAgentType;
+    const configuredAgent = this.agentConfig.get();
 
     // Hook 3: "show-ui" -- Show starting screen, capture waitForRetry
     const { results: showUiResults, errors: showUiErrors } =

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,10 @@ import { ViewManager } from "./boundaries/shell/view-manager";
 import { AutoUpdater } from "./modules/auto-updater";
 import { DefaultArchiveExtractor } from "./boundaries/platform/archive";
 import type { DownloadDeps } from "./utils/binary-download";
-import { getOpencodeExecutablePath } from "./modules/agent-module/opencode/setup-info";
+import {
+  getOpencodeBundleDir,
+  getOpencodeExecutablePath,
+} from "./modules/agent-module/opencode/setup-info";
 import { getClaudeExecutablePath } from "./modules/agent-module/claude/setup-info";
 import type { SupportedPlatform, SupportedArch } from "./boundaries/platform/platform-info";
 import { ClaudeCodeServerManager } from "./modules/agent-module/claude/server-manager";
@@ -439,6 +442,8 @@ const codeServerModule = createCodeServerModule({
   logger: apiLogger,
   archiveExtractor,
   configService,
+  resolveOpencodeBundleDir: (): string =>
+    getOpencodeBundleDir(pathProvider, configService.get("version.opencode") as string).toNative(),
 });
 
 const pluginServerModule = createPluginServerModule({

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { DefaultConfig } from "./boundaries/platform/config";
 import {
   configBoolean,
   configEnum,
+  configString,
   ConfigValidationError,
 } from "./boundaries/platform/config-definition";
 // Boundaries - Shell
@@ -52,8 +53,9 @@ import type { DownloadDeps } from "./utils/binary-download";
 import {
   getOpencodeBundleDir,
   getOpencodeExecutablePath,
+  OPENCODE_VERSION,
 } from "./modules/agent-module/opencode/setup-info";
-import { getClaudeExecutablePath } from "./modules/agent-module/claude/setup-info";
+import { getClaudeExecutablePath, CLAUDE_VERSION } from "./modules/agent-module/claude/setup-info";
 import type { SupportedPlatform, SupportedArch } from "./boundaries/platform/platform-info";
 import { ClaudeCodeServerManager } from "./modules/agent-module/claude/server-manager";
 import { OpenCodeServerManager } from "./modules/agent-module/opencode/server-manager";
@@ -212,27 +214,39 @@ const configService = new DefaultConfig({
   argv: process.argv,
 });
 
-// Register core config keys (not owned by any module)
-configService.register("agent", {
-  name: "agent",
+// Register core config keys (not owned by any single module). Their accessors
+// are threaded into the modules/intents that read or write them, so those
+// consumers never reach into the config service by string key.
+const agentConfig = configService.register("agent", {
   default: null,
   description: "Agent selection",
   ...configEnum(["claude", "opencode"], { nullable: true }),
 });
-configService.register("help", {
-  name: "help",
+const helpConfig = configService.register("help", {
   default: false,
   description: "Print config help and exit",
   ...configBoolean(),
 });
-configService.register("experimental.iframes", {
-  name: "experimental.iframes",
+const iframesConfig = configService.register("experimental.iframes", {
   default: true,
   description:
     "Render workspaces as iframes inside a single host WebContentsView " +
     "(experimental; requires app restart). Lower memory at the cost of " +
     "per-workspace devtools and crash recovery.",
   ...configBoolean(),
+});
+// Agent version keys. Registered here (composition root) rather than inside the
+// agent module so the accessors exist before the server managers and providers
+// that read them are constructed (those are built below, before the modules).
+const claudeVersionConfig = configService.register("version.claude", {
+  default: CLAUDE_VERSION,
+  description: "Claude agent version",
+  ...configString({ nullable: true }),
+});
+const opencodeVersionConfig = configService.register("version.opencode", {
+  default: OPENCODE_VERSION,
+  description: "OpenCode agent version",
+  ...configString(),
 });
 
 // 3. Electron layers (all constructors are pure — just store deps)
@@ -326,7 +340,7 @@ const agentServerManagers = {
     serverManagerDeps.portManager,
     serverManagerDeps.httpClient,
     serverManagerDeps.pathProvider,
-    configService,
+    opencodeVersionConfig,
     serverManagerDeps.logger
   ),
 };
@@ -358,7 +372,7 @@ const viewManager = new ViewManager({
   viewLayer,
   sessionLayer,
   appLayer,
-  configService,
+  iframesConfig,
   config: {
     uiPreloadPath: nodePath.join(__dirname, "../preload/index.cjs"),
     codeServerPort: 0,
@@ -443,7 +457,7 @@ const codeServerModule = createCodeServerModule({
   archiveExtractor,
   configService,
   resolveOpencodeBundleDir: (): string =>
-    getOpencodeBundleDir(pathProvider, configService.get("version.opencode") as string).toNative(),
+    getOpencodeBundleDir(pathProvider, opencodeVersionConfig.get()).toNative(),
 });
 
 const pluginServerModule = createPluginServerModule({
@@ -468,13 +482,13 @@ const claudeAgentModule = createAgentModule(
     serverManager: agentServerManagers.claude,
     downloadDeps,
     binaryConfig: claudeBinaryConfig,
-    configService,
+    versionConfig: claudeVersionConfig,
     pathProvider,
     platform,
     arch,
     logger: providerLogger,
   }),
-  { dispatcher, logger: apiLogger, configService }
+  { dispatcher, logger: apiLogger, agentConfig }
 );
 
 const opencodeAgentModule = createAgentModule(
@@ -482,13 +496,13 @@ const opencodeAgentModule = createAgentModule(
     serverManager: agentServerManagers.opencode,
     downloadDeps,
     binaryConfig: opencodeBinaryConfig,
-    configService,
+    versionConfig: opencodeVersionConfig,
     pathProvider,
     platform,
     arch,
     logger: providerLogger,
   }),
-  { dispatcher, logger: apiLogger, configService }
+  { dispatcher, logger: apiLogger, agentConfig }
 );
 
 const metadataModule = createMetadataModule({
@@ -496,7 +510,7 @@ const metadataModule = createMetadataModule({
 });
 const workspaceAgentResolverModule = createWorkspaceAgentResolverModule({
   gitWorktreeProvider,
-  configService,
+  agentConfig,
   logger: loggingService.createLogger("agent-resolver"),
 });
 const keepFilesModule = createKeepFilesModule({
@@ -520,6 +534,7 @@ const posthogModule = createPosthogModule({
   platformInfo,
   buildInfo,
   configService,
+  agentConfig,
   logger: loggingService.createLogger("telemetry"),
   apiKey: typeof __POSTHOG_API_KEY__ !== "undefined" ? __POSTHOG_API_KEY__ : undefined,
   host: typeof __POSTHOG_HOST__ !== "undefined" ? __POSTHOG_HOST__ : undefined,
@@ -660,8 +675,8 @@ const bugReportModule = createBugReportModule({
 
 dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
-dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(configService));
-dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(configService));
+dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(agentConfig));
+dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(agentConfig));
 // config:set-values operation removed — config is now a plain service
 dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
@@ -826,7 +841,7 @@ try {
 }
 
 // Handle --help
-if (configService.get("help") === true) {
+if (helpConfig.get()) {
   process.stdout.write(configService.getHelpText());
   app.quit();
 }

--- a/src/modules/agent-module/agent-module-provider.ts
+++ b/src/modules/agent-module/agent-module-provider.ts
@@ -10,7 +10,6 @@ import type { AgentType } from "../../shared/plugin-protocol";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../shared/ipc";
 import type { AgentSessionInfo, McpConfig, StopServerResult, RestartServerResult } from "./types";
 import type { BinaryType } from "../../utils/binary-resolution/types";
-import type { ConfigKeyDefinition } from "../../boundaries/platform/config-definition";
 import type { NormalizedInitialPrompt } from "../../shared/api/types";
 import type { DownloadProgressCallback } from "../../utils/binary-download";
 
@@ -67,11 +66,6 @@ export interface AgentModuleProvider {
 
   /** Download the agent binary */
   downloadBinary(onProgress?: DownloadProgressCallback): Promise<void>;
-
-  // --- Config ---
-
-  /** Get the config key definition for version override */
-  getConfigDefinition(): ConfigKeyDefinition<string | null>;
 
   // --- Lifecycle ---
 

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -46,9 +46,8 @@ import type { AgentModuleProvider, WorkspaceStartResult } from "./agent-module-p
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
 import { SetupError } from "../../shared/errors/service-errors";
 import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
-import { configString } from "../../boundaries/platform/config-definition";
-import type { Config } from "../../boundaries/platform/config";
-import { createMockConfig } from "../../boundaries/platform/config.test-utils";
+import type { ConfigAgentType, ConfigAccessor } from "../../boundaries/platform/config-definition";
+import { createMockAccessor } from "../../boundaries/platform/config.test-utils";
 
 // =============================================================================
 // Mock AgentModuleProvider Factory
@@ -73,12 +72,6 @@ function createMockProvider(overrides: Partial<AgentModuleProvider> = {}): Agent
 
     preflight: vi.fn().mockResolvedValue({ success: true, needsDownload: false }),
     downloadBinary: vi.fn().mockResolvedValue(undefined),
-    getConfigDefinition: vi.fn().mockReturnValue({
-      name: "version.claude",
-      default: null,
-      description: "Claude agent version",
-      ...configString({ nullable: true }),
-    }),
     initialize: vi.fn(),
     dispose: vi.fn().mockResolvedValue(undefined),
     startWorkspace: vi.fn().mockResolvedValue({
@@ -308,12 +301,9 @@ class MinimalShutdownOperation implements Operation<
 // Test Setup
 // =============================================================================
 
-function createTestSetup(
-  providerOverrides: Partial<AgentModuleProvider> = {},
-  configValues?: Record<string, unknown>
-) {
+function createTestSetup(providerOverrides: Partial<AgentModuleProvider> = {}) {
   const mockProvider = createMockProvider(providerOverrides);
-  const mockConfig = createMockConfig({ defaults: configValues });
+  const agentConfig = createMockAccessor<ConfigAgentType>("agent", null);
 
   const mockDispatcher = {
     dispatch: vi.fn().mockResolvedValue(undefined),
@@ -322,7 +312,7 @@ function createTestSetup(
   const moduleDeps: AgentModuleDeps = {
     dispatcher: mockDispatcher,
     logger: SILENT_LOGGER,
-    configService: mockConfig,
+    agentConfig,
   };
 
   const dispatcher = createMockDispatcher();
@@ -330,14 +320,17 @@ function createTestSetup(
 
   dispatcher.registerModule(agentModule);
 
-  return { mockProvider, mockConfig, moduleDeps, dispatcher, agentModule };
+  return { mockProvider, agentConfig, moduleDeps, dispatcher, agentModule };
 }
 
 /**
  * Set agent config value to activate the module, then run a start operation.
  */
-async function activateModule(dispatcher: Dispatcher, mockConfig: Config): Promise<void> {
-  await mockConfig.set("agent", "claude");
+async function activateModule(
+  dispatcher: Dispatcher,
+  agentConfig: ConfigAccessor<ConfigAgentType>
+): Promise<void> {
+  await agentConfig.set("claude");
   dispatcher.registerOperation("app:start", new MinimalStartOperation());
   await dispatcher.dispatch({ type: "app:start", payload: {} });
 }
@@ -394,11 +387,11 @@ describe("createAgentModule", () => {
 
   describe("config registration", () => {
     it("registers provider config definition via configService", () => {
-      const { mockConfig } = createTestSetup();
+      const { agentConfig } = createTestSetup();
       // The factory calls configService.register in the body, so
       // we just verify it was called. Since our mock is a no-op for register,
       // we verify that the module was created without errors.
-      expect(mockConfig).toBeDefined();
+      expect(agentConfig).toBeDefined();
     });
   });
 
@@ -629,18 +622,18 @@ describe("createAgentModule", () => {
 
   describe("save-agent", () => {
     it("calls configService.set when selectedAgent matches provider type", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      const setSpy = vi.spyOn(mockConfig, "set");
+      const { dispatcher, agentConfig } = createTestSetup();
+      const setSpy = vi.spyOn(agentConfig, "set");
       dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("claude"));
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
-      expect(setSpy).toHaveBeenCalledWith("agent", "claude");
+      expect(setSpy).toHaveBeenCalledWith("claude");
     });
 
     it("skips when selectedAgent does not match provider type", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      const setSpy = vi.spyOn(mockConfig, "set");
+      const { dispatcher, agentConfig } = createTestSetup();
+      const setSpy = vi.spyOn(agentConfig, "set");
       dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("opencode"));
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
@@ -649,8 +642,8 @@ describe("createAgentModule", () => {
     });
 
     it("throws SetupError on config save failure", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      vi.spyOn(mockConfig, "set").mockRejectedValue(new Error("disk full"));
+      const { dispatcher, agentConfig } = createTestSetup();
+      vi.spyOn(agentConfig, "set").mockRejectedValue(new Error("disk full"));
       dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("claude"));
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
@@ -763,8 +756,8 @@ describe("createAgentModule", () => {
 
   describe("workspace setup", () => {
     it("calls provider.startWorkspace and returns envVars when active", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "workspace:open",
@@ -792,8 +785,8 @@ describe("createAgentModule", () => {
     });
 
     it("passes initial prompt to startWorkspace when provided in intent", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "workspace:open",
@@ -820,8 +813,8 @@ describe("createAgentModule", () => {
     });
 
     it("passes isNewWorkspace=false for existing workspaces", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "workspace:open",
@@ -885,8 +878,8 @@ describe("createAgentModule", () => {
 
   describe("delete shutdown", () => {
     it("calls provider.stopWorkspace when active", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
 
@@ -906,8 +899,8 @@ describe("createAgentModule", () => {
     });
 
     it("calls clearWorkspaceTracking after successful stop", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
 
@@ -925,10 +918,10 @@ describe("createAgentModule", () => {
     });
 
     it("returns error in result when stop fails in force mode", async () => {
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher, agentConfig } = createTestSetup({
         stopWorkspace: vi.fn().mockResolvedValue({ success: false, error: "server busy" }),
       });
-      await activateModule(dispatcher, mockConfig);
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
 
@@ -947,10 +940,10 @@ describe("createAgentModule", () => {
     });
 
     it("throws when stop fails and not force mode", async () => {
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher, agentConfig } = createTestSetup({
         stopWorkspace: vi.fn().mockResolvedValue({ success: false, error: "server busy" }),
       });
-      await activateModule(dispatcher, mockConfig);
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
 
@@ -997,10 +990,10 @@ describe("createAgentModule", () => {
         status: "idle",
         counts: { idle: 1, busy: 0 },
       };
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher, agentConfig } = createTestSetup({
         getStatus: vi.fn().mockReturnValue(idleStatus),
       });
-      await activateModule(dispatcher, mockConfig);
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "workspace:get-status",
@@ -1059,8 +1052,8 @@ describe("createAgentModule", () => {
 
   describe("get-session", () => {
     it("returns session from provider when active", async () => {
-      const { dispatcher, mockConfig } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "agent:get-session",
@@ -1087,10 +1080,10 @@ describe("createAgentModule", () => {
     });
 
     it("returns null session when provider has no session", async () => {
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher, agentConfig } = createTestSetup({
         getSession: vi.fn().mockReturnValue(null),
       });
-      await activateModule(dispatcher, mockConfig);
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "agent:get-session",
@@ -1149,8 +1142,8 @@ describe("createAgentModule", () => {
 
   describe("restart", () => {
     it("restarts workspace via provider when active and returns port", async () => {
-      const { dispatcher, mockConfig, mockProvider } = createTestSetup();
-      await activateModule(dispatcher, mockConfig);
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "agent:restart",
@@ -1178,14 +1171,14 @@ describe("createAgentModule", () => {
     });
 
     it("throws when restart fails", async () => {
-      const { dispatcher, mockConfig } = createTestSetup({
+      const { dispatcher, agentConfig } = createTestSetup({
         restartWorkspace: vi.fn().mockResolvedValue({
           success: false,
           error: "restart failed",
           serverStopped: false,
         }),
       });
-      await activateModule(dispatcher, mockConfig);
+      await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
         "agent:restart",

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -16,7 +16,7 @@ import type { Logger } from "../../boundaries/platform/logging-types";
 import type { BinaryType } from "../../utils/binary-resolution/types";
 import type { AgentType } from "../../shared/plugin-protocol";
 import type { WorkspacePath } from "../../shared/ipc";
-import type { Config } from "../../boundaries/platform/config";
+import type { ConfigAccessor, ConfigAgentType } from "../../boundaries/platform/config-definition";
 
 import type { Dispatcher } from "../../intents/lib/dispatcher";
 import type {
@@ -71,7 +71,8 @@ import type { AgentModuleProvider } from "./agent-module-provider";
 export interface AgentModuleDeps {
   readonly dispatcher: Dispatcher;
   readonly logger: Logger;
-  readonly configService: Config;
+  /** Accessor for the user's agent selection (registered in the composition root). */
+  readonly agentConfig: ConfigAccessor<ConfigAgentType>;
 }
 
 // =============================================================================
@@ -87,10 +88,6 @@ export function createAgentModule(
   deps: AgentModuleDeps
 ): IntentModule {
   const { logger } = deps;
-
-  // Register provider's config key (e.g. version.claude, version.opencode)
-  const configDef = provider.getConfigDefinition();
-  deps.configService.register(configDef.name, configDef);
 
   // =========================================================================
   // Internal closure state
@@ -237,7 +234,7 @@ export function createAgentModule(
             if (selectedAgent !== provider.type) return;
 
             try {
-              await deps.configService.set("agent", selectedAgent);
+              await deps.agentConfig.set(selectedAgent);
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error);
               throw new SetupError(

--- a/src/modules/agent-module/claude/module-provider.integration.test.ts
+++ b/src/modules/agent-module/claude/module-provider.integration.test.ts
@@ -21,7 +21,7 @@ import type { DownloadDeps, ArchiveExtension } from "../../../utils/binary-downl
 import { createFileSystemMock } from "../../../boundaries/platform/filesystem.state-mock";
 import { createMockHttpClient } from "../../../boundaries/platform/http-client.state-mock";
 import { createArchiveExtractorMock } from "../../../boundaries/platform/archive-extractor.state-mock";
-import { createMockConfig } from "../../../boundaries/platform/config.test-utils";
+import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
 import { createMockPathProvider } from "../../../boundaries/platform/path-provider.test-utils";
 
 // =============================================================================
@@ -89,8 +89,8 @@ function createBinaryConfig() {
   };
 }
 
-function createMockConfigService(version: string | null = null) {
-  return createMockConfig({ defaults: { "version.claude": version } });
+function createVersionConfig(version: string | null = null) {
+  return createMockAccessor<string | null>("version.claude", version);
 }
 
 const WS_PATH = "/workspace/feature-a" as WorkspacePath;
@@ -104,7 +104,7 @@ describe("createClaudeModuleProvider", () => {
   let mockServerManager: ClaudeCodeServerManager;
   let downloadDeps: DownloadDeps;
   let binaryConfig: ReturnType<typeof createBinaryConfig>;
-  let configService: ReturnType<typeof createMockConfigService>;
+  let versionConfig: ReturnType<typeof createVersionConfig>;
   let pathProvider: ReturnType<typeof createMockPathProvider>;
 
   beforeEach(() => {
@@ -113,7 +113,7 @@ describe("createClaudeModuleProvider", () => {
     mockServerManager = createMockServerManager();
     downloadDeps = createDownloadDeps();
     binaryConfig = createBinaryConfig();
-    configService = createMockConfigService(null);
+    versionConfig = createVersionConfig(null);
     pathProvider = createMockPathProvider();
   });
 
@@ -122,7 +122,7 @@ describe("createClaudeModuleProvider", () => {
       serverManager: mockServerManager,
       downloadDeps,
       binaryConfig,
-      configService,
+      versionConfig,
       pathProvider,
       platform: "linux",
       arch: "x64",
@@ -182,21 +182,6 @@ describe("createClaudeModuleProvider", () => {
 
       // No HTTP requests should have been made since version is null
       expect(onProgress).not.toHaveBeenCalled();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Config
-  // ---------------------------------------------------------------------------
-
-  describe("getConfigDefinition", () => {
-    it("returns config definition with correct name and default", () => {
-      const provider = createProvider();
-      const config = provider.getConfigDefinition();
-
-      expect(config.name).toBe("version.claude");
-      expect(config.default).toBeNull();
-      expect(config.description).toBe("Claude agent version");
     });
   });
 

--- a/src/modules/agent-module/claude/module-provider.ts
+++ b/src/modules/agent-module/claude/module-provider.ts
@@ -26,16 +26,14 @@ import type {
 import { downloadBinary, isBinaryInstalled } from "../../../utils/binary-download";
 import type { BinaryType } from "../../../utils/binary-resolution/types";
 import { AgentBinaryError, getErrorMessage } from "../../../shared/errors/service-errors";
-import type { ConfigKeyDefinition } from "../../../boundaries/platform/config-definition";
+import type { ConfigAccessor } from "../../../boundaries/platform/config-definition";
 import type { StopServerResult, RestartServerResult } from "../types";
 import type { Logger } from "../../../boundaries/platform/logging";
 import type { ClaudeCodeServerManager } from "./server-manager";
 import { ClaudeCodeProvider } from "./provider";
-import { configString } from "../../../boundaries/platform/config-definition";
-import type { Config } from "../../../boundaries/platform/config";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
-import { CLAUDE_VERSION, getClaudeUrlForVersion, getClaudeSubPath } from "./setup-info";
+import { getClaudeUrlForVersion, getClaudeSubPath } from "./setup-info";
 
 // =============================================================================
 // Dependency Interface
@@ -52,7 +50,7 @@ export interface ClaudeModuleProviderDeps {
     readonly executablePath: string;
     readonly archiveExtension: ArchiveExtension;
   };
-  readonly configService: Config;
+  readonly versionConfig: ConfigAccessor<string | null>;
   readonly pathProvider: Pick<PathProvider, "bundlePath">;
   readonly platform: SupportedPlatform;
   readonly arch: SupportedArch;
@@ -74,7 +72,7 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
     serverManager,
     downloadDeps,
     binaryConfig,
-    configService,
+    versionConfig,
     pathProvider,
     platform,
     arch,
@@ -288,7 +286,7 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
     },
 
     async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
-      const version = configService.get("version.claude") as string | null;
+      const version = versionConfig.get();
       if (version === null) {
         return { success: true, needsDownload: false };
       }
@@ -302,7 +300,7 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
     },
 
     async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
-      const version = configService.get("version.claude") as string | null;
+      const version = versionConfig.get();
       if (version === null) return;
       const destDir = pathProvider.bundlePath(`claude/${version}`).toNative();
       const request: DownloadRequest = {
@@ -320,17 +318,6 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
           `Failed to download ${binaryConfig.name}: ${getErrorMessage(error)}`
         );
       }
-    },
-
-    // --- Config ---
-
-    getConfigDefinition(): ConfigKeyDefinition<string | null> {
-      return {
-        name: "version.claude",
-        default: CLAUDE_VERSION,
-        description: "Claude agent version",
-        ...configString({ nullable: true }),
-      };
     },
 
     // --- Lifecycle ---

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -17,7 +17,7 @@ import type { DownloadDeps, ArchiveExtension } from "../../../utils/binary-downl
 import { createFileSystemMock } from "../../../boundaries/platform/filesystem.state-mock";
 import { createMockHttpClient } from "../../../boundaries/platform/http-client.state-mock";
 import { createArchiveExtractorMock } from "../../../boundaries/platform/archive-extractor.state-mock";
-import { createMockConfig } from "../../../boundaries/platform/config.test-utils";
+import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
 import { createMockPathProvider } from "../../../boundaries/platform/path-provider.test-utils";
 
 // =============================================================================
@@ -166,8 +166,8 @@ function createBinaryConfig() {
   };
 }
 
-function createMockConfigService(version: string | null = "1.0.223") {
-  return createMockConfig({ defaults: { "version.opencode": version } });
+function createVersionConfig(version = "1.0.223") {
+  return createMockAccessor("version.opencode", version);
 }
 
 /**
@@ -201,7 +201,7 @@ describe("OpenCode module provider", () => {
   let serverManager: ReturnType<typeof createMockServerManager>;
   let downloadDeps: DownloadDeps;
   let binaryConfig: ReturnType<typeof createBinaryConfig>;
-  let configService: ReturnType<typeof createMockConfigService>;
+  let versionConfig: ReturnType<typeof createVersionConfig>;
   let pathProvider: ReturnType<typeof createMockPathProvider>;
   let provider: AgentModuleProvider;
 
@@ -212,14 +212,14 @@ describe("OpenCode module provider", () => {
     serverManager = createMockServerManager();
     downloadDeps = createDownloadDeps();
     binaryConfig = createBinaryConfig();
-    configService = createMockConfigService("1.0.223");
+    versionConfig = createVersionConfig("1.0.223");
     pathProvider = createMockPathProvider();
 
     const deps: OpenCodeModuleProviderDeps = {
       serverManager: serverManager as unknown as OpenCodeServerManager,
       downloadDeps,
       binaryConfig,
-      configService,
+      versionConfig,
       pathProvider,
       platform: "linux",
       arch: "x64",
@@ -259,19 +259,6 @@ describe("OpenCode module provider", () => {
 
     it("has correct binaryType", () => {
       expect(provider.binaryType).toBe("opencode");
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Config definition
-  // ---------------------------------------------------------------------------
-
-  describe("getConfigDefinition", () => {
-    it("returns config definition for version.opencode", () => {
-      const def = provider.getConfigDefinition();
-      expect(def.name).toBe("version.opencode");
-      expect(def.default).toBe("1.0.223");
-      expect(def.description).toBe("OpenCode agent version");
     });
   });
 

--- a/src/modules/agent-module/opencode/module-provider.ts
+++ b/src/modules/agent-module/opencode/module-provider.ts
@@ -38,7 +38,7 @@ import { configString } from "../../../boundaries/platform/config-definition";
 import type { Config } from "../../../boundaries/platform/config";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
-import { OPENCODE_VERSION, getOpencodeUrlForVersion } from "./setup-info";
+import { OPENCODE_VERSION, getOpencodeBundleDir, getOpencodeUrlForVersion } from "./setup-info";
 import { OpenCodeProvider } from "./provider";
 
 // =============================================================================
@@ -342,7 +342,7 @@ export function createOpenCodeModuleProvider(
     async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
       const version = configService.get("version.opencode") as string;
       try {
-        const destDir = pathProvider.bundlePath(`opencode/${version}`).toNative();
+        const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
         const installed = await isBinaryInstalled(destDir, downloadDeps);
         return { success: true, needsDownload: !installed };
       } catch {
@@ -352,7 +352,7 @@ export function createOpenCodeModuleProvider(
 
     async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
       const version = configService.get("version.opencode") as string;
-      const destDir = pathProvider.bundlePath(`opencode/${version}`).toNative();
+      const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
       const request: DownloadRequest = {
         name: binaryConfig.name,
         url: getOpencodeUrlForVersion(version, platform, arch),

--- a/src/modules/agent-module/opencode/module-provider.ts
+++ b/src/modules/agent-module/opencode/module-provider.ts
@@ -30,15 +30,13 @@ import { downloadBinary, isBinaryInstalled } from "../../../utils/binary-downloa
 import type { DownloadDeps } from "../../../utils/binary-download";
 import type { BinaryType } from "../../../utils/binary-resolution/types";
 import { AgentBinaryError, getErrorMessage } from "../../../shared/errors/service-errors";
-import type { ConfigKeyDefinition } from "../../../boundaries/platform/config-definition";
+import type { ConfigAccessor } from "../../../boundaries/platform/config-definition";
 import type { Logger } from "../../../boundaries/platform/logging";
 import type { Unsubscribe } from "../../../shared/api/interfaces";
 import type { OpenCodeServerManager, PendingPrompt } from "./server-manager";
-import { configString } from "../../../boundaries/platform/config-definition";
-import type { Config } from "../../../boundaries/platform/config";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
-import { OPENCODE_VERSION, getOpencodeBundleDir, getOpencodeUrlForVersion } from "./setup-info";
+import { getOpencodeBundleDir, getOpencodeUrlForVersion } from "./setup-info";
 import { OpenCodeProvider } from "./provider";
 
 // =============================================================================
@@ -56,7 +54,7 @@ export interface OpenCodeModuleProviderDeps {
     readonly executablePath: string;
     readonly archiveExtension: ArchiveExtension;
   };
-  readonly configService: Config;
+  readonly versionConfig: ConfigAccessor<string>;
   readonly pathProvider: Pick<PathProvider, "bundlePath">;
   readonly platform: SupportedPlatform;
   readonly arch: SupportedArch;
@@ -78,7 +76,7 @@ export function createOpenCodeModuleProvider(
     serverManager,
     downloadDeps,
     binaryConfig,
-    configService,
+    versionConfig,
     pathProvider,
     platform,
     arch,
@@ -340,7 +338,7 @@ export function createOpenCodeModuleProvider(
     binaryType: binaryConfig.name as BinaryType,
 
     async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
-      const version = configService.get("version.opencode") as string;
+      const version = versionConfig.get();
       try {
         const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
         const installed = await isBinaryInstalled(destDir, downloadDeps);
@@ -351,7 +349,7 @@ export function createOpenCodeModuleProvider(
     },
 
     async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
-      const version = configService.get("version.opencode") as string;
+      const version = versionConfig.get();
       const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
       const request: DownloadRequest = {
         name: binaryConfig.name,
@@ -367,16 +365,6 @@ export function createOpenCodeModuleProvider(
           `Failed to download ${binaryConfig.name}: ${getErrorMessage(error)}`
         );
       }
-    },
-
-    // --- Config ---
-    getConfigDefinition(): ConfigKeyDefinition<string | null> {
-      return {
-        name: "version.opencode",
-        default: OPENCODE_VERSION,
-        description: "OpenCode agent version",
-        ...configString(),
-      };
     },
 
     // --- Lifecycle ---

--- a/src/modules/agent-module/opencode/server-manager.boundary.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.boundary.test.ts
@@ -20,10 +20,7 @@ import { CI_TIMEOUT_MS } from "../../../boundaries/platform/network.test-utils";
 import { delay } from "@shared/test-fixtures";
 
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
-import { createMockConfig } from "../../../boundaries/platform/config.test-utils";
-
-/** Default config used by tests that don't pass an explicit override. */
-const DEFAULT_CONFIG_DEFAULTS = { "version.opencode": "1.0.223" };
+import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
 
 describe("OpenCodeServerManager Boundary Tests", () => {
   let testDir: string;
@@ -74,7 +71,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
         networkLayer,
         networkLayer,
         pathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: CI_TIMEOUT_MS }
       );
@@ -98,7 +95,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
         networkLayer,
         networkLayer,
         pathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: CI_TIMEOUT_MS }
       );
@@ -121,7 +118,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
         networkLayer,
         networkLayer,
         pathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: CI_TIMEOUT_MS }
       );
@@ -161,7 +158,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
         networkLayer,
         networkLayer,
         pathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: CI_TIMEOUT_MS }
       );
@@ -189,7 +186,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
         networkLayer,
         networkLayer,
         pathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: CI_TIMEOUT_MS }
       );

--- a/src/modules/agent-module/opencode/server-manager.integration.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.integration.test.ts
@@ -24,7 +24,7 @@ import {
 import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
 import type { HttpClient } from "../../../boundaries/platform/network";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
-import { createMockConfig } from "../../../boundaries/platform/config.test-utils";
+import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
 
 /**
  * Create a mock HttpClient with vitest spies.
@@ -43,9 +43,6 @@ function createTestHttpClient(): HttpClient & { fetch: ReturnType<typeof vi.fn> 
 function createTestPathProvider(): PathProvider {
   return createMockPathProvider();
 }
-
-/** Default config used by tests that don't pass an explicit override. */
-const DEFAULT_CONFIG_DEFAULTS = { "version.opencode": "1.0.223" };
 
 describe("OpenCodeServerManager integration", () => {
   let serverManager: OpenCodeServerManager;
@@ -78,7 +75,7 @@ describe("OpenCodeServerManager integration", () => {
       mockPortManager,
       mockHttpClient,
       mockPathProvider,
-      createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+      createMockAccessor("version.opencode", "1.0.223"),
       SILENT_LOGGER
     );
   });
@@ -278,7 +275,7 @@ describe("OpenCodeServerManager integration", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: 100, healthCheckIntervalMs: 10 }
       );

--- a/src/modules/agent-module/opencode/server-manager.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.test.ts
@@ -23,7 +23,7 @@ import {
 import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
 import type { HttpClient } from "../../../boundaries/platform/network";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
-import { createMockConfig } from "../../../boundaries/platform/config.test-utils";
+import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
 
 /**
  * Create a mock HttpClient with vitest spies.
@@ -47,9 +47,6 @@ function createTestHttpClient(options?: {
 function createTestPathProvider(): PathProvider {
   return createMockPathProvider();
 }
-
-/** Default config used by tests that don't pass an explicit override. */
-const DEFAULT_CONFIG_DEFAULTS = { "version.opencode": "1.0.223" };
 
 describe("OpenCodeServerManager", () => {
   // Common dependencies
@@ -79,7 +76,7 @@ describe("OpenCodeServerManager", () => {
       mockPortManager,
       mockHttpClient,
       mockPathProvider,
-      createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+      createMockAccessor("version.opencode", "1.0.223"),
       SILENT_LOGGER
     );
   });
@@ -125,7 +122,7 @@ describe("OpenCodeServerManager", () => {
         failingPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -146,7 +143,7 @@ describe("OpenCodeServerManager", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -165,7 +162,7 @@ describe("OpenCodeServerManager", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -187,7 +184,7 @@ describe("OpenCodeServerManager", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER,
         { healthCheckTimeoutMs: 100 } // Short timeout for testing
       );
@@ -301,7 +298,7 @@ describe("OpenCodeServerManager", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -338,7 +335,7 @@ describe("OpenCodeServerManager", () => {
         mockPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         loggerWithSpy
       );
 
@@ -377,7 +374,7 @@ describe("OpenCodeServerManager", () => {
         multiPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -409,7 +406,7 @@ describe("OpenCodeServerManager", () => {
         multiPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 
@@ -451,7 +448,7 @@ describe("OpenCodeServerManager", () => {
         multiPortManager,
         mockHttpClient,
         mockPathProvider,
-        createMockConfig({ defaults: DEFAULT_CONFIG_DEFAULTS }),
+        createMockAccessor("version.opencode", "1.0.223"),
         SILENT_LOGGER
       );
 

--- a/src/modules/agent-module/opencode/server-manager.ts
+++ b/src/modules/agent-module/opencode/server-manager.ts
@@ -21,7 +21,7 @@ import { waitForHealthy } from "../../../utils/health-check";
 import { Path } from "../../../utils/path/path";
 import type { PromptModel } from "../../../shared/api/types";
 import type { AgentServerManager, StopServerResult, RestartServerResult } from "../types";
-import { getOpencodeExecutablePath } from "./setup-info";
+import { getOpencodeBundleDir, getOpencodeExecutablePath } from "./setup-info";
 import type { SupportedPlatform } from "../../../boundaries/platform/platform-info";
 import type { Config } from "../../../boundaries/platform/config";
 
@@ -277,7 +277,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
     const platform = process.platform as SupportedPlatform;
     const version = this.configService.get("version.opencode") as string;
     const opencodeCmd = new Path(
-      this.pathProvider.bundlePath(`opencode/${version}`),
+      getOpencodeBundleDir(this.pathProvider, version),
       getOpencodeExecutablePath(platform)
     ).toNative();
     const proc = this.processRunner.run(opencodeCmd, ["serve", "--port", String(port)], {

--- a/src/modules/agent-module/opencode/server-manager.ts
+++ b/src/modules/agent-module/opencode/server-manager.ts
@@ -23,7 +23,7 @@ import type { PromptModel } from "../../../shared/api/types";
 import type { AgentServerManager, StopServerResult, RestartServerResult } from "../types";
 import { getOpencodeBundleDir, getOpencodeExecutablePath } from "./setup-info";
 import type { SupportedPlatform } from "../../../boundaries/platform/platform-info";
-import type { Config } from "../../../boundaries/platform/config";
+import type { ConfigAccessor } from "../../../boundaries/platform/config-definition";
 
 /**
  * Pending initial prompt to send when server becomes healthy.
@@ -110,7 +110,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
   private readonly portManager: PortManager;
   private readonly httpClient: HttpClient;
   private readonly pathProvider: PathProvider;
-  private readonly configService: Config;
+  private readonly versionConfig: ConfigAccessor<string>;
   private readonly logger: Logger;
   private readonly config: Required<OpenCodeServerManagerConfig>;
 
@@ -142,7 +142,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
     portManager: PortManager,
     httpClient: HttpClient,
     pathProvider: PathProvider,
-    configService: Config,
+    versionConfig: ConfigAccessor<string>,
     logger: Logger,
     config?: OpenCodeServerManagerConfig
   ) {
@@ -150,7 +150,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
     this.portManager = portManager;
     this.httpClient = httpClient;
     this.pathProvider = pathProvider;
-    this.configService = configService;
+    this.versionConfig = versionConfig;
     this.logger = logger;
     this.config = {
       healthCheckTimeoutMs: config?.healthCheckTimeoutMs ?? 30000,
@@ -275,7 +275,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
 
     // Spawn opencode serve
     const platform = process.platform as SupportedPlatform;
-    const version = this.configService.get("version.opencode") as string;
+    const version = this.versionConfig.get();
     const opencodeCmd = new Path(
       getOpencodeBundleDir(this.pathProvider, version),
       getOpencodeExecutablePath(platform)

--- a/src/modules/agent-module/opencode/setup-info.ts
+++ b/src/modules/agent-module/opencode/setup-info.ts
@@ -4,11 +4,26 @@
  */
 
 import type { SupportedArch, SupportedPlatform } from "../types";
+import type { PathProvider } from "../../../boundaries/platform/path-provider";
+import { Path } from "../../../utils/path/path";
 
 /**
  * Current version of OpenCode to download.
  */
 export const OPENCODE_VERSION = "1.0.223";
+
+/**
+ * Resolve the bundle directory holding the extracted OpenCode binary for a
+ * given version. Single source of truth for the `opencode/<version>` path
+ * shape used by the agent server, binary download/preflight, and the
+ * code-server environment (`_CH_OPENCODE_DIR`).
+ */
+export function getOpencodeBundleDir(
+  pathProvider: Pick<PathProvider, "bundlePath">,
+  version: string
+): Path {
+  return pathProvider.bundlePath(`opencode/${version}`);
+}
 
 /**
  * Architecture name mappings for OpenCode releases.

--- a/src/modules/auto-updater-module.ts
+++ b/src/modules/auto-updater-module.ts
@@ -90,15 +90,14 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
   let notification: NotificationHandle | null = null;
 
   // Register config key
-  deps.configService.register("update.notification", {
-    name: "update.notification",
+  const updateNotificationConfig = deps.configService.register("update.notification", {
     default: true,
     description: "Show a sidebar notification when an update is available",
     ...configBoolean(),
   });
 
   function isEnabled(): boolean {
-    return deps.configService.get("update.notification") === true;
+    return updateNotificationConfig.get();
   }
 
   function startDownload(version: string): void {

--- a/src/modules/auto-workspace/github-source.ts
+++ b/src/modules/auto-workspace/github-source.ts
@@ -31,10 +31,6 @@ interface GitHubRepoDetail {
 
 const GITHUB_API_BASE = "https://api.github.com";
 
-const CONFIG_KEYS = {
-  query: "experimental.github.query",
-} as const;
-
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -56,7 +52,7 @@ export interface GitHubSourceDeps {
 }
 
 export function createGitHubSource(deps: GitHubSourceDeps): AutoWorkspaceSource {
-  const queryConfig = deps.configService.register(CONFIG_KEYS.query, {
+  const queryConfig = deps.configService.register("experimental.github.query", {
     default: "is:open is:pr review-requested:@me",
     description: "GitHub search query (e.g. is:open is:pr review-requested:@me)",
     ...configString(),

--- a/src/modules/auto-workspace/github-source.ts
+++ b/src/modules/auto-workspace/github-source.ts
@@ -56,8 +56,7 @@ export interface GitHubSourceDeps {
 }
 
 export function createGitHubSource(deps: GitHubSourceDeps): AutoWorkspaceSource {
-  deps.configService.register(CONFIG_KEYS.query, {
-    name: CONFIG_KEYS.query,
+  const queryConfig = deps.configService.register(CONFIG_KEYS.query, {
     default: "is:open is:pr review-requested:@me",
     description: "GitHub search query (e.g. is:open is:pr review-requested:@me)",
     ...configString(),
@@ -74,7 +73,7 @@ export function createGitHubSource(deps: GitHubSourceDeps): AutoWorkspaceSource 
   }
 
   async function fetchSearchResults(): Promise<GitHubSearchItem[]> {
-    const query = encodeURIComponent(deps.configService.get(CONFIG_KEYS.query) as string);
+    const query = encodeURIComponent(queryConfig.get());
     const url = `${GITHUB_API_BASE}/search/issues?q=${query}&sort=created&order=desc&per_page=100`;
 
     const response = await deps.httpClient.fetch(url, {
@@ -137,7 +136,7 @@ export function createGitHubSource(deps: GitHubSourceDeps): AutoWorkspaceSource 
     fetchBasesBeforeDelete: true,
 
     isConfigured(): boolean {
-      return deps.configService.get(CONFIG_KEYS.query) !== null;
+      return queryConfig.get() !== null;
     },
 
     async initialize(): Promise<boolean> {

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -44,7 +44,7 @@ import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "../../intents/open-
 import { INTENT_LIST_PROJECTS, type ListProjectsIntent } from "../../intents/list-projects";
 import type { Config } from "../../boundaries/platform/config";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "../../intents/set-metadata";
-import { configPath } from "../../boundaries/platform/config-definition";
+import { configPath, type ConfigAccessor } from "../../boundaries/platform/config-definition";
 import type { FileSystemBoundary } from "../../boundaries/platform/filesystem";
 import type { Logger } from "../../boundaries/platform/logging-types";
 import type { NormalizedInitialPrompt } from "../../shared/api/types";
@@ -115,14 +115,15 @@ function templatePathConfigKey(sourceName: string): string {
 
 export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): IntentModule {
   // Register template-path config keys (sources register their own keys)
+  const templatePathConfigs = new Map<string, ConfigAccessor<string | null>>();
   for (const source of deps.sources) {
-    deps.configService.register(templatePathConfigKey(source.name), {
-      name: templatePathConfigKey(source.name),
+    const tplConfig = deps.configService.register(templatePathConfigKey(source.name), {
       default: null,
       description: `Path to Liquid template for ${source.name} auto-workspaces`,
       sensitive: true,
       ...configPath({ nullable: true }),
     });
+    templatePathConfigs.set(source.name, tplConfig);
   }
 
   let state: AutoWorkspaceState = emptyState();
@@ -556,8 +557,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
           handler: async (): Promise<void> => {
             // Read template paths from config
             for (const source of deps.sources) {
-              const tplKey = templatePathConfigKey(source.name);
-              const tplValue = deps.configService.get(tplKey) as string | null;
+              const tplValue = templatePathConfigs.get(source.name)?.get() ?? null;
               templatePaths.set(source.name, tplValue);
             }
           },

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -105,10 +105,6 @@ function stateKey(sourceName: string, itemKey: string): string {
   return `${sourceName}/${itemKey}`;
 }
 
-function templatePathConfigKey(sourceName: string): string {
-  return `experimental.${sourceName}.template-path`;
-}
-
 // =============================================================================
 // Module Factory
 // =============================================================================
@@ -117,7 +113,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
   // Register template-path config keys (sources register their own keys)
   const templatePathConfigs = new Map<string, ConfigAccessor<string | null>>();
   for (const source of deps.sources) {
-    const tplConfig = deps.configService.register(templatePathConfigKey(source.name), {
+    const tplConfig = deps.configService.register(`experimental.${source.name}.template-path`, {
       default: null,
       description: `Path to Liquid template for ${source.name} auto-workspaces`,
       sensitive: true,

--- a/src/modules/auto-workspace/youtrack-source.ts
+++ b/src/modules/auto-workspace/youtrack-source.ts
@@ -11,12 +11,6 @@ import type { AutoWorkspaceSource, PollResult, PollItem } from "./source";
 const YOUTRACK_FIELDS =
   "id,idReadable,summary,description,reporter(login,fullName),created,updated,resolved,project(id,name,shortName),customFields(name,value(name))";
 
-const CONFIG_KEYS = {
-  baseUrl: "experimental.youtrack.base-url",
-  token: "experimental.youtrack.token",
-  query: "experimental.youtrack.query",
-} as const;
-
 // =============================================================================
 // Source Factory
 // =============================================================================
@@ -28,19 +22,19 @@ export interface YouTrackSourceDeps {
 }
 
 export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSource {
-  const baseUrlConfig = deps.configService.register(CONFIG_KEYS.baseUrl, {
+  const baseUrlConfig = deps.configService.register("experimental.youtrack.base-url", {
     default: null,
     description: "YouTrack instance URL (e.g. https://youtrack.example.com)",
     sensitive: true,
     ...configString({ nullable: true }),
   });
-  const tokenConfig = deps.configService.register(CONFIG_KEYS.token, {
+  const tokenConfig = deps.configService.register("experimental.youtrack.token", {
     default: null,
     description: "YouTrack API permanent token",
     sensitive: true,
     ...configString({ nullable: true }),
   });
-  const queryConfig = deps.configService.register(CONFIG_KEYS.query, {
+  const queryConfig = deps.configService.register("experimental.youtrack.query", {
     default: null,
     description: "YouTrack search query (e.g. for:me State: {In Progress})",
     ...configString({ nullable: true }),

--- a/src/modules/auto-workspace/youtrack-source.ts
+++ b/src/modules/auto-workspace/youtrack-source.ts
@@ -28,22 +28,19 @@ export interface YouTrackSourceDeps {
 }
 
 export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSource {
-  deps.configService.register(CONFIG_KEYS.baseUrl, {
-    name: CONFIG_KEYS.baseUrl,
+  const baseUrlConfig = deps.configService.register(CONFIG_KEYS.baseUrl, {
     default: null,
     description: "YouTrack instance URL (e.g. https://youtrack.example.com)",
     sensitive: true,
     ...configString({ nullable: true }),
   });
-  deps.configService.register(CONFIG_KEYS.token, {
-    name: CONFIG_KEYS.token,
+  const tokenConfig = deps.configService.register(CONFIG_KEYS.token, {
     default: null,
     description: "YouTrack API permanent token",
     sensitive: true,
     ...configString({ nullable: true }),
   });
-  deps.configService.register(CONFIG_KEYS.query, {
-    name: CONFIG_KEYS.query,
+  const queryConfig = deps.configService.register(CONFIG_KEYS.query, {
     default: null,
     description: "YouTrack search query (e.g. for:me State: {In Progress})",
     ...configString({ nullable: true }),
@@ -51,14 +48,14 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
 
   function youtrackHeaders(): Readonly<Record<string, string>> {
     return {
-      Authorization: `Bearer ${deps.configService.get(CONFIG_KEYS.token) as string}`,
+      Authorization: `Bearer ${tokenConfig.get()}`,
       Accept: "application/json",
     };
   }
 
   async function fetchIssues(): Promise<Record<string, unknown>[]> {
-    const baseUrl = deps.configService.get(CONFIG_KEYS.baseUrl) as string;
-    const query = encodeURIComponent(deps.configService.get(CONFIG_KEYS.query) as string);
+    const baseUrl = baseUrlConfig.get();
+    const query = encodeURIComponent(queryConfig.get() ?? "");
     const fields = encodeURIComponent(YOUTRACK_FIELDS);
     const url = `${baseUrl}/api/issues?query=${query}&fields=${fields}`;
 
@@ -75,7 +72,7 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
   }
 
   function issueStateKey(issueId: string): string {
-    const baseUrl = deps.configService.get(CONFIG_KEYS.baseUrl) as string;
+    const baseUrl = baseUrlConfig.get();
     return `${baseUrl}/api/issues/${issueId}`;
   }
 
@@ -85,9 +82,7 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
 
     isConfigured(): boolean {
       return (
-        deps.configService.get(CONFIG_KEYS.baseUrl) !== null &&
-        deps.configService.get(CONFIG_KEYS.token) !== null &&
-        deps.configService.get(CONFIG_KEYS.query) !== null
+        baseUrlConfig.get() !== null && tokenConfig.get() !== null && queryConfig.get() !== null
       );
     },
 
@@ -111,7 +106,7 @@ export function createYouTrackSource(deps: YouTrackSourceDeps): AutoWorkspaceSou
 
         newItems.push({
           key,
-          url: `${deps.configService.get(CONFIG_KEYS.baseUrl) as string}/issue/${idReadable}`,
+          url: `${baseUrlConfig.get()}/issue/${idReadable}`,
           data: issue,
         });
       }

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -248,6 +248,7 @@ function createMockDeps(overrides?: Partial<CodeServerModuleDeps>): CodeServerMo
     logger: SILENT_LOGGER,
     archiveExtractor: createArchiveExtractorMock(),
     configService: createMockConfig({ defaults: { "version.opencode": "1.0.223" } }),
+    resolveOpencodeBundleDir: () => "/bundles/opencode/1.0.223",
     ...overrides,
   };
 }

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -261,6 +261,12 @@ export interface CodeServerModuleDeps {
   readonly logger: Logger;
   readonly archiveExtractor?: ArchiveExtractor;
   readonly configService: Config;
+  /**
+   * Resolve the native path to the bundled OpenCode binary directory, injected
+   * into the code-server environment as `_CH_OPENCODE_DIR`. Owned by the
+   * OpenCode layer so code-server doesn't reach into agent-owned config.
+   */
+  readonly resolveOpencodeBundleDir: () => string;
 }
 
 // =============================================================================
@@ -489,11 +495,8 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
       // Set code-server and opencode directories for wrapper scripts
       const { binaryPath, codeServerDir } = resolveCodeServerPaths();
-      const opencodeVersion = deps.configService.get("version.opencode") as string;
       cleanEnv._CH_CODE_SERVER_DIR = codeServerDir;
-      cleanEnv._CH_OPENCODE_DIR = deps.pathProvider
-        .bundlePath(`opencode/${opencodeVersion}`)
-        .toNative();
+      cleanEnv._CH_OPENCODE_DIR = deps.resolveOpencodeBundleDir();
 
       serverProcess = processRunner.run(binaryPath, args, {
         cwd: config.runtimeDir,

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -283,14 +283,12 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
   const { processRunner, fileSystemLayer, logger } = deps;
 
   // Register config keys
-  deps.configService.register("version.code-server", {
-    name: "version.code-server",
+  const codeServerVersionConfig = deps.configService.register("version.code-server", {
     default: CODE_SERVER_VERSION,
     description: "Code-server version",
     ...configString(),
   });
-  deps.configService.register("code-server.port", {
-    name: "code-server.port",
+  const codeServerPortConfig = deps.configService.register("code-server.port", {
     default: getCodeServerPort(deps.buildInfo),
     description: "Code-server port",
     ...configCustom<number>({
@@ -318,7 +316,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
   /** Resolve version-derived paths from configService (call only after load()). */
   function resolveCodeServerPaths() {
-    const version = deps.configService.get("version.code-server") as string;
+    const version = codeServerVersionConfig.get();
     return {
       binaryPath: new Path(
         deps.pathProvider.bundlePath(`code-server/${version}`),
@@ -368,7 +366,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
   /** Build download request from configService (call only after load()). */
   function getDownloadRequest(): DownloadRequest | null {
     if (!deps.archiveExtractor) return null;
-    const version = deps.configService.get("version.code-server") as string;
+    const version = codeServerVersionConfig.get();
     return {
       name: "code-server" as const,
       url: getCodeServerUrlForVersion(version, deps.platform, deps.arch),
@@ -435,7 +433,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
   async function doStart(): Promise<number> {
     logger.info("Starting code-server");
 
-    const port = deps.configService.get("code-server.port") as number;
+    const port = codeServerPortConfig.get();
 
     const portAvailable = await deps.portManager.isPortAvailable(port);
     if (!portAvailable) {

--- a/src/modules/debug-module.integration.test.ts
+++ b/src/modules/debug-module.integration.test.ts
@@ -10,7 +10,8 @@ import { describe, it, expect, vi } from "vitest";
 import { createDebugModule } from "./debug-module";
 import type { IntentModule } from "../intents/lib/module";
 import type { HookHandler, HookContext } from "../intents/lib/operation";
-import { createMockConfig } from "../boundaries/platform/config.test-utils";
+import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
+import type { Config } from "../boundaries/platform/config";
 import type { CheckDepsResult } from "../intents/app-start";
 import type { SetupProgressReporter } from "../intents/setup";
 import type { DeleteHookResult, DetectHookResult } from "../intents/delete-workspace";
@@ -69,9 +70,11 @@ describe("DebugModule Integration", () => {
     it("registers 3 config keys", () => {
       const registered: string[] = [];
       const config = createMockConfig();
-      config.register = (key: string) => {
+      config.register = ((key: string, _definition: unknown) => {
+        void _definition;
         registered.push(key);
-      };
+        return createMockAccessor(key, false);
+      }) as Config["register"];
       createDebugModule({ configService: config });
       expect(registered).toEqual(["debug.blocking-pids", "debug.setup", "debug.update"]);
     });

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -12,7 +12,7 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext } from "../intents/lib/operation";
 import type { Config } from "../boundaries/platform/config";
-import { configBoolean, type ConfigAccessor } from "../boundaries/platform/config-definition";
+import { configBoolean } from "../boundaries/platform/config-definition";
 import { APP_START_OPERATION_ID, type CheckDepsResult } from "../intents/app-start";
 import type { BinaryType } from "../utils/binary-resolution/types";
 import {
@@ -40,33 +40,27 @@ interface DebugModuleDeps {
 export function createDebugModule(deps: DebugModuleDeps): IntentModule {
   const { configService } = deps;
 
-  // Register debug config keys
-  const debugConfigs = new Map<string, ConfigAccessor<boolean>>([
+  // Register debug config keys, then index the accessors by their key name so
+  // the key string isn't duplicated between registration and lookup.
+  const debugConfigs = new Map(
     [
-      "debug.blocking-pids",
       configService.register("debug.blocking-pids", {
         default: false,
         description: "Simulate blocking processes during workspace deletion",
         ...configBoolean(),
       }),
-    ],
-    [
-      "debug.setup",
       configService.register("debug.setup", {
         default: false,
         description: "Force setup flow with simulated binary download progress",
         ...configBoolean(),
       }),
-    ],
-    [
-      "debug.update",
       configService.register("debug.update", {
         default: false,
         description: "Simulate available update with download progress",
         ...configBoolean(),
       }),
-    ],
-  ]);
+    ].map((accessor) => [accessor.name, accessor] as const)
+  );
 
   function isActive(key: string): boolean {
     return debugConfigs.get(key)?.get() === true;

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -12,7 +12,7 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext } from "../intents/lib/operation";
 import type { Config } from "../boundaries/platform/config";
-import { configBoolean } from "../boundaries/platform/config-definition";
+import { configBoolean, type ConfigAccessor } from "../boundaries/platform/config-definition";
 import { APP_START_OPERATION_ID, type CheckDepsResult } from "../intents/app-start";
 import type { BinaryType } from "../utils/binary-resolution/types";
 import {
@@ -41,27 +41,35 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
   const { configService } = deps;
 
   // Register debug config keys
-  configService.register("debug.blocking-pids", {
-    name: "debug.blocking-pids",
-    default: false,
-    description: "Simulate blocking processes during workspace deletion",
-    ...configBoolean(),
-  });
-  configService.register("debug.setup", {
-    name: "debug.setup",
-    default: false,
-    description: "Force setup flow with simulated binary download progress",
-    ...configBoolean(),
-  });
-  configService.register("debug.update", {
-    name: "debug.update",
-    default: false,
-    description: "Simulate available update with download progress",
-    ...configBoolean(),
-  });
+  const debugConfigs = new Map<string, ConfigAccessor<boolean>>([
+    [
+      "debug.blocking-pids",
+      configService.register("debug.blocking-pids", {
+        default: false,
+        description: "Simulate blocking processes during workspace deletion",
+        ...configBoolean(),
+      }),
+    ],
+    [
+      "debug.setup",
+      configService.register("debug.setup", {
+        default: false,
+        description: "Force setup flow with simulated binary download progress",
+        ...configBoolean(),
+      }),
+    ],
+    [
+      "debug.update",
+      configService.register("debug.update", {
+        default: false,
+        description: "Simulate available update with download progress",
+        ...configBoolean(),
+      }),
+    ],
+  ]);
 
   function isActive(key: string): boolean {
-    return configService.get(key) === true;
+    return debugConfigs.get(key)?.get() === true;
   }
 
   // Workspaces kept alive by debug.blocking-pids after deletion

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -138,14 +138,12 @@ export interface ElectronLifecycleModuleDeps {
 
 export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps): IntentModule {
   // Register config keys
-  deps.configService.register("electron.flags", {
-    name: "electron.flags",
+  const electronFlagsConfig = deps.configService.register("electron.flags", {
     default: null,
     description: "Electron switches (e.g., --disable-gpu)",
     ...configString({ nullable: true }),
   });
-  deps.configService.register("electron.disabled-features", {
-    name: "electron.disabled-features",
+  const electronDisabledFeaturesConfig = deps.configService.register("electron.disabled-features", {
     default: null,
     description:
       "Comma-separated Chromium features to disable via --disable-features. " +
@@ -175,12 +173,9 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
             deps.logger.info("Applied Electron flag", { flag: "no-proxy-server" });
             // Apply --disable-features from config (or curated defaults).
             // null/undefined = use defaults; "" = disable nothing; any other value fully replaces defaults.
-            const disabledFeaturesValue = deps.configService.get("electron.disabled-features") as
-              | string
-              | null
-              | undefined;
+            const disabledFeaturesValue = electronDisabledFeaturesConfig.get();
             const disabledFeatures =
-              disabledFeaturesValue === null || disabledFeaturesValue === undefined
+              disabledFeaturesValue === null
                 ? [...DEFAULT_DISABLED_FEATURES]
                 : disabledFeaturesValue
                     .split(",")
@@ -195,7 +190,7 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
               });
             }
             // Apply electron flags from config
-            const flagsValue = deps.configService.get("electron.flags") as string | null;
+            const flagsValue = electronFlagsConfig.get();
             const flags = parseElectronFlags(flagsValue ?? undefined);
             for (const flag of flags) {
               deps.app.commandLine.appendSwitch(

--- a/src/modules/logging-module.ts
+++ b/src/modules/logging-module.ts
@@ -12,7 +12,7 @@
 
 import type { IntentModule } from "../intents/lib/module";
 import type { Logging } from "../boundaries/platform/logging";
-import type { Logger, LogFormat } from "../boundaries/platform/logging-types";
+import type { Logger } from "../boundaries/platform/logging-types";
 import type { BuildInfo } from "../boundaries/platform/build-info";
 import type { PlatformInfo } from "../boundaries/platform/platform-info";
 import type { Config } from "../boundaries/platform/config";
@@ -68,8 +68,7 @@ export interface LoggingModuleDeps {
  */
 export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
   // Register config keys
-  deps.configService.register("log.level", {
-    name: "log.level",
+  const logLevelConfig = deps.configService.register("log.level", {
     default: "warn",
     description: "Level spec: <level> or <level>:<filter>",
     ...configCustom({
@@ -79,14 +78,12 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     }),
     computedDefault: (ctx) => (ctx.isDevelopment ? "debug" : undefined),
   });
-  deps.configService.register("log.output", {
-    name: "log.output",
+  const logOutputConfig = deps.configService.register("log.output", {
     default: "file",
     description: "Output destinations (comma-separated)",
     ...configEnumList(["file", "console"]),
   });
-  deps.configService.register("log.format", {
-    name: "log.format",
+  const logFormatConfig = deps.configService.register("log.format", {
     default: "text",
     description: "Log output format",
     ...configEnum(["text", "json"]),
@@ -132,10 +129,10 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
             deps.app.commandLine.appendSwitch("v", "1");
 
             // Configure logging from loaded config
-            const levelSpec = deps.configService.get("log.level") as string;
+            const levelSpec = logLevelConfig.get();
             const { level, filter } = splitLogLevelSpec(levelSpec);
-            const output = deps.configService.get("log.output") as string;
-            const logFormat = deps.configService.get("log.format") as LogFormat;
+            const output = logOutputConfig.get();
+            const logFormat = logFormatConfig.get();
             deps.loggingService.configure({
               logLevel: level,
               logFile: output.includes("file"),

--- a/src/modules/posthog-module.integration.test.ts
+++ b/src/modules/posthog-module.integration.test.ts
@@ -45,7 +45,8 @@ import {
   type MockPostHogClient,
 } from "./posthog-client.state-mock";
 import type { Config } from "../boundaries/platform/config";
-import { createMockConfig } from "../boundaries/platform/config.test-utils";
+import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
+import type { ConfigAgentType } from "../boundaries/platform/config-definition";
 import type { Operation, OperationContext } from "../intents/lib/operation";
 
 /**
@@ -108,10 +109,17 @@ function createTestSetup(overrides?: {
 
   const dispatcher = createMockDispatcher();
 
+  // The module distinguishes a configured agent from "not configured" via
+  // `=== undefined`. When a test supplies no agent, the accessor reads as
+  // undefined (the unset signal); otherwise it reflects the configured value.
+  const agentValue = overrides?.configValues?.agent as ConfigAgentType;
+  const agentConfig = createMockAccessor<ConfigAgentType>("agent", agentValue);
+
   const posthogModule = createPosthogModule({
     platformInfo,
     buildInfo,
     configService: mockConfig,
+    agentConfig,
     logger,
     apiKey: overrides && "apiKey" in overrides ? overrides.apiKey : "test-api-key",
     host: "https://test.posthog.com",

--- a/src/modules/posthog-module.ts
+++ b/src/modules/posthog-module.ts
@@ -28,7 +28,7 @@ import { configBoolean, configString } from "../boundaries/platform/config-defin
 import type { Config } from "../boundaries/platform/config";
 import type { PlatformInfo } from "../boundaries/platform/platform-info";
 import type { BuildInfo } from "../boundaries/platform/build-info";
-import type { ConfigAgentType } from "../boundaries/platform/config-definition";
+import type { ConfigAgentType, ConfigAccessor } from "../boundaries/platform/config-definition";
 import type { Logger } from "../boundaries/platform/logging";
 
 // =============================================================================
@@ -121,6 +121,8 @@ interface PosthogModuleDeps {
   readonly platformInfo: PlatformInfo;
   readonly buildInfo: BuildInfo;
   readonly configService: Config;
+  /** Accessor for the user's agent selection (registered in the composition root). */
+  readonly agentConfig: ConfigAccessor<ConfigAgentType>;
   readonly logger: Logger;
   /** PostHog API key. If undefined/empty, telemetry is disabled. */
   readonly apiKey?: string | undefined;
@@ -135,15 +137,13 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
   const clientFactory = deps.postHogClientFactory ?? createDefaultPostHogClient;
 
   // Register config keys
-  deps.configService.register("telemetry.enabled", {
-    name: "telemetry.enabled",
+  const telemetryEnabledConfig = deps.configService.register("telemetry.enabled", {
     default: true,
     description: "Enable telemetry (false in dev/unpackaged)",
     ...configBoolean(),
     computedDefault: (ctx) => (ctx.isDevelopment || !ctx.isPackaged ? false : undefined),
   });
-  deps.configService.register("telemetry.distinct-id", {
-    name: "telemetry.distinct-id",
+  const telemetryDistinctIdConfig = deps.configService.register("telemetry.distinct-id", {
     default: null,
     description: "Telemetry user ID (auto-generated)",
     sensitive: true,
@@ -297,7 +297,7 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
   // ---------------------------------------------------------------------------
 
   function eventProperties(): Record<string, unknown> {
-    const configuredAgent = deps.configService.get("agent") as ConfigAgentType;
+    const configuredAgent = deps.agentConfig.get();
     return {
       platform: deps.platformInfo.platform,
       arch: deps.platformInfo.arch,
@@ -333,11 +333,9 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
         start: {
           handler: async (): Promise<void> => {
             // Read config values
-            const telemetryEnabled = deps.configService.get("telemetry.enabled") as boolean;
-            const storedDistinctId = deps.configService.get("telemetry.distinct-id") as
-              | string
-              | null;
-            const configuredAgent = deps.configService.get("agent") as ConfigAgentType;
+            const telemetryEnabled = telemetryEnabledConfig.get();
+            const storedDistinctId = telemetryDistinctIdConfig.get();
+            const configuredAgent = deps.agentConfig.get();
 
             if (storedDistinctId) {
               distinctId = storedDistinctId;
@@ -363,7 +361,7 @@ export function createPosthogModule(deps: PosthogModuleDeps): IntentModule {
                   distinctId: newId,
                   agent: configuredAgent ?? undefined,
                 });
-                await deps.configService.set("telemetry.distinct-id", newId);
+                await telemetryDistinctIdConfig.set(newId);
               }
             }
 

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -143,8 +143,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
   const { viewManager, logger } = deps;
 
   // Register config keys
-  deps.configService.register("experimental.load-on-resume", {
-    name: "experimental.load-on-resume",
+  const loadOnResumeConfig = deps.configService.register("experimental.load-on-resume", {
     default: true,
     description: "Reload workspace views when system resumes from sleep",
     ...configBoolean(),
@@ -656,8 +655,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
         [APP_RESUME_HOOK_RESUME]: {
           requires: { codeServerReady: ANY_VALUE },
           handler: async (): Promise<void> => {
-            const loadOnResume = deps.configService.get("experimental.load-on-resume") as boolean;
-            if (!loadOnResume) return;
+            if (!loadOnResumeConfig.get()) return;
             logger.info("Reloading workspace views after system resume");
             viewManager.reloadAllViews();
           },

--- a/src/modules/workspace-agent-resolver-module.ts
+++ b/src/modules/workspace-agent-resolver-module.ts
@@ -11,7 +11,7 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext, HookHandler } from "../intents/lib/operation";
 import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
-import type { Config } from "../boundaries/platform/config";
+import type { ConfigAccessor, ConfigAgentType } from "../boundaries/platform/config-definition";
 import type { Logger } from "../boundaries/platform/logging-types";
 import type { AgentType } from "../shared/plugin-protocol";
 import { Path } from "../utils/path/path";
@@ -43,7 +43,8 @@ export const AGENT_METADATA_KEY = "agent";
 
 interface WorkspaceAgentResolverDeps {
   readonly gitWorktreeProvider: GitWorktreeProvider;
-  readonly configService: Config;
+  /** Accessor for the user's global agent selection (registered in the composition root). */
+  readonly agentConfig: ConfigAccessor<ConfigAgentType>;
   readonly logger: Logger;
 }
 
@@ -67,7 +68,7 @@ async function resolveAgent(
       error: error instanceof Error ? error.message : String(error),
     });
   }
-  const fromConfig = deps.configService.get("agent") as string | null;
+  const fromConfig = deps.agentConfig.get();
   if (fromConfig === "claude" || fromConfig === "opencode") {
     return fromConfig;
   }
@@ -107,7 +108,7 @@ export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverD
       const { workspacePath } = setupCtx;
       if (!workspacePath) return;
 
-      const defaultAgent = deps.configService.get("agent") as string | null;
+      const defaultAgent = deps.agentConfig.get();
       const requested = intent.payload.agent;
 
       if (requested !== undefined && requested !== defaultAgent) {


### PR DESCRIPTION
- `Config.register()` now returns a typed `ConfigAccessor<T>` (or a `DeprecatedConfigAccessor` for deprecated keys); reads/writes go through `get()`/`set()`/`reset()`/`isDefault()`. The string-keyed `get(key)`/`set(key)` are removed from the `Config` interface, and the redundant `name` field is dropped from `ConfigKeyDefinition`.
- `set()` always persists the value (including `null` where `T` allows); `reset()` reverts to default and deletes the key from `config.json`, replacing the old overloaded `set(key, null)` idiom.
- Deprecated keys return an accessor whose `get()`/`set()` are typed `never` (compile error to use; runtime throw backstop).
- `NoInfer<T>` on `default` plus a `const` type param on `configEnum` keep enum literal types from widening to `string`.
- Cross-module keys (`agent`, `experimental.iframes`, `version.claude`, `version.opencode`) are registered in the composition root and their accessors threaded into consumer deps — no module reaches config by string key. `getConfigDefinition()` removed from `AgentModuleProvider`.
- Prerequisite cleanup: decoupled code-server from `version.opencode` via a shared `getOpencodeBundleDir()` resolver (dedups 4 path computations); inlined single-use config-key constants.
- Tests fully migrated to accessors; `createMockConfig.register()` returns store-backed accessors and a new `createMockAccessor()` helper injects cross-module accessors.