### PR TITLE
fix: workspace creation was stuck when default branch was renamed

### DIFF
--- a/src/intents/get-project-bases.integration.test.ts
+++ b/src/intents/get-project-bases.integration.test.ts
@@ -66,6 +66,8 @@ interface TestSetupOptions {
   refreshThrows?: boolean;
   freshBases?: readonly { name: string; isRemote: boolean }[];
   unknownProject?: boolean;
+  /** When true, the list hook reports no default base branch. */
+  noDefaultBaseBranch?: boolean;
 }
 
 interface TestSetup {
@@ -112,7 +114,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
             listCallCount++;
             // First call returns cached, subsequent calls return fresh
             const bases = listCallCount === 1 ? [...CACHED_BASES] : [...freshBases];
-            return { bases, defaultBaseBranch: "main" };
+            return opts?.noDefaultBaseBranch ? { bases } : { bases, defaultBaseBranch: "main" };
           },
         },
         refresh: {
@@ -191,6 +193,24 @@ describe("GetProjectBases Operation", () => {
       expect(freshEvent.payload.projectId).toBe(PROJECT_ID);
       expect(freshEvent.payload.projectPath).toBe(PROJECT_ROOT);
       expect(freshEvent.payload.bases).toEqual(FRESH_BASES);
+      expect(freshEvent.payload.defaultBaseBranch).toBe("main");
+    });
+
+    it("omits defaultBaseBranch from the event when detection finds none", async () => {
+      const setup = createTestSetup({ noDefaultBaseBranch: true });
+      const events: DomainEvent[] = [];
+      setup.dispatcher.subscribe(EVENT_BASES_UPDATED, (event) => {
+        events.push(event);
+      });
+
+      await setup.dispatcher.dispatch(createIntent(PROJECT_ROOT, { refresh: true }));
+
+      await vi.waitFor(() => {
+        expect(events.length).toBe(1);
+      });
+
+      const freshEvent = events[0] as BasesUpdatedEvent;
+      expect("defaultBaseBranch" in freshEvent.payload).toBe(false);
     });
   });
 

--- a/src/intents/get-project-bases.ts
+++ b/src/intents/get-project-bases.ts
@@ -54,6 +54,8 @@ export interface BasesUpdatedPayload {
   readonly projectId: ProjectId;
   readonly projectPath: string;
   readonly bases: readonly { name: string; isRemote: boolean }[];
+  /** Fresh default base branch; absent when detection found none (authoritative). */
+  readonly defaultBaseBranch?: string;
 }
 
 export interface BasesUpdatedEvent extends DomainEvent {
@@ -167,7 +169,14 @@ export class GetProjectBasesOperation implements Operation<
             if (freshResult) {
               const freshEvent: BasesUpdatedEvent = {
                 type: EVENT_BASES_UPDATED,
-                payload: { projectId, projectPath, bases: freshResult.bases },
+                payload: {
+                  projectId,
+                  projectPath,
+                  bases: freshResult.bases,
+                  ...(freshResult.defaultBaseBranch !== undefined && {
+                    defaultBaseBranch: freshResult.defaultBaseBranch,
+                  }),
+                },
               };
               ctx.emit(freshEvent);
             }

--- a/src/modules/ui-ipc-module.integration.test.ts
+++ b/src/modules/ui-ipc-module.integration.test.ts
@@ -357,6 +357,30 @@ describe("UiIpcModule - bases:updated", () => {
       bases,
     });
   });
+
+  it("forwards defaultBaseBranch when the event carries one", async () => {
+    const deps = createBridgeDeps();
+    const uiIpcModule = createUiIpcModule(deps);
+
+    const bases = [{ name: "origin/main", isRemote: true }];
+
+    await uiIpcModule.events!["bases:updated"]!.handler({
+      type: "bases:updated",
+      payload: {
+        projectId: TEST_PROJECT_ID,
+        projectPath: TEST_PROJECT_PATH,
+        bases,
+        defaultBaseBranch: "origin/main",
+      },
+    });
+
+    expect(deps.sendToUI).toHaveBeenCalledWith(ApiIpcChannels.PROJECT_BASES_UPDATED, {
+      projectId: TEST_PROJECT_ID,
+      projectPath: TEST_PROJECT_PATH,
+      bases,
+      defaultBaseBranch: "origin/main",
+    });
+  });
 });
 
 // =============================================================================

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -253,6 +253,7 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
           projectId: p.projectId,
           projectPath: p.projectPath,
           bases: p.bases,
+          ...(p.defaultBaseBranch !== undefined && { defaultBaseBranch: p.defaultBaseBranch }),
         });
       },
     },

--- a/src/renderer/lib/components/BranchDropdown.svelte
+++ b/src/renderer/lib/components/BranchDropdown.svelte
@@ -16,7 +16,6 @@
   let branches = $state<readonly BaseInfo[]>([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
-  let hasValidatedInitialValue = $state(false);
 
   // Load cached branches immediately, then wait for bases-updated event
   $effect(() => {
@@ -43,6 +42,13 @@
         if (event.projectPath === currentProjectPath) {
           branches = event.bases;
           loading = false;
+          // The fresh list is authoritative: clear a selection it no longer
+          // contains. Validation runs once per arriving list — never on value
+          // changes, which would re-clear a value the parent just re-applied
+          // and feed an infinite clear/re-apply loop.
+          if (value && !event.bases.some((b) => b.name === value)) {
+            onSelect("");
+          }
         }
       }
     );
@@ -50,27 +56,6 @@
     return () => {
       unsubscribe();
     };
-  });
-
-  // Reset validation flag when value prop changes from parent
-  // This allows re-validation if parent updates value dynamically
-  $effect(() => {
-    // Track value to create dependency
-    void value;
-    // Reset flag so validation runs again with new value
-    hasValidatedInitialValue = false;
-  });
-
-  // Validate initial value exists in branches after loading
-  $effect(() => {
-    // Only validate once after branches load
-    if (loading || hasValidatedInitialValue) return;
-    hasValidatedInitialValue = true;
-
-    // If value is set but doesn't exist in branches, clear it
-    if (value && !branches.some((b) => b.name === value)) {
-      onSelect(""); // Notify parent the value is invalid
-    }
   });
 
   /**

--- a/src/renderer/lib/components/BranchDropdown.test.ts
+++ b/src/renderer/lib/components/BranchDropdown.test.ts
@@ -421,6 +421,25 @@ describe("BranchDropdown component", () => {
       expect(onSelect).toHaveBeenCalledWith("");
     });
 
+    it("does not re-clear when the parent re-applies a value after the list loaded", async () => {
+      // Regression: clearing on every value change fed an infinite clear/re-apply
+      // loop with the parent's default auto-fill (effect_update_depth_exceeded).
+      // Validation must run once per arriving list, not on value changes.
+      const onSelect = vi.fn();
+      const { rerender } = render(BranchDropdown, {
+        props: { ...defaultProps, value: "deleted-branch", onSelect },
+      });
+
+      await completeLoading();
+      expect(onSelect).toHaveBeenCalledTimes(1);
+
+      // Parent stubbornly re-applies the invalid value (simulates a stale default).
+      await rerender({ ...defaultProps, value: "deleted-branch", onSelect });
+      await tick();
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
     it("does not clear value when branches are still loading", async () => {
       const onSelect = vi.fn();
 

--- a/src/renderer/lib/components/NewWorkspaceView.svelte
+++ b/src/renderer/lib/components/NewWorkspaceView.svelte
@@ -16,6 +16,7 @@
   store so git-clone / folder-open can populate it.
 -->
 <script lang="ts">
+  import { SvelteSet } from "svelte/reactivity";
   import BranchDropdown from "./BranchDropdown.svelte";
   import ProjectDropdown from "./ProjectDropdown.svelte";
   import NameBranchDropdown, { type NameBranchSelection } from "./NameBranchDropdown.svelte";
@@ -91,11 +92,24 @@
   // Section ref for focus-trap enumeration.
   let sectionRef: HTMLElement | undefined = $state();
 
-  // Initialize selectedBranch from the project's default when available.
-  // Runs when defaultBaseBranch arrives or after switching projects (branch cleared).
+  // Auto-fill the base branch from the project's default. Each distinct default
+  // value is applied at most once per project selection, and only into an empty
+  // field: re-applying after BranchDropdown cleared a stale default would
+  // ping-pong forever (effect_update_depth_exceeded bricked the whole renderer
+  // once), while a *fresh* default arriving later is a new value and still fills
+  // the empty field. Defined before the apply effect so the reset runs first on
+  // project switches.
+  const appliedDefaults = new SvelteSet<string>();
   $effect(() => {
-    if (selectedBranch === "" && defaultBranch) {
-      selectedBranch = defaultBranch;
+    void selectedProjectId;
+    appliedDefaults.clear();
+  });
+
+  $effect(() => {
+    const branch = defaultBranch;
+    if (selectedBranch === "" && branch && !appliedDefaults.has(branch)) {
+      appliedDefaults.add(branch);
+      selectedBranch = branch;
     }
   });
 
@@ -250,6 +264,9 @@
 
   // Reset the whole form to defaults (used after create and on Escape).
   function resetForm(): void {
+    // Re-arm the default auto-fill: a reset is a deliberate user action (submit
+    // or Escape), so re-applying the same default afterwards cannot loop.
+    appliedDefaults.clear();
     name = "";
     selectedBranch = "";
     initialPrompt = "";

--- a/src/renderer/lib/components/NewWorkspaceView.test.ts
+++ b/src/renderer/lib/components/NewWorkspaceView.test.ts
@@ -10,16 +10,34 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
 import { asProjectId } from "@shared/test-fixtures";
 
-// Mock the API used by the panel and its child dropdowns.
-const mockApi = vi.hoisted(() => ({
-  workspaces: { create: vi.fn().mockResolvedValue({}) },
-  projects: {
-    fetchBases: vi.fn().mockResolvedValue({ bases: [] }),
-    open: vi.fn().mockResolvedValue(null),
-  },
-  on: vi.fn(() => () => {}),
-}));
+// Mock the API used by the panel and its child dropdowns. `on` keeps a real
+// handler registry so tests can push events (e.g. project:bases-updated) to
+// the mounted child dropdowns via emitApiEvent.
+const mockApi = vi.hoisted(() => {
+  const eventHandlers = new Map<string, Set<(event: unknown) => void>>();
+  return {
+    workspaces: { create: vi.fn().mockResolvedValue({}) },
+    projects: {
+      fetchBases: vi.fn().mockResolvedValue({ bases: [] }),
+      open: vi.fn().mockResolvedValue(null),
+    },
+    on: vi.fn((event: string, handler: (e: unknown) => void) => {
+      let handlers = eventHandlers.get(event);
+      if (!handlers) {
+        handlers = new Set();
+        eventHandlers.set(event, handlers);
+      }
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    }),
+    eventHandlers,
+  };
+});
 vi.mock("$lib/api", () => mockApi);
+
+function emitApiEvent(event: string, payload: unknown): void {
+  mockApi.eventHandlers.get(event)?.forEach((handler) => handler(payload));
+}
 
 import NewWorkspaceView from "./NewWorkspaceView.svelte";
 import * as projectsStore from "$lib/stores/projects.svelte.js";
@@ -51,6 +69,7 @@ async function typeName(value: string): Promise<void> {
 describe("NewWorkspaceView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApi.eventHandlers.clear();
     projectsStore.reset();
     newWorkspaceViewStore.reset();
     pendingStore.reset();
@@ -133,6 +152,89 @@ describe("NewWorkspaceView", () => {
     await typeName("second");
     const createButton = screen.getByRole("button", { name: "Create" });
     await waitFor(() => expect(createButton).not.toBeDisabled());
+  });
+
+  it("survives a stale default branch and heals to the fresh one (no effect loop)", async () => {
+    // Regression: the project's defaultBaseBranch went stale during the session
+    // (remote default-branch rename master → main). The auto-fill effect and
+    // BranchDropdown's clear-invalid-value validation ping-ponged forever,
+    // crashing Svelte with effect_update_depth_exceeded and bricking the UI.
+    projectsStore.setProjectDefaultBaseBranch(PROJECT_PATH, "origin/master");
+    // Cached branch list still contains the stale branch.
+    mockApi.projects.fetchBases.mockResolvedValue({
+      bases: [{ name: "origin/master", isRemote: true }],
+    });
+
+    render(NewWorkspaceView, { props: { open: true } });
+
+    const branchInput = document.getElementById(
+      `branch-dropdown-${PROJECT_PATH}-input`
+    ) as HTMLInputElement;
+    await waitFor(() => expect(branchInput.value).toBe("origin/master"));
+
+    // Background refresh pruned the stale branch; the event heals the store
+    // default (as the domain-event binding does) and updates the dropdown.
+    emitApiEvent("project:bases-updated", {
+      projectId: PROJECT_ID,
+      projectPath: PROJECT_PATH,
+      bases: [{ name: "origin/main", isRemote: true }],
+      defaultBaseBranch: "origin/main",
+    });
+    projectsStore.setProjectDefaultBaseBranch(PROJECT_PATH, "origin/main");
+
+    // No crash, and the selection healed to the fresh default.
+    await waitFor(() => expect(branchInput.value).toBe("origin/main"));
+
+    // Form is fully usable: Create enables once a name is typed.
+    await typeName("snap");
+    const createButton = screen.getByRole("button", { name: "Create" });
+    await waitFor(() => expect(createButton).not.toBeDisabled());
+  });
+
+  it("does not override a manual branch pick when a fresh default arrives", async () => {
+    mockApi.projects.fetchBases.mockResolvedValue({
+      bases: [
+        { name: "develop", isRemote: false },
+        { name: "origin/main", isRemote: true },
+      ],
+    });
+
+    render(NewWorkspaceView, { props: { open: true } });
+
+    const branchInput = document.getElementById(
+      `branch-dropdown-${PROJECT_PATH}-input`
+    ) as HTMLInputElement;
+    // Default ("main" from makeProject) is not in the list; pick manually.
+    emitApiEvent("project:bases-updated", {
+      projectId: PROJECT_ID,
+      projectPath: PROJECT_PATH,
+      bases: [
+        { name: "develop", isRemote: false },
+        { name: "origin/main", isRemote: true },
+      ],
+      defaultBaseBranch: "origin/main",
+    });
+    await fireEvent.focus(branchInput);
+    await waitFor(() => {
+      const option = screen.getByText("develop");
+      expect(option).not.toBeNull();
+    });
+    await fireEvent.mouseDown(screen.getByText("develop"));
+    await waitFor(() => expect(branchInput.value).toBe("develop"));
+
+    // Fresh default arriving later must not clobber the manual pick.
+    projectsStore.setProjectDefaultBaseBranch(PROJECT_PATH, "origin/main");
+    emitApiEvent("project:bases-updated", {
+      projectId: PROJECT_ID,
+      projectPath: PROJECT_PATH,
+      bases: [
+        { name: "develop", isRemote: false },
+        { name: "origin/main", isRemote: true },
+      ],
+      defaultBaseBranch: "origin/main",
+    });
+
+    await waitFor(() => expect(branchInput.value).toBe("develop"));
   });
 
   it("clears the form on Escape", async () => {

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -130,11 +130,7 @@ export function setActiveWorkspace(path: string | null): void {
   _activeWorkspacePath = path;
 }
 
-export function addWorkspace(
-  projectPath: string,
-  workspace: Workspace,
-  defaultBaseBranch?: string
-): void {
+export function addWorkspace(projectPath: string, workspace: Workspace): void {
   _projects = _projects.map((p) =>
     p.path === projectPath
       ? {
@@ -142,11 +138,27 @@ export function addWorkspace(
           workspaces: p.workspaces.some((w) => w.path === workspace.path)
             ? p.workspaces.map((w) => (w.path === workspace.path ? workspace : w))
             : [...p.workspaces, workspace],
-          // Update defaultBaseBranch if provided (remembers last-used branch for next workspace creation)
-          ...(defaultBaseBranch !== undefined ? { defaultBaseBranch } : {}),
         }
       : p
   );
+}
+
+/**
+ * Authoritatively set (or clear, when undefined) a project's default base branch.
+ * Fed by the project:bases-updated event so a default that went stale during the
+ * session (e.g. remote default-branch rename) heals after the next refresh.
+ */
+export function setProjectDefaultBaseBranch(
+  projectPath: string,
+  defaultBaseBranch: string | undefined
+): void {
+  _projects = _projects.map((p) => {
+    if (p.path !== projectPath) return p;
+    if (defaultBaseBranch !== undefined) return { ...p, defaultBaseBranch };
+    const cleared = { ...p };
+    delete cleared.defaultBaseBranch;
+    return cleared;
+  });
 }
 
 export function removeWorkspace(projectPath: string, workspacePath: string): void {

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -27,6 +27,7 @@ import {
   addWorkspace,
   removeWorkspace,
   updateWorkspaceMetadata,
+  setProjectDefaultBaseBranch,
   reset,
   getAllWorkspaces,
   getAwakeWorkspaceRefByIndex,
@@ -172,20 +173,7 @@ describe("projects store", () => {
       expect(projects.value[0]?.workspaces[0]).toEqual(newWorkspace);
     });
 
-    it("updates project defaultBaseBranch when provided", () => {
-      const project = createMockProject({
-        path: "/test/project" as ProjectPath,
-        workspaces: [],
-      });
-      addProject(project);
-
-      const newWorkspace = createMockWorkspace({ path: "/test/project/.worktrees/new" });
-      addWorkspace("/test/project" as ProjectPath, newWorkspace, "develop");
-
-      expect(projects.value[0]?.defaultBaseBranch).toBe("develop");
-    });
-
-    it("does not update defaultBaseBranch when not provided", () => {
+    it("does not touch defaultBaseBranch", () => {
       const project = createMockProject({
         path: "/test/project" as ProjectPath,
         workspaces: [],
@@ -196,22 +184,7 @@ describe("projects store", () => {
       const newWorkspace = createMockWorkspace({ path: "/test/project/.worktrees/new" });
       addWorkspace("/test/project" as ProjectPath, newWorkspace);
 
-      // Should preserve existing defaultBaseBranch
       expect(projects.value[0]?.defaultBaseBranch).toBe("main");
-    });
-
-    it("overwrites existing defaultBaseBranch when new value provided", () => {
-      const project = createMockProject({
-        path: "/test/project" as ProjectPath,
-        workspaces: [],
-        defaultBaseBranch: "main",
-      });
-      addProject(project);
-
-      const newWorkspace = createMockWorkspace({ path: "/test/project/.worktrees/new" });
-      addWorkspace("/test/project" as ProjectPath, newWorkspace, "feature/new-base");
-
-      expect(projects.value[0]?.defaultBaseBranch).toBe("feature/new-base");
     });
 
     // Regression: wake/reopen path emits workspace:created for an already-known
@@ -287,6 +260,53 @@ describe("projects store", () => {
       const nextIndex = wrapIndex(currentIndex + 1, all.length);
       const nextRef = getWorkspaceRefByIndex(nextIndex);
       expect(nextRef?.path).toBe(wsC.path);
+    });
+  });
+
+  describe("setProjectDefaultBaseBranch", () => {
+    it("sets the default base branch on the matching project", () => {
+      addProject(
+        createMockProject({
+          path: "/test/project" as ProjectPath,
+          defaultBaseBranch: "origin/master",
+        })
+      );
+
+      setProjectDefaultBaseBranch("/test/project", "origin/main");
+
+      expect(projects.value[0]?.defaultBaseBranch).toBe("origin/main");
+    });
+
+    it("clears the default base branch when undefined (authoritative)", () => {
+      addProject(
+        createMockProject({
+          path: "/test/project" as ProjectPath,
+          defaultBaseBranch: "origin/master",
+        })
+      );
+
+      setProjectDefaultBaseBranch("/test/project", undefined);
+
+      expect(projects.value[0]?.defaultBaseBranch).toBeUndefined();
+    });
+
+    it("leaves other projects untouched", () => {
+      addProject(
+        createMockProject({
+          path: "/test/project" as ProjectPath,
+          defaultBaseBranch: "main",
+        })
+      );
+      addProject(
+        createMockProject({
+          path: "/test/other" as ProjectPath,
+          defaultBaseBranch: "main",
+        })
+      );
+
+      setProjectDefaultBaseBranch("/test/project", "develop");
+
+      expect(projects.value[1]?.defaultBaseBranch).toBe("main");
     });
   });
 

--- a/src/renderer/lib/utils/domain-events.test.ts
+++ b/src/renderer/lib/utils/domain-events.test.ts
@@ -95,6 +95,7 @@ describe("setupDomainEvents", () => {
       setActiveWorkspace: vi.fn(),
       updateAgentStatus: vi.fn(),
       updateWorkspaceMetadata: vi.fn(),
+      setProjectDefaultBaseBranch: vi.fn(),
     };
   });
 
@@ -226,6 +227,39 @@ describe("setupDomainEvents", () => {
         TEST_WORKSPACE_NAME,
         "tags.bugfix",
         null
+      );
+    });
+  });
+
+  describe("bases-updated events", () => {
+    it("calls setProjectDefaultBaseBranch with the fresh default", () => {
+      setupDomainEvents(mockApi.api, mockStores);
+
+      mockApi.emit("project:bases-updated", {
+        projectId: TEST_PROJECT_ID,
+        projectPath: "/test/project",
+        bases: [{ name: "origin/main", isRemote: true }],
+        defaultBaseBranch: "origin/main",
+      });
+
+      expect(mockStores.setProjectDefaultBaseBranch).toHaveBeenCalledWith(
+        TEST_PROJECT_ID,
+        "origin/main"
+      );
+    });
+
+    it("calls setProjectDefaultBaseBranch with undefined when the event has no default", () => {
+      setupDomainEvents(mockApi.api, mockStores);
+
+      mockApi.emit("project:bases-updated", {
+        projectId: TEST_PROJECT_ID,
+        projectPath: "/test/project",
+        bases: [{ name: "develop", isRemote: false }],
+      });
+
+      expect(mockStores.setProjectDefaultBaseBranch).toHaveBeenCalledWith(
+        TEST_PROJECT_ID,
+        undefined
       );
     });
   });

--- a/src/renderer/lib/utils/domain-events.ts
+++ b/src/renderer/lib/utils/domain-events.ts
@@ -57,6 +57,11 @@ export interface DomainStores {
     key: string,
     value: string | null
   ) => void;
+  /** Set (or clear, when undefined) a project's default base branch */
+  setProjectDefaultBaseBranch: (
+    projectId: ProjectId,
+    defaultBaseBranch: string | undefined
+  ) => void;
 }
 
 /**
@@ -163,6 +168,14 @@ export function setupDomainEvents(
   unsubscribes.push(
     api.on("workspace:metadata-changed", (event) => {
       stores.updateWorkspaceMetadata(event.projectId, event.workspaceName, event.key, event.value);
+    })
+  );
+
+  // Project bases updated — refresh the project's default base branch so a
+  // default that went stale during the session heals (absent = no default found).
+  unsubscribes.push(
+    api.on("project:bases-updated", (event) => {
+      stores.setProjectDefaultBaseBranch(event.projectId, event.defaultBaseBranch);
     })
   );
 

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -190,6 +190,35 @@ describe("setupDomainEventBindings", () => {
     });
   });
 
+  describe("bases-updated events", () => {
+    it("updates the project's defaultBaseBranch when project:bases-updated is emitted", () => {
+      projectsStore.setProjects([{ ...TEST_PROJECT, defaultBaseBranch: "origin/master" }]);
+      setupDomainEventBindings(notificationService, mockApi.api);
+
+      mockApi.emit("project:bases-updated", {
+        projectId: TEST_PROJECT_ID,
+        projectPath: TEST_PROJECT.path,
+        bases: [{ name: "origin/main", isRemote: true }],
+        defaultBaseBranch: "origin/main",
+      });
+
+      expect(projectsStore.projects.value[0]?.defaultBaseBranch).toBe("origin/main");
+    });
+
+    it("clears the project's defaultBaseBranch when the event carries none", () => {
+      projectsStore.setProjects([{ ...TEST_PROJECT, defaultBaseBranch: "origin/master" }]);
+      setupDomainEventBindings(notificationService, mockApi.api);
+
+      mockApi.emit("project:bases-updated", {
+        projectId: TEST_PROJECT_ID,
+        projectPath: TEST_PROJECT.path,
+        bases: [{ name: "develop", isRemote: false }],
+      });
+
+      expect(projectsStore.projects.value[0]?.defaultBaseBranch).toBeUndefined();
+    });
+  });
+
   describe("workspace events", () => {
     beforeEach(() => {
       // Setup: add project first so workspace events can find it

--- a/src/renderer/lib/utils/setup-domain-event-bindings.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.ts
@@ -15,6 +15,7 @@ import {
   addWorkspace,
   removeWorkspace,
   updateWorkspaceMetadata,
+  setProjectDefaultBaseBranch,
 } from "$lib/stores/projects.svelte.js";
 import { bootstrap } from "$lib/stores/bootstrap.svelte.js";
 import { updateStatus } from "$lib/stores/agent-status.svelte.js";
@@ -125,6 +126,13 @@ export function setupDomainEventBindings(
           return;
         }
         logger.debug("Store updated", { store: "projects", key });
+      },
+      setProjectDefaultBaseBranch: (projectId, defaultBaseBranch) => {
+        const project = projects.value.find((p) => p.id === projectId);
+        if (project) {
+          setProjectDefaultBaseBranch(project.path, defaultBaseBranch);
+          logger.debug("Store updated", { store: "projects", key: "defaultBaseBranch" });
+        }
       },
     },
     {

--- a/src/shared/api/interfaces.ts
+++ b/src/shared/api/interfaces.ts
@@ -36,6 +36,8 @@ export interface ApiEvents {
     readonly projectId: ProjectId;
     readonly projectPath: string;
     readonly bases: readonly BaseInfo[];
+    /** Fresh default base branch; absent when detection found none (authoritative). */
+    readonly defaultBaseBranch?: string;
   }) => void;
   "workspace:created": (event: {
     readonly projectId: ProjectId;


### PR DESCRIPTION
- Fixed an infinite effect loop (`effect_update_depth_exceeded`) that bricked the entire UI when the create-workspace view auto-filled a default base branch that no longer exists (e.g. after a remote default-branch rename master → main): the default auto-fill now applies each value at most once per project selection, and BranchDropdown validates the selection once per arriving branch list instead of on every value change
- The `bases:updated` event now carries the freshly detected `defaultBaseBranch`; the renderer updates the project store authoritatively (absent = clear), so a stale default heals mid-dialog and the fresh default is auto-selected
- Removed the dead `defaultBaseBranch` parameter from the `addWorkspace` store action
- Regression tests replaying the rename scenario end-to-end (stale default + pruned branch list → no crash, selection heals, Create enables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)