### PR TITLE
fix: update notifications have been shown when running via uvx/npx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,7 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | Key                                   | Default   | Description                                                                                                                                         |
 | ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `agent`                               | `null`    | Agent selection: claude\|opencode                                                                                                                   |
-| `auto-update`                         | `ask`     | Auto-update preference: always\|ask\|never                                                                                                          |
+| `update.notification`                 | `true`    | Show a sidebar notification when an update is available (also gates the periodic update check)                                                      |
 | `version.claude`                      | `null`    | Claude agent version override                                                                                                                       |
 | `version.opencode`                    | `null`    | OpenCode agent version override                                                                                                                     |
 | `code-server.port`                    | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                      |

--- a/packages/npm/codehydra.js
+++ b/packages/npm/codehydra.js
@@ -136,7 +136,7 @@ async function main() {
     console.log("Done!\n");
   }
 
-  const child = spawn(binaryPath, ["--auto-update=never", ...process.argv.slice(2)], {
+  const child = spawn(binaryPath, ["--update.notification=false", ...process.argv.slice(2)], {
     stdio: "inherit",
   });
   child.on("exit", (code) => process.exit(code || 0));

--- a/packages/pypi/src/codehydra/__init__.py
+++ b/packages/pypi/src/codehydra/__init__.py
@@ -102,7 +102,7 @@ def main() -> None:
 
         print("Done!\n")
 
-    args = ["--auto-update=never"] + sys.argv[1:]
+    args = ["--update.notification=false"] + sys.argv[1:]
     if platform.system() == "Windows":
         sys.exit(subprocess.run([str(binary_path)] + args).returncode)
     else:


### PR DESCRIPTION
- The npm and PyPI launchers passed `--auto-update=never`, but no such config key exists, so the flag was silently ignored and the packaged binary still ran its update check and showed the notification.
- Pass the real key `--update.notification=false` in both launchers, which gates both the initial check and the periodic timer (no check, no download, no notification in launcher mode).
- Refresh the stale CLAUDE.md config row (`auto-update` → `update.notification`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)