### PR TITLE
refactor(dialog): use a flat keyed values map for field events

### DIFF
--- a/src/modules/bug-report-module.integration.test.ts
+++ b/src/modules/bug-report-module.integration.test.ts
@@ -170,7 +170,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "My edited report" } },
+      data: { description: "My edited report" },
     });
 
     await vi.waitFor(() => {
@@ -211,7 +211,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "It crashed" } },
+      data: { description: "It crashed" },
     });
 
     // Wait for async readFile + dispatch
@@ -277,7 +277,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "rotated" } },
+      data: { description: "rotated" },
     });
 
     await vi.waitFor(() => {
@@ -302,7 +302,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "both logs" } },
+      data: { description: "both logs" },
     });
 
     await vi.waitFor(() => {
@@ -329,7 +329,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "no electron yet" } },
+      data: { description: "no electron yet" },
     });
 
     await vi.waitFor(() => {
@@ -350,7 +350,7 @@ describe("BugReportModule", () => {
     handle._emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
-      data: { inputs: { description: "crash" } },
+      data: { description: "crash" },
     });
 
     await vi.waitFor(() => {

--- a/src/modules/bug-report-module.ts
+++ b/src/modules/bug-report-module.ts
@@ -107,8 +107,7 @@ export function createBugReportModule(deps: BugReportModuleDeps): IntentModule {
             readLogContent(),
             readElectronLogContent(),
           ]);
-          const inputs = (event.data?.inputs ?? {}) as Record<string, string>;
-          const description = inputs["description"] ?? "";
+          const description = event.data?.["description"] ?? "";
 
           void deps.dispatcher.dispatch({
             type: INTENT_SUBMIT_BUG_REPORT,

--- a/src/modules/dialog-manager.integration.test.ts
+++ b/src/modules/dialog-manager.integration.test.ts
@@ -176,7 +176,7 @@ describe("DialogManager", () => {
       const event: DialogUserEvent = {
         dialogId: handle.id,
         actionId: "continue",
-        data: { selection: "claude" },
+        data: { agent: "claude" },
       };
       manager.routeEvent(event);
 

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -479,6 +479,57 @@ describe("ViewModule Integration", () => {
         } as SetupIntent)
       ).rejects.toThrow("DialogManager not available");
     });
+
+    it("reads the selected agent from the dialog event values", async () => {
+      const availableAgents: RegisterAgentResult[] = [
+        { agent: "claude", label: "Claude", icon: "sparkle" },
+        { agent: "opencode", label: "OpenCode", icon: "terminal" },
+      ];
+
+      const dispatcher = createMockDispatcher();
+      const viewManager = createMockViewManager();
+
+      dispatcher.registerOperation(
+        INTENT_SETUP,
+        new MinimalAgentSelectionOperation(availableAgents)
+      );
+
+      // Selection dialog resolves to the "opencode" field value (keyed by id "agent").
+      const dialogManager = {
+        open: vi.fn(() => ({
+          id: "dlg-agent",
+          update: vi.fn(),
+          close: vi.fn(),
+          onEvent: vi.fn(() => () => {}),
+          nextEvent: vi.fn().mockResolvedValue({
+            dialogId: "dlg-agent",
+            actionId: "select",
+            data: { agent: "opencode" },
+          }),
+          closed: Promise.resolve(),
+        })),
+      };
+
+      const module = createViewModule({
+        viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
+        logger: SILENT_LOGGER,
+        viewLayer: null,
+        windowLayer: null,
+        sessionLayer: null,
+        configService: createMockConfig(),
+        dialogManager: dialogManager as unknown as NonNullable<ViewModuleDeps["dialogManager"]>,
+      });
+
+      dispatcher.registerModule(module);
+
+      const result = (await dispatcher.dispatch({
+        type: INTENT_SETUP,
+        payload: {},
+      } as SetupIntent)) as unknown as AgentSelectionResult;
+
+      expect(result.selectedAgent).toBe("opencode");
+      expect(dialogManager.open).toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -483,6 +483,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
                 { type: "text", content: "Choose Agent", style: "heading" },
                 {
                   type: "selection",
+                  id: "agent",
                   options: availableAgents.map((a) => ({
                     id: a.agent,
                     label: a.label,
@@ -498,8 +499,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             const event = await handle.nextEvent(5 * 60_000);
             handle.close();
 
-            const selectedAgent =
-              (event.data?.["selection"] as string) ?? availableAgents[0]?.agent;
+            const selectedAgent = event.data?.["agent"] ?? availableAgents[0]?.agent;
             capAgentType = selectedAgent as LifecycleAgentType;
             logger.info("Agent selected", { agent: capAgentType });
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -304,6 +304,18 @@ describe("preload API", () => {
 
       expect(mockIpcRenderer.send).toHaveBeenCalledWith("api:dialog:event", event);
     });
+
+    it("forwards a flat field-values data payload verbatim", () => {
+      const sendDialogEvent = exposedApi.sendDialogEvent as (event: unknown) => void;
+      const event = {
+        dialogId: "dlg-2",
+        actionId: "confirm",
+        data: { agent: "claude", description: "hi" },
+      };
+      sendDialogEvent(event);
+
+      expect(mockIpcRenderer.send).toHaveBeenCalledWith("api:dialog:event", event);
+    });
   });
 
   describe("event subscriptions", () => {

--- a/src/renderer/lib/components/Form.svelte
+++ b/src/renderer/lib/components/Form.svelte
@@ -29,43 +29,30 @@
 
   const { dialogId, config }: Props = $props();
 
-  // Track selection state for selection sections
-  let selectionState = $state<Record<number, string>>({});
+  // Track all field values (selection + input) keyed by field id.
+  let fieldValues = $state<Record<string, string>>({});
 
-  // Track input values for input sections (keyed by input id)
-  let inputState = $state<Record<string, string>>({});
-
-  // Initialize selection state when config changes (not when selection changes)
+  // Reconcile field values whenever the config changes: rebuild the map so it
+  // mirrors the current field sections (dropping removed-field keys) while
+  // preserving values for fields that remain.
+  // - selection: keep the existing choice if still a valid option, else the
+  //   first option.
+  // - input: keep existing edits/seeded value; otherwise seed from initialValue
+  //   on first sight (a later initialValue change does not re-seed).
+  // Existing values are read via untrack to avoid a write -> retrigger loop.
   $effect(() => {
-    const newState: Record<number, string> = {};
-    config.sections.forEach((section, index) => {
-      if (section.type === "selection" && section.options.length > 0) {
-        // Read existing selection without tracking — avoid circular dependency
-        const existing = untrack(() => selectionState[index]);
-        const stillValid = existing && section.options.some((o) => o.id === existing);
-        newState[index] = stillValid ? existing : section.options[0]!.id;
-      }
-    });
-    selectionState = newState;
-  });
-
-  // Seed input state from initialValue on first sight of each input id.
-  // Existing edits are preserved; re-seeds would overwrite user content.
-  $effect(() => {
-    const seeded: Record<string, string> = {};
-    let changed = false;
+    const next: Record<string, string> = {};
     for (const section of config.sections) {
-      if (section.type !== "input") continue;
-      const existing = untrack(() => inputState[section.id]);
-      if (existing !== undefined) continue;
-      if (section.initialValue !== undefined) {
-        seeded[section.id] = section.initialValue;
-        changed = true;
+      if (section.type === "selection") {
+        const existing = untrack(() => fieldValues[section.id]);
+        const stillValid = existing !== undefined && section.options.some((o) => o.id === existing);
+        next[section.id] = stillValid ? existing : (section.options[0]?.id ?? "");
+      } else if (section.type === "input") {
+        const existing = untrack(() => fieldValues[section.id]);
+        next[section.id] = existing ?? section.initialValue ?? "";
       }
     }
-    if (changed) {
-      inputState = { ...untrack(() => inputState), ...seeded };
-    }
+    fieldValues = next;
   });
 
   // Auto-focus the selected card on mount (for keyboard navigation)
@@ -123,40 +110,24 @@
     };
   }
 
-  /** Get the current selection data to include in events.
-   * NOTE: Supports one selection section per dialog. If multiple exist, last wins. */
-  function getSelectionData(): Record<string, unknown> {
-    const data: Record<string, unknown> = {};
-    config.sections.forEach((section, index) => {
-      if (section.type === "selection" && selectionState[index]) {
-        data["selection"] = selectionState[index];
-      }
-    });
-    return data;
-  }
-
-  /** Get input values to include in events. */
-  function getInputData(): Record<string, string> {
-    const inputs: Record<string, string> = {};
+  /** Snapshot every field's current value, keyed by field id. */
+  function getValues(): Record<string, string> {
+    const values: Record<string, string> = {};
     for (const section of config.sections) {
-      if (section.type === "input") {
-        inputs[section.id] = inputState[section.id] ?? "";
+      if (section.type === "selection" || section.type === "input") {
+        values[section.id] = fieldValues[section.id] ?? "";
       }
     }
-    return inputs;
+    return values;
   }
 
   /** Handle action button click. */
   function handleAction(action: DialogAction): void {
     if (action.disabled || action.busy) return;
-    const inputs = getInputData();
     const event: DialogUserEvent = {
       dialogId,
       actionId: action.id,
-      data: {
-        ...getSelectionData(),
-        ...(Object.keys(inputs).length > 0 ? { inputs } : {}),
-      },
+      data: getValues(),
     };
     sendDialogEvent(event);
   }
@@ -291,13 +262,13 @@
           <button
             type="button"
             class="selection-card"
-            class:selected={selectionState[sectionIndex] === option.id}
+            class:selected={fieldValues[s.id] === option.id}
             role="radio"
-            aria-checked={selectionState[sectionIndex] === option.id}
-            tabindex={selectionState[sectionIndex] === option.id ? 0 : -1}
+            aria-checked={fieldValues[s.id] === option.id}
+            tabindex={fieldValues[s.id] === option.id ? 0 : -1}
             data-option={option.id}
             onclick={() => {
-              selectionState = { ...selectionState, [sectionIndex]: option.id };
+              fieldValues = { ...fieldValues, [s.id]: option.id };
             }}
             onkeydown={(e) => {
               const opts = s.options;
@@ -316,12 +287,12 @@
                 return;
               } else if (e.key === " ") {
                 e.preventDefault();
-                selectionState = { ...selectionState, [sectionIndex]: option.id };
+                fieldValues = { ...fieldValues, [s.id]: option.id };
                 return;
               }
               if (targetIndex >= 0) {
                 const targetId = opts[targetIndex]!.id;
-                selectionState = { ...selectionState, [sectionIndex]: targetId };
+                fieldValues = { ...fieldValues, [s.id]: targetId };
                 const container = e.currentTarget.closest(".selection-cards");
                 setTimeout(() => {
                   const card = container?.querySelector(
@@ -339,7 +310,7 @@
             {/if}
             <span class="selection-card-title">{option.label}</span>
             <div class="selection-card-indicator">
-              {#if selectionState[sectionIndex] === option.id}
+              {#if fieldValues[s.id] === option.id}
                 <Icon name="circle-filled" size={16} />
               {:else}
                 <Icon name="circle-outline" size={16} />
@@ -354,14 +325,14 @@
           class="input-textarea"
           placeholder={s.placeholder ?? ""}
           aria-label={s.placeholder ?? "Text input"}
-          value={inputState[s.id] ?? ""}
+          value={fieldValues[s.id] ?? ""}
           use:seedCursor={{
             initialValue: s.initialValue,
             cursorOffset: s.cursorOffset,
             selectInitialValue: s.selectInitialValue,
           }}
           oninput={(e) => {
-            inputState = { ...inputState, [s.id]: e.currentTarget.value };
+            fieldValues = { ...fieldValues, [s.id]: e.currentTarget.value };
           }}
         ></textarea>
       {:else}
@@ -369,9 +340,9 @@
           class="input-textfield"
           placeholder={s.placeholder ?? ""}
           aria-label={s.placeholder ?? "Text input"}
-          value={inputState[s.id] ?? ""}
+          value={fieldValues[s.id] ?? ""}
           oninput={(e: Event) => {
-            inputState = { ...inputState, [s.id]: (e.currentTarget as HTMLInputElement).value };
+            fieldValues = { ...fieldValues, [s.id]: (e.currentTarget as HTMLInputElement).value };
           }}
         ></vscode-textfield>
       {/if}

--- a/src/renderer/lib/components/Form.test.ts
+++ b/src/renderer/lib/components/Form.test.ts
@@ -163,6 +163,7 @@ describe("Form component", () => {
         sections: [
           {
             type: "selection",
+            id: "choice",
             options: [
               { id: "opt-a", label: "Option A" },
               { id: "opt-b", label: "Option B" },
@@ -182,6 +183,7 @@ describe("Form component", () => {
         sections: [
           {
             type: "selection",
+            id: "choice",
             options: [
               { id: "opt-a", label: "Option A" },
               { id: "opt-b", label: "Option B" },
@@ -209,6 +211,7 @@ describe("Form component", () => {
         sections: [
           {
             type: "selection",
+            id: "choice",
             options: [
               { id: "opt-a", label: "Option A" },
               { id: "opt-b", label: "Option B" },
@@ -354,6 +357,7 @@ describe("Form component", () => {
           { type: "text", content: "Pick one", style: "heading" },
           {
             type: "selection",
+            id: "choice",
             options: [
               { id: "opt-a", label: "Option A" },
               { id: "opt-b", label: "Option B" },
@@ -376,7 +380,43 @@ describe("Form component", () => {
       expect(mockSendDialogEvent).toHaveBeenCalledWith({
         dialogId: "sel-dialog",
         actionId: "confirm",
-        data: { selection: "opt-b" },
+        data: { choice: "opt-b" },
+      });
+    });
+
+    it("includes all field values (selection + input) keyed by id", async () => {
+      const config: DialogConfig = {
+        sections: [
+          { type: "text", content: "Pick + note", style: "heading" },
+          {
+            type: "selection",
+            id: "agent",
+            options: [
+              { id: "claude", label: "Claude" },
+              { id: "opencode", label: "OpenCode" },
+            ],
+          },
+          { type: "input", id: "note", multiline: true, placeholder: "Note" },
+        ],
+        actions: [{ id: "confirm", label: "Confirm" }],
+      };
+
+      renderForm(config, { dialogId: "multi-dialog" });
+
+      // Switch the selection from its default (first option) to the second.
+      const radios = screen.getAllByRole("radio");
+      await fireEvent.click(radios[1]!);
+
+      // Type into the input.
+      const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+      await fireEvent.input(textarea, { target: { value: "hello" } });
+
+      await fireEvent.click(screen.getByText("Confirm"));
+
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({
+        dialogId: "multi-dialog",
+        actionId: "confirm",
+        data: { agent: "opencode", note: "hello" },
       });
     });
   });

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -42,9 +42,14 @@ interface ProgressSection {
 
 /**
  * Selection section - displays radio-group cards with icon + label.
+ *
+ * - id: stable field id. The chosen option's id is reported in
+ *   DialogUserEvent.data keyed by this id. Must be unique among the field
+ *   sections (input/selection) of a DialogConfig.
  */
 interface SelectionSection {
   readonly type: "selection";
+  readonly id: string;
   readonly options: readonly SelectionOption[];
 }
 
@@ -69,7 +74,7 @@ interface TableSection {
  *   (only applied when initialValue is set)
  * - selectInitialValue selects the seeded text instead of placing a caret, so
  *   the first keystroke replaces it (overrides cursorOffset)
- * - Input values are included in DialogUserEvent.data.inputs when actions fire
+ * - Input values are included in DialogUserEvent.data keyed by field id when actions fire
  */
 interface InputSection {
   readonly type: "input";
@@ -155,9 +160,15 @@ export type DialogCommand =
 
 /**
  * Events sent from renderer -> main when user interacts with a dialog.
+ *
+ * `data` is a flat snapshot of the dialog's field values, keyed by each field's
+ * stable id (input.id, selection.id, ...). Field ids must be unique within a
+ * DialogConfig. Every field is present; an empty/unset field reports "" (a
+ * key being absent means the field is not part of this dialog). Values are
+ * strings; widening the value type is a shared-type change.
  */
 export interface DialogUserEvent {
   readonly dialogId: string;
   readonly actionId: string;
-  readonly data?: Readonly<Record<string, unknown>>;
+  readonly data?: Readonly<Record<string, string>>;
 }


### PR DESCRIPTION
- Replace `DialogUserEvent.data`'s special-cased `selection` (single, last-wins) + `inputs` split with a uniform flat map keyed by stable field id (`Record<fieldId, string>`)
- `SelectionSection` gains a required `id`; the agent picker now produces `id: "agent"` and reads `data["agent"]`; bug-report reads `data["description"]`
- DialogView merges `selectionState`/`inputState` into one `fieldValues` map reconciled by a single effect; `getValues()` replaces the two getters
- Hard cutover, no compat shim — foundational for the upcoming form primitives and per-change channel
- Approved shared-type/IPC contract changes in `src/shared/dialog-types.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)