### PR TITLE
fix: Correct default base branch after remote renames

### DIFF
--- a/src/boundaries/platform/git-client.state-mock.ts
+++ b/src/boundaries/platform/git-client.state-mock.ts
@@ -63,6 +63,12 @@ interface RepositoryState {
   remoteBranches: Set<string>;
   /** Remote names (e.g., "origin") */
   remotes: Set<string>;
+  /** Remote HEAD symrefs: remote name -> default branch short name (refs/remotes/<remote>/HEAD) */
+  remoteHeads: Map<string, string>;
+  /** Default branch on the remote server; applied to remoteHeads on fetch (set-head simulation) */
+  serverDefaultBranch?: string;
+  /** The repository's own HEAD symref target (may dangle, unlike currentBranch) */
+  headBranch: string | null;
   /** Worktrees by normalized path */
   worktrees: Map<string, WorktreeState>;
   /** Branch configurations: branch -> key -> value */
@@ -109,6 +115,12 @@ export interface RepositoryInit {
   readonly remoteBranches?: readonly string[];
   /** Remote names (e.g., "origin") */
   readonly remotes?: readonly string[];
+  /** Remote HEAD symrefs: remote name -> default branch short name */
+  readonly remoteHeads?: Readonly<Record<string, string>>;
+  /** Default branch on the remote server; applied to remoteHeads on fetch (set-head simulation) */
+  readonly serverDefaultBranch?: string;
+  /** The repository's own HEAD symref target (defaults to currentBranch) */
+  readonly headBranch?: string | null;
   /** Worktrees in this repository (non-main) */
   readonly worktrees?: readonly WorktreeInit[];
   /** Branch configurations: branch -> { key: value } */
@@ -215,6 +227,15 @@ class GitClientMockStateImpl implements GitClientMockState {
       lines.push(`  branches: [${[...repo.branches].sort().join(", ")}]`);
       lines.push(`  remoteBranches: [${[...repo.remoteBranches].sort().join(", ")}]`);
       lines.push(`  remotes: [${[...repo.remotes].sort().join(", ")}]`);
+      if (repo.remoteHeads.size > 0) {
+        const heads = [...repo.remoteHeads.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([r, b]) => `${r}=${b}`);
+        lines.push(`  remoteHeads: [${heads.join(", ")}]`);
+      }
+      if (repo.headBranch !== repo.currentBranch) {
+        lines.push(`  headBranch: ${repo.headBranch ?? "(none)"}`);
+      }
 
       const worktreePaths = [...repo.worktrees.keys()].sort();
       for (const wtPath of worktreePaths) {
@@ -295,16 +316,22 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
         }
       }
 
+      const currentBranch = init.currentBranch ?? init.branches?.[0] ?? null;
       const repoState: RepositoryState = {
         branches: new Set(init.branches ?? []),
         remoteBranches: new Set(init.remoteBranches ?? []),
         remotes: new Set(init.remotes ?? []),
+        remoteHeads: new Map(Object.entries(init.remoteHeads ?? {})),
+        headBranch: init.headBranch !== undefined ? init.headBranch : currentBranch,
         worktrees,
         branchConfigs,
         mainIsDirty: init.mainIsDirty ?? false,
-        currentBranch: init.currentBranch ?? init.branches?.[0] ?? null,
+        currentBranch,
         isBare: init.isBare ?? false,
       };
+      if (init.serverDefaultBranch !== undefined) {
+        repoState.serverDefaultBranch = init.serverDefaultBranch;
+      }
       if (init.remoteUrl !== undefined) {
         repoState.remoteUrl = init.remoteUrl;
       }
@@ -553,7 +580,19 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
         throw new GitError(`Remote '${remote}' not found`);
       }
 
-      // No-op on success - mock doesn't actually fetch
+      // Simulate `remote set-head --auto`: record the server's default branch as the
+      // remote HEAD symref (mirrors SimpleGitClient.fetch)
+      if (remote !== undefined && repo.serverDefaultBranch !== undefined) {
+        repo.remoteHeads.set(remote, repo.serverDefaultBranch);
+      }
+    },
+
+    async getDefaultBranch(repoPath: Path, remote?: string): Promise<string | null> {
+      const repo = getRepoOrThrow(repoPath);
+      if (remote !== undefined) {
+        return repo.remoteHeads.get(remote) ?? null;
+      }
+      return repo.headBranch;
     },
 
     async listRemotes(repoPath: Path): Promise<readonly string[]> {
@@ -641,12 +680,14 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
       }
 
       // Create a new bare repository at target
-      // Mirrors real behavior: after clone --bare + fetch + delete local branches,
+      // Mirrors real behavior: after clone --bare + fetch + set-head + delete local branches,
       // we only have remote-tracking branches, no local branches
       (state as GitClientMockStateImpl).addRepository(normalizedTarget, {
         branches: new Set(), // No local branches after clone (all deleted)
         remoteBranches: new Set(["origin/main"]), // Only remote-tracking branches
         remotes: new Set(["origin"]),
+        remoteHeads: new Map([["origin", "main"]]), // set-head records the remote default
+        headBranch: "main", // bare HEAD symref dangles but still names the default
         worktrees: new Map(),
         branchConfigs: new Map(),
         mainIsDirty: false,
@@ -681,6 +722,8 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
         branches: hasCommit ? new Set(["main"]) : new Set(),
         remoteBranches: new Set(),
         remotes: new Set(),
+        remoteHeads: new Map(),
+        headBranch: "main", // git init points HEAD at the default branch even before any commit
         worktrees: new Map(),
         branchConfigs: new Map(),
         mainIsDirty: false,

--- a/src/boundaries/platform/git-client.ts
+++ b/src/boundaries/platform/git-client.ts
@@ -130,6 +130,24 @@ export interface IGitClient {
   listRemotes(repoPath: Path): Promise<readonly string[]>;
 
   /**
+   * Get the default branch recorded locally.
+   *
+   * With `remote`, reads the `refs/remotes/<remote>/HEAD` symref — the local record of
+   * the remote's default branch. The symref is created/updated by clone() and fetch()
+   * (via `git remote set-head --auto`); it may be absent in repositories that predate
+   * this behavior or were set up without a full clone.
+   *
+   * Without `remote`, reads the repository's own HEAD symref. Unlike getCurrentBranch(),
+   * this also works when HEAD dangles (points at a deleted branch), which is the normal
+   * state of CodeHydra's bare clones — there it names the default branch at clone time.
+   *
+   * @param repoPath Absolute path to the git repository
+   * @param remote Optional remote name to read the remote HEAD symref for
+   * @returns Promise resolving to the short branch name, or null when no symref answer exists
+   */
+  getDefaultBranch(repoPath: Path, remote?: string): Promise<string | null>;
+
+  /**
    * Get a branch-specific configuration value.
    * @param repoPath Absolute path to the git repository
    * @param branch Name of the branch

--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -1874,12 +1874,167 @@ describe("GitWorktreeProvider", () => {
   });
 
   describe("defaultBase", () => {
+    it("returns the remote default branch recorded in the origin HEAD symref", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: [],
+            remoteBranches: ["origin/develop", "origin/main"],
+            remotes: ["origin"],
+            remoteHeads: { origin: "develop" },
+            currentBranch: null,
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.defaultBase(PROJECT_ROOT);
+
+      expect(result).toBe("origin/develop");
+    });
+
+    it("returns the local branch when the symref default has no remote-tracking entry", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["develop", "feature"],
+            remotes: ["origin"],
+            remoteHeads: { origin: "develop" },
+            currentBranch: "feature",
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.defaultBase(PROJECT_ROOT);
+
+      expect(result).toBe("develop");
+    });
+
+    it("skips a stale symref pointing at a branch missing from the base list", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: [],
+            remoteBranches: ["origin/main"],
+            remotes: ["origin"],
+            // Stale: remote renamed master -> main, symref not yet updated
+            remoteHeads: { origin: "master" },
+            currentBranch: null,
+            headBranch: null,
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.defaultBase(PROJECT_ROOT);
+
+      expect(result).toBe("origin/main");
+    });
+
+    it("falls back to the repo HEAD symref when no remote HEAD symref exists (bare clone)", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: [],
+            remoteBranches: ["origin/develop", "origin/feature"],
+            remotes: ["origin"],
+            // Bare clone predating set-head: HEAD dangles but names the clone-time default
+            currentBranch: null,
+            headBranch: "develop",
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.defaultBase(PROJECT_ROOT);
+
+      expect(result).toBe("origin/develop");
+    });
+
+    it("falls back to the checked-out branch for a local-only repo without main/master", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["develop", "feature"],
+            currentBranch: "develop",
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.defaultBase(PROJECT_ROOT);
+
+      expect(result).toBe("develop");
+    });
+
+    it("reflects the remote default after updateBases heals a missing symref", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: [],
+            remoteBranches: ["origin/develop", "origin/master"],
+            remotes: ["origin"],
+            serverDefaultBranch: "develop",
+            currentBranch: null,
+            headBranch: null,
+          },
+        },
+      });
+      const provider = await GitWorktreeProvider.create(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      // Before refresh: no symref answer, legacy fallback picks origin/master
+      expect(await provider.defaultBase(PROJECT_ROOT)).toBe("origin/master");
+
+      // Refresh fetches and runs set-head, recording the server's actual default
+      await provider.updateBases(PROJECT_ROOT);
+
+      expect(await provider.defaultBase(PROJECT_ROOT)).toBe("origin/develop");
+    });
+
     it("prefers origin/main over local main", async () => {
       const mockClient = createMockGitClient({
         repositories: {
           [PROJECT_ROOT.toString()]: {
             branches: ["main", "feature"],
             remoteBranches: ["origin/main"],
+            remotes: ["origin"],
             currentBranch: "main",
           },
         },
@@ -1925,6 +2080,7 @@ describe("GitWorktreeProvider", () => {
           [PROJECT_ROOT.toString()]: {
             branches: ["master", "feature"],
             remoteBranches: ["origin/master"],
+            remotes: ["origin"],
             currentBranch: "master",
           },
         },
@@ -1970,6 +2126,7 @@ describe("GitWorktreeProvider", () => {
           [PROJECT_ROOT.toString()]: {
             branches: ["master", "main", "feature"],
             remoteBranches: ["origin/main", "origin/master"],
+            remotes: ["origin"],
             currentBranch: "main",
           },
         },
@@ -1987,12 +2144,13 @@ describe("GitWorktreeProvider", () => {
       expect(result).toBe("origin/main");
     });
 
-    it("returns undefined when neither main nor master exists", async () => {
+    it("returns undefined when no symref answer exists and neither main nor master exists", async () => {
       const mockClient = createMockGitClient({
         repositories: {
           [PROJECT_ROOT.toString()]: {
             branches: ["feature", "develop"],
             currentBranch: "feature",
+            headBranch: null,
           },
         },
       });

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -691,8 +691,18 @@ export class GitWorktreeProvider {
 
   /**
    * Returns the default base branch for creating new workspaces.
-   * Prefers remote branches over local to ensure proper tracking.
-   * Check order: origin/main -> main -> origin/master -> master
+   *
+   * Detection order:
+   * 1. The remote's recorded default branch (refs/remotes/<remote>/HEAD symref,
+   *    maintained by clone/fetch) — covers repos whose default is develop/trunk/etc.
+   *    and self-heals after a remote default-branch rename on the next refresh.
+   * 2. The repository's own HEAD symref (clone-time default in bare clones,
+   *    checked-out branch in local repos).
+   * 3. Legacy hardcoded order: origin/main -> main -> origin/master -> master.
+   *
+   * Every candidate must exist in listBases() — the result is used as the dialog's
+   * preselected entry, so it must be selectable. Prefers remote-tracking entries
+   * over local ones to ensure proper tracking. Purely local: never hits the network.
    *
    * @param projectRoot Root of the git repository
    * @returns Promise resolving to the default base branch, or undefined if none found
@@ -702,18 +712,33 @@ export class GitWorktreeProvider {
       const bases = await this.listBases(projectRoot);
       const branchNames = new Set(bases.map((b) => b.name));
 
-      // Prefer remote branches for proper tracking
-      if (branchNames.has("origin/main")) {
-        return "origin/main";
+      // Resolve a detected branch name to a selectable base, preferring remote-tracking
+      const pick = (branchName: string | null, remote?: string): string | undefined => {
+        if (!branchName) return undefined;
+        if (remote !== undefined && branchNames.has(`${remote}/${branchName}`)) {
+          return `${remote}/${branchName}`;
+        }
+        return branchNames.has(branchName) ? branchName : undefined;
+      };
+
+      const remotes = await this.gitClient.listRemotes(projectRoot);
+      const remote = remotes.includes("origin") ? "origin" : remotes[0];
+
+      if (remote !== undefined) {
+        const remoteDefault = await this.gitClient.getDefaultBranch(projectRoot, remote);
+        const base = pick(remoteDefault, remote);
+        if (base !== undefined) return base;
       }
-      if (branchNames.has("main")) {
-        return "main";
-      }
-      if (branchNames.has("origin/master")) {
-        return "origin/master";
-      }
-      if (branchNames.has("master")) {
-        return "master";
+
+      const headDefault = await this.gitClient.getDefaultBranch(projectRoot);
+      const headBase = pick(headDefault, remote);
+      if (headBase !== undefined) return headBase;
+
+      // Legacy fallback for repos where no symref answer exists
+      for (const candidate of ["origin/main", "main", "origin/master", "master"]) {
+        if (branchNames.has(candidate)) {
+          return candidate;
+        }
       }
       return undefined;
     } catch (error: unknown) {

--- a/src/boundaries/platform/simple-git-client.boundary.test.ts
+++ b/src/boundaries/platform/simple-git-client.boundary.test.ts
@@ -368,6 +368,85 @@ describe("SimpleGitClient", () => {
         }
       });
     }, 30000);
+
+    it("creates the remote HEAD symref from the remote's default branch", async () => {
+      await withTempRepoWithRemote(async (path, remotePath) => {
+        // init+push repos have no refs/remotes/origin/HEAD
+        expect(await client.getDefaultBranch(new Path(path), "origin")).toBeNull();
+
+        await simpleGit(remotePath).raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+        await client.fetch(new Path(path), "origin");
+
+        expect(await client.getDefaultBranch(new Path(path), "origin")).toBe("main");
+      });
+    }, 15000);
+
+    it("updates a stale remote HEAD symref after the remote default changes", async () => {
+      await withTempRepoWithRemote(async (path, remotePath) => {
+        const remoteGit = simpleGit(remotePath);
+        await remoteGit.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+        await client.fetch(new Path(path), "origin");
+        expect(await client.getDefaultBranch(new Path(path), "origin")).toBe("main");
+
+        // Simulate a default-branch rename on the server
+        await remoteGit.branch(["develop", "main"]);
+        await remoteGit.raw(["symbolic-ref", "HEAD", "refs/heads/develop"]);
+        await client.fetch(new Path(path), "origin");
+
+        expect(await client.getDefaultBranch(new Path(path), "origin")).toBe("develop");
+      });
+    }, 15000);
+
+    it("does not throw when the remote HEAD cannot be determined", async () => {
+      await withTempRepoWithRemote(async (path, remotePath) => {
+        // Dangling HEAD on the server: set-head --auto fails, fetch must still succeed
+        await simpleGit(remotePath).raw(["symbolic-ref", "HEAD", "refs/heads/nonexistent"]);
+
+        await expect(client.fetch(new Path(path), "origin")).resolves.not.toThrow();
+        expect(await client.getDefaultBranch(new Path(path), "origin")).toBeNull();
+      });
+    }, 15000);
+  });
+
+  describe("getDefaultBranch", () => {
+    it("returns the current branch via the repo HEAD symref", async () => {
+      expect(await client.getDefaultBranch(repoPath)).toBe("main");
+    });
+
+    it("returns null for detached HEAD", async () => {
+      const git = simpleGit(repoPath.toNative());
+      const log = await git.log();
+      await git.checkout(log.latest!.hash);
+
+      expect(await client.getDefaultBranch(repoPath)).toBeNull();
+    });
+
+    it("returns null for a non-git directory", async () => {
+      const tempDir = await createTempDir();
+      try {
+        expect(await client.getDefaultBranch(new Path(tempDir.path))).toBeNull();
+      } finally {
+        await tempDir.cleanup();
+      }
+    });
+
+    it("reads the HEAD symref of a bare clone even when it dangles", async () => {
+      const sourceRepo = await createTestGitRepo();
+      const targetDir = await createTempDir();
+      const targetPath = new Path(targetDir.path, "cloned.git");
+
+      try {
+        await client.clone(sourceRepo.path, targetPath);
+
+        // clone() deletes local branches, leaving HEAD dangling — but it still
+        // names the default branch, and getCurrentBranch() can't read it
+        expect(await client.getCurrentBranch(targetPath)).toBeNull();
+        expect(await client.getDefaultBranch(targetPath)).toBe("main");
+      } finally {
+        await sourceRepo.cleanup();
+        await targetDir.cleanup();
+      }
+    }, 15000);
   });
 
   describe("listRemotes", () => {
@@ -580,6 +659,21 @@ describe("SimpleGitClient", () => {
         await targetDir.cleanup();
       }
     });
+
+    it("records the remote default branch as refs/remotes/origin/HEAD", async () => {
+      const sourceRepo = await createTestGitRepo();
+      const targetDir = await createTempDir();
+      const targetPath = new Path(targetDir.path, "cloned.git");
+
+      try {
+        await client.clone(sourceRepo.path, targetPath);
+
+        expect(await client.getDefaultBranch(targetPath, "origin")).toBe("main");
+      } finally {
+        await sourceRepo.cleanup();
+        await targetDir.cleanup();
+      }
+    }, 15000);
 
     it("sets up remote-tracking branches and removes local branches", async () => {
       // Create a source repo with multiple branches

--- a/src/boundaries/platform/simple-git-client.ts
+++ b/src/boundaries/platform/simple-git-client.ts
@@ -328,7 +328,43 @@ export class SimpleGitClient implements IGitClient {
       },
       `Failed to fetch${remote ? ` from ${remote}` : ""}`
     );
+    if (remote) {
+      await this.updateRemoteHead(repoPath, remote);
+    }
     this.logger.debug("Fetch", { path: repoPath.toString(), remote: remote ?? "all" });
+  }
+
+  /**
+   * Create/update the refs/remotes/<remote>/HEAD symref from the remote's actual HEAD.
+   * Backports git >= 2.47 followRemoteHEAD behavior; failures are tolerated because the
+   * symref is an optimization for default-branch detection, never a correctness requirement.
+   */
+  private async updateRemoteHead(repoPath: Path, remote: string): Promise<void> {
+    try {
+      const git = this.getGit(repoPath);
+      await git.raw(["remote", "set-head", remote, "--auto"]);
+    } catch (error: unknown) {
+      this.logger.warn("Failed to update remote HEAD", {
+        path: repoPath.toString(),
+        remote,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  async getDefaultBranch(repoPath: Path, remote?: string): Promise<string | null> {
+    try {
+      const git = this.getGit(repoPath);
+      const ref = remote ? `refs/remotes/${remote}/HEAD` : "HEAD";
+      // symbolic-ref (unlike rev-parse) resolves dangling symrefs, which is the normal
+      // HEAD state of bare clones after their local branches are deleted
+      const target = (await git.raw(["symbolic-ref", ref])).trim();
+      const prefix = remote ? `refs/remotes/${remote}/` : "refs/heads/";
+      return target.startsWith(prefix) ? target.substring(prefix.length) : null;
+    } catch {
+      // Missing symref, detached HEAD, or not a repository — no answer
+      return null;
+    }
   }
 
   async listRemotes(repoPath: Path): Promise<readonly string[]> {
@@ -462,6 +498,10 @@ export class SimpleGitClient implements IGitClient {
       const bareGit = this.getGit(targetPath);
       await bareGit.addConfig("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*");
       await bareGit.fetch(["origin"]);
+
+      // Record the remote's default branch as refs/remotes/origin/HEAD
+      // (bare clones don't get this symref; defaultBase() reads it)
+      await this.updateRemoteHead(targetPath, "origin");
 
       // Delete local branches - only keep remote-tracking branches
       // This prevents confusion: branches show under "Remote Branches" header in UI

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -715,7 +715,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         };
 
         await expect(dispatchCreateWorkspace(dispatcher, createIntent)).rejects.toThrow(
-          "No base branch specified and no default branch found"
+          "No base branch specified and no default branch could be detected"
         );
       });
 

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -311,7 +311,7 @@ export function createGitWorktreeWorkspaceModule(
             const base = payload.base ?? (await gitWorktreeProvider.defaultBase(projectPathObj));
             if (!base) {
               throw new WorkspaceError(
-                "No base branch specified and no default branch found (looked for origin/main, main, origin/master, master)"
+                "No base branch specified and no default branch could be detected"
               );
             }
 


### PR DESCRIPTION
- Detect the default base branch for new workspaces from the `refs/remotes/<remote>/HEAD` symref instead of guessing from a hardcoded origin/main → main → origin/master → master list; repos defaulting to develop/trunk/etc. now get a correct dialog preselection
- Maintain the symref in `clone()` and `fetch()` via `git remote set-head --auto` (backports git ≥ 2.47 followRemoteHEAD), so existing clones heal on their first bases refresh and remote default-branch renames self-correct on the next refresh
- Fall back to the repo's own HEAD symref (clone-time default in bare clones, checked-out branch in local repos), then the legacy hardcoded list; every candidate must exist in the base list so the dialog never preselects an unselectable branch
- Add `IGitClient.getDefaultBranch(repo, remote?)` backed by `git symbolic-ref`, which unlike `getCurrentBranch()` also reads the dangling HEAD of bare clones
- Extend the behavioral git mock (`remoteHeads`, `headBranch`, `serverDefaultBranch`) plus integration and boundary test coverage, including the rename-healing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)