### PR TITLE
feat(agent): drive agent status from sidekick lifecycle events

### DIFF
--- a/extensions/sidekick/src/extension.test.ts
+++ b/extensions/sidekick/src/extension.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for the sidekick extension's agent terminal lifecycle emits.
+ *
+ * Verifies that opening the agent terminal emits api:workspace:agentLifecycle
+ * { event: "open" } and closing it emits { event: "close" } over the plugin
+ * socket (replacing the wrapper's WrapperStart/WrapperEnd POSTs).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Terminal, TerminalOptions } from "vscode";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+interface FakeSocket {
+  connected: boolean;
+  emit: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  _handlers: Record<string, (...args: unknown[]) => unknown>;
+}
+
+vi.mock("socket.io-client", () => {
+  return {
+    io: vi.fn((): FakeSocket => {
+      const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+      const socket: FakeSocket = {
+        connected: true,
+        emit: vi.fn(),
+        on: vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
+          handlers[event] = cb;
+          return socket;
+        }),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        _handlers: handlers,
+      };
+      return socket;
+    }),
+  };
+});
+
+// Captured terminal-close callbacks registered via window.onDidCloseTerminal.
+let closeHandlers: Array<(t: Terminal) => void> = [];
+// Terminals created via window.createTerminal.
+let createdTerminals: Terminal[] = [];
+
+vi.mock("vscode", () => {
+  return {
+    window: {
+      createTerminal: vi.fn((opts: TerminalOptions): Terminal => {
+        const terminal = {
+          name: opts.name,
+          creationOptions: opts,
+          show: vi.fn(),
+          sendText: vi.fn(),
+          dispose: vi.fn(),
+        } as unknown as Terminal;
+        createdTerminals.push(terminal);
+        return terminal;
+      }),
+      onDidCloseTerminal: vi.fn((cb: (t: Terminal) => void) => {
+        closeHandlers.push(cb);
+        return { dispose: vi.fn() };
+      }),
+      terminals: [],
+      showInformationMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
+      showErrorMessage: vi.fn(),
+      createStatusBarItem: vi.fn(() => ({ show: vi.fn(), dispose: vi.fn() })),
+      createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), dispose: vi.fn() })),
+      activeTextEditor: undefined,
+    },
+    commands: {
+      registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+      executeCommand: vi.fn(() => Promise.resolve()),
+    },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/workspace/feature-a" } }],
+      updateWorkspaceFolders: vi.fn(),
+    },
+    ViewColumn: { Active: 1 },
+    StatusBarAlignment: { Left: 1 },
+    Uri: { file: (p: string) => ({ fsPath: p }), parse: (s: string) => ({ toString: () => s }) },
+  };
+});
+
+import { io } from "socket.io-client";
+import { activate, deactivate } from "./extension";
+
+function makeContext() {
+  return {
+    subscriptions: { push: vi.fn() },
+    workspaceState: {
+      get: vi.fn((_key: string, def: unknown) => def),
+      update: vi.fn(),
+    },
+  } as unknown as Parameters<typeof activate>[0];
+}
+
+function getSocket(): FakeSocket {
+  const mockedIo = vi.mocked(io);
+  return mockedIo.mock.results[mockedIo.mock.results.length - 1]!.value as FakeSocket;
+}
+
+const CONFIG = {
+  isDevelopment: false,
+  env: { _CH_WORKSPACE_PATH: "/workspace/feature-a", _CH_BRIDGE_PORT: "9000" },
+  agentType: "claude" as const,
+  resetWorkspace: true,
+};
+
+describe("sidekick agent lifecycle emits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    closeHandlers = [];
+    createdTerminals = [];
+    process.env._CH_PLUGIN_PORT = "8123";
+  });
+
+  afterEach(() => {
+    deactivate();
+    delete process.env._CH_PLUGIN_PORT;
+  });
+
+  it("emits agentLifecycle 'open' when the agent terminal is created", async () => {
+    activate(makeContext());
+    const socket = getSocket();
+
+    await socket._handlers.config!(CONFIG);
+
+    expect(createdTerminals).toHaveLength(1);
+    expect(socket.emit).toHaveBeenCalledWith("api:workspace:agentLifecycle", { event: "open" });
+  });
+
+  it("emits agentLifecycle 'close' when the agent terminal closes", async () => {
+    activate(makeContext());
+    const socket = getSocket();
+    await socket._handlers.config!(CONFIG);
+
+    socket.emit.mockClear();
+
+    // Fire the terminal-close listener with the agent terminal.
+    expect(closeHandlers.length).toBeGreaterThan(0);
+    closeHandlers[0]!(createdTerminals[0]!);
+
+    expect(socket.emit).toHaveBeenCalledWith("api:workspace:agentLifecycle", { event: "close" });
+  });
+
+  it("does not emit when the socket is disconnected", async () => {
+    activate(makeContext());
+    const socket = getSocket();
+    await socket._handlers.config!(CONFIG);
+
+    socket.emit.mockClear();
+    socket.connected = false;
+
+    closeHandlers[0]!(createdTerminals[0]!);
+
+    expect(socket.emit).not.toHaveBeenCalledWith("api:workspace:agentLifecycle", {
+      event: "close",
+    });
+  });
+});

--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -122,6 +122,18 @@ let agentTerminal: vscode.Terminal | null = null;
 let terminalCloseListener: vscode.Disposable | null = null;
 
 /**
+ * Report an agent terminal lifecycle transition to the main process.
+ * Fire-and-forget; no-op when not connected. Drives agent status:
+ * "open" → WrapperStart, "close" → WrapperEnd / TUI detach. Replaces the
+ * wrapper-synthesized WrapperStart/WrapperEnd hooks.
+ */
+function emitAgentLifecycle(event: "open" | "close"): void {
+  if (!socket?.connected) return;
+  socket.emit("api:workspace:agentLifecycle", { event });
+  codehydraApi.log.debug("Agent lifecycle reported", { event });
+}
+
+/**
  * Open agent terminal in the editor area.
  * Creates a new terminal if none exists, otherwise focuses the existing one.
  * On reopened workspaces (show=false), disposes any stale restored terminals
@@ -174,6 +186,9 @@ function openAgentTerminal(
   agentTerminal.sendText(command);
   void extensionContext?.workspaceState.update("agentTerminalOpen", true);
 
+  // Agent terminal created → agent is starting (replaces wrapper's WrapperStart).
+  emitAgentLifecycle("open");
+
   codehydraApi.log.debug("Agent terminal opened", { agentType, command });
 }
 
@@ -189,6 +204,8 @@ function setupTerminalCloseListener(): void {
     if (terminal === agentTerminal) {
       agentTerminal = null;
       void extensionContext?.workspaceState.update("agentTerminalOpen", false);
+      // Agent terminal closed → agent gone (replaces wrapper's WrapperEnd).
+      emitAgentLifecycle("close");
       codehydraApi.log.debug("Agent terminal closed");
     }
   });

--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -52,6 +52,13 @@ export interface LogRequest {
   readonly context?: LogContext;
 }
 
+/** Agent terminal lifecycle event reported to the main process. */
+export type AgentLifecycleEvent = "open" | "close";
+
+export interface AgentLifecycleRequest {
+  readonly event: AgentLifecycleEvent;
+}
+
 export interface WorkspaceCreateRequest {
   readonly name: string;
   readonly base: string;
@@ -168,6 +175,7 @@ export interface ClientToServerEvents {
     ack: (result: PluginResult<Workspace>) => void
   ) => void;
   "api:log": (request: LogRequest) => void;
+  "api:workspace:agentLifecycle": (request: AgentLifecycleRequest) => void;
 }
 
 export type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;

--- a/src/intents/agent-lifecycle.ts
+++ b/src/intents/agent-lifecycle.ts
@@ -1,0 +1,71 @@
+/**
+ * AgentLifecycleOperation - Applies an agent terminal lifecycle transition.
+ *
+ * The sidekick reports when the agent terminal opens or closes (over the plugin
+ * socket). This operation routes that signal into the owning agent provider,
+ * which drives the status state machine:
+ *  - "open"  → WrapperStart (Claude) / markActive (OpenCode)
+ *  - "close" → WrapperEnd (Claude) / TUI detach (OpenCode)
+ *
+ * Replaces the wrapper-synthesized WrapperStart/WrapperEnd HTTP POSTs. No domain
+ * event is emitted here — the provider's own status change propagates via
+ * agent:update-status. The "lifecycle" hook is resolved per-workspace agent by
+ * the workspace-agent resolver, then handled by the matching agent module.
+ */
+
+import type { Intent } from "./lib/types";
+import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import type { AgentLifecycleEvent } from "../shared/plugin-protocol";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface AgentLifecyclePayload {
+  readonly workspacePath: string;
+  readonly event: AgentLifecycleEvent;
+}
+
+export interface AgentLifecycleIntent extends Intent<void> {
+  readonly type: "agent:lifecycle";
+  readonly payload: AgentLifecyclePayload;
+}
+
+export const INTENT_AGENT_LIFECYCLE = "agent:lifecycle" as const;
+
+// =============================================================================
+// Hook Input Types
+// =============================================================================
+
+export const AGENT_LIFECYCLE_OPERATION_ID = "agent-lifecycle";
+
+/** Input context for the "lifecycle" hook point. */
+export interface AgentLifecycleHookInput extends HookContext {
+  readonly workspacePath: string;
+  readonly event: AgentLifecycleEvent;
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class AgentLifecycleOperation implements Operation<AgentLifecycleIntent, void> {
+  readonly id = AGENT_LIFECYCLE_OPERATION_ID;
+
+  async execute(ctx: OperationContext<AgentLifecycleIntent>): Promise<void> {
+    const { payload } = ctx.intent;
+
+    const lifecycleCtx: AgentLifecycleHookInput = {
+      intent: ctx.intent,
+      workspacePath: payload.workspacePath,
+      event: payload.event,
+    };
+    const { errors } = await ctx.hooks.collect<void>("lifecycle", lifecycleCtx);
+    if (errors.length === 1) {
+      throw errors[0]!;
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "agent-lifecycle lifecycle hooks failed");
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,6 +86,7 @@ import {
 } from "./intents/get-workspace-status";
 import { GetAgentSessionOperation, INTENT_GET_AGENT_SESSION } from "./intents/get-agent-session";
 import { RestartAgentOperation, INTENT_RESTART_AGENT } from "./intents/restart-agent";
+import { AgentLifecycleOperation, INTENT_AGENT_LIFECYCLE } from "./intents/agent-lifecycle";
 import {
   GetActiveWorkspaceOperation,
   INTENT_GET_ACTIVE_WORKSPACE,
@@ -687,6 +688,7 @@ dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
 dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
 dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
 dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
+dispatcher.registerOperation(INTENT_AGENT_LIFECYCLE, new AgentLifecycleOperation());
 dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());

--- a/src/modules/agent-module/agent-module-provider.ts
+++ b/src/modules/agent-module/agent-module-provider.ts
@@ -6,7 +6,7 @@
  * keeping the module itself a thin adapter between the intent system and the provider.
  */
 
-import type { AgentType } from "../../shared/plugin-protocol";
+import type { AgentType, AgentLifecycleEvent } from "../../shared/plugin-protocol";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../shared/ipc";
 import type { AgentSessionInfo, McpConfig, StopServerResult, RestartServerResult } from "./types";
 import type { BinaryType } from "../../utils/binary-resolution/types";
@@ -88,6 +88,16 @@ export interface AgentModuleProvider {
 
   /** Restart agent for a workspace */
   restartWorkspace(workspacePath: string): Promise<RestartServerResult>;
+
+  /**
+   * Apply an agent terminal lifecycle transition (reported by the sidekick).
+   * - "open": agent terminal created → WrapperStart (Claude) / markActive (OpenCode).
+   * - "close": agent terminal closed → WrapperEnd (Claude) / TUI detach (OpenCode).
+   *
+   * Replaces the wrapper-synthesized WrapperStart/WrapperEnd POSTs. Idempotent and
+   * a no-op for unknown/untracked workspaces.
+   */
+  applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void;
 
   // --- Query ---
 

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -40,6 +40,7 @@ import { GET_AGENT_SESSION_OPERATION_ID } from "../../intents/get-agent-session"
 import type { GetAgentSessionHookResult } from "../../intents/get-agent-session";
 import { RESTART_AGENT_OPERATION_ID } from "../../intents/restart-agent";
 import type { RestartAgentHookResult } from "../../intents/restart-agent";
+import { AGENT_LIFECYCLE_OPERATION_ID } from "../../intents/agent-lifecycle";
 import { INTENT_UPDATE_AGENT_STATUS } from "../../intents/update-agent-status";
 import { createAgentModule, type AgentModuleDeps } from "./agent-module";
 import type { AgentModuleProvider, WorkspaceStartResult } from "./agent-module-provider";
@@ -79,6 +80,7 @@ function createMockProvider(overrides: Partial<AgentModuleProvider> = {}): Agent
     } satisfies WorkspaceStartResult),
     stopWorkspace: vi.fn().mockResolvedValue({ success: true }),
     restartWorkspace: vi.fn().mockResolvedValue({ success: true, port: 8081 }),
+    applyTerminalLifecycle: vi.fn(),
     getStatus: vi.fn().mockReturnValue({
       status: "none",
       counts: { idle: 0, busy: 0 },
@@ -1228,6 +1230,64 @@ describe("createAgentModule", () => {
 
       expect(result).toBeUndefined();
       expect(mockProvider.restartWorkspace).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // lifecycle (agent:lifecycle)
+  // ---------------------------------------------------------------------------
+
+  describe("lifecycle", () => {
+    function registerLifecycleOp(dispatcher: Dispatcher, agent: string): void {
+      dispatcher.registerOperation(
+        "agent:lifecycle",
+        createMinimalOperation<Intent, void>(AGENT_LIFECYCLE_OPERATION_ID, "lifecycle", {
+          hookContext: (ctx) => ({
+            intent: ctx.intent,
+            workspacePath: (ctx.intent.payload as { workspacePath: string }).workspacePath,
+            event: (ctx.intent.payload as { event: "open" | "close" }).event,
+            capabilities: { agent },
+          }),
+        })
+      );
+    }
+
+    it("forwards open to provider.applyTerminalLifecycle when active", async () => {
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
+      registerLifecycleOp(dispatcher, "claude");
+
+      await dispatcher.dispatch({
+        type: "agent:lifecycle",
+        payload: { workspacePath: "/test/workspace", event: "open" },
+      });
+
+      expect(mockProvider.applyTerminalLifecycle).toHaveBeenCalledWith("/test/workspace", "open");
+    });
+
+    it("forwards close to provider.applyTerminalLifecycle when active", async () => {
+      const { dispatcher, agentConfig, mockProvider } = createTestSetup();
+      await activateModule(dispatcher, agentConfig);
+      registerLifecycleOp(dispatcher, "claude");
+
+      await dispatcher.dispatch({
+        type: "agent:lifecycle",
+        payload: { workspacePath: "/test/workspace", event: "close" },
+      });
+
+      expect(mockProvider.applyTerminalLifecycle).toHaveBeenCalledWith("/test/workspace", "close");
+    });
+
+    it("does not run when agent capability does not match provider type", async () => {
+      const { dispatcher, mockProvider } = createTestSetup();
+      registerLifecycleOp(dispatcher, "opencode");
+
+      await dispatcher.dispatch({
+        type: "agent:lifecycle",
+        payload: { workspacePath: "/test/workspace", event: "open" },
+      });
+
+      expect(mockProvider.applyTerminalLifecycle).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -46,6 +46,7 @@ import type {
   GetAgentSessionHookResult,
 } from "../../intents/get-agent-session";
 import type { RestartAgentHookInput, RestartAgentHookResult } from "../../intents/restart-agent";
+import type { AgentLifecycleHookInput } from "../../intents/agent-lifecycle";
 import type { UpdateAgentStatusIntent } from "../../intents/update-agent-status";
 import { APP_START_OPERATION_ID } from "../../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
@@ -56,6 +57,7 @@ import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
 import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../../intents/get-workspace-status";
 import { GET_AGENT_SESSION_OPERATION_ID } from "../../intents/get-agent-session";
 import { RESTART_AGENT_OPERATION_ID } from "../../intents/restart-agent";
+import { AGENT_LIFECYCLE_OPERATION_ID } from "../../intents/agent-lifecycle";
 import { INTENT_UPDATE_AGENT_STATUS } from "../../intents/update-agent-status";
 import { SetupError, getErrorMessage } from "../../shared/errors/service-errors";
 import { normalizeInitialPrompt } from "../../shared/api/types";
@@ -373,6 +375,16 @@ export function createAgentModule(
             } else {
               throw new Error(result.error);
             }
+          },
+        },
+      },
+
+      [AGENT_LIFECYCLE_OPERATION_ID]: {
+        lifecycle: {
+          requires: { agent: provider.type },
+          handler: async (ctx: HookContext): Promise<void> => {
+            const { workspacePath, event } = ctx as AgentLifecycleHookInput;
+            provider.applyTerminalLifecycle(workspacePath, event);
           },
         },
       },

--- a/src/modules/agent-module/claude/module-provider.ts
+++ b/src/modules/agent-module/claude/module-provider.ts
@@ -16,6 +16,7 @@ import type {
   WorkspaceStartResult,
 } from "../agent-module-provider";
 import type { AgentProvider, AgentSessionInfo, AgentStatus, McpConfig } from "../types";
+import type { AgentLifecycleEvent } from "../../../shared/plugin-protocol";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
 import type {
   ArchiveExtension,
@@ -382,6 +383,13 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
 
     async restartWorkspace(workspacePath: string): Promise<RestartServerResult> {
       return serverManager.restartServer(workspacePath);
+    },
+
+    applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void {
+      serverManager.triggerWrapperLifecycle(
+        workspacePath,
+        event === "open" ? "WrapperStart" : "WrapperEnd"
+      );
     },
 
     // --- Query ---

--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -169,7 +169,7 @@ describe("ClaudeCodeServerManager integration", () => {
       const port = await serverManager.startServer("/workspace/feature-a");
 
       // WrapperStart sets status to idle
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
       expect(readyCallback).toHaveBeenCalledTimes(1);
       expect(readyCallback).toHaveBeenCalledWith("/workspace/feature-a");
 
@@ -186,7 +186,7 @@ describe("ClaudeCodeServerManager integration", () => {
       const port = await serverManager.startServer("/workspace/feature-a");
 
       // WrapperStart sets status to idle, should trigger markActiveHandler
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(markActiveHandler).toHaveBeenCalledWith("/workspace/feature-a");
 
@@ -304,10 +304,16 @@ describe("ClaudeCodeServerManager integration", () => {
         for (const hook of setupHooks) {
           await sendHook(port, hook, { workspacePath: "/workspace/feature-a" });
         }
-        await sendHook(port, hookName, {
-          workspacePath: "/workspace/feature-a",
-          ...extraPayload,
-        });
+        if (hookName === "WrapperStart" || hookName === "WrapperEnd") {
+          // Wrapper lifecycle hooks are no longer accepted over HTTP — they are
+          // driven internally (via the sidekick's agent:lifecycle event).
+          serverManager.triggerWrapperLifecycle("/workspace/feature-a", hookName);
+        } else {
+          await sendHook(port, hookName, {
+            workspacePath: "/workspace/feature-a",
+            ...extraPayload,
+          });
+        }
 
         expect(statusChanges).toEqual(expectedChanges);
         expect(serverManager.getStatus("/workspace/feature-a")).toBe(finalStatus);
@@ -316,6 +322,42 @@ describe("ClaudeCodeServerManager integration", () => {
         }
       }
     );
+
+    it("rejects WrapperStart/WrapperEnd over HTTP (driven internally only)", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      const startRes = await sendHook(port, "WrapperStart", {
+        workspacePath: "/workspace/feature-a",
+      });
+      const endRes = await sendHook(port, "WrapperEnd", {
+        workspacePath: "/workspace/feature-a",
+      });
+
+      expect(startRes.status).toBe(404);
+      expect(endRes.status).toBe(404);
+      // No status changes — the HTTP path must not drive wrapper lifecycle.
+      expect(statusChanges).toEqual([]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("none");
+    });
+
+    it("WrapperEnd is idempotent — a second call produces no extra transition", async () => {
+      await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
+
+      expect(statusChanges).toEqual(["idle", "none"]);
+      expect(serverManager.getStatus("/workspace/feature-a")).toBe("none");
+    });
 
     it("SessionStart during automatic compaction stays busy", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
@@ -429,10 +471,10 @@ describe("ClaudeCodeServerManager integration", () => {
       await sendHook(port, "PreCompact", { workspacePath: "/workspace/feature-a" });
 
       // Claude exits before SessionStart (abnormal exit clears flag)
-      await sendHook(port, "WrapperEnd", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
 
       // New session should go idle (flag was defensively cleared)
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
       await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
 
       expect(statusChanges).toEqual(["idle", "busy", "none", "idle"]);
@@ -938,7 +980,7 @@ describe("ClaudeCodeServerManager integration", () => {
     });
 
     it("WrapperStart with non-plan initial prompt sets status to busy", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
+      await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
       serverManager.onStatusChange("/workspace/feature-a", (status) => {
         statusChanges.push(status);
@@ -956,7 +998,7 @@ describe("ClaudeCodeServerManager integration", () => {
       });
 
       // WrapperStart should set status to busy instead of idle
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(statusChanges).toEqual(["busy"]);
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("busy");
@@ -976,7 +1018,7 @@ describe("ClaudeCodeServerManager integration", () => {
       });
 
       // Full startup sequence: WrapperStart → SessionStart → UserPromptSubmit
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
       await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
 
@@ -986,7 +1028,7 @@ describe("ClaudeCodeServerManager integration", () => {
     });
 
     it("WrapperStart with plan initial prompt sets status to idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
+      await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
       serverManager.onStatusChange("/workspace/feature-a", (status) => {
         statusChanges.push(status);
@@ -999,14 +1041,14 @@ describe("ClaudeCodeServerManager integration", () => {
       });
 
       // WrapperStart should set status to idle (normal behavior)
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(statusChanges).toEqual(["idle"]);
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
     });
 
     it("WrapperStart without initial prompt sets status to idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
+      await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
       serverManager.onStatusChange("/workspace/feature-a", (status) => {
         statusChanges.push(status);
@@ -1015,7 +1057,7 @@ describe("ClaudeCodeServerManager integration", () => {
       // No setInitialPrompt called
 
       // WrapperStart should set status to idle (normal behavior)
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(statusChanges).toEqual(["idle"]);
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
@@ -1033,14 +1075,14 @@ describe("ClaudeCodeServerManager integration", () => {
       });
 
       // First session: flag consumed on SessionStart
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
       await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "WrapperEnd", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
 
       // Second session: normal idle behavior
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(statusChanges).toEqual(["busy", "idle", "none", "idle"]);
       expect(serverManager.getStatus("/workspace/feature-a")).toBe("idle");
@@ -1290,12 +1332,12 @@ describe("ClaudeCodeServerManager integration", () => {
       await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
 
       // WrapperEnd — clears all tracking
-      await sendHook(port, "WrapperEnd", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
 
       expect(statusChanges).toEqual(["idle", "busy", "none"]);
 
       // New session: Stop should go idle normally (sub-agent tracking was cleared)
-      await sendHook(port, "WrapperStart", { workspacePath: "/workspace/feature-a" });
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
       await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -28,6 +28,7 @@ import {
   type ClaudeCodeBridgePayload,
   isValidHookName,
   getStatusChangeForHook,
+  WRAPPER_HOOK_NAMES,
 } from "./types";
 import hooksConfigTemplate from "./hooks.template.json";
 import mcpConfigTemplate from "./mcp.template.json";
@@ -638,6 +639,14 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       return;
     }
 
+    // WrapperStart/WrapperEnd are no longer accepted over HTTP — they are driven
+    // by the sidekick via triggerWrapperLifecycle(). Reject stray POSTs.
+    if (WRAPPER_HOOK_NAMES.has(hookName)) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: `Hook not accepted over HTTP: ${hookName}` }));
+      return;
+    }
+
     // Read request body
     let body = "";
     req.on("data", (chunk: Buffer) => {
@@ -665,6 +674,19 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Internal error" }));
     });
+  }
+
+  /**
+   * Trigger a wrapper lifecycle transition for a workspace.
+   *
+   * Replaces the wrapper's HTTP POST of WrapperStart/WrapperEnd: invoked via the
+   * agent:lifecycle intent when the sidekick reports the agent terminal opening
+   * ("WrapperStart") or closing ("WrapperEnd"). Routes through the same state
+   * machine as all other hooks (status, markActive, workspace-ready, subagent
+   * cleanup). Idempotent and a no-op for unknown workspaces.
+   */
+  triggerWrapperLifecycle(workspacePath: string, hookName: "WrapperStart" | "WrapperEnd"): void {
+    this.handleHook(hookName, { workspacePath });
   }
 
   /**

--- a/src/modules/agent-module/claude/types.ts
+++ b/src/modules/agent-module/claude/types.ts
@@ -129,3 +129,14 @@ export function getStatusChangeForHook(hookName: ClaudeCodeHookName): HookStatus
 export function isValidHookName(name: string): name is ClaudeCodeHookName {
   return name in HOOK_STATUS_MAP;
 }
+
+/**
+ * Wrapper-synthesized hooks. These are NOT POSTed over HTTP anymore — they are
+ * triggered internally via ClaudeCodeServerManager.triggerWrapperLifecycle()
+ * (driven by the sidekick's agent:lifecycle event). The bridge HTTP server
+ * rejects them so a stray POST can't drive status out-of-band.
+ */
+export const WRAPPER_HOOK_NAMES: ReadonlySet<ClaudeCodeHookName> = new Set([
+  "WrapperStart",
+  "WrapperEnd",
+]);

--- a/src/modules/agent-module/claude/wrapper.test.ts
+++ b/src/modules/agent-module/claude/wrapper.test.ts
@@ -12,7 +12,6 @@ import {
   buildInitialPromptArgs,
   buildPermissionArgs,
   consumeNoSessionMarker,
-  installSignalHandlers,
   type InitialPromptConfig,
 } from "./wrapper";
 
@@ -125,25 +124,5 @@ describe("consumeNoSessionMarker", () => {
   it("returns false when env var is set but file does not exist", () => {
     process.env._CH_CLAUDE_NO_SESSION_MARKER_PATH = join(tempDir, "nonexistent");
     expect(consumeNoSessionMarker()).toBe(false);
-  });
-});
-
-describe("installSignalHandlers", () => {
-  it("registers handlers for SIGHUP and SIGTERM", () => {
-    const handlers: Array<{ signal: string; handler: () => void }> = [];
-    const fakeProcess = {
-      on(signal: string, handler: () => void) {
-        handlers.push({ signal, handler });
-        return fakeProcess as unknown as NodeJS.Process;
-      },
-    };
-
-    installSignalHandlers(fakeProcess);
-
-    expect(handlers).toHaveLength(2);
-    expect(handlers.map((h) => h.signal)).toEqual(["SIGHUP", "SIGTERM"]);
-    for (const h of handlers) {
-      expect(() => h.handler()).not.toThrow();
-    }
   });
 });

--- a/src/modules/agent-module/claude/wrapper.ts
+++ b/src/modules/agent-module/claude/wrapper.ts
@@ -13,7 +13,6 @@
  * Environment variables (set by sidekick extension):
  * - _CH_CLAUDE_SETTINGS: Path to codehydra-hooks.json
  * - _CH_CLAUDE_MCP_CONFIG: Path to codehydra-mcp.json
- * - _CH_BRIDGE_PORT: Bridge server port (for hook notifications)
  * - _CH_MCP_PORT: Main MCP server port
  * - _CH_WORKSPACE_PATH: Workspace path for MCP header
  * - _CH_INITIAL_PROMPT_FILE: Path to initial prompt JSON file (optional)
@@ -23,7 +22,6 @@
 import { spawnSync, execSync } from "node:child_process";
 import { readFileSync, unlinkSync, rmdirSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
-import { request } from "node:http";
 
 /**
  * Config read from initial-prompt.json file.
@@ -357,85 +355,6 @@ function findSystemClaude(): { command: string; useShell: boolean } | null {
 }
 
 /**
- * Send a hook notification to the bridge server.
- * Waits for request to complete (or timeout) before returning.
- * Silent on error - fallback to 10-second timeout works.
- *
- * @param hookName - Name of the hook (WrapperStart or WrapperEnd)
- */
-async function notifyHook(hookName: "WrapperStart" | "WrapperEnd"): Promise<void> {
-  const bridgePort = process.env._CH_BRIDGE_PORT;
-  const workspacePath = process.env._CH_WORKSPACE_PATH;
-
-  // Not in CodeHydra context
-  if (!bridgePort || !workspacePath) {
-    return;
-  }
-
-  const payload = JSON.stringify({ workspacePath });
-
-  return new Promise((resolve) => {
-    const req = request(
-      {
-        hostname: "127.0.0.1",
-        port: parseInt(bridgePort, 10),
-        path: `/hook/${hookName}`,
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Length": Buffer.byteLength(payload),
-        },
-        timeout: 2000, // 2 second timeout
-      },
-      () => {
-        resolve();
-      }
-    );
-
-    req.on("error", () => {
-      resolve(); // Silent failure
-    });
-
-    req.on("timeout", () => {
-      req.destroy();
-      resolve();
-    });
-
-    req.write(payload);
-    req.end();
-  });
-}
-
-/**
- * Signals to catch so the wrapper survives long enough to send WrapperEnd.
- *
- * - SIGHUP: PTY hangup when the terminal tab is closed.
- * - SIGTERM: Graceful termination from process managers (code-server may
- *   send this after SIGHUP if the process hasn't exited yet).
- *
- * Without these handlers Node.js terminates immediately on these signals,
- * preventing the async notifyHook("WrapperEnd") call from executing after
- * spawnSync returns.
- */
-const WRAPPER_SIGNALS: NodeJS.Signals[] = ["SIGHUP", "SIGTERM"];
-
-/**
- * Install no-op signal handlers to prevent default process termination.
- *
- * Must be called before spawnSync so the wrapper survives terminal-close
- * signals and can still send the WrapperEnd hook notification.
- * The process exits via the explicit process.exit() in main().
- *
- * @param proc - Process-like object for testability (defaults to global process)
- */
-function installSignalHandlers(proc: Pick<NodeJS.Process, "on"> = process): void {
-  const noop = (): void => {};
-  for (const signal of WRAPPER_SIGNALS) {
-    proc.on(signal, noop);
-  }
-}
-
-/**
  * Main entry point for the wrapper script.
  */
 async function main(): Promise<never> {
@@ -484,24 +403,16 @@ async function main(): Promise<never> {
   // 5. Clear CLAUDECODE to allow nested Claude Code sessions inside CodeHydra
   delete process.env.CLAUDECODE;
 
-  // 6. Catch SIGHUP/SIGTERM so the wrapper survives terminal-close signals
-  //    and can still send WrapperEnd after Claude exits.
-  installSignalHandlers();
-
-  // 7. Notify wrapper start (clears loading screen before Claude shows dialogs)
-  await notifyHook("WrapperStart");
-
-  // 8. Spawn Claude with automatic session resume
-  // Skip --continue attempt for new workspaces (no prior session to resume)
+  // 6. Spawn Claude with automatic session resume.
+  // Skip --continue attempt for new workspaces (no prior session to resume).
+  // Agent status (WrapperStart/WrapperEnd) is driven by the sidekick via the
+  // agent terminal's open/close — this wrapper no longer posts hooks.
   const result = runClaude(claudeBinary.command, args, {
     skipContinue: consumeNoSessionMarker(),
     useShell: claudeBinary.useShell,
   });
 
-  // 9. Notify wrapper end (Claude has exited)
-  await notifyHook("WrapperEnd");
-
-  // 10. Handle result
+  // 7. Handle result
   if (result.error) {
     console.error(`Error: Failed to start Claude: ${result.error.message}`);
     process.exit(EXIT_SPAWN_FAILED);
@@ -522,10 +433,8 @@ if (!process.env.VITEST) {
 // Export for testing
 export {
   findSystemClaude,
-  notifyHook,
   getInitialPromptConfig,
   buildInitialPromptArgs,
   buildPermissionArgs,
   consumeNoSessionMarker,
-  installSignalHandlers,
 };

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -57,8 +57,8 @@ const {
     getSession = vi.fn().mockReturnValue({ port: 8080, sessionId: "s1" });
     getEnvironmentVariables = vi.fn().mockReturnValue({ _CH_OPENCODE_PORT: "8080" });
     markActive = vi.fn();
+    detachTui = vi.fn();
     fetchStatus = vi.fn().mockResolvedValue(undefined);
-    setBridgePort = vi.fn();
     getEffectiveCounts = vi.fn().mockReturnValue({ idle: 0, busy: 0 });
     createSession = vi.fn().mockResolvedValue({ ok: true, value: { id: "session-1" } });
     sendPrompt = vi.fn().mockResolvedValue({ ok: true, value: {} });
@@ -123,7 +123,7 @@ function createMockServerManager(): OpenCodeServerManager & {
     dispose: vi.fn().mockResolvedValue(undefined),
     setMcpConfig: vi.fn(),
     setMarkActiveHandler: vi.fn(),
-    getBridgePort: vi.fn().mockReturnValue(9090),
+    triggerWrapperStart: vi.fn(),
     onServerStarted: vi.fn((cb: ServerStartedHandler) => {
       startedHandler = cb;
       return vi.fn();
@@ -184,7 +184,7 @@ async function initializeAndStart(
   moduleProvider.initialize(null);
   serverManager._triggerStarted(workspacePath, port, pendingPrompt);
   // Wait for the full handleServerStarted chain to settle.
-  // addProvider is called after connect+fetchStatus+setBridgePort, and it calls onStatusChange.
+  // addProvider is called after connect+fetchStatus, and it calls onStatusChange.
   await vi.waitFor(() => {
     expect(getLatestMockProvider().onStatusChange).toHaveBeenCalled();
   });
@@ -307,19 +307,11 @@ describe("OpenCode module provider", () => {
   // ---------------------------------------------------------------------------
 
   describe("handleServerStarted", () => {
-    it("creates provider, connects, fetches status, and sets bridge port", async () => {
+    it("creates provider, connects, and fetches status", async () => {
       const mockProv = await initializeAndStart(provider, serverManager);
 
       expect(mockProv.connect).toHaveBeenCalledWith(8080);
       expect(mockProv.fetchStatus).toHaveBeenCalledOnce();
-      expect(mockProv.setBridgePort).toHaveBeenCalledWith(9090);
-    });
-
-    it("does not set bridge port when getBridgePort returns null", async () => {
-      vi.mocked(serverManager.getBridgePort).mockReturnValue(null);
-      const mockProv = await initializeAndStart(provider, serverManager);
-
-      expect(mockProv.setBridgePort).not.toHaveBeenCalled();
     });
 
     it("registers onStatusChange listener on new provider", async () => {
@@ -338,6 +330,35 @@ describe("OpenCode module provider", () => {
 
       // Should be the same provider (reconnect on existing, not a new MockOpenCodeProvider)
       expect(firstProvider.reconnect).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // applyTerminalLifecycle (open/close)
+  // ---------------------------------------------------------------------------
+
+  describe("applyTerminalLifecycle", () => {
+    it("open triggers wrapper-start (loading-screen clear + mark active)", async () => {
+      await initializeAndStart(provider, serverManager);
+
+      provider.applyTerminalLifecycle(WS_PATH, "open");
+
+      expect(serverManager.triggerWrapperStart).toHaveBeenCalledWith(WS_PATH);
+    });
+
+    it("close detaches the TUI on the provider (status → none)", async () => {
+      const mockProv = await initializeAndStart(provider, serverManager);
+
+      provider.applyTerminalLifecycle(WS_PATH, "close");
+
+      expect(mockProv.detachTui).toHaveBeenCalledOnce();
+    });
+
+    it("close is a no-op for an unknown workspace", async () => {
+      await initializeAndStart(provider, serverManager);
+
+      // Different workspace with no provider — must not throw.
+      expect(() => provider.applyTerminalLifecycle(WS_PATH_B, "close")).not.toThrow();
     });
   });
 

--- a/src/modules/agent-module/opencode/module-provider.ts
+++ b/src/modules/agent-module/opencode/module-provider.ts
@@ -20,7 +20,9 @@ import type {
   RestartServerResult,
 } from "../types";
 import type { AgentSessionInfo } from "../types";
+import type { AgentLifecycleEvent } from "../../../shared/plugin-protocol";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
+import { Path } from "../../../utils/path/path";
 import type {
   ArchiveExtension,
   DownloadProgressCallback,
@@ -209,6 +211,14 @@ export function createOpenCodeModuleProvider(
     }
   }
 
+  function markProviderInactive(path: WorkspacePath): void {
+    tuiAttachedWorkspaces.delete(path);
+    const provider = providers.get(path);
+    if (provider) {
+      provider.detachTui?.();
+    }
+  }
+
   // ===========================================================================
   // Internal functions
   // ===========================================================================
@@ -251,12 +261,6 @@ export function createOpenCodeModuleProvider(
       try {
         await provider.connect(port);
         await provider.fetchStatus();
-
-        // Set bridge port so getEnvironmentVariables() includes it
-        const bridgePort = serverManager.getBridgePort();
-        if (bridgePort !== null) {
-          provider.setBridgePort(bridgePort);
-        }
 
         addProvider(workspacePath, provider);
 
@@ -426,6 +430,16 @@ export function createOpenCodeModuleProvider(
 
     async restartWorkspace(workspacePath: string): Promise<RestartServerResult> {
       return serverManager.restartServer(workspacePath);
+    },
+
+    applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void {
+      if (event === "open") {
+        // Clears the loading screen (workspace-ready) and marks active (TUI attached),
+        // mirroring the old WrapperStart bridge route.
+        serverManager.triggerWrapperStart(workspacePath);
+      } else {
+        markProviderInactive(new Path(workspacePath).toString() as WorkspacePath);
+      }
     },
 
     // --- Query ---

--- a/src/modules/agent-module/opencode/provider.ts
+++ b/src/modules/agent-module/opencode/provider.ts
@@ -36,12 +36,6 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
   private _port: number | null = null;
 
   /**
-   * Bridge server port for wrapper notifications.
-   * Set via setBridgePort() after server starts.
-   */
-  private _bridgePort: number | null = null;
-
-  /**
    * Primary session ID for this workspace.
    * Created or found during connect(), preserved during restart.
    */
@@ -100,18 +94,7 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
       _CH_OPENCODE_SESSION_ID: session.sessionId,
       _CH_WORKSPACE_PATH: this.workspacePath,
     };
-    if (this._bridgePort !== null) {
-      envVars._CH_BRIDGE_PORT = String(this._bridgePort);
-    }
     return envVars;
-  }
-
-  /**
-   * Set the bridge server port for wrapper notifications.
-   * Called after the server starts when the bridge is known to be running.
-   */
-  setBridgePort(port: number): void {
-    this._bridgePort = port;
   }
 
   /**
@@ -128,6 +111,19 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
   markActive(): void {
     if (!this.tuiAttached) {
       this.tuiAttached = true;
+      this.notifyStatusChange();
+    }
+  }
+
+  /**
+   * Detach the TUI without stopping the SDK server.
+   * Called when the agent terminal closes (sidekick "close" lifecycle): sets
+   * tuiAttached=false so status reports "none", while keeping the SDK server and
+   * session state alive so the user can re-attach. Idempotent.
+   */
+  detachTui(): void {
+    if (this.tuiAttached) {
+      this.tuiAttached = false;
       this.notifyStatusChange();
     }
   }
@@ -370,7 +366,6 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
       this.client = null;
     }
     this._port = null;
-    this._bridgePort = null;
     this._primarySessionId = null;
     this.clientStatus = "idle";
     this.tuiAttached = false;

--- a/src/modules/agent-module/opencode/server-manager.integration.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.integration.test.ts
@@ -9,7 +9,6 @@
  * - Callbacks fire correctly for start/stop events
  */
 
-import { request as httpRequest } from "http";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { OpenCodeServerManager } from "./server-manager";
 import {
@@ -300,127 +299,35 @@ describe("OpenCodeServerManager integration", () => {
     });
   });
 
-  describe("bridge server", () => {
-    it("starts lazily on first startServer and exposes bridge port", async () => {
-      expect(serverManager.getBridgePort()).toBeNull();
-
-      await serverManager.startServer("/workspace/feature-a");
-
-      // Bridge port is OS-assigned (port 0), so just check it's a valid port
-      const bridgePort = serverManager.getBridgePort();
-      expect(bridgePort).not.toBeNull();
-      expect(bridgePort).toBeGreaterThan(0);
-    });
-
-    it("reuses bridge server across multiple workspaces", async () => {
-      await serverManager.startServer("/workspace/feature-a");
-      const bridgePort1 = serverManager.getBridgePort();
-
-      await serverManager.startServer("/workspace/feature-b");
-      const bridgePort2 = serverManager.getBridgePort();
-
-      expect(bridgePort1).toBe(bridgePort2);
-    });
-
-    it("fires onWorkspaceReady callback when WrapperStart notification received", async () => {
+  describe("agent terminal lifecycle (triggerWrapperStart)", () => {
+    it("fires onWorkspaceReady callback on triggerWrapperStart", async () => {
       const readyCallback = vi.fn();
       serverManager.onWorkspaceReady(readyCallback);
 
       await serverManager.startServer("/workspace/feature-a");
-
-      const bridgePort = serverManager.getBridgePort()!;
-      const payload = JSON.stringify({ workspacePath: "/workspace/feature-a" });
-
-      // Send WrapperStart notification to bridge server
-      await new Promise<void>((resolve, reject) => {
-        const req = httpRequest(
-          {
-            hostname: "127.0.0.1",
-            port: bridgePort,
-            path: "/hook/WrapperStart",
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Content-Length": Buffer.byteLength(payload),
-            },
-          },
-          (res) => {
-            let body = "";
-            res.on("data", (chunk: Buffer) => {
-              body += chunk.toString();
-            });
-            res.on("end", () => {
-              try {
-                const parsed = JSON.parse(body) as { success: boolean };
-                expect(parsed.success).toBe(true);
-                resolve();
-              } catch (e) {
-                reject(e);
-              }
-            });
-          }
-        );
-        req.on("error", reject);
-        req.write(payload);
-        req.end();
-      });
+      serverManager.triggerWrapperStart("/workspace/feature-a");
 
       expect(readyCallback).toHaveBeenCalledWith("/workspace/feature-a");
     });
 
-    it("calls markActiveHandler when WrapperStart notification received", async () => {
+    it("calls markActiveHandler on triggerWrapperStart", async () => {
       const markActiveHandler = vi.fn();
       serverManager.setMarkActiveHandler(markActiveHandler);
 
       await serverManager.startServer("/workspace/feature-a");
-
-      const bridgePort = serverManager.getBridgePort()!;
-      const payload = JSON.stringify({ workspacePath: "/workspace/feature-a" });
-
-      // Send WrapperStart notification to bridge server
-      await new Promise<void>((resolve, reject) => {
-        const req = httpRequest(
-          {
-            hostname: "127.0.0.1",
-            port: bridgePort,
-            path: "/hook/WrapperStart",
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Content-Length": Buffer.byteLength(payload),
-            },
-          },
-          (res) => {
-            let body = "";
-            res.on("data", (chunk: Buffer) => {
-              body += chunk.toString();
-            });
-            res.on("end", () => {
-              try {
-                const parsed = JSON.parse(body) as { success: boolean };
-                expect(parsed.success).toBe(true);
-                resolve();
-              } catch (e) {
-                reject(e);
-              }
-            });
-          }
-        );
-        req.on("error", reject);
-        req.write(payload);
-        req.end();
-      });
+      serverManager.triggerWrapperStart("/workspace/feature-a");
 
       expect(markActiveHandler).toHaveBeenCalledWith("/workspace/feature-a");
     });
 
-    it("cleans up bridge server on dispose", async () => {
+    it("normalizes the workspace path passed to callbacks", async () => {
+      const readyCallback = vi.fn();
+      serverManager.onWorkspaceReady(readyCallback);
+
       await serverManager.startServer("/workspace/feature-a");
-      expect(serverManager.getBridgePort()).not.toBeNull();
+      serverManager.triggerWrapperStart("/workspace/feature-a/");
 
-      await serverManager.dispose();
-
-      expect(serverManager.getBridgePort()).toBeNull();
+      expect(readyCallback).toHaveBeenCalledWith("/workspace/feature-a");
     });
   });
 

--- a/src/modules/agent-module/opencode/server-manager.ts
+++ b/src/modules/agent-module/opencode/server-manager.ts
@@ -7,7 +7,6 @@
  * and redirects to `opencode attach`.
  */
 
-import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http";
 import type { ProcessRunner, SpawnedProcess } from "../../../boundaries/platform/process";
 import {
   PROCESS_KILL_GRACEFUL_TIMEOUT_MS,
@@ -126,15 +125,9 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
 
   private mcpConfig: McpConfig | null = null;
 
-  /** Bridge HTTP server for receiving wrapper notifications (shared across all workspaces) */
-  private bridgeServer: Server | null = null;
-  /** Port the bridge server is listening on */
-  private bridgePort: number | null = null;
-  /** Promise for the in-progress bridge server start (prevents concurrent double-start) */
-  private bridgeStartPromise: Promise<void> | null = null;
-  /** Callbacks for workspace ready events (wrapper started) */
+  /** Callbacks for workspace ready events (agent terminal opened) */
   private readonly workspaceReadyCallbacks = new Set<WorkspaceReadyCallback>();
-  /** Handler called when workspace becomes active (WrapperStart) */
+  /** Handler called when workspace becomes active (agent terminal opened) */
   private markActiveHandler: ((workspacePath: string) => void) | null = null;
 
   constructor(
@@ -187,9 +180,9 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
       return existing.port;
     }
 
-    // Create the start promise (includes bridge initialization)
+    // Create the start promise.
     // Set entry BEFORE any async work so concurrent callers (e.g. restartServer) can see it
-    const startPromise = this.doStartWithBridge(workspacePath);
+    const startPromise = this.doStartServer(workspacePath);
     this.servers.set(workspacePath, { state: "starting", startPromise });
 
     try {
@@ -200,19 +193,6 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
       this.servers.delete(workspacePath);
       throw error;
     }
-  }
-
-  /**
-   * Internal method that ensures bridge is running, then starts the server.
-   */
-  private async doStartWithBridge(workspacePath: string): Promise<number> {
-    // Start bridge server if not running (shared across all workspaces)
-    if (!this.bridgeStartPromise) {
-      this.bridgeStartPromise = this.startBridgeServer();
-    }
-    await this.bridgeStartPromise;
-
-    return this.doStartServer(workspacePath);
   }
 
   /**
@@ -545,17 +525,26 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
   }
 
   /**
-   * Get the bridge server port.
-   * Returns null if bridge server is not running.
+   * Trigger the "agent terminal opened" transition for a workspace.
+   *
+   * Replaces the wrapper's WrapperStart HTTP POST: invoked via the
+   * agent:lifecycle intent when the sidekick reports the agent terminal opening.
+   * Clears the loading screen (workspace-ready) and marks the workspace active
+   * (TUI attached). Idempotent.
    */
-  getBridgePort(): number | null {
-    return this.bridgePort;
+  triggerWrapperStart(workspacePath: string): void {
+    const normalizedPath = new Path(workspacePath).toString();
+    this.logger.debug("Agent terminal opened", { workspacePath: normalizedPath });
+    for (const callback of this.workspaceReadyCallbacks) {
+      callback(normalizedPath);
+    }
+    this.markActiveHandler?.(normalizedPath);
   }
 
   /**
    * Subscribe to workspace ready events.
-   * Triggered when a wrapper start notification is received,
-   * indicating the loading screen should be cleared.
+   * Triggered when the agent terminal opens, indicating the loading screen
+   * should be cleared.
    *
    * @param callback - Callback invoked with workspace path
    * @returns Unsubscribe function
@@ -566,7 +555,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
   }
 
   /**
-   * Set handler called when workspace becomes active (WrapperStart).
+   * Set handler called when the workspace becomes active (agent terminal opened).
    * The handler is invoked with the normalized workspace path.
    */
   setMarkActiveHandler(handler: (workspacePath: string) => void): void {
@@ -642,129 +631,6 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
   }
 
   /**
-   * Start the bridge HTTP server for receiving wrapper notifications.
-   * Allocates a port and listens for POST /hook/WrapperStart requests.
-   */
-  private async startBridgeServer(): Promise<void> {
-    const server = createServer((req, res) => {
-      this.handleBridgeRequest(req, res);
-    });
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        // Use port 0 to let the OS assign a free port
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
-        });
-      });
-    } catch (error) {
-      // Reset promise so next attempt can retry
-      this.bridgeStartPromise = null;
-      throw error;
-    }
-
-    // Read the OS-assigned port from the listening server
-    const addr = server.address();
-    const port = typeof addr === "object" && addr !== null ? addr.port : null;
-    if (port === null) {
-      server.close();
-      this.bridgeStartPromise = null;
-      throw new Error("Bridge server started but could not determine port");
-    }
-
-    this.bridgeServer = server;
-    this.bridgePort = port;
-    this.logger.info("Bridge server started", { port });
-  }
-
-  /**
-   * Stop the bridge HTTP server.
-   */
-  private async stopBridgeServer(): Promise<void> {
-    if (this.bridgeServer === null) {
-      this.bridgeStartPromise = null;
-      return;
-    }
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        this.bridgeServer!.close((err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        });
-      });
-    } catch (error) {
-      // Bridge server may not have been listening (e.g., listen failed)
-      this.logger.warn("Error closing bridge server", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-
-    this.logger.info("Bridge server stopped", { port: this.bridgePort });
-    this.bridgeServer = null;
-    this.bridgePort = null;
-    this.bridgeStartPromise = null;
-  }
-
-  /**
-   * Handle an incoming bridge HTTP request.
-   */
-  private handleBridgeRequest(req: IncomingMessage, res: ServerResponse): void {
-    if (req.method !== "POST") {
-      res.writeHead(405, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Method not allowed" }));
-      return;
-    }
-
-    const url = new URL(req.url ?? "/", `http://127.0.0.1:${this.bridgePort}`);
-    if (url.pathname !== "/hook/WrapperStart") {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Not found" }));
-      return;
-    }
-
-    let body = "";
-    req.on("data", (chunk: Buffer) => {
-      body += chunk.toString();
-    });
-
-    req.on("end", () => {
-      try {
-        const payload = JSON.parse(body) as { workspacePath: string };
-        const normalizedPath = new Path(payload.workspacePath).toString();
-
-        this.logger.debug("WrapperStart received", { workspacePath: normalizedPath });
-
-        for (const callback of this.workspaceReadyCallbacks) {
-          callback(normalizedPath);
-        }
-
-        this.markActiveHandler?.(normalizedPath);
-
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ success: true }));
-      } catch (error) {
-        this.logger.warn("Failed to parse bridge payload", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Invalid JSON body" }));
-      }
-    });
-
-    req.on("error", (error) => {
-      this.logger.warn("Bridge request error", { error: error.message });
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Internal error" }));
-    });
-  }
-
-  /**
    * Dispose the manager, stopping all servers.
    */
   async dispose(): Promise<void> {
@@ -774,6 +640,5 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
     this.stoppedCallbacks.clear();
     this.workspaceReadyCallbacks.clear();
     this.markActiveHandler = null;
-    await this.stopBridgeServer();
   }
 }

--- a/src/modules/agent-module/opencode/wrapper.ts
+++ b/src/modules/agent-module/opencode/wrapper.ts
@@ -12,65 +12,18 @@
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
-import { request } from "node:http";
 
 // Exit codes
 const EXIT_ENV_ERROR = 1;
 const EXIT_SPAWN_FAILED = 2;
 
 /**
- * Send a hook notification to the bridge server.
- * Fire-and-forget: does not wait for response.
- * Silent on error - bridge server may not be available.
- *
- * @param hookName - Name of the hook
- */
-async function notifyHook(hookName: "WrapperStart"): Promise<void> {
-  const bridgePort = process.env._CH_BRIDGE_PORT;
-  const workspacePath = process.env._CH_WORKSPACE_PATH;
-
-  if (!bridgePort || !workspacePath) {
-    return;
-  }
-
-  const payload = JSON.stringify({ workspacePath });
-
-  return new Promise((resolve) => {
-    const req = request(
-      {
-        hostname: "127.0.0.1",
-        port: parseInt(bridgePort, 10),
-        path: `/hook/${hookName}`,
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Length": Buffer.byteLength(payload),
-        },
-        timeout: 2000,
-      },
-      () => {
-        resolve();
-      }
-    );
-
-    req.on("error", () => {
-      resolve(); // Silent failure
-    });
-
-    req.on("timeout", () => {
-      req.destroy();
-      resolve();
-    });
-
-    req.write(payload);
-    req.end();
-  });
-}
-
-/**
  * Main entry point for the wrapper script.
+ *
+ * Agent status (the old WrapperStart notification) is driven by the sidekick via
+ * the agent terminal's open/close — this wrapper no longer posts hooks.
  */
-async function main(): Promise<never> {
+function main(): never {
   // 1. Read and validate _CH_OPENCODE_PORT
   const portStr = process.env._CH_OPENCODE_PORT;
   if (!portStr) {
@@ -118,17 +71,14 @@ async function main(): Promise<never> {
     args.push("--session", sessionId);
   }
 
-  // 7. Notify wrapper start (must complete before spawnSync blocks event loop)
-  await notifyHook("WrapperStart");
-
-  // 8. Spawn opencode binary
+  // 7. Spawn opencode binary
   // Note: .cmd files on Windows require shell:true to execute
   const result = spawnSync(binaryPath, args, {
     stdio: "inherit",
     shell: binaryPath.endsWith(".cmd"),
   });
 
-  // 9. Handle result
+  // 8. Handle result
   if (result.error) {
     console.error(`Error: Failed to start opencode: ${result.error.message}`);
     process.exit(EXIT_SPAWN_FAILED);
@@ -140,10 +90,10 @@ async function main(): Promise<never> {
 // Run main and handle any uncaught errors
 // Skip when running in test environment (Vitest sets VITEST env var)
 if (!process.env.VITEST) {
-  main().catch((error: unknown) => {
+  try {
+    main();
+  } catch (error: unknown) {
     console.error("Fatal error:", error instanceof Error ? error.message : error);
     process.exit(EXIT_ENV_ERROR);
-  });
+  }
 }
-
-export { notifyHook };

--- a/src/modules/agent-module/types.ts
+++ b/src/modules/agent-module/types.ts
@@ -154,6 +154,13 @@ export interface AgentProvider {
   /** Mark agent as active (first MCP request received) */
   markActive(): void;
 
+  /**
+   * Detach the TUI without stopping the server (agent terminal closed).
+   * Optional — only providers with a TUI-attached status gate implement it
+   * (e.g. OpenCode). Claude drives terminal-close via its server-manager hook.
+   */
+  detachTui?(): void;
+
   /** Dispose the provider completely */
   dispose(): void;
 }

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -58,6 +58,7 @@ import {
   validateWorkspaceCreateRequest,
   validateGetWorkspaceStatusRequest,
   validateLogRequest,
+  validateAgentLifecycleRequest,
 } from "../shared/plugin-protocol";
 import type { OpenSystemPathRequest } from "../shared/plugin-protocol";
 import type { FinalizeHookInput, OpenWorkspaceIntent } from "../intents/open-workspace";
@@ -83,6 +84,8 @@ import {
 import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
 import { INTENT_GET_AGENT_SESSION } from "../intents/get-agent-session";
 import { INTENT_RESTART_AGENT } from "../intents/restart-agent";
+import type { AgentLifecycleIntent } from "../intents/agent-lifecycle";
+import { INTENT_AGENT_LIFECYCLE } from "../intents/agent-lifecycle";
 import { INTENT_GET_METADATA } from "../intents/get-metadata";
 import { INTENT_SET_METADATA } from "../intents/set-metadata";
 import { INTENT_RESOLVE_WORKSPACE } from "../intents/resolve-workspace";
@@ -778,6 +781,25 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
 
       const level = request.level as LogLevel;
       logAtLevel(extensionLogger, level, request.message, context);
+    });
+
+    // Handle api:workspace:agentLifecycle (fire-and-forget) — drives agent
+    // status open/close by dispatching the agent:lifecycle intent.
+    socket.on("api:workspace:agentLifecycle", (request) => {
+      const validation = validateAgentLifecycleRequest(request);
+      if (!validation.valid) {
+        logger.warn("Invalid agentLifecycle request", {
+          workspace: workspacePath,
+          error: validation.error,
+        });
+        return;
+      }
+
+      const intent: AgentLifecycleIntent = {
+        type: INTENT_AGENT_LIFECYCLE,
+        payload: { workspacePath, event: request.event },
+      };
+      void dispatcher.dispatch(intent);
     });
   }
 

--- a/src/modules/plugin-server.boundary.test.ts
+++ b/src/modules/plugin-server.boundary.test.ts
@@ -6,7 +6,7 @@
  * through the mock dispatcher and return results via Socket.IO acks.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { io as ioClient } from "socket.io-client";
 import { IntentHandle } from "../intents/lib/dispatcher";
 import type { Intent } from "../intents/lib/types";
@@ -24,6 +24,7 @@ import type { PluginConfig, PluginResult } from "../shared/plugin-protocol";
 import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
 import { INTENT_GET_AGENT_SESSION } from "../intents/get-agent-session";
 import { INTENT_SET_METADATA } from "../intents/set-metadata";
+import { INTENT_AGENT_LIFECYCLE } from "../intents/agent-lifecycle";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
 import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import { INTENT_RESOLVE_WORKSPACE } from "../intents/resolve-workspace";
@@ -402,6 +403,69 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
           type: INTENT_SET_METADATA,
           payload: { workspacePath: "/test/workspace", key: "note", value: "my note" },
         })
+      );
+    });
+
+    it("agentLifecycle open dispatches agent:lifecycle intent (fire-and-forget)", async () => {
+      env.mockDispatch.mockImplementation(() => {
+        const handle = new IntentHandle();
+        handle.signalAccepted(true);
+        handle.resolve(undefined);
+        return handle;
+      });
+
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      // Fire-and-forget: no ack callback.
+      client.emit("api:workspace:agentLifecycle", { event: "open" });
+
+      await vi.waitFor(() =>
+        expect(env.mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: INTENT_AGENT_LIFECYCLE,
+            payload: { workspacePath: "/test/workspace", event: "open" },
+          })
+        )
+      );
+    });
+
+    it("agentLifecycle close dispatches agent:lifecycle intent", async () => {
+      env.mockDispatch.mockImplementation(() => {
+        const handle = new IntentHandle();
+        handle.signalAccepted(true);
+        handle.resolve(undefined);
+        return handle;
+      });
+
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      client.emit("api:workspace:agentLifecycle", { event: "close" });
+
+      await vi.waitFor(() =>
+        expect(env.mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: INTENT_AGENT_LIFECYCLE,
+            payload: { workspacePath: "/test/workspace", event: "close" },
+          })
+        )
+      );
+    });
+
+    it("agentLifecycle ignores invalid event (no dispatch)", async () => {
+      const client = createClient("/test/workspace");
+      await waitForConnect(client);
+
+      // Invalid event value — handler validates and drops it.
+      client.emit("api:workspace:agentLifecycle", {
+        event: "bogus",
+      } as unknown as { event: "open" | "close" });
+
+      // Give the server a tick to (not) process it.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(env.mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: INTENT_AGENT_LIFECYCLE })
       );
     });
 

--- a/src/modules/workspace-agent-resolver-module.ts
+++ b/src/modules/workspace-agent-resolver-module.ts
@@ -38,6 +38,10 @@ import {
   type GetAgentSessionHookInput,
 } from "../intents/get-agent-session";
 import { RESTART_AGENT_OPERATION_ID, type RestartAgentHookInput } from "../intents/restart-agent";
+import {
+  AGENT_LIFECYCLE_OPERATION_ID,
+  type AgentLifecycleHookInput,
+} from "../intents/agent-lifecycle";
 
 export const AGENT_METADATA_KEY = "agent";
 
@@ -158,6 +162,12 @@ export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverD
       },
       [RESTART_AGENT_OPERATION_ID]: {
         restart: makeResolverHandler(deps, (ctx) => (ctx as RestartAgentHookInput).workspacePath),
+      },
+      [AGENT_LIFECYCLE_OPERATION_ID]: {
+        lifecycle: makeResolverHandler(
+          deps,
+          (ctx) => (ctx as AgentLifecycleHookInput).workspacePath
+        ),
       },
     },
   };

--- a/src/renderer/lib/services/agent-notifications.test.ts
+++ b/src/renderer/lib/services/agent-notifications.test.ts
@@ -82,6 +82,19 @@ describe("AgentNotificationService", () => {
       expect(mockPlayChime).toHaveBeenCalledTimes(1);
     });
 
+    it("chimes again when an idle agent goes none then idle (close → reopen)", () => {
+      // Agent idle (green).
+      service.handleStatusChange("/test", { idle: 1, busy: 0 });
+      expect(mockPlayChime).toHaveBeenCalledTimes(1);
+
+      // Terminal closed → none, delivered as zero idle by the status binding.
+      service.handleStatusChange("/test", { idle: 0, busy: 0 });
+      // Terminal reopened → idle again.
+      service.handleStatusChange("/test", { idle: 1, busy: 0 });
+
+      expect(mockPlayChime).toHaveBeenCalledTimes(2);
+    });
+
     it("does not trigger when idle count decreases", () => {
       // Seed to establish initial state without triggering first-report chime
       service.seedInitialCounts({ "/test": { idle: 2, busy: 0 } });

--- a/src/renderer/lib/utils/domain-events.test.ts
+++ b/src/renderer/lib/utils/domain-events.test.ts
@@ -315,7 +315,7 @@ describe("setupDomainEvents", () => {
       });
     });
 
-    it("does not call notification service when agent type is none", () => {
+    it("resets notification tracking to zero idle when agent type is none", () => {
       const handleStatusChangeSpy = vi.spyOn(mockNotificationService, "handleStatusChange");
 
       setupDomainEvents(mockApi.api, mockStores, undefined, {
@@ -329,7 +329,11 @@ describe("setupDomainEvents", () => {
       };
       mockApi.emit("workspace:status-changed", { ...TEST_WORKSPACE_REF, status });
 
-      expect(handleStatusChangeSpy).not.toHaveBeenCalled();
+      // "none" carries no counts; we pass zero so a later idle counts as an increase.
+      expect(handleStatusChangeSpy).toHaveBeenCalledWith(TEST_WORKSPACE_PATH, {
+        idle: 0,
+        busy: 0,
+      });
     });
 
     it("cleans up notification service when workspace is removed", () => {

--- a/src/renderer/lib/utils/domain-events.ts
+++ b/src/renderer/lib/utils/domain-events.ts
@@ -149,11 +149,13 @@ export function setupDomainEvents(
   unsubscribes.push(
     api.on("workspace:status-changed", (event) => {
       stores.updateAgentStatus(event, event.status);
-      // Play chime when idle count increases (agent finished work)
-      // Note: status uses AgentStatus type which has counts in the busy/idle/mixed variants
-      if (event.status.agent.type !== "none" && "counts" in event.status.agent) {
-        notificationService.handleStatusChange(event.path, event.status.agent.counts);
-      }
+      // Play chime when idle count increases (agent finished work).
+      // Treat "none" (agent gone — e.g. agent terminal closed) as zero idle so a
+      // later gray → green transition (reopening the terminal) registers as an
+      // idle increase and chimes. The "none" variant carries no counts.
+      const counts =
+        "counts" in event.status.agent ? event.status.agent.counts : { idle: 0, busy: 0 };
+      notificationService.handleStatusChange(event.path, counts);
     })
   );
 

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -557,6 +557,43 @@ export interface ShowInputBoxResponse {
   readonly value: string | null;
 }
 
+/**
+ * Agent terminal lifecycle event reported by the sidekick.
+ * - "open": the agent terminal was created (agent starting) → maps to WrapperStart.
+ * - "close": the agent terminal was closed (agent gone) → maps to WrapperEnd / TUI detach.
+ */
+export type AgentLifecycleEvent = "open" | "close";
+
+/**
+ * Request payload for the api:workspace:agentLifecycle event.
+ * The workspace is taken from the socket's auth, not this payload.
+ */
+export interface AgentLifecycleRequest {
+  readonly event: AgentLifecycleEvent;
+}
+
+/**
+ * Runtime validation for AgentLifecycleRequest.
+ *
+ * @param payload - The payload to validate
+ * @returns Object with valid boolean and optional error message
+ */
+export function validateAgentLifecycleRequest(
+  payload: unknown
+): { valid: true } | { valid: false; error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { valid: false, error: "Request must be an object" };
+  }
+
+  const request = payload as Record<string, unknown>;
+
+  if (request.event !== "open" && request.event !== "close") {
+    return { valid: false, error: `Invalid agent lifecycle event: ${String(request.event)}` };
+  }
+
+  return { valid: true };
+}
+
 // ============================================================================
 // Socket.IO Event Types
 // ============================================================================
@@ -667,6 +704,16 @@ export interface ClientToServerEvents {
    * @param request - Log request with level, message, and optional context
    */
   "api:log": (request: LogRequest) => void;
+
+  /**
+   * Report an agent terminal lifecycle transition (open/close).
+   * Fire-and-forget (no acknowledgment callback). The workspace context is
+   * taken from the socket's auth. Drives agent status: "open" → WrapperStart,
+   * "close" → WrapperEnd / TUI detach.
+   *
+   * @param request - The lifecycle event ("open" | "close")
+   */
+  "api:workspace:agentLifecycle": (request: AgentLifecycleRequest) => void;
 }
 
 /**


### PR DESCRIPTION
Moves WrapperStart/WrapperEnd out of the ch-claude/ch-opencode wrappers and drives agent status from the sidekick over the plugin socket instead.

- Add fire-and-forget `api:workspace:agentLifecycle` `{ event: "open" | "close" }` and the `agent:lifecycle` intent, routed per-workspace via the agent resolver.
- Sidekick emits `open` on agent-terminal create and `close` on terminal close.
- Claude: `triggerWrapperLifecycle()` drives `handleHook(WrapperStart/WrapperEnd)`; the bridge HTTP server now rejects those hooks (Claude's own hooks still use it).
- OpenCode: `triggerWrapperStart()` + new `detachTui()` so closing the terminal grays the dot (previously a stale idle/busy); its bridge HTTP server is removed.
- Remove the wrappers' `notifyHook` + SIGHUP/SIGTERM survival handlers.
- Chime on gray → green reopen by treating `none` as zero idle in the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)