### PR TITLE
fix: update notification was not dismissable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,7 @@ Precedence (highest wins): CLI flag > env var > config.json > computed defaults 
 | ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `agent`                               | `null`    | Agent selection: claude\|opencode                                                                                                                   |
 | `update.notification`                 | `true`    | Show a sidebar notification when an update is available (also gates the periodic update check)                                                      |
+| `update.dismissed-version`            | `null`    | Internal: the update version the user last dismissed; persisted so it stays silent across restarts (a newer version still re-surfaces)              |
 | `version.claude`                      | `null`    | Claude agent version override                                                                                                                       |
 | `version.opencode`                    | `null`    | OpenCode agent version override                                                                                                                     |
 | `code-server.port`                    | (auto)    | Code-server port (auto = 25448 in prod, branch-derived in dev)                                                                                      |

--- a/src/modules/auto-updater-module.integration.test.ts
+++ b/src/modules/auto-updater-module.integration.test.ts
@@ -171,10 +171,12 @@ function createTestSetup(overrides?: {
   disposeThrows?: Error;
   checkReturns?: boolean;
   configValues?: Record<string, unknown>;
+  config?: Config;
 }): TestSetup {
   const autoUpdater = createMockAutoUpdater(overrides);
   const notificationManager = createMockNotificationManager();
-  const mockConfig = createMockConfig({ defaults: overrides?.configValues ?? {} });
+  const mockConfig =
+    overrides?.config ?? createMockConfig({ defaults: overrides?.configValues ?? {} });
 
   const dispatcher = createMockDispatcher();
 
@@ -475,6 +477,45 @@ describe("AutoUpdaterModule Integration", () => {
     const newest = notificationManager.notifications[1]!;
     expect(newest.opened.title).toBe("Update available");
     expect(newest.opened.message).toContain("3.0.0");
+  });
+
+  it("dismissing closes the notification so the renderer removes it", async () => {
+    const { dispatcher, notificationManager } = createTestSetup({ checkReturns: true });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    notificationManager.emitEvent(0, { actionId: "dismiss" });
+
+    expect(notificationManager.notifications[0]!.closed).toBe(true);
+  });
+
+  it("dismissing persists the dismissed version to config", async () => {
+    const { dispatcher, notificationManager, mockConfig } = createTestSetup({ checkReturns: true });
+    await dispatcher.dispatch(startIntent());
+    await flush();
+
+    notificationManager.emitEvent(0, { actionId: "dismiss" });
+    await flush();
+
+    expect(mockConfig.getEffective()["update.dismissed-version"]).toBe("2.0.0");
+  });
+
+  it("a version dismissed in a previous run stays silent after restart", async () => {
+    // First run: dismiss the surfaced version, which persists to the shared config.
+    const config = createMockConfig();
+    const first = createTestSetup({ checkReturns: true, config });
+    await first.dispatcher.dispatch(startIntent());
+    await flush();
+    first.notificationManager.emitEvent(0, { actionId: "dismiss" });
+    await flush();
+
+    // Second run (fresh module + notifications) reusing the same persisted config.
+    const second = createTestSetup({ checkReturns: true, config });
+    await second.dispatcher.dispatch(startIntent());
+    await flush();
+
+    // The restored dismissed version silences the same-version notification.
+    expect(second.notificationManager.notifications).toHaveLength(0);
   });
 
   it("app:shutdown calls autoUpdater.dispose()", async () => {

--- a/src/modules/auto-updater-module.ts
+++ b/src/modules/auto-updater-module.ts
@@ -21,7 +21,8 @@
  *   completes) keep running. When a newer version is detected, the single
  *   notification refreshes to "Update available" for that version — including
  *   reverting a "ready" notification so one restart always lands on newest.
- * - Dismiss = silent for that version. A genuinely newer version re-surfaces.
+ * - Dismiss = silent for that version, persisted via `update.dismissed-version`
+ *   so it stays silent across restarts. A genuinely newer version re-surfaces.
  * - A check is skipped while a download is in progress; the check fired right
  *   after the download completes catches anything released mid-download.
  */
@@ -32,7 +33,7 @@ import { APP_START_OPERATION_ID } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID, type AppShutdownIntent } from "../intents/app-shutdown";
 import { APP_RESUME_OPERATION_ID, APP_RESUME_HOOK_RESUME } from "../intents/app-resume";
 import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
-import { configBoolean } from "../boundaries/platform/config-definition";
+import { configBoolean, configString } from "../boundaries/platform/config-definition";
 import type { Config } from "../boundaries/platform/config";
 import type { AutoUpdater } from "./auto-updater";
 import type { Dispatcher } from "../intents/lib/dispatcher";
@@ -104,11 +105,19 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
   let periodicTimer: NodeJS.Timeout | null = null;
   let notification: NotificationHandle | null = null;
 
-  // Register config key
+  // Register config keys
   const updateNotificationConfig = deps.configService.register("update.notification", {
     default: true,
     description: "Show a sidebar notification when an update is available",
     ...configBoolean(),
+  });
+  // Persisted so a dismissed update stays silent across restarts; a genuinely
+  // newer version still re-surfaces (reconcile compares against this value).
+  const dismissedVersionConfig = deps.configService.register("update.dismissed-version", {
+    default: null,
+    description:
+      "Internal: the update version the user last dismissed (silences re-notification across restarts)",
+    ...configString({ nullable: true }),
   });
 
   function isEnabled(): boolean {
@@ -131,9 +140,11 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
       return;
     }
     if (event.actionId === "dismiss") {
-      dismissedVersion = targetVersion;
+      notification?.close();
       notification = null;
       notificationState = "none";
+      dismissedVersion = targetVersion;
+      void dismissedVersionConfig.set(targetVersion);
     }
   }
 
@@ -228,6 +239,10 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
       [APP_START_OPERATION_ID]: {
         start: {
           handler: async (): Promise<void> => {
+            // Restore the last dismissed version so an update the user already
+            // dismissed stays silent across restarts.
+            dismissedVersion = dismissedVersionConfig.get();
+
             // Persistent callback captures the version whenever electron-updater
             // fires `update-available`. checkForUpdates() also returns the
             // boolean result; the callback simply ensures we always have the


### PR DESCRIPTION
- Dismiss handler now calls `notification.close()` so the renderer removes the notification from the sidebar stack — clicking the X previously updated internal state but left the notification on screen.
- Persist the dismissed version via a new `update.dismissed-version` config key so a dismissed update stays silent across restarts; a genuinely newer version still re-surfaces.
- Added integration tests: dismiss closes the notification, dismiss persists the version, and a previously-dismissed version stays silent after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)