### PR TITLE
fix: workspace creation view was very sluggish

### DIFF
--- a/src/renderer/lib/components/BranchDropdown.svelte
+++ b/src/renderer/lib/components/BranchDropdown.svelte
@@ -1,62 +1,31 @@
 <script lang="ts">
-  import { projects, on, type BaseInfo } from "$lib/api";
+  import type { BaseInfo } from "@shared/api/types";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
   import Icon from "./Icon.svelte";
 
   interface BranchDropdownProps {
-    projectPath: string;
+    /** Branch list to display. Owned by the parent (one fetch shared across dropdowns). */
+    branches: readonly BaseInfo[];
+    /** Whether the parent is still waiting for fresh branch data. */
+    loading: boolean;
+    /** Fetch error to display, if any. */
+    error: string | null;
     value: string;
     onSelect: (branch: string) => void;
     disabled?: boolean;
+    /** Id for the dropdown input (for label association). */
+    id: string;
   }
 
-  let { projectPath, value, onSelect, disabled = false }: BranchDropdownProps = $props();
-
-  // State
-  let branches = $state<readonly BaseInfo[]>([]);
-  let loading = $state(true);
-  let error = $state<string | null>(null);
-
-  // Load cached branches immediately, then wait for bases-updated event
-  $effect(() => {
-    const currentProjectPath = projectPath;
-    loading = true;
-    error = null;
-
-    // Fetch cached branches immediately for display
-    projects
-      .fetchBases(currentProjectPath)
-      .then((result: { bases: readonly BaseInfo[] }) => {
-        branches = result.bases;
-        // Keep loading=true until bases-updated event arrives
-      })
-      .catch((err: unknown) => {
-        error = err instanceof Error ? err.message : "Failed to load branches";
-        loading = false;
-      });
-
-    // Subscribe to bases-updated event for when fresh data arrives
-    const unsubscribe = on<{ projectPath: string; bases: readonly BaseInfo[] }>(
-      "project:bases-updated",
-      (event) => {
-        if (event.projectPath === currentProjectPath) {
-          branches = event.bases;
-          loading = false;
-          // The fresh list is authoritative: clear a selection it no longer
-          // contains. Validation runs once per arriving list — never on value
-          // changes, which would re-clear a value the parent just re-applied
-          // and feed an infinite clear/re-apply loop.
-          if (value && !event.bases.some((b) => b.name === value)) {
-            onSelect("");
-          }
-        }
-      }
-    );
-
-    return () => {
-      unsubscribe();
-    };
-  });
+  let {
+    branches,
+    loading,
+    error,
+    value,
+    onSelect,
+    disabled = false,
+    id,
+  }: BranchDropdownProps = $props();
 
   /**
    * Transform branches to DropdownOption[] with headers for local/remote groups.
@@ -118,7 +87,7 @@
       {disabled}
       placeholder="Select branch..."
       filterOption={filterBranch}
-      id={`branch-dropdown-${projectPath}`}
+      {id}
     >
       {#snippet optionSnippet(option)}
         {#if option.type === "header"}

--- a/src/renderer/lib/components/BranchDropdown.test.ts
+++ b/src/renderer/lib/components/BranchDropdown.test.ts
@@ -1,11 +1,16 @@
 /**
  * Tests for the BranchDropdown component.
+ *
+ * The component is presentational: the parent owns the branch data (one fetch
+ * shared across dropdowns) and passes branches/loading/error as props.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 import type { BaseInfo } from "@shared/api/types";
+
+import BranchDropdown from "./BranchDropdown.svelte";
 
 // Mock branches data
 const mockLocalBranches: BaseInfo[] = [
@@ -20,67 +25,14 @@ const mockRemoteBranches: BaseInfo[] = [
 
 const allBranches = [...mockLocalBranches, ...mockRemoteBranches];
 
-// Use vi.hoisted to create mocks that can be referenced in vi.mock factory
-const { mockFetchBases, basesUpdatedHandlers } = vi.hoisted(() => ({
-  mockFetchBases: vi.fn(),
-  // Store handlers to trigger bases-updated events in tests
-  basesUpdatedHandlers: new Set<(event: { projectPath: string; bases: BaseInfo[] }) => void>(),
-}));
-
-// Mock $lib/api module
-vi.mock("$lib/api", () => ({
-  openProject: vi.fn().mockResolvedValue(undefined),
-  closeProject: vi.fn().mockResolvedValue(undefined),
-  listProjects: vi.fn().mockResolvedValue({ projects: [], activeWorkspacePath: null }),
-  createWorkspace: vi.fn().mockResolvedValue(undefined),
-  removeWorkspace: vi.fn().mockResolvedValue(undefined),
-  switchWorkspace: vi.fn().mockResolvedValue(undefined),
-  listBases: vi.fn().mockResolvedValue([]),
-  updateBases: vi.fn().mockResolvedValue(undefined),
-  onProjectOpened: vi.fn(() => vi.fn()),
-  onProjectClosed: vi.fn(() => vi.fn()),
-  onWorkspaceCreated: vi.fn(() => vi.fn()),
-  onWorkspaceRemoved: vi.fn(() => vi.fn()),
-  onWorkspaceSwitched: vi.fn(() => vi.fn()),
-  // Flat API structure
-  projects: {
-    fetchBases: mockFetchBases,
-  },
-  // Event subscription mock - directly return the implementation
-  on: (event: string, handler: (event: { projectPath: string; bases: BaseInfo[] }) => void) => {
-    if (event === "project:bases-updated") {
-      basesUpdatedHandlers.add(handler);
-      return () => basesUpdatedHandlers.delete(handler);
-    }
-    return () => {};
-  },
-}));
-
-// Helper to emit bases-updated event in tests
-function emitBasesUpdated(projectPath: string, bases: BaseInfo[]): void {
-  basesUpdatedHandlers.forEach((handler) => handler({ projectPath, bases }));
-}
-
-// Helper to complete loading: run timers then emit bases-updated event
-async function completeLoading(
-  projectPath: string = testProjectPath,
-  bases: BaseInfo[] = allBranches
-): Promise<void> {
-  await vi.runAllTimersAsync();
-  emitBasesUpdated(projectPath, bases);
-  await tick();
-}
-
-// Import component after mock setup
-import BranchDropdown from "./BranchDropdown.svelte";
-import { projects } from "$lib/api";
-
-// Test project path
 const testProjectPath = "/test/project";
 
 describe("BranchDropdown component", () => {
   const defaultProps = {
-    projectPath: testProjectPath,
+    id: `branch-dropdown-${testProjectPath}`,
+    branches: allBranches,
+    loading: false,
+    error: null,
     value: "",
     onSelect: vi.fn(),
   };
@@ -88,9 +40,6 @@ describe("BranchDropdown component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    basesUpdatedHandlers.clear();
-    // Reset the mock implementation for each test (v2 API returns { bases: [...] })
-    mockFetchBases.mockResolvedValue({ bases: allBranches });
   });
 
   afterEach(() => {
@@ -102,8 +51,6 @@ describe("BranchDropdown component", () => {
     it("renders with combobox role and aria attributes", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const combobox = screen.getByRole("combobox");
       expect(combobox).toBeInTheDocument();
       expect(combobox).toHaveAttribute("aria-expanded");
@@ -112,8 +59,6 @@ describe("BranchDropdown component", () => {
 
     it("aria-expanded reflects dropdown open state", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       expect(input).toHaveAttribute("aria-expanded", "false");
@@ -125,8 +70,6 @@ describe("BranchDropdown component", () => {
     it("selected option has aria-selected true", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
       await fireEvent.keyDown(input, { key: "ArrowDown" });
@@ -137,8 +80,6 @@ describe("BranchDropdown component", () => {
 
     it("aria-activedescendant updates on navigation", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -152,62 +93,36 @@ describe("BranchDropdown component", () => {
       // Should have an active descendant now
       const activedescendant = input.getAttribute("aria-activedescendant");
       expect(activedescendant).toBeTruthy();
-      // The ID is now generated by FilterableDropdown with format: branch-dropdown-{projectPath}-option-{value}
+      // The ID is generated by FilterableDropdown with format: {id}-option-{value}
       expect(activedescendant).toContain("option");
     });
   });
 
-  describe("loading", () => {
-    it("loads branches using projects.fetchBases(projectPath) on mount", async () => {
-      render(BranchDropdown, { props: defaultProps });
+  describe("loading and error props", () => {
+    it("shows spinner while loading is true", () => {
+      render(BranchDropdown, { props: { ...defaultProps, loading: true } });
 
-      await completeLoading();
-
-      expect(projects.fetchBases).toHaveBeenCalledWith(testProjectPath);
-    });
-
-    it("shows spinner while loading", async () => {
-      render(BranchDropdown, { props: defaultProps });
-
-      // Spinner should be visible immediately
       expect(screen.getByRole("status", { name: /loading branches/i })).toBeInTheDocument();
-      // Input should also be rendered immediately (not hidden during loading)
+      // Input is also rendered (not hidden during loading)
       expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
 
-      // Run timers to let fetchBases resolve (cached data arrives)
-      await vi.runAllTimersAsync();
+    it("hides spinner when loading is false", () => {
+      render(BranchDropdown, { props: defaultProps });
 
-      // Spinner should STILL be visible (waiting for bases-updated event)
-      expect(screen.getByRole("status", { name: /loading branches/i })).toBeInTheDocument();
-
-      // Emit bases-updated event (simulating background refresh completing)
-      emitBasesUpdated(testProjectPath, allBranches);
-      await tick();
-
-      // Spinner should be gone after bases-updated event
       expect(screen.queryByRole("status", { name: /loading branches/i })).not.toBeInTheDocument();
     });
 
-    it("handles fetchBases error gracefully", async () => {
-      mockFetchBases.mockRejectedValue(new Error("Network error"));
+    it("shows error message when error is set", () => {
+      render(BranchDropdown, { props: { ...defaultProps, error: "Network error" } });
 
-      render(BranchDropdown, { props: defaultProps });
-
-      // Run timers to let the error propagate
-      await vi.runAllTimersAsync();
-
-      // Should show error state, not crash (loading stops on error)
-      expect(screen.queryByRole("alert")).toBeInTheDocument();
-      // Spinner should be gone when error occurs
-      expect(screen.queryByRole("status", { name: /loading branches/i })).not.toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent("Network error");
     });
   });
 
   describe("display", () => {
     it("displays Local and Remote branch groups", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -218,8 +133,6 @@ describe("BranchDropdown component", () => {
 
     it('shows "No matches found" when filter has no matches', async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -232,13 +145,30 @@ describe("BranchDropdown component", () => {
 
       expect(screen.getByText(/no matches found/i)).toBeInTheDocument();
     });
+
+    it("updates the list when the branches prop changes", async () => {
+      const { rerender } = render(BranchDropdown, { props: defaultProps });
+
+      const input = screen.getByRole("combobox");
+      await fireEvent.focus(input);
+      expect(screen.getByText("origin/feature")).toBeInTheDocument();
+
+      // Parent received fresh data (e.g. bases-updated pruned a branch)
+      const updatedBases: BaseInfo[] = [
+        { name: "main", isRemote: false },
+        { name: "origin/main", isRemote: true },
+      ];
+      await rerender({ ...defaultProps, branches: updatedBases });
+      await tick();
+
+      expect(screen.queryByText("origin/feature")).not.toBeInTheDocument();
+      expect(screen.getByText("main")).toBeInTheDocument();
+    });
   });
 
   describe("debounce", () => {
     it("typing doesn't filter immediately", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -250,8 +180,6 @@ describe("BranchDropdown component", () => {
 
     it("filter applies after 200ms debounce", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -269,8 +197,6 @@ describe("BranchDropdown component", () => {
 
     it("rapid typing resets debounce timer", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -300,8 +226,6 @@ describe("BranchDropdown component", () => {
     it("navigates local branches then remote branches", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -318,8 +242,6 @@ describe("BranchDropdown component", () => {
 
     it("ArrowDown from last local branch goes to first remote branch (skipping header)", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -341,8 +263,6 @@ describe("BranchDropdown component", () => {
     it("mousedown on option prevents blur and selects branch", async () => {
       const onSelect = vi.fn();
       render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -378,8 +298,6 @@ describe("BranchDropdown component", () => {
       const onSelect = vi.fn();
       render(BranchDropdown, { props: { ...defaultProps, onSelect } });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -392,82 +310,13 @@ describe("BranchDropdown component", () => {
     it("displays selected value in input", async () => {
       render(BranchDropdown, { props: { ...defaultProps, value: "main" } });
 
-      await completeLoading();
-
-      const input = screen.getByRole("combobox") as HTMLInputElement;
-      expect(input.value).toBe("main");
-    });
-  });
-
-  describe("initial value validation", () => {
-    it("displays initial value prop in input when it exists in loaded branches", async () => {
-      render(BranchDropdown, { props: { ...defaultProps, value: "main" } });
-
-      await completeLoading();
-
       const input = screen.getByRole("combobox") as HTMLInputElement;
       expect(input.value).toBe("main");
     });
 
-    it("clears value and calls onSelect empty when initial value not in branch list", async () => {
-      const onSelect = vi.fn();
-      render(BranchDropdown, {
-        props: { ...defaultProps, value: "deleted-branch", onSelect },
-      });
-
-      await completeLoading();
-
-      // Should have called onSelect with empty string to clear invalid value
-      expect(onSelect).toHaveBeenCalledWith("");
-    });
-
-    it("does not re-clear when the parent re-applies a value after the list loaded", async () => {
-      // Regression: clearing on every value change fed an infinite clear/re-apply
-      // loop with the parent's default auto-fill (effect_update_depth_exceeded).
-      // Validation must run once per arriving list, not on value changes.
-      const onSelect = vi.fn();
-      const { rerender } = render(BranchDropdown, {
-        props: { ...defaultProps, value: "deleted-branch", onSelect },
-      });
-
-      await completeLoading();
-      expect(onSelect).toHaveBeenCalledTimes(1);
-
-      // Parent stubbornly re-applies the invalid value (simulates a stale default).
-      await rerender({ ...defaultProps, value: "deleted-branch", onSelect });
-      await tick();
-
-      expect(onSelect).toHaveBeenCalledTimes(1);
-    });
-
-    it("does not clear value when branches are still loading", async () => {
-      const onSelect = vi.fn();
-
-      // Delay the response to keep loading state
-      mockFetchBases.mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ bases: allBranches }), 1000))
-      );
-
-      render(BranchDropdown, {
-        props: { ...defaultProps, value: "nonexistent", onSelect },
-      });
-
-      // Advance only partially - should still be loading
-      await vi.advanceTimersByTimeAsync(500);
-      await tick();
-
-      // Should NOT have called onSelect while still loading
-      expect(onSelect).not.toHaveBeenCalled();
-
-      // Now finish loading
-      await completeLoading();
-    });
-
-    it("user can override initial value by selecting different branch", async () => {
+    it("user can override value by selecting different branch", async () => {
       const onSelect = vi.fn();
       render(BranchDropdown, { props: { ...defaultProps, value: "main", onSelect } });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -489,8 +338,6 @@ describe("BranchDropdown component", () => {
     it("dropdown uses fixed positioning when open", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -506,8 +353,6 @@ describe("BranchDropdown component", () => {
 
     it("dropdown position updates on window resize", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -549,8 +394,6 @@ describe("BranchDropdown component", () => {
     it("transforms branches to DropdownOption array", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -568,8 +411,6 @@ describe("BranchDropdown component", () => {
     it("adds Local Branches header before local branches", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -582,8 +423,6 @@ describe("BranchDropdown component", () => {
     it("adds Remote Branches header before remote branches", async () => {
       render(BranchDropdown, { props: defaultProps });
 
-      await completeLoading();
-
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
@@ -594,8 +433,6 @@ describe("BranchDropdown component", () => {
 
     it("headers are non-interactive (skipped in navigation)", async () => {
       render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -609,11 +446,7 @@ describe("BranchDropdown component", () => {
     });
 
     it("renders only local header when no remote branches", async () => {
-      mockFetchBases.mockResolvedValue({ bases: mockLocalBranches });
-
-      render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading(testProjectPath, mockLocalBranches);
+      render(BranchDropdown, { props: { ...defaultProps, branches: mockLocalBranches } });
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -623,11 +456,7 @@ describe("BranchDropdown component", () => {
     });
 
     it("renders only remote header when no local branches", async () => {
-      mockFetchBases.mockResolvedValue({ bases: mockRemoteBranches });
-
-      render(BranchDropdown, { props: defaultProps });
-
-      await completeLoading(testProjectPath, mockRemoteBranches);
+      render(BranchDropdown, { props: { ...defaultProps, branches: mockRemoteBranches } });
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -636,17 +465,14 @@ describe("BranchDropdown component", () => {
       expect(screen.getByText("Remote Branches")).toBeInTheDocument();
     });
 
-    it("full async load, filter, and select flow works", async () => {
+    it("full filter and select flow works", async () => {
       const onSelect = vi.fn();
       render(BranchDropdown, { props: { ...defaultProps, onSelect } });
-
-      // Wait for async load
-      await completeLoading();
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
 
-      // Verify branches loaded
+      // Verify branches rendered
       expect(screen.getByText("main")).toBeInTheDocument();
       expect(screen.getByText("develop")).toBeInTheDocument();
 
@@ -665,65 +491,6 @@ describe("BranchDropdown component", () => {
       await fireEvent.keyDown(input, { key: "Enter" });
 
       expect(onSelect).toHaveBeenCalledWith("origin/main");
-    });
-  });
-
-  describe("bases-updated event", () => {
-    it("subscribes to project:bases-updated event on mount", async () => {
-      render(BranchDropdown, { props: defaultProps });
-      await vi.runAllTimersAsync();
-
-      // Handler should be registered in basesUpdatedHandlers set
-      expect(basesUpdatedHandlers.size).toBeGreaterThan(0);
-    });
-
-    it("updates branches when project:bases-updated event is received for matching projectPath", async () => {
-      render(BranchDropdown, { props: defaultProps });
-      await completeLoading();
-
-      // Verify initial branches
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-      expect(screen.getByText("main")).toBeInTheDocument();
-      expect(screen.getByText("origin/feature")).toBeInTheDocument();
-
-      // Simulate bases-updated event with pruned branches
-      const updatedBases: BaseInfo[] = [
-        { name: "main", isRemote: false },
-        { name: "origin/main", isRemote: true },
-      ];
-      emitBasesUpdated(testProjectPath, updatedBases);
-      await tick();
-
-      // origin/feature should be gone
-      expect(screen.queryByText("origin/feature")).not.toBeInTheDocument();
-      expect(screen.getByText("main")).toBeInTheDocument();
-    });
-
-    it("ignores project:bases-updated event for different projectPath", async () => {
-      render(BranchDropdown, { props: defaultProps });
-      await completeLoading();
-
-      const input = screen.getByRole("combobox");
-      await fireEvent.focus(input);
-
-      // Simulate event for different project
-      emitBasesUpdated("/different/project", []);
-      await tick();
-
-      // Should still have original branches
-      expect(screen.getByText("main")).toBeInTheDocument();
-    });
-
-    it("unsubscribes from event on cleanup", async () => {
-      const { unmount } = render(BranchDropdown, { props: defaultProps });
-      await vi.runAllTimersAsync();
-
-      const handlersBeforeUnmount = basesUpdatedHandlers.size;
-      unmount();
-
-      // Handler should be removed
-      expect(basesUpdatedHandlers.size).toBeLessThan(handlersBeforeUnmount);
     });
   });
 });

--- a/src/renderer/lib/components/NameBranchDropdown.svelte
+++ b/src/renderer/lib/components/NameBranchDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { projects, on, type BaseInfo } from "$lib/api";
+  import type { BaseInfo } from "@shared/api/types";
   import FilterableDropdown, { type DropdownOption } from "./FilterableDropdown.svelte";
 
   /**
@@ -15,7 +15,10 @@
   }
 
   interface NameBranchDropdownProps {
-    projectPath: string;
+    /** Branch list for suggestions. Owned by the parent (one fetch shared across dropdowns). */
+    branches: readonly BaseInfo[];
+    /** Fetch error to display, if any. */
+    error?: string | null;
     value: string;
     onSelect: (selection: NameBranchSelection) => void;
     disabled?: boolean;
@@ -32,7 +35,8 @@
   }
 
   let {
-    projectPath,
+    branches,
+    error = null,
     value,
     onSelect,
     disabled = false,
@@ -42,38 +46,6 @@
     openOnFocus = false, // Default to false for name field - user types custom names
     autofocus = false,
   }: NameBranchDropdownProps = $props();
-
-  // State
-  let branches = $state<readonly BaseInfo[]>([]);
-  let error = $state<string | null>(null);
-
-  // Load branches on mount or when projectPath changes
-  $effect(() => {
-    const currentProjectPath = projectPath;
-    error = null;
-
-    projects
-      .fetchBases(currentProjectPath)
-      .then((result: { bases: readonly BaseInfo[] }) => {
-        branches = result.bases;
-      })
-      .catch((err: unknown) => {
-        error = err instanceof Error ? err.message : "Failed to load branches";
-      });
-
-    const unsubscribe = on<{ projectPath: string; bases: readonly BaseInfo[] }>(
-      "project:bases-updated",
-      (event) => {
-        if (event.projectPath === currentProjectPath) {
-          branches = event.bases;
-        }
-      }
-    );
-
-    return () => {
-      unsubscribe();
-    };
-  });
 
   /**
    * Filter branches to only those with derives set (can create workspace from them).
@@ -183,7 +155,7 @@
       {disabled}
       placeholder="Enter name or select branch..."
       filterOption={filterBranch}
-      id={id ?? `name-branch-dropdown-${projectPath}`}
+      id={id ?? "name-branch-dropdown"}
       allowFreeText={true}
       {onEnter}
       {onInput}

--- a/src/renderer/lib/components/NameBranchDropdown.test.ts
+++ b/src/renderer/lib/components/NameBranchDropdown.test.ts
@@ -1,5 +1,8 @@
 /**
  * Tests for the NameBranchDropdown component.
+ *
+ * The component is presentational: the parent owns the branch data (one fetch
+ * shared across dropdowns) and passes branches/error as props.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -7,28 +10,11 @@ import { render, screen, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 import type { BaseInfo } from "@shared/api/types";
 
-// Create mock functions with vi.hoisted - required for vitest mocking pattern
-const { mockFetchBases, mockOn } = vi.hoisted(() => ({
-  mockFetchBases: vi.fn(),
-  mockOn: vi.fn().mockReturnValue(() => {}),
-}));
-
-// Mock $lib/api - must be a static mock, not dynamic (no importOriginal)
-vi.mock("$lib/api", () => ({
-  projects: {
-    fetchBases: mockFetchBases,
-  },
-  on: mockOn,
-}));
-
-// Import component after mocks
 import NameBranchDropdown, { type NameBranchSelection } from "./NameBranchDropdown.svelte";
 
 describe("NameBranchDropdown component", () => {
-  const testProjectPath = "/test/project";
-
   const defaultProps = {
-    projectPath: testProjectPath,
+    branches: [] as readonly BaseInfo[],
     value: "",
     onSelect: vi.fn(),
   };
@@ -44,24 +30,21 @@ describe("NameBranchDropdown component", () => {
   });
 
   /**
-   * Helper to set up mock branches and render component
+   * Helper to render the component with the given branches.
    */
-  async function renderWithBranches(
+  function renderWithBranches(
     branches: BaseInfo[],
     props: Partial<
       typeof defaultProps & {
         id?: string;
+        error?: string | null;
         onEnter?: () => void;
         openOnFocus?: boolean;
         autofocus?: boolean;
       }
     > = {}
-  ): Promise<void> {
-    mockFetchBases.mockResolvedValue({ bases: branches });
-    render(NameBranchDropdown, { props: { ...defaultProps, ...props } });
-    // Wait for promise to resolve
-    await vi.advanceTimersByTimeAsync(0);
-    await tick();
+  ): ReturnType<typeof render> {
+    return render(NameBranchDropdown, { props: { ...defaultProps, branches, ...props } });
   }
 
   /**
@@ -82,7 +65,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-login", isRemote: false, derives: "feature-login" }, // Has derives - no worktree
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -102,7 +85,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -116,7 +99,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/feature-x", isRemote: true, derives: "feature-x" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -134,7 +117,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/feature-dashboard", isRemote: true, derives: "feature-dashboard" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -155,7 +138,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/feature-x", isRemote: true, derives: "feature-x" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -169,7 +152,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/main", isRemote: true }, // No derives
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -191,7 +174,7 @@ describe("NameBranchDropdown component", () => {
         },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -217,7 +200,7 @@ describe("NameBranchDropdown component", () => {
         },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -238,7 +221,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-x", isRemote: false, derives: "feature-x" }, // No base field
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -264,7 +247,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -283,7 +266,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth", base: "main" },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -301,7 +284,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth", base: "main" },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -317,12 +300,8 @@ describe("NameBranchDropdown component", () => {
   });
 
   describe("error states", () => {
-    it("shows error message when fetch fails", async () => {
-      mockFetchBases.mockRejectedValue(new Error("Network error"));
-      render(NameBranchDropdown, { props: defaultProps });
-
-      await vi.advanceTimersByTimeAsync(0);
-      await tick();
+    it("shows error message when error prop is set", () => {
+      renderWithBranches([], { error: "Network error" });
 
       expect(screen.getByText("Network error")).toBeInTheDocument();
     });
@@ -336,7 +315,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/feature-payment", isRemote: true, derives: "feature-payment" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -357,7 +336,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/bugfix-payment", isRemote: true, derives: "bugfix-payment" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -375,15 +354,12 @@ describe("NameBranchDropdown component", () => {
   });
 
   describe("id prop", () => {
-    it("forwards id prop to FilterableDropdown input", async () => {
+    it("forwards id prop to FilterableDropdown input", () => {
       const branches: BaseInfo[] = [
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      mockFetchBases.mockResolvedValue({ bases: branches });
-      render(NameBranchDropdown, { props: { ...defaultProps, id: "workspace-name" } });
-      await vi.advanceTimersByTimeAsync(0);
-      await tick();
+      renderWithBranches(branches, { id: "workspace-name" });
 
       const input = screen.getByRole("combobox");
       expect(input).toHaveAttribute("id", "workspace-name-input");
@@ -397,7 +373,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      await renderWithBranches(branches, { onEnter });
+      renderWithBranches(branches, { onEnter });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -409,96 +385,39 @@ describe("NameBranchDropdown component", () => {
   });
 
   describe("autofocus prop", () => {
-    it("sets data-autofocus attribute when autofocus is true", async () => {
+    it("sets data-autofocus attribute when autofocus is true", () => {
       const branches: BaseInfo[] = [
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      await renderWithBranches(branches, { autofocus: true });
+      renderWithBranches(branches, { autofocus: true });
 
       const input = screen.getByRole("combobox");
       expect(input).toHaveAttribute("data-autofocus");
     });
   });
 
-  describe("project:bases-updated event updates branches", () => {
-    it("subscribes to project:bases-updated and updates branch list", async () => {
+  describe("branches prop updates", () => {
+    it("updates the suggestion list when the branches prop changes", async () => {
       const initialBranches: BaseInfo[] = [
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
-
       const updatedBranches: BaseInfo[] = [
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
         { name: "origin/feature-new", isRemote: true, derives: "feature-new" },
       ];
 
-      // Capture the on() callback so we can invoke it
-      let basesUpdatedHandler:
-        | ((event: { projectPath: string; bases: readonly BaseInfo[] }) => void)
-        | undefined;
-      mockOn.mockImplementation(
-        (
-          _event: string,
-          handler: (event: { projectPath: string; bases: readonly BaseInfo[] }) => void
-        ) => {
-          basesUpdatedHandler = handler;
-          return () => {};
-        }
-      );
+      const { rerender } = renderWithBranches(initialBranches);
 
-      await renderWithBranches(initialBranches);
-
-      // Verify subscription was made
-      expect(mockOn).toHaveBeenCalledWith("project:bases-updated", expect.any(Function));
-
-      // Simulate bases-updated event
-      basesUpdatedHandler!({
-        projectPath: testProjectPath,
-        bases: updatedBranches,
-      });
+      // Parent received fresh data (e.g. bases-updated added a branch)
+      await rerender({ ...defaultProps, branches: updatedBranches });
       await tick();
 
-      // Open dropdown and verify updated branches
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
 
       expect(screen.getByText("feature-auth")).toBeInTheDocument();
       expect(screen.getByText("feature-new")).toBeInTheDocument();
-    });
-
-    it("ignores events for different project paths", async () => {
-      const initialBranches: BaseInfo[] = [
-        { name: "feature-auth", isRemote: false, derives: "feature-auth" },
-      ];
-
-      let basesUpdatedHandler:
-        | ((event: { projectPath: string; bases: readonly BaseInfo[] }) => void)
-        | undefined;
-      mockOn.mockImplementation(
-        (
-          _event: string,
-          handler: (event: { projectPath: string; bases: readonly BaseInfo[] }) => void
-        ) => {
-          basesUpdatedHandler = handler;
-          return () => {};
-        }
-      );
-
-      await renderWithBranches(initialBranches);
-
-      // Simulate event for a different project
-      basesUpdatedHandler!({
-        projectPath: "/other/project",
-        bases: [{ name: "other-branch", isRemote: false, derives: "other-branch" }],
-      });
-      await tick();
-
-      // Open dropdown - should still show original branches only
-      const input = screen.getByRole("combobox");
-      await focusAndOpenDropdown(input);
-
-      expect(screen.getByText("feature-auth")).toBeInTheDocument();
-      expect(screen.queryByText("other-branch")).not.toBeInTheDocument();
     });
   });
 
@@ -512,7 +431,7 @@ describe("NameBranchDropdown component", () => {
         { name: "origin/feature-payments", isRemote: true, derives: "feature-payments" },
       ];
 
-      await renderWithBranches(branches);
+      renderWithBranches(branches);
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);
@@ -546,7 +465,7 @@ describe("NameBranchDropdown component", () => {
         },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await focusAndOpenDropdown(input);
@@ -566,7 +485,7 @@ describe("NameBranchDropdown component", () => {
         { name: "feature-auth", isRemote: false, derives: "feature-auth" },
       ];
 
-      await renderWithBranches(branches, { onSelect });
+      renderWithBranches(branches, { onSelect });
 
       const input = screen.getByRole("combobox");
       await fireEvent.focus(input);

--- a/src/renderer/lib/components/NewWorkspaceView.svelte
+++ b/src/renderer/lib/components/NewWorkspaceView.svelte
@@ -24,9 +24,11 @@
   import {
     workspaces,
     projects as projectsApi,
+    on,
     type Workspace,
     type ProjectId,
     type Project,
+    type BaseInfo,
   } from "$lib/api";
   import { validateWorkspaceName, type InitialPrompt } from "@shared/api/types";
   import type { LifecycleAgentType } from "@shared/ipc";
@@ -70,6 +72,12 @@
   const selectedProjectId = $derived(newWorkspaceView.selectedProjectId);
   const hasProject = $derived(selectedProjectId !== undefined);
   const selectedProject = $derived(getProjectById(selectedProjectId));
+  // Memoized path string for the dropdowns: passing selectedProject.path
+  // directly would make their fetch effects track selectedProject's identity,
+  // which changes on every projects-store write — each bases:updated event
+  // would re-trigger fetchBases and feed a fetch/event loop. A $derived only
+  // propagates when the string actually changes.
+  const selectedProjectPath = $derived(selectedProject?.path);
   const defaultBranch = $derived(selectedProject?.defaultBaseBranch);
 
   let name = $state("");
@@ -91,6 +99,57 @@
   let promptRef: HTMLElement | undefined = $state();
   // Section ref for focus-trap enumeration.
   let sectionRef: HTMLElement | undefined = $state();
+
+  // ============ Branch data (shared by both dropdowns) ============
+
+  // The view owns the bases data: one fetch (and one background git refresh)
+  // per project selection, shared by the name and base-branch dropdowns, which
+  // are purely presentational. Cached bases display immediately; loading stays
+  // on until the background refresh confirms via project:bases-updated.
+  let branches = $state<readonly BaseInfo[]>([]);
+  let branchesLoading = $state(false);
+  let branchesError = $state<string | null>(null);
+
+  $effect(() => {
+    const currentProjectPath = selectedProjectPath;
+    branches = [];
+    branchesError = null;
+    branchesLoading = currentProjectPath !== undefined;
+    if (currentProjectPath === undefined) return;
+
+    let cancelled = false;
+    projectsApi
+      .fetchBases(currentProjectPath)
+      .then((result: { bases: readonly BaseInfo[] }) => {
+        if (!cancelled) branches = result.bases;
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        branchesError = err instanceof Error ? err.message : "Failed to load branches";
+        branchesLoading = false;
+      });
+
+    const unsubscribe = on<{ projectPath: string; bases: readonly BaseInfo[] }>(
+      "project:bases-updated",
+      (event) => {
+        if (event.projectPath !== currentProjectPath) return;
+        branches = event.bases;
+        branchesLoading = false;
+        // The fresh list is authoritative: clear a selection it no longer
+        // contains. Runs once per arriving list — never on value changes,
+        // which would re-clear a value just re-applied by the default
+        // auto-fill and feed an infinite clear/re-apply loop.
+        if (selectedBranch && !event.bases.some((b) => b.name === selectedBranch)) {
+          selectedBranch = "";
+        }
+      }
+    );
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  });
 
   // Auto-fill the base branch from the project's default. Each distinct default
   // value is applied at most once per project selection, and only into an empty
@@ -442,10 +501,11 @@
 
       <div class="ch-form-field">
         <label for="workspace-name" class="ch-form-label">Name</label>
-        {#if selectedProject}
+        {#if selectedProjectPath}
           <NameBranchDropdown
             id="workspace-name"
-            projectPath={selectedProject.path}
+            {branches}
+            error={branchesError}
             value={name}
             onSelect={handleNameSelect}
             onInput={handleNameInput}
@@ -465,9 +525,12 @@
 
       <div class="ch-form-field">
         <label for="branch-select" class="ch-form-label">Base Branch</label>
-        {#if selectedProject}
+        {#if selectedProjectPath}
           <BranchDropdown
-            projectPath={selectedProject.path}
+            id={`branch-dropdown-${selectedProjectPath}`}
+            {branches}
+            loading={branchesLoading}
+            error={branchesError}
             value={selectedBranch}
             onSelect={handleBranchSelect}
             disabled={isSubmitting || isOpeningProject}

--- a/src/renderer/lib/components/NewWorkspaceView.test.ts
+++ b/src/renderer/lib/components/NewWorkspaceView.test.ts
@@ -191,6 +191,42 @@ describe("NewWorkspaceView", () => {
     await waitFor(() => expect(createButton).not.toBeDisabled());
   });
 
+  it("does not re-fetch bases when a bases-updated event rewrites the project (fetch loop regression)", async () => {
+    // Regression: every bases:updated event rewrote the projects store, handing
+    // out a new project object. The dropdowns' fetch effects were keyed on that
+    // identity (via the projectPath prop expression), so each event re-triggered
+    // fetchBases — whose background refresh emitted the next event: a
+    // self-amplifying loop of git fetches that kept the spinner loading forever.
+    mockApi.projects.fetchBases.mockResolvedValue({
+      bases: [{ name: "main", isRemote: false }],
+    });
+
+    render(NewWorkspaceView, { props: { open: true } });
+
+    // The view fetches once per project selection (shared by both dropdowns).
+    await waitFor(() => expect(mockApi.projects.fetchBases).toHaveBeenCalledTimes(1));
+
+    // A refresh completes: the event plus a store rewrite that changes the
+    // project's object identity (fresh default), as the domain-event binding does.
+    emitApiEvent("project:bases-updated", {
+      projectId: PROJECT_ID,
+      projectPath: PROJECT_PATH,
+      bases: [
+        { name: "main", isRemote: false },
+        { name: "develop", isRemote: false },
+      ],
+      defaultBaseBranch: "develop",
+    });
+    projectsStore.setProjectDefaultBaseBranch(PROJECT_PATH, "develop");
+
+    // Let any (rogue) effect re-runs and their async fetches settle.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // No additional fetches, and the spinner stays settled.
+    expect(mockApi.projects.fetchBases).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("status", { name: "Loading branches" })).toBeNull();
+  });
+
   it("does not override a manual branch pick when a fresh default arrives", async () => {
     mockApi.projects.fetchBases.mockResolvedValue({
       bases: [

--- a/src/renderer/lib/stores/projects.svelte.ts
+++ b/src/renderer/lib/stores/projects.svelte.ts
@@ -28,18 +28,37 @@ let _activeWorkspacePath = $state<string | null>(null);
 // ============ Derived ============
 
 /**
+ * Identity-stable cache of sorted projections, keyed by source project object.
+ * Mutators replace a project's object only when it actually changes, so a
+ * cache hit means the projection (and its identity) can be reused. Without
+ * this, every store write would hand out all-new project objects, and any
+ * effect keyed on a project's identity would re-run on unrelated updates
+ * (this once fed a fetch/event loop in the New Workspace view's dropdowns).
+ * Relies on mutators never mutating a project in place.
+ */
+const _sortedProjectionCache = new WeakMap<Project, Project>();
+
+function sortedProjection(p: Project): Project {
+  const cached = _sortedProjectionCache.get(p);
+  if (cached) return cached;
+  const projection = {
+    ...p,
+    workspaces: [...p.workspaces].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { caseFirst: "upper" })
+    ),
+  };
+  _sortedProjectionCache.set(p, projection);
+  return projection;
+}
+
+/**
  * Projects sorted alphabetically (AaBbCc ordering) with their workspaces also sorted.
  * This is the canonical order used for display and navigation.
  */
 const _sortedProjects = $derived(
   [...(_projects ?? [])]
     .sort((a, b) => a.name.localeCompare(b.name, undefined, { caseFirst: "upper" }))
-    .map((p) => ({
-      ...p,
-      workspaces: [...p.workspaces].sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, { caseFirst: "upper" })
-      ),
-    }))
+    .map(sortedProjection)
 );
 
 /**
@@ -152,6 +171,11 @@ export function setProjectDefaultBaseBranch(
   projectPath: string,
   defaultBaseBranch: string | undefined
 ): void {
+  // No-op when nothing changes: refreshes re-deliver the same default on
+  // every bases:updated event, and a write here would churn object
+  // identities for all identity-keyed consumers.
+  const project = _projects.find((p) => p.path === projectPath);
+  if (!project || project.defaultBaseBranch === defaultBaseBranch) return;
   _projects = _projects.map((p) => {
     if (p.path !== projectPath) return p;
     if (defaultBaseBranch !== undefined) return { ...p, defaultBaseBranch };

--- a/src/renderer/lib/stores/projects.test.ts
+++ b/src/renderer/lib/stores/projects.test.ts
@@ -310,6 +310,58 @@ describe("projects store", () => {
     });
   });
 
+  describe("identity stability", () => {
+    // Identity-keyed consumers (e.g. effects fed by a project prop) must not
+    // re-run on writes that don't change their project. These tests pin the
+    // reference-equality guarantees the New Workspace view relies on to avoid
+    // a fetch/event feedback loop.
+    it("preserves project identity when setProjectDefaultBaseBranch value is unchanged", () => {
+      addProject(
+        createMockProject({
+          path: "/test/project" as ProjectPath,
+          defaultBaseBranch: "main",
+        })
+      );
+      const before = projects.value[0];
+
+      setProjectDefaultBaseBranch("/test/project", "main");
+
+      expect(projects.value[0]).toBe(before);
+    });
+
+    it("preserves project identity when clearing an already-absent default", () => {
+      addProject(createMockProject({ path: "/test/project" as ProjectPath }));
+      const before = projects.value[0];
+
+      setProjectDefaultBaseBranch("/test/project", undefined);
+
+      expect(projects.value[0]).toBe(before);
+    });
+
+    it("preserves untouched projects' identity across unrelated writes", () => {
+      addProject(
+        createMockProject({
+          path: "/test/a" as ProjectPath,
+          name: "project-a",
+          defaultBaseBranch: "main",
+        })
+      );
+      addProject(
+        createMockProject({
+          path: "/test/b" as ProjectPath,
+          name: "project-b",
+          defaultBaseBranch: "main",
+        })
+      );
+      const otherBefore = projects.value.find((p) => p.path === "/test/b");
+
+      setProjectDefaultBaseBranch("/test/a", "develop");
+
+      expect(projects.value.find((p) => p.path === "/test/b")).toBe(otherBefore);
+      expect(projects.value.find((p) => p.path === "/test/a")?.defaultBaseBranch).toBe("develop");
+    });
+  });
+
   describe("updateWorkspaceMetadata", () => {
     it("clears the key and returns true when the workspace matches", () => {
       const ws = createMockWorkspace({


### PR DESCRIPTION
- Fixed a self-amplifying fetch/event feedback loop in the new-workspace view: every `project:bases-updated` event rewrote the projects store with new project object identities, both dropdowns' fetch effects re-triggered `fetchBases` (each spawning another background `git fetch`), and the resulting process pile-up degraded the branch list read to ~55s while the spinner never settled.
- NewWorkspaceView now owns the bases data: one fetch and one `bases-updated` subscription per project selection (keyed on a memoized `$derived` path string), shared by both dropdowns; stale-selection clearing moved along.
- BranchDropdown and NameBranchDropdown are now purely presentational (`branches`/`loading`/`error` props, no `$lib/api` dependency).
- Projects store keeps object identities stable: `_sortedProjects` memoizes projections per source object and `setProjectDefaultBaseBranch` no-ops on unchanged values.
- Regression tests: the view must not re-fetch when a `bases-updated` event rewrites the store; store identity-stability tests pin the reference-equality guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)