### PR TITLE
fix: UI crashes dont freeze the app but kill it

### DIFF
--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -62,6 +62,12 @@ export interface IViewManager {
   create(): void;
 
   /**
+   * Returns the handle of the UI layer view, for subscribing to view-level
+   * events (e.g. the renderer crash guard). Only valid after `create()`.
+   */
+  getUIViewHandle(): ViewHandle;
+
+  /**
    * Returns a narrow capability for toggling devtools on the UI view.
    */
   getUIDevtoolsTarget(): DevtoolsTarget;

--- a/src/boundaries/shell/view-manager.test-utils.ts
+++ b/src/boundaries/shell/view-manager.test-utils.ts
@@ -28,6 +28,7 @@ export function createMockViewManager(options?: CreateMockViewManagerOptions): I
 
   const base: IViewManager = {
     create: vi.fn(),
+    getUIViewHandle: vi.fn().mockReturnValue({ id: "ui-view", __brand: "ViewHandle" }),
     getUIDevtoolsTarget: vi.fn(),
     getActiveWorkspaceDevtoolsTarget: vi.fn(),
     getUIKeyboardTarget: vi.fn(),

--- a/src/boundaries/shell/view-manager.ts
+++ b/src/boundaries/shell/view-manager.ts
@@ -97,6 +97,9 @@ export class ViewManager implements IViewManager {
   // IViewManager — full delegation
   // ---------------------------------------------------------------------------
 
+  getUIViewHandle(): ViewHandle {
+    return this.vm.getUIViewHandle();
+  }
   getUIDevtoolsTarget(): DevtoolsTarget {
     return this.vm.getUIDevtoolsTarget();
   }

--- a/src/boundaries/shell/view.state-mock.ts
+++ b/src/boundaries/shell/view.state-mock.ts
@@ -26,6 +26,7 @@ import type {
   KeyboardInput,
   FailLoadDetails,
   RenderProcessGoneDetails,
+  UncaughtExceptionDetails,
 } from "./view";
 import type { ViewHandle, Rectangle, WindowHandle } from "./types";
 import { ShellError } from "../../shared/errors/shell-errors";
@@ -139,6 +140,22 @@ export interface ViewBoundaryMockState extends MockState {
    */
   triggerDestroyed(handle: ViewHandle): void;
 
+  /**
+   * Simulates an uncaught exception in the view's page (CDP
+   * Runtime.exceptionThrown). Invokes all registered handlers.
+   *
+   * @example
+   * mock.onUncaughtException(handle, (details) => console.log(details.message));
+   * mock.$.triggerUncaughtException(handle, { message: "Error: boom", stack: "", isPromiseRejection: false });
+   */
+  triggerUncaughtException(handle: ViewHandle, details: UncaughtExceptionDetails): void;
+
+  /**
+   * Simulates Electron's 'render-process-gone' event.
+   * Invokes all registered handlers for the specified view.
+   */
+  triggerRenderProcessGone(handle: ViewHandle, details: RenderProcessGoneDetails): void;
+
   snapshot(): Snapshot;
   toString(): string;
 }
@@ -181,6 +198,14 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
     Set<(input: KeyboardInput, preventDefault: () => void) => void>
   >;
   private readonly _destroyedCallbacks: Map<string, Set<() => void>>;
+  private readonly _uncaughtExceptionCallbacks: Map<
+    string,
+    Set<(details: UncaughtExceptionDetails) => void>
+  >;
+  private readonly _renderProcessGoneCallbacks: Map<
+    string,
+    Set<(details: RenderProcessGoneDetails) => void>
+  >;
   private readonly _devToolsOpen: Set<string>;
 
   constructor() {
@@ -192,6 +217,8 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
     this._willNavigateCallbacks = new Map();
     this._beforeInputEventCallbacks = new Map();
     this._destroyedCallbacks = new Map();
+    this._uncaughtExceptionCallbacks = new Map();
+    this._renderProcessGoneCallbacks = new Map();
     this._devToolsOpen = new Set();
   }
 
@@ -229,6 +256,14 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
 
   get destroyedCallbacks(): Map<string, Set<() => void>> {
     return this._destroyedCallbacks;
+  }
+
+  get uncaughtExceptionCallbacks(): Map<string, Set<(details: UncaughtExceptionDetails) => void>> {
+    return this._uncaughtExceptionCallbacks;
+  }
+
+  get renderProcessGoneCallbacks(): Map<string, Set<(details: RenderProcessGoneDetails) => void>> {
+    return this._renderProcessGoneCallbacks;
   }
 
   get devToolsOpen(): Set<string> {
@@ -299,6 +334,24 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
     // Clean up callbacks for the destroyed view
     this._beforeInputEventCallbacks.delete(handle.id);
     this._destroyedCallbacks.delete(handle.id);
+  }
+
+  triggerUncaughtException(handle: ViewHandle, details: UncaughtExceptionDetails): void {
+    const callbacks = this._uncaughtExceptionCallbacks.get(handle.id);
+    if (callbacks) {
+      for (const callback of callbacks) {
+        callback(details);
+      }
+    }
+  }
+
+  triggerRenderProcessGone(handle: ViewHandle, details: RenderProcessGoneDetails): void {
+    const callbacks = this._renderProcessGoneCallbacks.get(handle.id);
+    if (callbacks) {
+      for (const callback of callbacks) {
+        callback(details);
+      }
+    }
   }
 
   snapshot(): Snapshot {
@@ -431,6 +484,8 @@ export function createViewBoundaryMock(): MockViewBoundary {
       state.willNavigateCallbacks.set(id, new Set());
       state.beforeInputEventCallbacks.set(id, new Set());
       state.destroyedCallbacks.set(id, new Set());
+      state.uncaughtExceptionCallbacks.set(id, new Set());
+      state.renderProcessGoneCallbacks.set(id, new Set());
       return { id, __brand: "ViewHandle" };
     },
 
@@ -456,6 +511,8 @@ export function createViewBoundaryMock(): MockViewBoundary {
       state.willNavigateCallbacks.delete(handle.id);
       state.beforeInputEventCallbacks.delete(handle.id);
       state.destroyedCallbacks.delete(handle.id);
+      state.uncaughtExceptionCallbacks.delete(handle.id);
+      state.renderProcessGoneCallbacks.delete(handle.id);
     },
 
     destroyAll(): void {
@@ -466,6 +523,8 @@ export function createViewBoundaryMock(): MockViewBoundary {
       state.willNavigateCallbacks.clear();
       state.beforeInputEventCallbacks.clear();
       state.destroyedCallbacks.clear();
+      state.uncaughtExceptionCallbacks.clear();
+      state.renderProcessGoneCallbacks.clear();
       state.windowChildren.clear();
     },
 
@@ -643,13 +702,28 @@ export function createViewBoundaryMock(): MockViewBoundary {
       };
     },
 
-    onRenderProcessGone(
+    onUncaughtException(
       handle: ViewHandle,
-      _callback: (details: RenderProcessGoneDetails) => void
+      callback: (details: UncaughtExceptionDetails) => void
     ): Unsubscribe {
       getView(handle); // Validate handle exists
-      // Mock has no built-in crash simulation; tests can extend if needed.
-      return () => {};
+      const callbacks = state.uncaughtExceptionCallbacks.get(handle.id);
+      callbacks?.add(callback);
+      return () => {
+        callbacks?.delete(callback);
+      };
+    },
+
+    onRenderProcessGone(
+      handle: ViewHandle,
+      callback: (details: RenderProcessGoneDetails) => void
+    ): Unsubscribe {
+      getView(handle); // Validate handle exists
+      const callbacks = state.renderProcessGoneCallbacks.get(handle.id);
+      callbacks?.add(callback);
+      return () => {
+        callbacks?.delete(callback);
+      };
     },
 
     onUnresponsive(handle: ViewHandle, _callback: () => void): Unsubscribe {
@@ -689,6 +763,8 @@ export function createViewBoundaryMock(): MockViewBoundary {
       state.willNavigateCallbacks.clear();
       state.beforeInputEventCallbacks.clear();
       state.destroyedCallbacks.clear();
+      state.uncaughtExceptionCallbacks.clear();
+      state.renderProcessGoneCallbacks.clear();
       state.windowChildren.clear();
     },
   };

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -83,6 +83,18 @@ export interface RenderProcessGoneDetails {
 }
 
 /**
+ * Details about an uncaught JavaScript exception in a view's page.
+ */
+export interface UncaughtExceptionDetails {
+  /** Human-readable message (e.g. "Error: boom"). */
+  readonly message: string;
+  /** Stack trace in V8 `error.stack` format; empty string when unavailable. */
+  readonly stack: string;
+  /** True when the exception came from an unhandled promise rejection. */
+  readonly isPromiseRejection: boolean;
+}
+
+/**
  * Keyboard input descriptor (no Electron types).
  */
 export interface KeyboardInput {
@@ -343,6 +355,28 @@ export interface ViewBoundary {
   ): Unsubscribe;
 
   /**
+   * Subscribe to uncaught JavaScript exceptions (and unhandled promise
+   * rejections) thrown inside the view's page.
+   *
+   * Implemented via the Chrome DevTools Protocol (webContents.debugger +
+   * Runtime.exceptionThrown), so it needs no code inside the page and fires
+   * even for errors thrown before the page's own handlers could register.
+   *
+   * Known limitation: opening DevTools for the view takes over the CDP
+   * session and detaches the debugger — exceptions thrown while DevTools is
+   * open are not delivered. The subscription re-attaches when DevTools closes.
+   *
+   * @param handle - Handle to the view
+   * @param callback - Called with exception details
+   * @returns Unsubscribe function
+   * @throws ShellError with code VIEW_NOT_FOUND if handle is invalid
+   */
+  onUncaughtException(
+    handle: ViewHandle,
+    callback: (details: UncaughtExceptionDetails) => void
+  ): Unsubscribe;
+
+  /**
    * Subscribe to renderer unresponsive events (event loop hang).
    *
    * @param handle - Handle to the view
@@ -434,11 +468,61 @@ interface ViewState {
   label: string;
 }
 
+/** Minimal slice of CDP's Runtime.exceptionThrown payload. */
+interface CdpExceptionDetails {
+  readonly text?: string;
+  readonly exception?: { readonly description?: string; readonly value?: unknown };
+  readonly stackTrace?: {
+    readonly callFrames?: readonly {
+      readonly functionName: string;
+      readonly url: string;
+      readonly lineNumber: number;
+      readonly columnNumber: number;
+    }[];
+  };
+}
+
+/**
+ * Map a CDP exceptionDetails payload to UncaughtExceptionDetails.
+ *
+ * For thrown Error objects, `exception.description` is already in V8
+ * `error.stack` format (message line + frames). For non-Error throws the
+ * frames are synthesized from `stackTrace`.
+ */
+function toUncaughtExceptionDetails(
+  cdp: CdpExceptionDetails | undefined
+): UncaughtExceptionDetails {
+  const text = cdp?.text ?? "Uncaught";
+  const isPromiseRejection = text.includes("(in promise)");
+  const description = cdp?.exception?.description ?? "";
+  const firstLine = description.split("\n", 1)[0] ?? "";
+  const thrownValue = cdp?.exception?.value;
+  const message =
+    firstLine !== ""
+      ? firstLine
+      : thrownValue !== undefined
+        ? `${text} ${String(thrownValue)}`
+        : text;
+  const stack = description.includes("\n")
+    ? description
+    : (cdp?.stackTrace?.callFrames ?? [])
+        .map(
+          (f) =>
+            `    at ${f.functionName || "<anonymous>"} (${f.url}:${f.lineNumber + 1}:${f.columnNumber + 1})`
+        )
+        .join("\n");
+  return { message, stack, isPromiseRejection };
+}
+
 /**
  * Default implementation of ViewBoundary using Electron's WebContentsView.
  */
 export class DefaultViewBoundary implements ViewBoundary {
   private readonly views = new Map<string, ViewState>();
+  private readonly exceptionCallbacks = new Map<
+    string,
+    Set<(details: UncaughtExceptionDetails) => void>
+  >();
   private nextId = 1;
 
   constructor(
@@ -511,6 +595,7 @@ export class DefaultViewBoundary implements ViewBoundary {
     }
 
     this.views.delete(handle.id);
+    this.exceptionCallbacks.delete(handle.id);
 
     const wc = state.view.webContents;
     if (wc && !wc.isDestroyed()) {
@@ -834,6 +919,60 @@ export class DefaultViewBoundary implements ViewBoundary {
         wc.off("render-process-gone", handler);
       }
     };
+  }
+
+  onUncaughtException(
+    handle: ViewHandle,
+    callback: (details: UncaughtExceptionDetails) => void
+  ): Unsubscribe {
+    const state = this.getView(handle);
+    let callbacks = this.exceptionCallbacks.get(handle.id);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.exceptionCallbacks.set(handle.id, callbacks);
+      this.wireExceptionDebugger(handle.id, state);
+    }
+    callbacks.add(callback);
+    return () => {
+      callbacks.delete(callback);
+    };
+  }
+
+  /**
+   * Attach the CDP debugger once per view and fan Runtime.exceptionThrown
+   * events out to the registered callbacks.
+   */
+  private wireExceptionDebugger(id: string, state: ViewState): void {
+    const wc = state.view.webContents;
+
+    const attach = (): void => {
+      if (wc.isDestroyed() || wc.debugger.isAttached()) return;
+      try {
+        wc.debugger.attach("1.3");
+        void wc.debugger.sendCommand("Runtime.enable");
+      } catch (error) {
+        this.logger.warn("Failed to attach exception debugger", {
+          id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    wc.debugger.on("message", (_event, method, params) => {
+      if (method !== "Runtime.exceptionThrown") return;
+      const cdp = (params as { exceptionDetails?: CdpExceptionDetails }).exceptionDetails;
+      const details = toUncaughtExceptionDetails(cdp);
+      for (const callback of this.exceptionCallbacks.get(id) ?? []) {
+        callback(details);
+      }
+    });
+
+    // Opening DevTools for this view takes over the CDP session and detaches
+    // the debugger (exceptions thrown while DevTools is open are lost) —
+    // re-attach once DevTools closes.
+    wc.on("devtools-closed", attach);
+
+    attach();
   }
 
   onUnresponsive(handle: ViewHandle, callback: () => void): Unsubscribe {

--- a/src/main.ts
+++ b/src/main.ts
@@ -710,6 +710,9 @@ const errorReportModule = createErrorReportModule({
   configService,
   stateService,
   telemetryEnabled: telemetryEnabledConfig,
+  dialogBoundary: dialogLayer,
+  viewLayer,
+  viewManager,
   logger: loggingService.createLogger("error-report"),
 });
 

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -27,6 +27,12 @@ import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 import { createMockPostHogBoundary } from "../boundaries/platform/posthog.state-mock";
 import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
 import { createMockState } from "../boundaries/platform/state.test-utils";
+import { createViewBoundaryMock } from "../boundaries/shell/view.state-mock";
+import { createBehavioralDialogBoundary } from "../boundaries/shell/dialog.test-utils";
+import { createMockViewManager } from "../boundaries/shell/view-manager.test-utils";
+import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
+import type { DialogMessageBoxOptions } from "../boundaries/shell/dialog";
+import type { HookContext } from "../intents/lib/operation";
 import type { DialogHandle } from "./dialog-manager";
 import type { DialogUserEvent, DialogConfig } from "../shared/dialog-types";
 
@@ -75,6 +81,9 @@ function setup(overrides?: SetupOverrides) {
   const boundary = createMockPostHogBoundary();
   const logger = createMockLogger();
   const exits: number[] = [];
+  const viewLayer = createViewBoundaryMock();
+  const uiViewHandle = viewLayer.createView({ label: "ui" });
+  const dialogBoundary = createBehavioralDialogBoundary();
 
   const deps: ErrorReportModuleDeps = {
     dialogManager: {
@@ -100,12 +109,15 @@ function setup(overrides?: SetupOverrides) {
       "telemetry.enabled",
       overrides?.telemetryEnabled ?? true
     ),
+    dialogBoundary,
+    viewLayer,
+    viewManager: createMockViewManager({ overrides: { getUIViewHandle: () => uiViewHandle } }),
     logger,
     exit: (code: number) => exits.push(code),
   };
 
   const module = createErrorReportModule(deps);
-  return { module, deps, handle, boundary, logger, exits };
+  return { module, deps, handle, boundary, logger, exits, viewLayer, uiViewHandle, dialogBoundary };
 }
 
 async function emitKey(module: ReturnType<typeof setup>["module"], key: string): Promise<void> {
@@ -359,5 +371,129 @@ describe("ErrorReportModule — crash handlers", () => {
     await Promise.resolve();
 
     expect(boundary.$.capturedEvents).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// UI renderer crash guard
+// =============================================================================
+
+/** Run the app-start/init hook that subscribes the guard on the UI view. */
+async function subscribeUiCrashGuard(module: ReturnType<typeof setup>["module"]): Promise<void> {
+  const ctx: HookContext = {
+    intent: { type: INTENT_APP_START, payload: {} } as AppStartIntent,
+    capabilities: { "ui-ready": true },
+  };
+  await module.hooks![APP_START_OPERATION_ID]!["init"]!.handler(ctx);
+}
+
+const UI_EXCEPTION = {
+  message: "Error: effect_update_depth_exceeded",
+  stack: "Error: effect_update_depth_exceeded\n    at flush (file:///ui/main.js:1:1)",
+  isPromiseRejection: false,
+};
+
+describe("ErrorReportModule — UI renderer crash guard", () => {
+  it("requires the ui-ready capability before subscribing", () => {
+    const { module } = setup();
+    expect(module.hooks![APP_START_OPERATION_ID]!["init"]!.requires).toHaveProperty("ui-ready");
+  });
+
+  it("uncaught exception: logs, reports with crash_source + logs/config, shows the quit dialog", async () => {
+    const s = setup({ telemetryEnabled: true, configOverrides: { "log.level": "debug" } });
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+
+    expect(s.logger.error).toHaveBeenCalledWith(
+      "UI renderer crashed",
+      { source: "ui-renderer-exception" },
+      expect.any(Error)
+    );
+    await vi.waitFor(() => {
+      const captured = s.boundary.$.capturedEvents.find((e) => e.event === "$exception");
+      expect(captured).toBeDefined();
+      expect(captured!.properties["crash_source"]).toBe("ui-renderer-exception");
+      expect(captured!.properties["logs_format"]).toBe("gzip+base64");
+      expect(captured!.properties["config"]).toEqual({ "log.level": "debug" });
+    });
+
+    const state = s.dialogBoundary._getState();
+    expect(state.messageBoxCount).toBe(1);
+    const options = state.calls[0]!.options as DialogMessageBoxOptions;
+    expect(options.type).toBe("error");
+    expect(options.buttons).toEqual(["Quit CodeHydra"]);
+    expect(options.detail).toContain("effect_update_depth_exceeded");
+  });
+
+  it("dispatches app:shutdown once the quit dialog is dismissed", async () => {
+    const s = setup();
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+
+    await vi.waitFor(() => {
+      expect(s.deps.dispatcher.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: INTENT_APP_SHUTDOWN })
+      );
+    });
+  });
+
+  it("still shows the dialog but does NOT report when telemetry is off", async () => {
+    const s = setup({ telemetryEnabled: false });
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
+    await Promise.resolve();
+    expect(s.boundary.$.capturedEvents).toHaveLength(0);
+  });
+
+  it("unhandled rejection: reports without a dialog", async () => {
+    const s = setup({ telemetryEnabled: true });
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, {
+      message: "Error: lost in space",
+      stack: "",
+      isPromiseRejection: true,
+    });
+
+    await vi.waitFor(() => {
+      const captured = s.boundary.$.capturedEvents.find((e) => e.event === "$exception");
+      expect(captured).toBeDefined();
+      expect(captured!.properties["crash_source"]).toBe("ui-renderer-rejection");
+    });
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(0);
+    expect(s.deps.dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("render-process-gone: shows the quit dialog and reports", async () => {
+    const s = setup({ telemetryEnabled: true });
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "oom", exitCode: 137 });
+
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
+    await vi.waitFor(() => {
+      const captured = s.boundary.$.capturedEvents.find((e) => e.event === "$exception");
+      expect(captured).toBeDefined();
+      expect(captured!.properties["crash_source"]).toBe("ui-renderer-process-gone");
+      expect(captured!.properties["$exception_list"]).toEqual([
+        { type: "UIRendererProcessGone", value: "UI renderer process gone: oom (exit code 137)" },
+      ]);
+    });
+  });
+
+  it("does not stack dialogs on repeated crash signals", async () => {
+    const s = setup();
+    await subscribeUiCrashGuard(s.module);
+
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+    s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "crashed", exitCode: 1 });
+
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
   });
 });

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -13,6 +13,15 @@
  *     uncaughtException  → log; report + flush (if telemetry on, with timeout);
  *       ALWAYS exit(1). Logging + exit are unconditional (crash behavior is
  *       preserved with telemetry off); only the telemetry report is gated.
+ * - app:start / init (after "ui-ready"): subscribe the UI renderer crash guard
+ *     on the UI view. An uncaught exception in the UI renderer (e.g. a Svelte
+ *     effect loop killing the effect runtime) bricks the UI silently, so:
+ *     uncaught exception / render-process-gone → log; report (if telemetry on);
+ *       show a quit-only native dialog (the UI itself can't be trusted to
+ *       render anything), then dispatch app:shutdown.
+ *     unhandled rejection → log; report (if telemetry on); no dialog —
+ *       rejections rarely brick the UI and may even be handled later.
+ *     unresponsive → log only.
  *
  * Events:
  * - shortcut:key-pressed "b": open the bug report dialog.
@@ -35,7 +44,12 @@ import type { PostHogBoundary } from "../boundaries/platform/posthog";
 import type { Config } from "../boundaries/platform/config";
 import type { StateService } from "../boundaries/platform/state-service";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
+import type { DialogBoundary } from "../boundaries/shell/dialog";
+import type { ViewBoundary, UncaughtExceptionDetails } from "../boundaries/shell/view";
+import type { IViewManager } from "../boundaries/shell/view-manager.interface";
+import { ANY_VALUE } from "../intents/lib/operation";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
+import { INTENT_APP_SHUTDOWN, type AppShutdownIntent } from "../intents/app-shutdown";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 import { INTENT_SUBMIT_BUG_REPORT, type SubmitBugReportIntent } from "../intents/submit-bug-report";
 import {
@@ -126,6 +140,15 @@ export interface ErrorReportModuleDeps {
   readonly stateService: Pick<StateService, "getRedactedOverrides">;
   /** Accessor for telemetry.enabled (registered in the composition root). */
   readonly telemetryEnabled: PersistedAccessor<boolean>;
+  /** Native message box for the UI crash dialog (the UI itself may be dead). */
+  readonly dialogBoundary: Pick<DialogBoundary, "showMessageBox">;
+  /** View events the UI renderer crash guard subscribes to. */
+  readonly viewLayer: Pick<
+    ViewBoundary,
+    "onUncaughtException" | "onRenderProcessGone" | "onUnresponsive"
+  >;
+  /** Source of the UI view handle (valid once "ui-ready" is provided). */
+  readonly viewManager: Pick<IViewManager, "getUIViewHandle">;
   readonly logger: Logger;
   /** Terminate the process. Injected for tests; defaults to process.exit. */
   readonly exit?: (code: number) => void;
@@ -180,11 +203,17 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
    * Compress logs, attach redacted config + state, and send the exception
    * through the boundary. The boundary stamps version/platform/arch/agent.
    */
-  function captureIncident(error: Error, logs: string, electronLogs: string): void {
+  function captureIncident(
+    error: Error,
+    logs: string,
+    electronLogs: string,
+    extraProps?: Record<string, unknown>
+  ): void {
     const appLogs = compressAndTrim(logs);
     const electronLogsBlob = compressAndTrim(electronLogs);
 
     deps.boundary.captureException(error, {
+      ...extraProps,
       logs: appLogs.compressed,
       logs_format: appLogs.compressed ? "gzip+base64" : "none",
       logs_raw_bytes: appLogs.rawBytesKept,
@@ -199,9 +228,9 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
   }
 
   /** Read both log streams, then capture the crash. */
-  async function captureCrash(error: Error): Promise<void> {
+  async function captureCrash(error: Error, extraProps?: Record<string, unknown>): Promise<void> {
     const [logs, electronLogs] = await Promise.all([readLogContent(), readElectronLogContent()]);
-    captureIncident(error, logs, electronLogs);
+    captureIncident(error, logs, electronLogs, extraProps);
   }
 
   /** Flush (and close) the boundary, but never block the exit beyond the cap. */
@@ -262,6 +291,83 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
   }
 
   // ---------------------------------------------------------------------------
+  // UI renderer crash guard
+  // ---------------------------------------------------------------------------
+
+  /** True once the (single) UI crash dialog has been shown. */
+  let uiCrashDialogShown = false;
+
+  function reportUiError(error: Error, source: string): void {
+    if (deps.telemetryEnabled.get()) {
+      void captureCrash(error, { crash_source: source }).catch(() => {});
+    }
+  }
+
+  /**
+   * Log + report, then show the quit-only native dialog. The UI renderer
+   * can't be trusted to render anything at this point, and a reloaded UI
+   * can't re-bootstrap mid-session — so the only recovery is a restart.
+   * Further signals while the dialog is up are logged/reported, not stacked.
+   */
+  function handleUiCrash(error: Error, source: string): void {
+    deps.logger.error("UI renderer crashed", { source }, error);
+    reportUiError(error, source);
+
+    if (uiCrashDialogShown) return;
+    uiCrashDialogShown = true;
+    void deps.dialogBoundary
+      .showMessageBox({
+        type: "error",
+        title: "CodeHydra",
+        message: "The CodeHydra UI hit an unexpected error and cannot recover.",
+        detail: `${error.message}\n\nCodeHydra needs to quit. Please start it again.`,
+        buttons: ["Quit CodeHydra"],
+        defaultId: 0,
+      })
+      .then(() =>
+        deps.dispatcher.dispatch({
+          type: INTENT_APP_SHUTDOWN,
+          payload: {},
+        } as AppShutdownIntent)
+      )
+      .catch(() => {
+        // Dialog failure must not mask the crash; log + report already happened.
+      });
+  }
+
+  function toUiError(details: UncaughtExceptionDetails): Error {
+    const error = new Error(details.message);
+    error.name = details.isPromiseRejection ? "UIRendererRejection" : "UIRendererError";
+    error.stack = details.stack;
+    return error;
+  }
+
+  function subscribeUiCrashGuard(): void {
+    const uiViewHandle = deps.viewManager.getUIViewHandle();
+
+    deps.viewLayer.onUncaughtException(uiViewHandle, (details) => {
+      const error = toUiError(details);
+      if (details.isPromiseRejection) {
+        deps.logger.error("Unhandled promise rejection in UI renderer", {}, error);
+        reportUiError(error, "ui-renderer-rejection");
+        return;
+      }
+      handleUiCrash(error, "ui-renderer-exception");
+    });
+
+    deps.viewLayer.onRenderProcessGone(uiViewHandle, ({ reason, exitCode }) => {
+      const error = new Error(`UI renderer process gone: ${reason} (exit code ${exitCode})`);
+      error.name = "UIRendererProcessGone";
+      error.stack = "";
+      handleUiCrash(error, "ui-renderer-process-gone");
+    });
+
+    deps.viewLayer.onUnresponsive(uiViewHandle, () => {
+      deps.logger.warn("UI renderer unresponsive");
+    });
+  }
+
+  // ---------------------------------------------------------------------------
   // Manual bug report dialog
   // ---------------------------------------------------------------------------
 
@@ -306,6 +412,16 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
         "before-ready": {
           handler: async (): Promise<Record<string, never>> => {
             registerErrorHandlers();
+            return {};
+          },
+        },
+        // The UI view exists once the view module's init handler has run
+        // (it provides "ui-ready"); subscribe the crash guard right after,
+        // before show-main-view mounts the Svelte app.
+        init: {
+          requires: { "ui-ready": ANY_VALUE },
+          handler: async (): Promise<Record<string, never>> => {
+            subscribeUiCrashGuard();
             return {};
           },
         },


### PR DESCRIPTION
- Detect uncaught exceptions in the UI renderer from the main process via a new `ViewBoundary.onUncaughtException` capability (`webContents.debugger` + CDP `Runtime.exceptionThrown`) — no renderer code, no new IPC; re-attaches when DevTools closes
- Wire `render-process-gone` and `unresponsive` for the UI view (previously only workspace views were watched)
- Extend `error-report-module` with a UI renderer crash guard: log the crash, report it through the existing `captureCrash` path (logs + redacted config/state, gated by `telemetry.enabled`, tagged with `crash_source`), show a native quit-only dialog, and dispatch `app:shutdown` on dismissal
- Unhandled rejections in the UI renderer are logged + reported without a dialog; repeated crash signals never stack dialogs
- Expose `getUIViewHandle()` on `IViewManager`; add `onUncaughtException`/`triggerUncaughtException` and a working `triggerRenderProcessGone` to the ViewBoundary behavioral mock
- 7 new integration tests covering dialog content, quit dispatch, telemetry gating, rejection path, process-gone, and dialog dedupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)