### PR TITLE
fix: update notification missed newer updates

### DIFF
--- a/src/modules/auto-updater-module.integration.test.ts
+++ b/src/modules/auto-updater-module.integration.test.ts
@@ -375,6 +375,108 @@ describe("AutoUpdaterModule Integration", () => {
     expect(notificationManager.notifications).toHaveLength(1);
   });
 
+  it("a newer version on resume refreshes the existing notification in place", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      checkReturns: true,
+    });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+    expect(notificationManager.notifications).toHaveLength(1);
+    expect(notificationManager.notifications[0]!.opened.message).toContain("2.0.0");
+
+    autoUpdater.setCheckResult(true, "3.0.0");
+    await dispatcher.dispatch(resumeIntent());
+    await flush();
+
+    // Still a single notification, updated (not re-opened) to the newer version.
+    expect(notificationManager.notifications).toHaveLength(1);
+    const slot = notificationManager.notifications[0]!;
+    const last = slot.updates[slot.updates.length - 1]!;
+    expect(last.title).toBe("Update available");
+    expect(last.message).toContain("3.0.0");
+  });
+
+  it("a newer version reverts a 'ready' notification back to 'Update available'", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      checkReturns: true,
+    });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    // Download to completion → "Update ready".
+    notificationManager.emitEvent(0, { actionId: "install" });
+    await flush();
+    autoUpdater.resolveDownload!();
+    await flush();
+    const slot = notificationManager.notifications[0]!;
+    expect(slot.updates[slot.updates.length - 1]!.title).toBe("Update ready");
+
+    // Newer version detected on resume reverts to "Update available".
+    autoUpdater.setCheckResult(true, "3.0.0");
+    await dispatcher.dispatch(resumeIntent());
+    await flush();
+
+    expect(notificationManager.notifications).toHaveLength(1);
+    const last = slot.updates[slot.updates.length - 1]!;
+    expect(last.title).toBe("Update available");
+    expect(last.message).toContain("3.0.0");
+    expect(last.actions).toEqual([{ id: "install", label: "Install" }]);
+  });
+
+  it("Install after a version refresh downloads the newer version", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      checkReturns: true,
+    });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    autoUpdater.setCheckResult(true, "3.0.0");
+    await dispatcher.dispatch(resumeIntent());
+    await flush();
+
+    notificationManager.emitEvent(0, { actionId: "install" });
+    await flush();
+
+    expect(autoUpdater.downloadCalled).toBe(true);
+    const slot = notificationManager.notifications[0]!;
+    const downloading = slot.updates.find((u) => u.title === "Downloading update");
+    expect(downloading!.message).toContain("3.0.0");
+  });
+
+  it("dismissing then re-checking the same version stays silent", async () => {
+    const { dispatcher, notificationManager } = createTestSetup({ checkReturns: true });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    notificationManager.emitEvent(0, { actionId: "dismiss" });
+
+    await dispatcher.dispatch(resumeIntent());
+    await flush();
+
+    // No second notification opened for the already-dismissed version.
+    expect(notificationManager.notifications).toHaveLength(1);
+  });
+
+  it("dismissing then a newer version re-surfaces the notification", async () => {
+    const { dispatcher, autoUpdater, notificationManager } = createTestSetup({
+      checkReturns: true,
+    });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    notificationManager.emitEvent(0, { actionId: "dismiss" });
+
+    autoUpdater.setCheckResult(true, "3.0.0");
+    await dispatcher.dispatch(resumeIntent());
+    await flush();
+
+    // A fresh notification opened for the genuinely newer version.
+    expect(notificationManager.notifications).toHaveLength(2);
+    const newest = notificationManager.notifications[1]!;
+    expect(newest.opened.title).toBe("Update available");
+    expect(newest.opened.message).toContain("3.0.0");
+  });
+
   it("app:shutdown calls autoUpdater.dispose()", async () => {
     const { dispatcher, autoUpdater } = createTestSetup();
 

--- a/src/modules/auto-updater-module.ts
+++ b/src/modules/auto-updater-module.ts
@@ -9,13 +9,21 @@
  * - app:shutdown -> "quit": quitAndInstall if installUpdate flag is set.
  *
  * Behavior:
- * - All update flow happens via a single mutating sidebar notification.
+ * - All update flow happens via a single mutating sidebar notification that
+ *   always reflects the latest pending version (electron-updater only ever
+ *   reports feed-latest, so any detected version that differs from the one we
+ *   are currently showing is treated as newer).
  * - First detected version surfaces "Update available" notification.
  * - User clicks "Install" → notification mutates into a progress bar while
  *   download runs → on completion mutates into "Update ready / Restart Now".
  * - Download failures swap to an error notification with a Retry action.
- * - Once a version was detected and surfaced, no further checks/notifications
- *   happen until the app is restarted (dismiss = silent for this session).
+ * - Re-checks (periodic timer, app:resume, immediately after a download
+ *   completes) keep running. When a newer version is detected, the single
+ *   notification refreshes to "Update available" for that version — including
+ *   reverting a "ready" notification so one restart always lands on newest.
+ * - Dismiss = silent for that version. A genuinely newer version re-surfaces.
+ * - A check is skipped while a download is in progress; the check fired right
+ *   after the download completes catches anything released mid-download.
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -29,7 +37,7 @@ import type { Config } from "../boundaries/platform/config";
 import type { AutoUpdater } from "./auto-updater";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { NotificationManager, NotificationHandle } from "./notification-manager";
-import type { NotificationConfig } from "../shared/notification-types";
+import type { NotificationConfig, NotificationUserEvent } from "../shared/notification-types";
 
 /** How often to re-check for updates while the app is running. */
 const PERIODIC_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
@@ -81,9 +89,16 @@ function errorConfig(version: string): NotificationConfig {
   };
 }
 
+type NotificationState = "none" | "available" | "downloading" | "ready" | "error";
+
 export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModule {
-  let detectedVersion: string | null = null;
-  let surfaced = false;
+  // Latest version reported by electron-updater's update-detected callback.
+  let lastDetectedVersion: string | null = null;
+  // The version the current notification represents (read by action handlers).
+  let targetVersion: string | null = null;
+  // The version the user last dismissed; same-version re-checks stay silent.
+  let dismissedVersion: string | null = null;
+  let notificationState: NotificationState = "none";
   let checkInProgress = false;
   let downloadInProgress = false;
   let periodicTimer: NodeJS.Timeout | null = null;
@@ -100,12 +115,36 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
     return updateNotificationConfig.get();
   }
 
+  function handleNotificationEvent(event: NotificationUserEvent): void {
+    if (event.actionId === "install" || event.actionId === "retry") {
+      if (targetVersion !== null) startDownload(targetVersion);
+      return;
+    }
+    if (event.actionId === "restart") {
+      notification?.close();
+      notification = null;
+      notificationState = "none";
+      void deps.dispatcher.dispatch({
+        type: INTENT_APP_SHUTDOWN,
+        payload: { installUpdate: true },
+      });
+      return;
+    }
+    if (event.actionId === "dismiss") {
+      dismissedVersion = targetVersion;
+      notification = null;
+      notificationState = "none";
+    }
+  }
+
   function startDownload(version: string): void {
     if (downloadInProgress) return;
     downloadInProgress = true;
+    notificationState = "downloading";
 
     if (notification === null) {
       notification = deps.notificationManager.open(downloadingConfig(version, 0));
+      notification.onEvent(handleNotificationEvent);
     } else {
       notification.update(downloadingConfig(version, 0));
     }
@@ -120,59 +159,66 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
       () => {
         unsubProgress();
         downloadInProgress = false;
+        notificationState = "ready";
         handle.update(readyConfig(version));
+        // Catch a version released while this download was running.
+        void runCheck();
       },
       () => {
         unsubProgress();
         downloadInProgress = false;
+        notificationState = "error";
         handle.update(errorConfig(version));
       }
     );
   }
 
+  /**
+   * Open or update the single notification to surface `version` as available.
+   * Reverts a "ready"/"error" notification and refreshes an existing
+   * "available" one so the notification always reflects the latest version.
+   */
   function showAvailableNotification(version: string): void {
-    if (notification !== null) return;
+    notificationState = "available";
+    if (notification === null) {
+      notification = deps.notificationManager.open(availableConfig(version));
+      notification.onEvent(handleNotificationEvent);
+    } else {
+      notification.update(availableConfig(version));
+    }
+  }
 
-    notification = deps.notificationManager.open(availableConfig(version));
-    notification.onEvent((event) => {
-      if (event.actionId === "install") {
-        startDownload(version);
-        return;
-      }
-      if (event.actionId === "restart") {
-        notification?.close();
-        notification = null;
-        void deps.dispatcher.dispatch({
-          type: INTENT_APP_SHUTDOWN,
-          payload: { installUpdate: true },
-        });
-        return;
-      }
-      if (event.actionId === "retry") {
-        startDownload(version);
-        return;
-      }
-      if (event.actionId === "dismiss") {
-        notification = null;
-      }
-    });
+  /**
+   * Reconcile a freshly detected version against what we are currently showing.
+   * electron-updater only reports feed-latest, so a version that differs from
+   * the one on screen (or the one the user dismissed) is necessarily newer.
+   */
+  function reconcile(version: string): void {
+    // Already showing this exact version — nothing changed.
+    if (notificationState !== "none" && version === targetVersion) return;
+    // User dismissed this exact version and nothing newer has appeared.
+    if (notificationState === "none" && version === dismissedVersion) return;
+    // A download is running; the post-download check will reconcile.
+    if (notificationState === "downloading") return;
+
+    targetVersion = version;
+    showAvailableNotification(version);
   }
 
   async function runCheck(): Promise<void> {
     if (!isEnabled()) return;
     if (checkInProgress || downloadInProgress) return;
-    if (surfaced) return;
 
     checkInProgress = true;
+    let found: boolean;
     try {
-      await deps.autoUpdater.checkForUpdates();
+      found = await deps.autoUpdater.checkForUpdates();
     } finally {
       checkInProgress = false;
     }
 
-    if (detectedVersion !== null && !surfaced) {
-      surfaced = true;
-      showAvailableNotification(detectedVersion);
+    if (found && lastDetectedVersion !== null) {
+      reconcile(lastDetectedVersion);
     }
   }
 
@@ -187,7 +233,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
             // boolean result; the callback simply ensures we always have the
             // version string.
             deps.autoUpdater.onUpdateDetected((version: string) => {
-              detectedVersion = version;
+              lastDetectedVersion = version;
             });
 
             deps.autoUpdater.start();


### PR DESCRIPTION
- Re-checks (periodic timer, app:resume, post-download) no longer no-op after the first version is surfaced — the single update notification now always reflects the latest pending version
- Replaced the `surfaced` guard + closure-captured version with an explicit state model (`targetVersion`, `notificationState`, `dismissedVersion`)
- A newer version reverts a "ready" notification back to "Update available" so one restart lands on newest (previously required two restarts)
- A dismissed version stays silent; a genuinely newer version re-surfaces
- Download completion triggers an immediate re-check to catch a release that landed mid-download
- Added integration tests covering in-place refresh on resume, ready→available reversion, Install acting on the refreshed version, and the dismiss-then-same vs dismiss-then-newer cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)