### PR TITLE
fix(config): don't crash on unknown env vars; unify source parsing

### DIFF
--- a/src/boundaries/platform/config-definition.ts
+++ b/src/boundaries/platform/config-definition.ts
@@ -54,10 +54,13 @@ export interface ConfigKeyDefinition<T> {
    */
   readonly deprecated?: true;
   /**
-   * Map of legacy config.json key -> translator that produces the new value
-   * from the raw legacy JSON value. Used to migrate renamed keys without
-   * crashing on the old name. Legacy entries are preserved in config.json.
-   * Applies to config.json only; env vars and CLI flags don't honor legacy names.
+   * Map of legacy key -> translator that produces the new value from the legacy
+   * JSON value. Used to migrate renamed keys without crashing on the old name.
+   *
+   * In config.json the translator runs on the typed legacy value, and the legacy
+   * entry is preserved on disk. Env vars and CLI flags honor legacy names too, but
+   * via pure-rename: the raw string is run through the new key's parse() (the
+   * translator is not invoked), since a string can't be fed to the typed translator.
    */
   readonly legacyNames?: Record<string, (legacyValue: unknown) => T | undefined>;
 }
@@ -300,6 +303,225 @@ export class ConfigValidationError extends Error {
     super(lines.join("\n"));
     this.name = "ConfigValidationError";
     this.detail = detail;
+  }
+}
+
+// =============================================================================
+// Config Issues
+// =============================================================================
+
+/**
+ * A diagnostic produced while parsing or validating config sources.
+ *
+ * The transform functions (ConfigDefinitions.parse / .validate, readConfigFile)
+ * are pure: they return issues instead of logging or throwing. `Config.load()`
+ * is the single place that interprets them — logging the benign kinds and
+ * throwing a ConfigValidationError on `invalid`.
+ */
+export type ConfigIssue =
+  | { kind: "invalid"; key: string; value: unknown; description?: string; validValues?: string }
+  | { kind: "unknown"; key: string }
+  | { kind: "deprecated"; key: string }
+  | { kind: "legacy-shadowed"; legacy: string; newKey: string }
+  | { kind: "legacy-untranslatable"; legacy: string; newKey: string; value: unknown }
+  | { kind: "broken-json"; path: string; backup: string; error: string };
+
+function invalidIssue(key: string, value: unknown, def: ConfigKeyDefinition<unknown>): ConfigIssue {
+  return {
+    kind: "invalid",
+    key,
+    value,
+    ...(def.description !== undefined && { description: def.description }),
+    ...(def.validValues !== undefined && { validValues: def.validValues }),
+  };
+}
+
+// =============================================================================
+// Config Definitions (schema object)
+// =============================================================================
+
+/**
+ * The set of registered config-key definitions, plus the record-level
+ * operations that run against them.
+ *
+ * Two input formats, two methods:
+ *  - parse():    raw strings (env/CLI) → typed values, using each def.parse.
+ *  - validate(): typed values (config.json, or parse() output) → validated,
+ *                using each def.validate. This is the shared-policy gate:
+ *                unknown keys, deprecated keys, and typed legacy translation
+ *                are all resolved here.
+ *
+ * Both are pure: they return { values, issues } and never log or throw.
+ * Raw legacy keys are resolved in parse() (pure-rename through the new key's
+ * parse) because validate() cannot coerce a string into a typed value.
+ */
+export class ConfigDefinitions {
+  private readonly map = new Map<string, ConfigKeyDefinition<unknown>>();
+
+  add(key: string, definition: ConfigKeyDefinition<unknown>): void {
+    this.map.set(key, definition);
+  }
+
+  has(key: string): boolean {
+    return this.map.has(key);
+  }
+
+  get(key: string): ConfigKeyDefinition<unknown> | undefined {
+    return this.map.get(key);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  entries(): IterableIterator<[string, ConfigKeyDefinition<unknown>]> {
+    return this.map.entries();
+  }
+
+  /** The underlying map as a ReadonlyMap, for help-text generation and the public getter. */
+  asReadonlyMap(): ReadonlyMap<string, ConfigKeyDefinition<unknown>> {
+    return this.map;
+  }
+
+  [Symbol.iterator](): IterableIterator<[string, ConfigKeyDefinition<unknown>]> {
+    return this.map[Symbol.iterator]();
+  }
+
+  /** Build legacyName -> { newKey, translator }. Last writer wins on collision. */
+  private buildLegacyLookup(): Map<
+    string,
+    { newKey: string; translator: (v: unknown) => unknown }
+  > {
+    const lookup = new Map<string, { newKey: string; translator: (v: unknown) => unknown }>();
+    for (const [newKey, def] of this.map) {
+      if (!def.legacyNames) continue;
+      for (const [legacyName, translator] of Object.entries(def.legacyNames)) {
+        lookup.set(legacyName, { newKey, translator });
+      }
+    }
+    return lookup;
+  }
+
+  /**
+   * Parse raw string values (env vars / CLI flags) into typed values.
+   *
+   * Per key:
+   *  - active known key → def.parse(string); won't parse → `invalid` issue.
+   *  - legacy name (new key absent) → rename, newDef.parse(string) (pure-rename).
+   *  - legacy name (new key present) → `legacy-shadowed` issue.
+   *  - unknown or deprecated key → pass the raw string through; validate() classifies it.
+   */
+  parse(rawValues: Record<string, string>): {
+    values: Record<string, unknown>;
+    issues: ConfigIssue[];
+  } {
+    const values: Record<string, unknown> = {};
+    const issues: ConfigIssue[] = [];
+    const legacyLookup = this.buildLegacyLookup();
+
+    for (const [key, raw] of Object.entries(rawValues)) {
+      const def = this.map.get(key);
+      if (def && !def.deprecated) {
+        const parsed = def.parse(raw);
+        if (parsed === undefined) {
+          issues.push(invalidIssue(key, raw, def));
+        } else {
+          values[key] = parsed;
+        }
+        continue;
+      }
+
+      if (!def) {
+        const legacy = legacyLookup.get(key);
+        if (legacy) {
+          if (Object.prototype.hasOwnProperty.call(rawValues, legacy.newKey)) {
+            issues.push({ kind: "legacy-shadowed", legacy: key, newKey: legacy.newKey });
+            continue;
+          }
+          const newDef = this.map.get(legacy.newKey)!;
+          const parsed = newDef.parse(raw);
+          if (parsed === undefined) {
+            issues.push(invalidIssue(key, raw, newDef));
+          } else {
+            values[legacy.newKey] = parsed;
+          }
+          continue;
+        }
+      }
+
+      // Unknown or deprecated: pass the raw string through. validate() emits the issue.
+      values[key] = raw;
+    }
+
+    return { values, issues };
+  }
+
+  /**
+   * Validate typed values (config.json, or the output of parse()). The shared-policy gate.
+   *
+   * Per key:
+   *  - active known key → def.validate(value); won't validate → `invalid` issue.
+   *  - deprecated key → `deprecated` issue (skipped).
+   *  - legacy name (new key absent) → translate; translator returns undefined → `legacy-untranslatable`.
+   *  - legacy name (new key present) → `legacy-shadowed` issue.
+   *  - unknown key → `unknown` issue.
+   */
+  validate(input: Record<string, unknown>): {
+    values: Record<string, unknown>;
+    issues: ConfigIssue[];
+  } {
+    const values: Record<string, unknown> = {};
+    const issues: ConfigIssue[] = [];
+    const legacyLookup = this.buildLegacyLookup();
+
+    for (const [key, value] of Object.entries(input)) {
+      const def = this.map.get(key);
+      if (def) {
+        if (def.deprecated) {
+          issues.push({ kind: "deprecated", key });
+          continue;
+        }
+        const validated = def.validate(value);
+        if (validated === undefined) {
+          issues.push(invalidIssue(key, value, def));
+        } else {
+          values[key] = validated;
+        }
+        continue;
+      }
+
+      const legacy = legacyLookup.get(key);
+      if (legacy) {
+        if (Object.prototype.hasOwnProperty.call(input, legacy.newKey)) {
+          issues.push({ kind: "legacy-shadowed", legacy: key, newKey: legacy.newKey });
+          continue;
+        }
+        const translated = legacy.translator(value);
+        if (translated === undefined) {
+          issues.push({ kind: "legacy-untranslatable", legacy: key, newKey: legacy.newKey, value });
+          continue;
+        }
+        values[legacy.newKey] = translated;
+        continue;
+      }
+
+      issues.push({ kind: "unknown", key });
+    }
+
+    return { values, issues };
+  }
+
+  /**
+   * Convenience for the raw-string sources: parse() then validate() the result,
+   * concatenating the issues from both passes. Used for env vars and CLI flags.
+   */
+  parseAndValidate(rawValues: Record<string, string>): {
+    values: Record<string, unknown>;
+    issues: ConfigIssue[];
+  } {
+    const parsed = this.parse(rawValues);
+    const validated = this.validate(parsed.values);
+    return { values: validated.values, issues: [...parsed.issues, ...validated.issues] };
   }
 }
 

--- a/src/boundaries/platform/config.integration.test.ts
+++ b/src/boundaries/platform/config.integration.test.ts
@@ -3,12 +3,12 @@
  * Integration tests for Config.
  *
  * Covers:
- * - register() / load() / get() / set() lifecycle
+ * - register() / load() / accessor get/set/reset lifecycle
  * - Precedence: CLI > env > file > computed defaults > static defaults
- * - Validation errors for unknown keys and invalid values
+ * - Lenient handling of unknown/deprecated/legacy keys across all sources
  * - Sync load from config.json via readFileSync
- * - Async set() persistence via FileSystemBoundary
- * - parseEnvVars / parseCliArgs standalone
+ * - Async accessor.set() persistence via FileSystemBoundary
+ * - parseEnvVars / parseCliArgs standalone tokenizers
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -269,7 +269,8 @@ describe("Config", () => {
       svc.load();
 
       expect(key.get()).toBe("kept");
-      expect(logger.warn).toHaveBeenCalledWith("Unknown config key in config.json (stripped)", {
+      expect(logger.warn).toHaveBeenCalledWith("Unknown config key (ignored)", {
+        source: "config.json",
         key: "unknown.key",
       });
       expect(writes).toHaveLength(1);
@@ -310,6 +311,42 @@ describe("Config", () => {
       svc.register("test.flag", boolDef("test.flag"));
 
       expect(() => svc.load()).toThrow(ConfigValidationError);
+    });
+
+    it("warns and ignores unknown env vars instead of crashing", () => {
+      const logger = { ...SILENT_LOGGER, warn: vi.fn() };
+      const svc = createService({
+        env: { CH_TEST__KEY: "kept", CH_UNKNOWN__OLD: "leftover" },
+        logger,
+      });
+      const key = svc.register("test.key", stringDef("test.key", "fallback"));
+
+      expect(() => svc.load()).not.toThrow();
+      expect(key.get()).toBe("kept");
+      expect(logger.warn).toHaveBeenCalledWith("Unknown config key (ignored)", {
+        source: "env var",
+        key: "unknown.old",
+      });
+    });
+
+    it("warns and ignores unknown CLI flags instead of crashing", () => {
+      const logger = { ...SILENT_LOGGER, warn: vi.fn() };
+      const svc = createService({ argv: ["--test.key=cli", "--inspect=9229"], logger });
+      const key = svc.register("test.key", stringDef("test.key"));
+
+      expect(() => svc.load()).not.toThrow();
+      expect(key.get()).toBe("cli");
+      expect(logger.warn).toHaveBeenCalledWith("Unknown config key (ignored)", {
+        source: "CLI flag",
+        key: "inspect",
+      });
+    });
+
+    it("ignores a deprecated key set via env var (no crash)", () => {
+      const svc = createService({ env: { CH_TEST__OLD: "ignored" } });
+      svc.register("test.old", { ...stringDef("test.old", "default"), deprecated: true });
+
+      expect(() => svc.load()).not.toThrow();
     });
 
     it("throws on duplicate register()", () => {
@@ -642,7 +679,7 @@ describe("Config", () => {
       expect(writes).toHaveLength(0);
     });
 
-    it("new key wins on conflict; legacy ignored with warn", () => {
+    it("new key wins on conflict in config.json; legacy ignored with warn", () => {
       const logger = { ...SILENT_LOGGER, warn: vi.fn() };
       const svc = createService({
         fileEntries: {
@@ -657,10 +694,11 @@ describe("Config", () => {
       svc.load();
 
       expect(newKey.get()).toBe("explicit");
-      expect(logger.warn).toHaveBeenCalledWith(
-        "Legacy config key shadowed by new key (legacy ignored)",
-        { legacy: "legacy.old-name", newKey: "test.new" }
-      );
+      expect(logger.warn).toHaveBeenCalledWith("Legacy config key shadowed by new key (ignored)", {
+        source: "config.json",
+        legacy: "legacy.old-name",
+        newKey: "test.new",
+      });
     });
 
     it("falls back to default when translator returns undefined", () => {
@@ -678,17 +716,47 @@ describe("Config", () => {
       expect(newKey.get()).toBe("default");
       expect(logger.warn).toHaveBeenCalledWith(
         "Legacy config key could not be translated (using default)",
-        { legacy: "legacy.old-name", newKey: "test.new", value: "42" }
+        { source: "config.json", legacy: "legacy.old-name", newKey: "test.new", value: "42" }
       );
     });
 
-    it("env vars and CLI flags do not honor legacy names", () => {
+    it("honors a legacy name via env var with pure-rename (new key's parse, not the translator)", () => {
       const svc = createService({
         env: { CH_LEGACY__OLD_NAME: "raw" },
       });
-      svc.register("test.new", defWithLegacy("test.new"));
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
 
-      expect(() => svc.load()).toThrow(ConfigValidationError);
+      // Pure-rename runs the raw string through the new key's parse(), so the value
+      // is "raw" — NOT "migrated:raw" (the translator only applies to typed config.json).
+      expect(() => svc.load()).not.toThrow();
+      expect(newKey.get()).toBe("raw");
+    });
+
+    it("honors a legacy name via CLI flag with pure-rename", () => {
+      const svc = createService({
+        argv: ["--legacy.old-name=raw"],
+      });
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
+
+      expect(() => svc.load()).not.toThrow();
+      expect(newKey.get()).toBe("raw");
+    });
+
+    it("new key wins over legacy via env var (legacy shadowed)", () => {
+      const logger = { ...SILENT_LOGGER, warn: vi.fn() };
+      const svc = createService({
+        env: { CH_LEGACY__OLD_NAME: "raw", CH_TEST__NEW: "explicit" },
+        logger,
+      });
+      const newKey = svc.register("test.new", defWithLegacy("test.new"));
+      svc.load();
+
+      expect(newKey.get()).toBe("explicit");
+      expect(logger.warn).toHaveBeenCalledWith("Legacy config key shadowed by new key (ignored)", {
+        source: "env var",
+        legacy: "legacy.old-name",
+        newKey: "test.new",
+      });
     });
 
     it("warns at register() on legacy-name collision (last writer wins)", () => {
@@ -761,59 +829,45 @@ describe("Config", () => {
 });
 
 // =============================================================================
-// Standalone parser tests (moved from config-module tests)
+// Standalone tokenizer tests
 // =============================================================================
 
 describe("parseEnvVars", () => {
-  const definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>> = new Map([
-    ["test.key", stringDef("test.key")],
-    ["test.flag", boolDef("test.flag")],
-    ["test.dev-option", stringDef("test.dev-option")],
-  ]);
-
-  it("parses CH_* env vars to config keys", () => {
-    const result = parseEnvVars({ CH_TEST__KEY: "hello", CH_TEST__FLAG: "true" }, definitions);
-    expect(result).toEqual({ "test.key": "hello", "test.flag": true });
+  it("extracts CH_* env vars as raw string values keyed by config key", () => {
+    const result = parseEnvVars({ CH_TEST__KEY: "hello", CH_TEST__FLAG: "true" });
+    expect(result).toEqual({ "test.key": "hello", "test.flag": "true" });
   });
 
   it("skips _CH_ prefixed vars", () => {
-    const result = parseEnvVars({ _CH_TEST__KEY: "skip" }, definitions);
+    const result = parseEnvVars({ _CH_TEST__KEY: "skip" });
     expect(result).toEqual({});
   });
 
   it("handles kebab-case conversion (underscore → hyphen)", () => {
-    const result = parseEnvVars({ CH_TEST__DEV_OPTION: "value" }, definitions);
+    const result = parseEnvVars({ CH_TEST__DEV_OPTION: "value" });
     expect(result).toEqual({ "test.dev-option": "value" });
+  });
+
+  it("collects unknown CH_* keys as raw values (classification happens later)", () => {
+    const result = parseEnvVars({ CH_UNKNOWN__KEY: "leftover" });
+    expect(result).toEqual({ "unknown.key": "leftover" });
   });
 });
 
 describe("parseCliArgs", () => {
-  const definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>> = new Map([
-    ["test.key", stringDef("test.key")],
-    ["test.flag", boolDef("test.flag")],
-  ]);
-
-  it("parses --key=value format", () => {
-    const result = parseCliArgs(["--test.key=hello"], definitions, SILENT_LOGGER);
-    expect(result).toEqual({ "test.key": "hello" });
+  it("tokenizes --key=value format", () => {
+    expect(parseCliArgs(["--test.key=hello"])).toEqual({ "test.key": "hello" });
   });
 
-  it("parses --key value format", () => {
-    const result = parseCliArgs(["--test.key", "hello"], definitions, SILENT_LOGGER);
-    expect(result).toEqual({ "test.key": "hello" });
+  it("tokenizes --key value format", () => {
+    expect(parseCliArgs(["--test.key", "hello"])).toEqual({ "test.key": "hello" });
   });
 
-  it("treats bare --flag as true", () => {
-    const result = parseCliArgs(["--test.flag"], definitions, SILENT_LOGGER);
-    expect(result).toEqual({ "test.flag": true });
+  it("treats bare --flag as 'true'", () => {
+    expect(parseCliArgs(["--test.flag"])).toEqual({ "test.flag": "true" });
   });
 
-  it("skips unknown flags with warning", () => {
-    const logger = { ...SILENT_LOGGER, warn: vi.fn() };
-    const result = parseCliArgs(["--unknown-flag=val"], definitions, logger);
-    expect(result).toEqual({});
-    expect(logger.warn).toHaveBeenCalledWith("Unknown CLI flag (ignored)", {
-      flag: "unknown-flag",
-    });
+  it("tokenizes unknown flags too (classification happens later)", () => {
+    expect(parseCliArgs(["--unknown-flag=val"])).toEqual({ "unknown-flag": "val" });
   });
 });

--- a/src/boundaries/platform/config.ts
+++ b/src/boundaries/platform/config.ts
@@ -10,6 +10,14 @@
  *
  * Precedence (highest wins): CLI flags > env vars > config.json > computed defaults > static defaults
  *
+ * Two input formats flow through one schema (ConfigDefinitions):
+ *   - env vars / CLI flags are pure strings → tokenized here, then ConfigDefinitions.parse()
+ *   - config.json is typed JSON → readConfigFile() reads it, then ConfigDefinitions.validate()
+ * Both producers feed validate(), the shared-policy gate. parse(), validate(), and
+ * readConfigFile() are pure: they return { values, issues } and never log or throw.
+ * load() is the only place that interprets issues — logging the benign kinds and throwing
+ * a ConfigValidationError on `invalid`.
+ *
  * load() uses node:fs (readFileSync / writeFileSync / renameSync) directly because it must
  * run before Electron app.ready, and the FileSystemBoundary interface is async-only.
  * The sync write fires only when unknown (no-longer-registered) keys are stripped from
@@ -24,8 +32,9 @@ import type {
   ComputedDefaultContext,
   ConfigAccessor,
   DeprecatedConfigAccessor,
+  ConfigIssue,
 } from "./config-definition";
-import { ConfigValidationError } from "./config-definition";
+import { ConfigValidationError, ConfigDefinitions } from "./config-definition";
 import type { FileSystemBoundary } from "./filesystem";
 import { Path } from "../../utils/path/path";
 import type { Logger } from "./logging-types";
@@ -125,7 +134,7 @@ export interface Config {
    * static defaults < computed defaults < config.json < env vars < CLI flags.
    *
    * Uses sync filesystem I/O. Call once after all register() calls.
-   * Throws on validation errors or duplicate keys.
+   * Throws ConfigValidationError on an invalid value for a known key.
    */
   load(): void;
 
@@ -169,60 +178,15 @@ export interface ConfigDeps {
 }
 
 // =============================================================================
-// Validation Helpers
+// Source Tokenizers
 // =============================================================================
 
 /**
- * Validate and parse raw string values (from env vars or CLI flags).
- * Throws ConfigValidationError on unknown keys or invalid values.
+ * Scan an env object for CH_* keys (not _CH_*), convert to config keys, and
+ * collect their raw string values. Pure key extraction — no parsing, no validation.
+ * The result feeds ConfigDefinitions.parse().
  */
-export function validateAndParse(
-  rawValues: Record<string, string>,
-  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
-  source: string
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  for (const [key, rawValue] of Object.entries(rawValues)) {
-    const def = definitions.get(key);
-    if (!def) {
-      throw new ConfigValidationError({
-        key,
-        value: rawValue,
-        reason: "unknown",
-        source,
-      });
-    }
-
-    const parsed = def.parse(rawValue);
-    if (parsed === undefined) {
-      throw new ConfigValidationError({
-        key,
-        value: rawValue,
-        reason: "invalid",
-        source,
-        ...(def.description !== undefined && { description: def.description }),
-        ...(def.validValues !== undefined && { validValues: def.validValues }),
-      });
-    }
-    result[key] = parsed;
-  }
-
-  return result;
-}
-
-// =============================================================================
-// Source Parsers
-// =============================================================================
-
-/**
- * Scan an env object for CH_* keys (not _CH_*), convert to config keys,
- * collect as raw string values for validation.
- */
-export function parseEnvVars(
-  env: Record<string, string | undefined>,
-  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>
-): Record<string, unknown> {
+export function parseEnvVars(env: Record<string, string | undefined>): Record<string, string> {
   const rawValues: Record<string, string> = {};
 
   for (const [envKey, rawValue] of Object.entries(env)) {
@@ -235,18 +199,16 @@ export function parseEnvVars(
     rawValues[configKey] = rawValue;
   }
 
-  return validateAndParse(rawValues, definitions, "env var");
+  return rawValues;
 }
 
 /**
- * Parse CLI args in the form --key=value or --key value.
- * Unknown flags (e.g. Electron's --inspect) are skipped with a warning.
+ * Tokenize CLI args of the form --key=value or --key value (bare --flag → "true").
+ * Pure tokenization — no parsing, no validation. Unrecognized flags (e.g. Electron's
+ * --inspect) are collected too and surface as `unknown` issues from validate(), which
+ * load() logs and ignores. The result feeds ConfigDefinitions.parse().
  */
-export function parseCliArgs(
-  argv: readonly string[],
-  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
-  logger: Logger
-): Record<string, unknown> {
+export function parseCliArgs(argv: readonly string[]): Record<string, string> {
   const rawValues: Record<string, string> = {};
 
   for (let i = 0; i < argv.length; i++) {
@@ -271,117 +233,70 @@ export function parseCliArgs(
       }
     }
 
-    if (!definitions.has(key)) {
-      logger.warn("Unknown CLI flag (ignored)", { flag: key });
-      continue;
-    }
-
     rawValues[key] = value;
   }
 
-  return validateAndParse(rawValues, definitions, "CLI flag");
+  return rawValues;
 }
 
-export interface ParseConfigFileResult {
-  /** Typed values to merge into the effective config (file precedence layer). */
-  readonly values: Record<string, unknown>;
-  /**
-   * Subset of original file entries to keep on disk. Non-null only when at least
-   * one unknown key was stripped; null means no rewrite needed.
-   */
-  readonly rewrite: Record<string, unknown> | null;
-}
+// =============================================================================
+// Config File Reader
+// =============================================================================
 
 /**
- * Parse a config.json object (flat kebab-case format) into typed config values.
+ * Read and JSON-parse config.json (sync). Pure of logging — returns the parsed
+ * object plus any issues for load() to log.
  *
- * Per-key behavior:
- *  - Active registered key: validated; throws ConfigValidationError on invalid value.
- *  - Deprecated registered key: entry preserved on disk, value ignored, debug-logged.
- *  - Legacy name (matches some def's `legacyNames`): translated to the new key's value.
- *    If the new key is also present, the new value wins and the legacy is ignored.
- *    If the translator returns undefined, the value is dropped (default applies).
- *    Legacy entries are preserved on disk.
- *  - Unknown key: warn-logged and stripped (triggers a rewrite).
+ * Behavior:
+ *  - missing or unreadable file → empty object (ENOENT is the common case).
+ *  - invalid JSON → move the file aside to config.json.broken (read-recovery I/O)
+ *    and return a `broken-json` issue. If the rename itself fails, it throws —
+ *    silently discarding would destroy a broken-but-recoverable file.
+ *  - non-object JSON (e.g. a bare number) → empty object.
+ *
+ * The returned `data` is the original parsed object (untransformed); load() passes
+ * it to ConfigDefinitions.validate() and also uses it to compute the on-disk rewrite.
  */
-export function parseConfigFile(
-  data: unknown,
-  definitions: ReadonlyMap<string, ConfigKeyDefinition<unknown>>,
-  logger: Logger
-): ParseConfigFileResult {
-  if (typeof data !== "object" || data === null) {
-    return { values: {}, rewrite: null };
+export function readConfigFile(
+  configPath: Path,
+  syncRead: (path: string) => string,
+  syncRename: (oldPath: string, newPath: string) => void
+): { data: Record<string, unknown>; issues: ConfigIssue[] } {
+  let content: string;
+  try {
+    content = syncRead(configPath.toNative());
+  } catch {
+    return { data: {}, issues: [] };
   }
 
-  const obj = data as Record<string, unknown>;
-
-  // Build legacy lookup: legacyName -> { newKey, translator }.
-  // Map.set overwrite gives last-writer-wins on collision (the register-time
-  // warning has already alerted the developer).
-  const legacyLookup = new Map<string, { newKey: string; translator: (v: unknown) => unknown }>();
-  for (const [newKey, def] of definitions) {
-    if (!def.legacyNames) continue;
-    for (const [legacyName, translator] of Object.entries(def.legacyNames)) {
-      legacyLookup.set(legacyName, { newKey, translator });
-    }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    const backupPath = new Path(configPath.dirname, BROKEN_CONFIG_FILENAME);
+    syncRename(configPath.toNative(), backupPath.toNative());
+    return {
+      data: {},
+      issues: [
+        {
+          kind: "broken-json",
+          path: configPath.toString(),
+          backup: backupPath.toString(),
+          error: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
   }
 
-  const values: Record<string, unknown> = {};
-  const kept: Record<string, unknown> = {};
-  let stripped = false;
-
-  for (const [key, value] of Object.entries(obj)) {
-    const def = definitions.get(key);
-    if (def) {
-      kept[key] = value;
-      if (def.deprecated) {
-        logger.debug("Deprecated config key in config.json (ignored)", { key });
-        continue;
-      }
-      const validated = def.validate(value);
-      if (validated === undefined) {
-        throw new ConfigValidationError({
-          key,
-          value,
-          reason: "invalid",
-          source: "config.json",
-          ...(def.description !== undefined && { description: def.description }),
-          ...(def.validValues !== undefined && { validValues: def.validValues }),
-        });
-      }
-      values[key] = validated;
-      continue;
-    }
-
-    const legacy = legacyLookup.get(key);
-    if (legacy) {
-      kept[key] = value;
-      if (Object.prototype.hasOwnProperty.call(obj, legacy.newKey)) {
-        logger.warn("Legacy config key shadowed by new key (legacy ignored)", {
-          legacy: key,
-          newKey: legacy.newKey,
-        });
-        continue;
-      }
-      const translated = legacy.translator(value);
-      if (translated === undefined) {
-        logger.warn("Legacy config key could not be translated (using default)", {
-          legacy: key,
-          newKey: legacy.newKey,
-          value: JSON.stringify(value),
-        });
-        continue;
-      }
-      values[legacy.newKey] = translated;
-      continue;
-    }
-
-    logger.warn("Unknown config key in config.json (stripped)", { key });
-    stripped = true;
+  if (typeof parsed !== "object" || parsed === null) {
+    return { data: {}, issues: [] };
   }
-
-  return { values, rewrite: stripped ? kept : null };
+  return { data: parsed as Record<string, unknown>, issues: [] };
 }
+
+// =============================================================================
+// Defaults
+// =============================================================================
 
 /**
  * Build default values from definitions, applying computedDefault where available.
@@ -416,7 +331,7 @@ function overrideEquals(a: unknown, b: unknown): boolean {
 // =============================================================================
 
 export class DefaultConfig implements Config {
-  private readonly definitions = new Map<string, ConfigKeyDefinition<unknown>>();
+  private readonly definitions = new ConfigDefinitions();
   private readonly effective: Record<string, unknown> = {};
   private readonly defaults: Record<string, unknown> = {};
   private loaded = false;
@@ -457,7 +372,7 @@ export class DefaultConfig implements Config {
         }
       }
     }
-    this.definitions.set(key, definition);
+    this.definitions.add(key, definition);
     return definition.deprecated ? this.createDeprecatedAccessor(key) : this.createAccessor(key);
   }
 
@@ -499,96 +414,123 @@ export class DefaultConfig implements Config {
     }
     this.loaded = true;
 
-    const { configPath, logger, isDevelopment, isPackaged, env, argv } = this.deps;
+    const { configPath, isDevelopment, isPackaged, env, argv } = this.deps;
     const syncRead = this.deps.readFileSync ?? ((p: string) => readFileSync(p, "utf-8"));
+    const syncRename = this.deps.renameSync ?? renameSync;
     const computedDefaultCtx: ComputedDefaultContext = { isDevelopment, isPackaged };
 
     // 1. Build defaults (static + computed) and seed effective immediately
-    //    so getHelpText()/getEffective() work even if parsing throws below
-    const defaults = buildDefaults(this.definitions, computedDefaultCtx);
+    //    so getHelpText()/getEffective() work even if we throw below.
+    const defaults = buildDefaults(this.definitions.asReadonlyMap(), computedDefaultCtx);
     for (const [key, value] of Object.entries(defaults)) {
       this.effective[key] = value;
       this.defaults[key] = value;
     }
 
-    // 2. Read config.json from disk (sync)
-    let fileValues: Record<string, unknown> = {};
-    let rewrite: Record<string, unknown> | null = null;
-    let content: string | null = null;
-    try {
-      content = syncRead(configPath.toNative());
-    } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-        logger.debug("Config not found, using defaults", { path: configPath.toString() });
-      } else {
-        logger.warn("Config load failed, using defaults", {
-          path: configPath.toString(),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
+    // 2. config.json: read (I/O) → validate (typed values).
+    const file = readConfigFile(configPath, syncRead, syncRename);
+    const fileResult = this.definitions.validate(file.data);
 
-    if (content !== null) {
-      let parsed: unknown = null;
-      let parseOk = false;
-      try {
-        parsed = JSON.parse(content);
-        parseOk = true;
-      } catch (error) {
-        // Invalid JSON: move config.json aside so the user can recover it,
-        // then proceed with defaults. If the rename itself fails, throw —
-        // silently writing fresh would destroy the broken-but-recoverable file.
-        const backupPath = new Path(configPath.dirname, BROKEN_CONFIG_FILENAME);
-        const syncRen = this.deps.renameSync ?? renameSync;
-        syncRen(configPath.toNative(), backupPath.toNative());
-        logger.warn(
-          "Invalid JSON in config.json, backed up to config.json.broken; using defaults",
-          {
-            path: configPath.toString(),
-            backup: backupPath.toString(),
-            error: error instanceof Error ? error.message : String(error),
-          }
-        );
-      }
-      if (parseOk) {
-        const result = parseConfigFile(parsed, this.definitions, logger);
-        fileValues = result.values;
-        rewrite = result.rewrite;
-        logger.debug("Config loaded from disk", { path: configPath.toString() });
-      }
-    }
+    // 3. env + CLI: tokenize → parse (strings → typed) → validate.
+    const envResult = this.definitions.parseAndValidate(parseEnvVars(env));
+    const cliResult = this.definitions.parseAndValidate(parseCliArgs(argv));
 
-    // 3. Parse env vars and CLI args
-    const envValues = parseEnvVars(env, this.definitions);
-    const cliValues = parseCliArgs(argv, this.definitions, logger);
+    // 4. Interpret issues per source (precedence order): log benign kinds, throw on invalid.
+    this.reportIssues("config.json", [...file.issues, ...fileResult.issues]);
+    this.reportIssues("env var", envResult.issues);
+    this.reportIssues("CLI flag", cliResult.issues);
 
-    // 4. Merge with precedence: defaults < file < env < CLI
+    // 5. Merge with precedence: defaults < file < env < CLI.
     const merged = {
       ...defaults,
-      ...fileValues,
-      ...envValues,
-      ...cliValues,
+      ...fileResult.values,
+      ...envResult.values,
+      ...cliResult.values,
     };
-
     for (const [key, value] of Object.entries(merged)) {
       this.effective[key] = value;
     }
 
-    // 5. If unknown keys were stripped, rewrite config.json (sync).
-    if (rewrite !== null) {
+    // 6. If config.json contained unknown keys, rewrite it with those stripped
+    //    (active, deprecated, and legacy entries are preserved).
+    const unknownFileKeys = fileResult.issues.flatMap((issue) =>
+      issue.kind === "unknown" ? [issue.key] : []
+    );
+    if (unknownFileKeys.length > 0) {
+      const stripped = new Set(unknownFileKeys);
+      const kept: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(file.data)) {
+        if (!stripped.has(key)) kept[key] = value;
+      }
       const syncWrite =
         this.deps.writeFileSync ?? ((p: string, c: string) => writeFileSync(p, c, "utf-8"));
       try {
-        syncWrite(configPath.toNative(), JSON.stringify(rewrite, null, 2));
-        logger.debug("Config rewritten (unknown keys stripped)", {
+        syncWrite(configPath.toNative(), JSON.stringify(kept, null, 2));
+        this.deps.logger.debug("Config rewritten (unknown keys stripped)", {
           path: configPath.toString(),
         });
       } catch (error) {
-        logger.warn("Config rewrite failed", {
+        this.deps.logger.warn("Config rewrite failed", {
           path: configPath.toString(),
           error: error instanceof Error ? error.message : String(error),
         });
       }
+    }
+  }
+
+  /**
+   * Interpret the issues from one source: log the benign kinds, and throw a
+   * ConfigValidationError on the first `invalid` (which main.ts turns into exit(1)).
+   * Benign issues are logged first so they surface even when an invalid follows.
+   */
+  private reportIssues(source: string, issues: ConfigIssue[]): void {
+    const { logger } = this.deps;
+    for (const issue of issues) {
+      switch (issue.kind) {
+        case "unknown":
+          logger.warn("Unknown config key (ignored)", { source, key: issue.key });
+          break;
+        case "deprecated":
+          logger.debug("Deprecated config key (ignored)", { source, key: issue.key });
+          break;
+        case "legacy-shadowed":
+          logger.warn("Legacy config key shadowed by new key (ignored)", {
+            source,
+            legacy: issue.legacy,
+            newKey: issue.newKey,
+          });
+          break;
+        case "legacy-untranslatable":
+          logger.warn("Legacy config key could not be translated (using default)", {
+            source,
+            legacy: issue.legacy,
+            newKey: issue.newKey,
+            value: JSON.stringify(issue.value),
+          });
+          break;
+        case "broken-json":
+          logger.warn(
+            "Invalid JSON in config.json, backed up to config.json.broken; using defaults",
+            { path: issue.path, backup: issue.backup, error: issue.error }
+          );
+          break;
+        case "invalid":
+          break;
+      }
+    }
+
+    const invalid = issues.find(
+      (i): i is Extract<ConfigIssue, { kind: "invalid" }> => i.kind === "invalid"
+    );
+    if (invalid) {
+      throw new ConfigValidationError({
+        key: invalid.key,
+        value: invalid.value,
+        reason: "invalid",
+        source,
+        ...(invalid.description !== undefined && { description: invalid.description }),
+        ...(invalid.validValues !== undefined && { validValues: invalid.validValues }),
+      });
     }
   }
 
@@ -696,7 +638,7 @@ export class DefaultConfig implements Config {
   }
 
   getDefinitions(): ReadonlyMap<string, ConfigKeyDefinition<unknown>> {
-    return this.definitions;
+    return this.definitions.asReadonlyMap();
   }
 
   getEffective(): Readonly<Record<string, unknown>> {
@@ -718,6 +660,10 @@ export class DefaultConfig implements Config {
   }
 
   getHelpText(): string {
-    return generateHelpText(this.deps.configPath.toString(), this.definitions, this.effective);
+    return generateHelpText(
+      this.deps.configPath.toString(),
+      this.definitions.asReadonlyMap(),
+      this.effective
+    );
   }
 }


### PR DESCRIPTION
- Unknown \`CH_*\` env vars no longer hard-crash startup — they warn and are ignored, matching how config.json and CLI flags already behaved.
- Unify all three sources behind one schema (\`ConfigDefinitions\`):
  - pure \`parse()\` (strings → typed) and \`validate()\` (typed → validated, the shared-policy gate), plus a \`parseAndValidate()\` convenience for raw-string sources. All return \`{ values, issues }\` and never log or throw.
  - \`parseEnvVars\`/\`parseCliArgs\` are now pure tokenizers; \`readConfigFile\` is a pure reader returning \`{ data, issues }\`.
  - \`load()\` is the single place that logs benign issues and throws \`ConfigValidationError\` on an invalid value for a known key.
- Deprecated keys via env/CLI skip cleanly; legacy keys resolve via pure-rename for env/CLI and the typed translator for config.json.
- Invalid values on known keys still throw everywhere; accessor \`set()\`/\`reset()\` keep their own throws.