### PR TITLE
chore(ui): unify sidebar expanded/collapsed layouts into one responsive DOM tree

### DIFF
--- a/src/renderer/lib/components/NotificationStack.svelte
+++ b/src/renderer/lib/components/NotificationStack.svelte
@@ -2,7 +2,9 @@
   NotificationStack.svelte
 
   Renders notifications stacked at the bottom of the sidebar.
-  Two modes: expanded (full cards) and collapsed (type icons only).
+  Each entry uses the sidebar's two-column row layout: [label cell | icon
+  cell at the right edge]. Collapsing the sidebar hides the label content,
+  leaving the type icon as the whole entry.
   Newest notifications appear on top.
 -->
 <script lang="ts">
@@ -43,10 +45,10 @@
     {#each entries as entry (entry.notificationId)}
       {@const config = entry.config}
       {@const pct = progressPercent(config)}
-      {#if isExpanded}
-        <div class="notification-entry" role="status" aria-label={config.title}>
-          <vscode-divider></vscode-divider>
-          <div class="notification-row">
+      <div class="notification-entry" role="status" aria-label={config.title}>
+        <vscode-divider class="expanded-only"></vscode-divider>
+        <div class="notification-row">
+          <div class="ch-label-cell notification-label">
             <span class="notification-title" title={config.title}>{config.title}</span>
             {#if config.dismissible}
               <button
@@ -58,57 +60,49 @@
                 <Icon name="close" size={14} />
               </button>
             {/if}
-            <span class="notification-indicator" aria-hidden="true">
-              {#if config.type === "spinner"}
-                <vscode-progress-ring class="notification-spinner"></vscode-progress-ring>
-              {:else}
-                <Icon name={config.type} size={14} />
-              {/if}
-            </span>
           </div>
-          {#if config.message}
-            <div class="notification-detail">{config.message}</div>
-          {/if}
-          {#if config.progress !== undefined}
-            <div class="notification-progress">
-              {#if typeof config.progress === "number"}
-                <div class="progress-row">
-                  <div class="progress-bar">
-                    <div class="progress-fill" style="width: {config.progress * 100}%"></div>
-                  </div>
-                  <span class="notification-pct">{pct}%</span>
-                </div>
-              {:else}
-                <div class="progress-bar indeterminate">
-                  <div class="progress-fill"></div>
-                </div>
-              {/if}
-            </div>
-          {/if}
-          {#if config.actions && config.actions.length > 0}
-            <div class="notification-actions">
-              {#each config.actions as action (action.id)}
-                <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-                <vscode-button
-                  secondary={action.variant !== "primary" || undefined}
-                  disabled={action.disabled || action.busy || undefined}
-                  onclick={() => handleAction(entry.notificationId, action)}
-                >
-                  {action.busy ? (action.busyLabel ?? action.label) : action.label}
-                </vscode-button>
-              {/each}
-            </div>
-          {/if}
+          <span class="ch-icon-cell notification-indicator" aria-hidden="true">
+            {#if config.type === "spinner"}
+              <vscode-progress-ring class="notification-spinner"></vscode-progress-ring>
+            {:else}
+              <Icon name={config.type} size={14} />
+            {/if}
+          </span>
         </div>
-      {:else}
-        <div class="notification-entry-minimized" role="status" aria-label={config.title}>
-          {#if config.type === "spinner"}
-            <vscode-progress-ring class="notification-spinner"></vscode-progress-ring>
-          {:else}
-            <Icon name={config.type} size={14} />
-          {/if}
-        </div>
-      {/if}
+        {#if config.message}
+          <div class="notification-detail expanded-only">{config.message}</div>
+        {/if}
+        {#if config.progress !== undefined}
+          <div class="notification-progress expanded-only">
+            {#if typeof config.progress === "number"}
+              <div class="progress-row">
+                <div class="progress-bar">
+                  <div class="progress-fill" style="width: {config.progress * 100}%"></div>
+                </div>
+                <span class="notification-pct">{pct}%</span>
+              </div>
+            {:else}
+              <div class="progress-bar indeterminate">
+                <div class="progress-fill"></div>
+              </div>
+            {/if}
+          </div>
+        {/if}
+        {#if config.actions && config.actions.length > 0}
+          <div class="notification-actions expanded-only">
+            {#each config.actions as action (action.id)}
+              <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+              <vscode-button
+                secondary={action.variant !== "primary" || undefined}
+                disabled={action.disabled || action.busy || undefined}
+                onclick={() => handleAction(entry.notificationId, action)}
+              >
+                {action.busy ? (action.busyLabel ?? action.label) : action.label}
+              </vscode-button>
+            {/each}
+          </div>
+        {/if}
+      </div>
     {/each}
   </div>
 {/if}
@@ -121,25 +115,44 @@
   .notification-stack.expanded {
     max-height: 280px;
     overflow-y: auto;
-    min-width: var(--ch-sidebar-width, 250px);
   }
 
-  /* Expanded notification entry */
   .notification-entry {
-    padding: 0 0 8px 0;
-    min-width: var(--ch-sidebar-width, 250px);
     flex-shrink: 0;
+  }
+
+  .notification-stack.expanded .notification-entry {
+    padding-bottom: 8px;
+  }
+
+  /* Blocks that only exist in the expanded card (collapsed entries are
+     uniform icon rows). */
+  .notification-stack:not(.expanded) .expanded-only {
+    display: none;
   }
 
   .notification-row {
     display: flex;
     align-items: center;
-    padding: 8px 12px 0 calc(var(--ch-sidebar-minimized-width, 20px) + 8px);
+    min-height: 36px;
+  }
+
+  /* Label cell visibility / icon cell sizing come from the global
+     .ch-label-cell / .ch-icon-cell utilities; this zone shrinks to zero with
+     the collapsing sidebar. */
+  .notification-label {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    align-items: center;
     gap: 8px;
+    overflow: hidden;
   }
 
   .notification-title {
-    flex: 1;
+    flex: 1 1 0;
+    min-width: 0;
+    margin-left: 28px;
     font-size: 13px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -147,9 +160,6 @@
   }
 
   .notification-indicator {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
     opacity: 0.7;
   }
 
@@ -244,17 +254,5 @@
     width: 14px;
     height: 14px;
     flex-shrink: 0;
-  }
-
-  /* Collapsed notification entry */
-  .notification-entry-minimized {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--ch-sidebar-minimized-width, 20px);
-    min-height: 36px;
-    padding: 4px;
-    flex-shrink: 0;
-    opacity: 0.7;
   }
 </style>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -9,14 +9,21 @@
   import { getCounts } from "$lib/stores/agent-status.svelte.js";
   import { getDeletionStatus } from "$lib/stores/deletion.svelte.js";
   import { isPending } from "$lib/stores/pending-workspaces.svelte.js";
-  import { uiMode, setSidebarExpanded } from "$lib/stores/ui-mode.svelte.js";
+  import {
+    desiredMode,
+    hoverExpansionEligible,
+    setSidebarExpanded,
+  } from "$lib/stores/ui-mode.svelte.js";
   import {
     getWorkspaceGlobalIndex,
     formatIndexDisplay,
     getShortcutHint,
     getStatusText,
   } from "$lib/utils/sidebar-utils.js";
+  import { createLogger } from "$lib/logging";
   import type { Project } from "$lib/api";
+
+  const logger = createLogger("ui");
 
   interface SidebarProps {
     projects: readonly Project[];
@@ -45,59 +52,113 @@
 
   // ============ Expansion State ============
 
-  let isHovering = $state(false);
+  /** Debounce for both arming expansion (deliberate-hover filter) and collapsing. */
+  const HOVER_DELAY_MS = 150;
+  /**
+   * Hover only arms expansion once the cursor has penetrated the collapsed
+   * gutter past the outer quarter; shallow grazes along its outer edge are
+   * ignored.
+   */
+  const HOVER_TRIGGER_DEPTH_PX = 15;
+
+  let isHovering = false;
+  let openTimeout: ReturnType<typeof setTimeout> | null = null;
   let collapseTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Sidebar is expanded when:
-  // - User is hovering over it, OR
-  // - UI mode is not "workspace" (shortcut/dialog mode), OR
-  // - There are no workspaces (so user can open a project)
-  const isExpanded = $derived(isHovering || uiMode.value !== "workspace" || totalWorkspaces === 0);
+  // - any ui-mode input forces the UI on top (hover, shortcut, dialog, New workspace view), OR
+  // - there are no workspaces (so user can open a project)
+  const isExpanded = $derived(desiredMode.value !== "workspace" || totalWorkspaces === 0);
 
-  function handleMouseEnter(): void {
+  function clearOpenTimeout(): void {
+    if (openTimeout) {
+      clearTimeout(openTimeout);
+      openTimeout = null;
+    }
+  }
+
+  function clearCollapseTimeout(): void {
     if (collapseTimeout) {
       clearTimeout(collapseTimeout);
       collapseTimeout = null;
     }
+  }
 
-    // Don't set hover state when in shortcut mode - the sidebar is already
-    // expanded due to shortcut mode, not hover. This prevents the hover state
-    // from "locking in" when the sidebar expands into the mouse cursor.
-    if (shortcutModeActive) {
+  function maybeArmExpansion(clientX: number): void {
+    if (isHovering) return;
+    // Hover may only initiate expansion when nothing else forces the UI on
+    // top; otherwise the sidebar expanding into a parked cursor would latch
+    // hover and keep the sidebar open after that mode exits.
+    if (!hoverExpansionEligible.value) {
+      logger.debug("sidebar hover: not eligible", { clientX });
       return;
     }
+    if (clientX > HOVER_TRIGGER_DEPTH_PX) {
+      if (openTimeout) logger.debug("sidebar hover: disarm (shallow)", { clientX });
+      clearOpenTimeout();
+      return;
+    }
+    if (!openTimeout) {
+      logger.debug("sidebar hover: arm", { clientX });
+      openTimeout = setTimeout(() => {
+        openTimeout = null;
+        if (!hoverExpansionEligible.value) return;
+        logger.debug("sidebar hover: expand");
+        isHovering = true;
+        setSidebarExpanded(true);
+      }, HOVER_DELAY_MS);
+    }
+  }
 
-    isHovering = true;
-    setSidebarExpanded(true);
+  function handleMouseEnter(event: MouseEvent): void {
+    logger.debug("sidebar hover: enter", { clientX: event.clientX, isHovering });
+    clearCollapseTimeout();
+    // A cursor slammed against the window edge can come to rest in the same
+    // frame it enters — no mousemove ever fires, so arm from the enter too.
+    maybeArmExpansion(event.clientX);
+  }
+
+  function handleMouseMove(event: MouseEvent): void {
+    maybeArmExpansion(event.clientX);
+  }
+
+  function pinnedAgainstScreenEdge(): boolean {
+    // An exit through our left boundary can only be a "pin" when the
+    // window's left edge sits at the screen's left edge; otherwise the
+    // cursor genuinely left the window (windowed mode) and a normal leave
+    // applies. (Under native Wayland window positions report 0, degrading
+    // to treating every left exit as a pin.)
+    const availLeft = (window.screen as Screen & { availLeft?: number }).availLeft ?? 0;
+    return window.screenX <= availLeft;
   }
 
   function handleMouseLeave(event: MouseEvent): void {
-    // Don't collapse if mouse is at the left edge of the window
-    // (user likely moved to window boundary, not away from sidebar)
-    if (event.clientX < 5) {
+    // A leave through the left boundary while the window sits at the screen
+    // edge means the cursor is pinned: the OS keeps the pointer there but
+    // reports it just outside, and NO further events arrive while it rests
+    // (a fast slam delivers only a shallow enter + this leave). Treat it as
+    // the deepest possible hover — arm expansion / keep the sidebar open —
+    // not as a leave.
+    if (event.clientX <= 0 && pinnedAgainstScreenEdge()) {
+      logger.debug("sidebar hover: edge pin", { clientX: event.clientX, isHovering });
+      maybeArmExpansion(0);
       return;
     }
-
-    collapseTimeout = setTimeout(() => {
+    logger.debug("sidebar hover: leave", { clientX: event.clientX, isHovering });
+    clearOpenTimeout();
+    if (!isHovering) return;
+    collapseTimeout ??= setTimeout(() => {
+      collapseTimeout = null;
+      logger.debug("sidebar hover: collapse");
       isHovering = false;
       setSidebarExpanded(false);
-      collapseTimeout = null;
-    }, 150); // 150ms debounce
+    }, HOVER_DELAY_MS);
   }
 
-  // Clear hover state when entering shortcut mode (cleanup pending collapse)
-  $effect(() => {
-    if (shortcutModeActive && collapseTimeout) {
-      clearTimeout(collapseTimeout);
-      collapseTimeout = null;
-    }
-  });
-
-  // Clean up timeout on component destroy
+  // Clean up timeouts on component destroy
   onDestroy(() => {
-    if (collapseTimeout) {
-      clearTimeout(collapseTimeout);
-    }
+    clearOpenTimeout();
+    clearCollapseTimeout();
   });
 
   // ============ Actions ============
@@ -107,56 +168,55 @@
   }
 </script>
 
+<!--
+  Two-column row layout: every row is [flexible label cell | fixed icon cell
+  at the right edge]. Collapsing the sidebar shrinks the label cells to zero
+  width, so the icon column IS the collapsed sidebar.
+-->
 <nav
   class="sidebar"
   class:expanded={isExpanded}
+  class:ch-sidebar-expanded={isExpanded}
   aria-label="Projects"
   onmouseenter={handleMouseEnter}
+  onmousemove={handleMouseMove}
   onmouseleave={handleMouseLeave}
 >
   <header class="sidebar-header">
+    <div class="ch-label-cell header-label">
+      <h2>PROJECTS</h2>
+    </div>
     {#if !isExpanded}
-      <span class="expand-hint" aria-hidden="true">
+      <span class="ch-icon-cell expand-hint" aria-hidden="true">
         <Icon name="chevron-right" size={12} />
       </span>
     {/if}
-    <h2 class:visually-collapsed={!isExpanded}>PROJECTS</h2>
   </header>
 
   <div class="sidebar-content">
     <!-- Global "New workspace" entry, pinned above the projects. -->
-    {#if isExpanded}
-      <button
-        type="button"
-        class="new-workspace-entry"
-        class:active={newWorkspaceViewOpen}
-        aria-current={newWorkspaceViewOpen ? "true" : undefined}
-        onclick={() => onOpenNewWorkspace()}
-      >
-        <span class="new-workspace-icon"><Icon name="add" size={14} /></span>
+    <button
+      type="button"
+      class="new-workspace-entry"
+      class:active={newWorkspaceViewOpen}
+      aria-label="New workspace"
+      aria-current={newWorkspaceViewOpen ? "true" : undefined}
+      onclick={() => onOpenNewWorkspace()}
+    >
+      <span class="ch-label-cell new-workspace-label-cell">
         <span class="new-workspace-label">New workspace</span>
-      </button>
-    {:else}
-      <button
-        type="button"
-        class="new-workspace-entry-minimized"
-        class:active={newWorkspaceViewOpen}
-        aria-label="New workspace"
-        aria-current={newWorkspaceViewOpen ? "true" : undefined}
-        onclick={() => onOpenNewWorkspace()}
-      >
-        <Icon name="add" size={14} />
-      </button>
-    {/if}
+      </span>
+      <span class="ch-icon-cell new-workspace-icon"><Icon name="add" size={14} /></span>
+    </button>
 
     <ul class="project-list">
       {#each projects as project, projectIndex (project.path)}
         {#if projectIndex > 0}
-          <vscode-divider inert={!isExpanded}></vscode-divider>
+          <vscode-divider></vscode-divider>
         {/if}
         {@const projectTitle = project.remoteUrl ?? project.path}
         <li class="project-item">
-          <div class="project-header" inert={!isExpanded}>
+          <div class="project-header ch-label-cell">
             <span class="project-icon" title={projectTitle}>
               <Icon name={project.remoteUrl ? "source-control" : "folder-opened"} size={14} />
             </span>
@@ -192,20 +252,19 @@
                 : false}
               {@const pending = isPending(workspace.path)}
               {@const hibernated = workspace.metadata?.["hibernated"] === "true"}
-              {#if isExpanded}
-                <!-- Expanded layout: two-row when tags exist -->
-                <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
-                <li
-                  class="workspace-item"
-                  class:active={isActive}
-                  class:has-tags={hasTags}
-                  class:hibernated
-                  aria-current={isActive ? "true" : undefined}
-                  onclick={() => {
-                    if (!pending) onSwitchWorkspace(workspaceRef);
-                  }}
-                >
-                  <div class="workspace-row">
+              <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
+              <li
+                class="workspace-item"
+                class:active={isActive}
+                class:has-tags={hasTags}
+                class:hibernated
+                aria-current={isActive ? "true" : undefined}
+                onclick={() => {
+                  if (!pending) onSwitchWorkspace(workspaceRef);
+                }}
+              >
+                <div class="workspace-row">
+                  <div class="ch-label-cell workspace-label-cell">
                     <button
                       type="button"
                       class="workspace-btn"
@@ -236,46 +295,15 @@
                         <Icon name="trash" size={14} />
                       </button>
                     {/if}
-                    {#if pending}
-                      <!-- Creating: show red "busy" immediately (work is queued) -->
-                      <AgentStatusIndicator idleCount={0} busyCount={1} />
-                    {:else if deletionStatus === "in-progress"}
-                      <vscode-progress-ring class="deletion-spinner"></vscode-progress-ring>
-                    {:else if deletionStatus === "error"}
-                      <span class="deletion-error" role="img" aria-label="Deletion failed">
-                        <Icon name="warning" size={14} />
-                      </span>
-                    {:else if hibernated}
-                      <span class="hibernation-indicator" role="img" aria-label="Hibernated">
-                        <Icon name="debug-pause" size={14} />
-                      </span>
-                    {:else}
-                      <AgentStatusIndicator
-                        idleCount={agentCounts.idle}
-                        busyCount={agentCounts.busy}
-                      />
-                    {/if}
                   </div>
-                  {#if hasTags}
-                    <WorkspaceTags metadata={workspace.metadata} />
-                  {/if}
-                </li>
-              {:else}
-                <!-- Minimized layout: clickable status indicators -->
-                <!-- Workspace name kept in DOM (visually hidden) for accessibility -->
-                <li
-                  class="workspace-item-minimized"
-                  class:active={isActive}
-                  aria-current={isActive ? "true" : undefined}
-                >
+                  <!-- Status cell: a button in both modes (clicks bubble to the
+                       row's switch handler); the collapsed sidebar shows only
+                       this cell. -->
                   <button
                     type="button"
-                    class="status-indicator-btn"
+                    class="ch-icon-cell status-cell"
                     aria-label={`${workspace.name} in ${project.name} - ${pending ? "Creating" : deletionStatus === "in-progress" ? "Deleting" : deletionStatus === "error" ? "Deletion failed" : hibernated ? "Hibernated" : statusText}`}
                     aria-current={isActive ? "true" : undefined}
-                    onclick={() => {
-                      if (!pending) onSwitchWorkspace(workspaceRef);
-                    }}
                   >
                     {#if pending}
                       <!-- Creating: show red "busy" immediately (work is queued) -->
@@ -296,10 +324,14 @@
                         busyCount={agentCounts.busy}
                       />
                     {/if}
-                    <span class="ch-visually-hidden">{workspace.name}</span>
                   </button>
-                </li>
-              {/if}
+                </div>
+                {#if hasTags}
+                  <div class="workspace-tags-row">
+                    <WorkspaceTags metadata={workspace.metadata} />
+                  </div>
+                {/if}
+              </li>
             {/each}
           </ul>
         </li>
@@ -315,14 +347,14 @@
     position: absolute;
     left: 0;
     top: 0;
-    /* Minimized: show only left 20px, expanded: full width */
+    /* Minimized: show only the icon column, expanded: full width */
     width: var(--ch-sidebar-minimized-width, 20px);
     height: 100%;
     background: var(--ch-surface-1, var(--ch-background));
     color: var(--ch-foreground);
     display: flex;
     flex-direction: column;
-    overflow: clip;
+    overflow: hidden;
     transition:
       width var(--ch-sidebar-transition, 150ms ease-out),
       box-shadow var(--ch-sidebar-transition, 150ms ease-out);
@@ -331,12 +363,32 @@
     user-select: none;
   }
 
+  /* Collapse snaps instead of animating: collapsing also drops the UI view
+     below the workspace views (native z-order, instant), which covers
+     everything beyond the gutter — an animated slide would only be visible
+     as the icons popping in at the end. */
+  .sidebar:not(.expanded) {
+    transition: none;
+  }
+
   .sidebar.expanded {
     width: var(--ch-sidebar-width, 250px);
     z-index: var(--ch-z-sidebar-expanded, 50);
     box-shadow: var(--ch-shadow);
+  }
+
+  /* Two-column row cells: .ch-icon-cell / .ch-label-cell come from global.css. */
+
+  /* Shrink-to-zero zones inside two-column rows. Inner content keeps its own
+     spacing and is clipped while the width animates. */
+  .header-label,
+  .new-workspace-label-cell,
+  .workspace-label-cell {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    align-items: center;
     overflow: hidden;
-    overflow-y: auto;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -345,29 +397,18 @@
     }
   }
 
+  /* ============ Header ============ */
+
   .sidebar-header {
     display: flex;
     align-items: center;
-    padding: 12px 16px 12px 12px;
+    padding: 12px 0;
     border-bottom: 1px solid var(--ch-input-border);
-    gap: 0;
-    min-width: var(--ch-sidebar-width, 250px);
-  }
-
-  /* When minimized, expand-hint takes up left space */
-  .sidebar-header:has(.expand-hint) {
-    padding-left: 0;
   }
 
   .expand-hint {
-    width: var(--ch-sidebar-minimized-width, 20px);
-    min-width: var(--ch-sidebar-minimized-width, 20px);
-    align-self: stretch;
     opacity: 0.5;
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    align-self: stretch;
   }
 
   .expand-hint:hover {
@@ -379,31 +420,25 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin: 0;
-    margin-left: 8px;
+    margin: 0 0 0 20px;
     opacity: 0.7;
-    flex: 1;
     white-space: nowrap;
-  }
-
-  .sidebar-header h2.visually-collapsed {
-    visibility: hidden;
   }
 
   .sidebar-content {
     flex: 1;
     overflow-y: auto;
-    min-width: var(--ch-sidebar-width, 250px);
+    overflow-x: hidden;
   }
 
-  /* Global "New workspace" entry (expanded) */
+  /* ============ New workspace entry ============ */
+
   .new-workspace-entry {
     display: flex;
     align-items: center;
-    gap: 8px;
     width: 100%;
-    min-width: var(--ch-sidebar-width, 250px);
-    padding: 8px 12px 8px calc(var(--ch-sidebar-minimized-width, 20px) + 8px);
+    min-height: 36px;
+    padding: 4px 0;
     background: transparent;
     border: none;
     color: var(--ch-foreground);
@@ -439,63 +474,23 @@
     background: var(--ch-focus-border);
   }
 
-  .new-workspace-icon {
-    display: flex;
-    align-items: center;
-    opacity: 0.8;
-    flex-shrink: 0;
-  }
-
   .new-workspace-label {
+    margin-left: 28px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  /* Global "New workspace" entry (minimized) */
-  .new-workspace-entry-minimized {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--ch-sidebar-minimized-width, 20px);
-    min-width: var(--ch-sidebar-minimized-width, 20px);
-    min-height: 36px;
-    background: transparent;
-    border: none;
-    color: var(--ch-foreground);
-    cursor: pointer;
-    padding: 4px;
+  .new-workspace-icon {
     opacity: 0.8;
-    flex-shrink: 0;
   }
 
-  .new-workspace-entry-minimized:hover {
-    background: var(--ch-input-bg);
+  .new-workspace-entry:hover .new-workspace-icon,
+  .new-workspace-entry.active .new-workspace-icon {
     opacity: 1;
   }
 
-  .new-workspace-entry-minimized:focus-visible {
-    outline: 1px solid var(--ch-focus-border);
-    outline-offset: -1px;
-  }
-
-  .new-workspace-entry-minimized.active {
-    background: var(--ch-accent-muted, var(--ch-list-active-bg));
-    color: var(--ch-list-active-fg);
-    opacity: 1;
-    position: relative;
-  }
-
-  .new-workspace-entry-minimized.active::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 8px;
-    bottom: 8px;
-    width: 3px;
-    border-radius: 0 2px 2px 0;
-    background: var(--ch-focus-border);
-  }
+  /* ============ Projects ============ */
 
   .project-list {
     list-style: none;
@@ -507,9 +502,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 4px 12px 4px calc(var(--ch-sidebar-minimized-width, 20px) + 8px);
+    padding: 4px 12px 4px 28px;
     gap: 8px;
-    min-width: var(--ch-sidebar-width, 250px);
   }
 
   .project-icon {
@@ -558,6 +552,8 @@
     background: var(--ch-list-hover-bg);
   }
 
+  /* ============ Workspaces ============ */
+
   .workspace-list {
     list-style: none;
     padding: 0;
@@ -567,44 +563,53 @@
   .workspace-item {
     display: flex;
     flex-direction: column;
-    padding: 4px 12px 4px 12px;
+    justify-content: center;
+    padding: 4px 0;
     min-height: 44px; /* Accessible click target */
-    min-width: var(--ch-sidebar-width, 250px);
     cursor: pointer;
     border-radius: var(--ch-radius-sm, 6px);
     position: relative;
   }
 
-  .workspace-item.has-tags {
+  .sidebar.expanded .workspace-item.has-tags {
     padding-bottom: 6px;
   }
 
   .workspace-row {
     display: flex;
     align-items: center;
-    gap: 4px;
   }
 
-  .status-indicator-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--ch-sidebar-minimized-width, 20px);
-    min-width: var(--ch-sidebar-minimized-width, 20px);
+  .workspace-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    color: var(--ch-foreground);
+    cursor: pointer;
+    text-align: left;
+    padding: 4px 8px 4px 20px;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-radius: var(--ch-radius-sm, 6px);
+  }
+
+  .status-cell {
     min-height: 36px;
     background: transparent;
     border: none;
     cursor: pointer;
     padding: 4px;
-    flex-shrink: 0;
     border-radius: var(--ch-radius-sm, 6px);
   }
 
-  .status-indicator-btn:hover {
+  .status-cell:hover {
     background: var(--ch-input-bg);
   }
 
-  .status-indicator-btn:focus {
+  .status-cell:focus {
     outline: 1px solid var(--ch-focus-border);
     outline-offset: -1px;
   }
@@ -642,21 +647,6 @@
     outline-offset: -1px;
   }
 
-  .workspace-btn {
-    flex: 1;
-    background: transparent;
-    border: none;
-    color: var(--ch-foreground);
-    cursor: pointer;
-    text-align: left;
-    padding: 4px 8px;
-    font-size: 13px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    border-radius: var(--ch-radius-sm, 6px);
-  }
-
   .workspace-item .remove-btn {
     opacity: 0;
   }
@@ -666,28 +656,12 @@
     opacity: 0.7;
   }
 
-  /* Minimized layout: only status indicator visible */
-  .workspace-item-minimized {
-    display: flex;
-    align-items: center;
-    min-height: 44px; /* Accessible click target */
-    position: relative;
+  .workspace-tags-row {
+    padding-left: 12px;
   }
 
-  .workspace-item-minimized.active .status-indicator-btn {
-    background: var(--ch-accent-muted, var(--ch-list-active-bg));
-    border-radius: 0;
-  }
-
-  .workspace-item-minimized.active::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 8px;
-    bottom: 8px;
-    width: 3px;
-    border-radius: 0 2px 2px 0;
-    background: var(--ch-focus-border);
+  .sidebar:not(.expanded) .workspace-tags-row {
+    display: none;
   }
 
   .shortcut-badge {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -1,28 +1,20 @@
 /**
  * Tests for the Sidebar component.
+ *
+ * The sidebar uses one DOM tree for both the expanded and collapsed state:
+ * every row is [label cell | icon cell at the right edge] and the collapsed
+ * sidebar shows only the icon column (via CSS keyed on the `.expanded`
+ * class). Expansion is derived from the real ui-mode store, so these tests
+ * use the actual store (reset between tests) instead of mocking it.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { flushSync } from "svelte";
 import type { Api } from "@shared/electron-api";
 import { createMockApi } from "../test-utils";
-import type { UIMode } from "@shared/ipc";
 // Import utility functions directly from the utility module
 import { getStatusText } from "$lib/utils/sidebar-utils";
-
-// Create mock for uiMode store
-const mockUiModeStore = vi.hoisted(() => ({
-  uiMode: {
-    value: "workspace" as UIMode,
-  },
-  setSidebarExpanded: vi.fn(),
-}));
-
-// Mock the ui-mode store (used directly by Sidebar)
-vi.mock("$lib/stores/ui-mode.svelte", () => mockUiModeStore);
-
-// Mock the shortcuts store (re-exports from ui-mode)
-vi.mock("$lib/stores/shortcuts.svelte", () => mockUiModeStore);
 
 // Create mock API (flat structure) — must be set before Sidebar import
 // because NotificationStack transitively imports $lib/api which checks window.api
@@ -41,7 +33,23 @@ import { createMockProject, createMockWorkspace } from "$lib/test-fixtures";
 import type { ProjectPath, WorkspacePath } from "@shared/ipc";
 import * as agentStatusStore from "$lib/stores/agent-status.svelte.js";
 import * as deletionStore from "$lib/stores/deletion.svelte.js";
+import {
+  desiredMode,
+  setModeFromMain,
+  setDialogOpen,
+  reset as resetUiMode,
+} from "$lib/stores/ui-mode.svelte.js";
 import type { ProjectId, WorkspaceName } from "@shared/api/types";
+
+const HOVER_DELAY_MS = 150;
+
+/** Deliberate hover: cursor deep in the gutter, sustained past the open delay. */
+async function hoverExpand(sidebar: Element): Promise<void> {
+  await fireEvent.mouseEnter(sidebar);
+  await fireEvent.mouseMove(sidebar, { clientX: 8 });
+  vi.advanceTimersByTime(HOVER_DELAY_MS);
+  flushSync();
+}
 
 describe("getStatusText helper", () => {
   it('returns "No agents running" for (0, 0)', () => {
@@ -84,12 +92,12 @@ describe("Sidebar component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    // Reset uiMode to workspace
-    mockUiModeStore.uiMode.value = "workspace";
+    resetUiMode();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    resetUiMode();
     document.body.innerHTML = "";
   });
 
@@ -501,11 +509,11 @@ describe("Sidebar component", () => {
     });
   });
 
-  describe("status indicator button column (minimized state)", () => {
-    // Tests for the clickable status indicator column (only visible in minimized state)
-    // Note: These tests check minimized state behavior (totalWorkspaces > 0, not hovering)
+  describe("status cell button", () => {
+    // The status cell is a button in BOTH modes; clicks bubble to the row's
+    // switch handler. When collapsed it is the entire visible row.
 
-    it("renders status indicator button for each workspace in minimized state", () => {
+    it("renders a status cell button for each workspace", () => {
       const ws1 = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const ws2 = createMockWorkspace({ path: "/test/.worktrees/ws2", name: "ws2" });
       const project = createMockProject({
@@ -517,13 +525,12 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project], totalWorkspaces: 2 },
       });
 
-      // Sidebar is minimized (totalWorkspaces > 0, not hovering, uiMode is workspace)
-      // Each workspace should have a status indicator button
+      // Sidebar is collapsed (totalWorkspaces > 0, not hovering, uiMode is workspace)
       const statusButtons = screen.getAllByRole("button", { name: /in test.*agent/i });
       expect(statusButtons).toHaveLength(2);
     });
 
-    it("clicking status indicator button calls onSwitchWorkspace", async () => {
+    it("clicking status cell button calls onSwitchWorkspace", async () => {
       const onSwitchWorkspace = vi.fn();
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
@@ -545,7 +552,7 @@ describe("Sidebar component", () => {
       });
     });
 
-    it("status indicator button has descriptive aria-label with workspace, project, and status", () => {
+    it("status cell button has descriptive aria-label with workspace, project, and status", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -612,11 +619,10 @@ describe("Sidebar component", () => {
   });
 
   describe("expand hint chevrons", () => {
-    // Note: Expand hints are only visible when sidebar is minimized
-    // When totalWorkspaces=0, sidebar is expanded (no expand hints visible)
-    // When totalWorkspaces>0 and not hovering, sidebar is minimized (expand hints visible)
+    // The expand hint is the one element that truly only exists in one mode
+    // (collapsed); everything else is a single DOM tree styled per mode.
 
-    it("renders expand hint chevron in header when minimized", () => {
+    it("renders expand hint chevron in header when collapsed", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -627,7 +633,7 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project], totalWorkspaces: 1 },
       });
 
-      // Sidebar is minimized - check that header contains an expand hint chevron
+      // Sidebar is collapsed - check that header contains an expand hint chevron
       const header = container.querySelector(".sidebar-header");
       expect(header).not.toBeNull();
 
@@ -758,122 +764,255 @@ describe("Sidebar component", () => {
       return { ...defaultProps, projects: [project], totalWorkspaces: 1 };
     };
 
-    it("expands on mouseenter", async () => {
+    it("expands after deliberate hover (trigger depth + open delay)", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
       expect(sidebar).not.toHaveClass("expanded");
 
-      await fireEvent.mouseEnter(sidebar!);
+      await hoverExpand(sidebar!);
 
       expect(sidebar).toHaveClass("expanded");
     });
 
-    it("collapses on mouseleave after 150ms debounce", async () => {
+    it("expands when the cursor enters and rests without further movement (edge slam)", async () => {
+      // A cursor slammed against the window edge can come to rest in the
+      // same frame it enters: mouseenter fires, but no mousemove follows.
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!, { clientX: 0 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS);
+      flushSync();
+
+      expect(sidebar).toHaveClass("expanded");
+    });
+
+    it("does not expand before the open delay elapses", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 8 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS - 50);
+      flushSync();
+
+      expect(sidebar).not.toHaveClass("expanded");
+    });
+
+    it("does not expand while the cursor stays in the outer quarter of the gutter", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 18 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
+
+      expect(sidebar).not.toHaveClass("expanded");
+    });
+
+    it("moving back out of the trigger depth cancels the pending expansion", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 8 });
+      vi.advanceTimersByTime(HOVER_DELAY_MS - 50);
+      await fireEvent.mouseMove(sidebar!, { clientX: 18 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
+
+      expect(sidebar).not.toHaveClass("expanded");
+    });
+
+    it("leaving before the open delay elapses cancels the pending expansion", async () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 8 });
+      vi.advanceTimersByTime(HOVER_DELAY_MS - 50);
+      await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
+
+      expect(sidebar).not.toHaveClass("expanded");
+    });
+
+    it("collapses on mouseleave after the debounce", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
 
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
+      await hoverExpand(sidebar!);
       expect(sidebar).toHaveClass("expanded");
 
-      // Start collapse - provide clientX > 5 to simulate leaving away from window edge
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
       // Should still be expanded immediately (debounce hasn't elapsed)
       expect(sidebar).toHaveClass("expanded");
 
-      // Wait for debounce
-      vi.advanceTimersByTime(150);
+      vi.advanceTimersByTime(HOVER_DELAY_MS);
+      flushSync();
 
-      await waitFor(() => {
-        expect(sidebar).not.toHaveClass("expanded");
-      });
+      expect(sidebar).not.toHaveClass("expanded");
     });
 
-    it("stays expanded when uiMode is 'shortcut'", async () => {
-      mockUiModeStore.uiMode.value = "shortcut";
+    it("expands after a slam to the left edge (shallow enter, then leave reported outside)", async () => {
+      // Observed event stream of a fast slam: one shallow enter (x=18), then
+      // a leave at x=-1 as the OS pins the cursor against the window edge.
+      // No further events arrive while the cursor rests there.
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await fireEvent.mouseEnter(sidebar!, { clientX: 18 });
+      await fireEvent.mouseLeave(sidebar!, { clientX: -1 });
+
+      vi.advanceTimersByTime(HOVER_DELAY_MS);
+      flushSync();
+
+      expect(sidebar).toHaveClass("expanded");
+    });
+
+    it("collapses on left exit when the window is not at the screen edge (windowed mode)", async () => {
+      // With space left of the window the cursor genuinely leaves; the pin
+      // interpretation only applies when the window sits at the screen edge.
+      const original = Object.getOwnPropertyDescriptor(window, "screenX");
+      Object.defineProperty(window, "screenX", { value: 120, configurable: true });
+      try {
+        const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+        const sidebar = container.querySelector(".sidebar");
+        await hoverExpand(sidebar!);
+        expect(sidebar).toHaveClass("expanded");
+
+        await fireEvent.mouseLeave(sidebar!, { clientX: -1 });
+        vi.advanceTimersByTime(HOVER_DELAY_MS);
+        flushSync();
+
+        expect(sidebar).not.toHaveClass("expanded");
+      } finally {
+        if (original) {
+          Object.defineProperty(window, "screenX", original);
+        } else {
+          Object.defineProperty(window, "screenX", { value: 0, configurable: true });
+        }
+      }
+    });
+
+    it("stays expanded while the cursor is pinned at the left window edge", async () => {
+      // A leave through the left boundary is a pin (deepest hover), not a
+      // leave — the sidebar must not collapse underneath the pinned cursor.
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const sidebar = container.querySelector(".sidebar");
+      await hoverExpand(sidebar!);
+      expect(sidebar).toHaveClass("expanded");
+
+      await fireEvent.mouseLeave(sidebar!, { clientX: 0 });
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
+
+      expect(sidebar).toHaveClass("expanded");
+    });
+
+    it("stays expanded when uiMode is 'shortcut'", () => {
+      setModeFromMain("shortcut");
+      flushSync();
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
       expect(sidebar).toHaveClass("expanded");
     });
 
-    it("does not set hover state when mouseenter occurs during shortcut mode", async () => {
-      // Scenario: Alt+X is pressed, sidebar expands into mouse position, mouseenter fires.
-      // When Alt is released, sidebar should collapse because hover state was not set.
-      const props = propsWithWorkspaces();
-
-      // Set uiMode to shortcut BEFORE render (like the "stays expanded" test above)
-      mockUiModeStore.uiMode.value = "shortcut";
+    it("does not latch hover while shortcut mode forces expansion", async () => {
+      // Scenario: Alt+X is pressed, sidebar expands into a parked cursor and
+      // mousemove events fire. When Alt is released the sidebar must collapse
+      // because hover was never latched.
+      setModeFromMain("shortcut");
+      flushSync();
 
       const { container } = render(Sidebar, {
-        props: { ...props, shortcutModeActive: true },
+        props: { ...propsWithWorkspaces(), shortcutModeActive: true },
       });
 
       const sidebar = container.querySelector(".sidebar");
-      // Sidebar is expanded due to shortcut mode (uiMode !== "workspace" check)
       expect(sidebar).toHaveClass("expanded");
 
-      // Mouse enters the expanded sidebar area during shortcut mode
+      // Cursor sits deep in the sidebar area during shortcut mode
       await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 8 });
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
 
-      // setSidebarExpanded should NOT have been called (hover state not set)
-      expect(mockUiModeStore.setSidebarExpanded).not.toHaveBeenCalled();
-    });
+      // Shortcut mode exits — sidebar collapses (hover was not latched)
+      setModeFromMain("workspace");
+      flushSync();
 
-    it("sets hover state when mouseenter occurs outside shortcut mode", async () => {
-      // Verify normal hover behavior works when not in shortcut mode
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-
-      const sidebar = container.querySelector(".sidebar");
       expect(sidebar).not.toHaveClass("expanded");
-
-      // Mouse enters when NOT in shortcut mode
-      await fireEvent.mouseEnter(sidebar!);
-
-      // setSidebarExpanded SHOULD have been called with true
-      expect(mockUiModeStore.setSidebarExpanded).toHaveBeenCalledWith(true);
-      expect(sidebar).toHaveClass("expanded");
     });
 
-    it("stays expanded when uiMode is 'dialog'", async () => {
-      mockUiModeStore.uiMode.value = "dialog";
+    it("does not latch hover while a dialog forces expansion", async () => {
+      setDialogOpen(true);
+      flushSync();
+
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+      const sidebar = container.querySelector(".sidebar");
+      expect(sidebar).toHaveClass("expanded");
+
+      await fireEvent.mouseEnter(sidebar!);
+      await fireEvent.mouseMove(sidebar!, { clientX: 8 });
+      vi.advanceTimersByTime(HOVER_DELAY_MS * 3);
+      flushSync();
+
+      setDialogOpen(false);
+      flushSync();
+
+      expect(sidebar).not.toHaveClass("expanded");
+    });
+
+    it("stays expanded when a dialog is open", () => {
+      setDialogOpen(true);
+      flushSync();
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
       expect(sidebar).toHaveClass("expanded");
     });
 
-    it("stays expanded when totalWorkspaces is 0", async () => {
+    it("stays expanded when totalWorkspaces is 0", () => {
       const { container } = render(Sidebar, { props: { ...defaultProps, totalWorkspaces: 0 } });
 
       const sidebar = container.querySelector(".sidebar");
       expect(sidebar).toHaveClass("expanded");
     });
 
-    it("rapid mouseenter/mouseleave settles to correct final state", async () => {
+    it("rapid hover in/out settles to correct final state", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
 
-      // Rapid hover in/out - provide clientX > 5 for mouseleave events
-      await fireEvent.mouseEnter(sidebar!);
+      await hoverExpand(sidebar!);
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
       await fireEvent.mouseEnter(sidebar!);
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
       await fireEvent.mouseEnter(sidebar!);
+      flushSync();
 
-      // Should be expanded because last action was mouseenter
+      // Should be expanded because last action was re-entering
       expect(sidebar).toHaveClass("expanded");
 
       // Leave and wait
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
-      vi.advanceTimersByTime(150);
+      vi.advanceTimersByTime(HOVER_DELAY_MS);
+      flushSync();
 
-      await waitFor(() => {
-        expect(sidebar).not.toHaveClass("expanded");
-      });
+      expect(sidebar).not.toHaveClass("expanded");
     });
 
     it("cancels collapse when mouse re-enters during debounce", async () => {
@@ -881,11 +1020,9 @@ describe("Sidebar component", () => {
 
       const sidebar = container.querySelector(".sidebar");
 
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
+      await hoverExpand(sidebar!);
       expect(sidebar).toHaveClass("expanded");
 
-      // Start collapse - provide clientX > 5 for valid mouseleave
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
 
       // Wait partial debounce
@@ -895,52 +1032,33 @@ describe("Sidebar component", () => {
       await fireEvent.mouseEnter(sidebar!);
 
       // Wait full debounce time
-      vi.advanceTimersByTime(150);
+      vi.advanceTimersByTime(HOVER_DELAY_MS);
+      flushSync();
 
       // Should still be expanded because re-enter cancelled collapse
       expect(sidebar).toHaveClass("expanded");
     });
 
-    it("clears collapse timeout on unmount to prevent memory leak", async () => {
+    it("clears pending timeouts on unmount", async () => {
       const { container, unmount } = render(Sidebar, { props: propsWithWorkspaces() });
 
       const sidebar = container.querySelector(".sidebar");
 
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
+      await hoverExpand(sidebar!);
       expect(sidebar).toHaveClass("expanded");
 
-      // Start collapse (this schedules a timeout) - provide clientX > 5
+      // Start collapse (this schedules a timeout)
       await fireEvent.mouseLeave(sidebar!, { clientX: 100 });
 
       // Unmount before timeout fires
       unmount();
 
-      // Advance timers past the debounce period
-      // If timeout was not cleared, this would throw due to accessing unmounted component state
       vi.advanceTimersByTime(200);
+      flushSync();
 
-      // No error thrown means cleanup worked correctly
-      // The component's onDestroy should have cleared the timeout
-    });
-
-    it("does not collapse when mouse leaves at window edge (clientX < 5)", async () => {
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-
-      const sidebar = container.querySelector(".sidebar");
-
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
-      expect(sidebar).toHaveClass("expanded");
-
-      // Mouse leaves at window edge (clientX < 5 indicates user hit window boundary)
-      await fireEvent.mouseLeave(sidebar!, { clientX: 0 });
-
-      // Wait for what would be the debounce period
-      vi.advanceTimersByTime(200);
-
-      // Should still be expanded because we don't collapse at window edge
-      expect(sidebar).toHaveClass("expanded");
+      // The collapse timeout was cleared: the store input set by hover is
+      // untouched after unmount.
+      expect(desiredMode.value).toBe("hover");
     });
 
     it("respects prefers-reduced-motion media query (CSS verification)", () => {
@@ -957,7 +1075,7 @@ describe("Sidebar component", () => {
     });
   });
 
-  describe("expanded vs minimized layout", () => {
+  describe("unified layout (expanded vs collapsed)", () => {
     const propsWithWorkspaces = () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
@@ -967,108 +1085,74 @@ describe("Sidebar component", () => {
       return { ...defaultProps, projects: [project], totalWorkspaces: 1 };
     };
 
-    it("expanded layout does not have status-indicator-btn in workspace rows", async () => {
-      // Set to expanded (hovering)
+    it("renders one DOM tree: status cell, workspace button, and remove button exist in both modes", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
       const sidebar = container.querySelector(".sidebar");
 
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
-      expect(sidebar).toHaveClass("expanded");
-
-      // In expanded state, status-indicator-btn should NOT be rendered
-      const statusBtn = container.querySelector(".status-indicator-btn");
-      expect(statusBtn).not.toBeInTheDocument();
-    });
-
-    it("minimized layout shows status indicators with aria-labels", async () => {
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-
-      // Initially minimized (uiMode is workspace and totalWorkspaces > 0)
-      // However, the mock uiMode starts as "workspace" but we need to ensure
-      // the sidebar is NOT expanded (not hovering)
-      const sidebar = container.querySelector(".sidebar");
+      // Collapsed
       expect(sidebar).not.toHaveClass("expanded");
+      expect(container.querySelector(".status-cell")).toBeInTheDocument();
+      expect(container.querySelector(".workspace-btn")).toBeInTheDocument();
+      expect(container.querySelector(".remove-btn")).toBeInTheDocument();
 
-      // In minimized state, status-indicator-btn should be rendered with aria-label
-      const statusBtns = container.querySelectorAll(".status-indicator-btn");
-      expect(statusBtns.length).toBeGreaterThan(0);
-
-      // Check that buttons have descriptive aria-labels
-      statusBtns.forEach((btn) => {
-        expect(btn).toHaveAttribute("aria-label");
-        expect(btn.getAttribute("aria-label")).toMatch(/ws1 in test/);
-      });
+      // Expanded — same elements, no markup swap
+      await hoverExpand(sidebar!);
+      expect(sidebar).toHaveClass("expanded");
+      expect(container.querySelector(".status-cell")).toBeInTheDocument();
+      expect(container.querySelector(".workspace-btn")).toBeInTheDocument();
+      expect(container.querySelector(".remove-btn")).toBeInTheDocument();
     });
 
-    it("expand hint only visible when minimized", async () => {
+    it("status cell has descriptive aria-label in both modes", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
       const sidebar = container.querySelector(".sidebar");
 
-      // Initially minimized - expand hints should be visible
-      expect(sidebar).not.toHaveClass("expanded");
-      let expandHints = container.querySelectorAll(".expand-hint");
-      expect(expandHints.length).toBeGreaterThan(0);
+      const assertLabel = (): void => {
+        const statusCell = container.querySelector(".status-cell");
+        expect(statusCell).toHaveAttribute("aria-label");
+        expect(statusCell!.getAttribute("aria-label")).toMatch(/ws1 in test/);
+      };
 
-      // Expand - expand hints should be hidden
-      await fireEvent.mouseEnter(sidebar!);
-      expect(sidebar).toHaveClass("expanded");
-      expandHints = container.querySelectorAll(".expand-hint");
-      expect(expandHints.length).toBe(0);
+      assertLabel();
+      await hoverExpand(sidebar!);
+      assertLabel();
     });
 
-    it("expanded layout has status indicator on right side (original layout)", async () => {
+    it("workspace label and remove button are in a label cell (hidden when collapsed via CSS)", () => {
+      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
+
+      const labelCell = container.querySelector(".workspace-label-cell");
+      expect(labelCell).toHaveClass("ch-label-cell");
+      expect(labelCell!.querySelector(".workspace-btn")).toBeInTheDocument();
+      expect(labelCell!.querySelector(".remove-btn")).toBeInTheDocument();
+    });
+
+    it("project header is a label cell and has no inert attribute", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
       const sidebar = container.querySelector(".sidebar");
 
-      // Expand
-      await fireEvent.mouseEnter(sidebar!);
-      expect(sidebar).toHaveClass("expanded");
-
-      // In expanded state, AgentStatusIndicator should be rendered (as part of workspace-item)
-      const indicators = container.querySelectorAll('[role="status"]');
-      expect(indicators.length).toBeGreaterThan(0);
-    });
-
-    it("project header is inert when minimized", () => {
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-
-      // Sidebar is minimized (totalWorkspaces > 0, uiMode is workspace, no hover)
       const header = container.querySelector(".project-header");
-      expect(header).toHaveAttribute("inert");
+      expect(header).toHaveClass("ch-label-cell");
+      expect(header).not.toHaveAttribute("inert");
+
+      await hoverExpand(sidebar!);
+      expect(header).not.toHaveAttribute("inert");
     });
 
-    it("project header is interactive when expanded via hover", async () => {
+    it("h2 heading exists in both modes inside a label cell", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
       const sidebar = container.querySelector(".sidebar");
 
-      await fireEvent.mouseEnter(sidebar!);
-      expect(sidebar).toHaveClass("expanded");
-
-      expect(container.querySelector(".project-header")).not.toHaveAttribute("inert");
-    });
-
-    it("h2 heading is visually hidden when minimized", () => {
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-
-      expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
+      expect(sidebar).not.toHaveClass("expanded");
       const heading = container.querySelector(".sidebar-header h2");
       expect(heading).toBeInTheDocument();
-      expect(heading).toHaveClass("visually-collapsed");
+      expect(heading!.closest(".ch-label-cell")).not.toBeNull();
+
+      await hoverExpand(sidebar!);
+      expect(container.querySelector(".sidebar-header h2")).toBeInTheDocument();
     });
 
-    it("h2 heading is visible when expanded", async () => {
-      const { container } = render(Sidebar, { props: propsWithWorkspaces() });
-      const sidebar = container.querySelector(".sidebar");
-
-      await fireEvent.mouseEnter(sidebar!);
-
-      const heading = container.querySelector(".sidebar-header h2");
-      expect(heading).toBeInTheDocument();
-      expect(heading).not.toHaveClass("visually-collapsed");
-    });
-
-    it("vscode-divider is inert when minimized", () => {
+    it("vscode-divider has no inert attribute", () => {
       const ws1 = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const ws2 = createMockWorkspace({ path: "/test2/.worktrees/ws2", name: "ws2" });
       const project1 = createMockProject({
@@ -1087,7 +1171,7 @@ describe("Sidebar component", () => {
       expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
       const divider = container.querySelector("vscode-divider");
       expect(divider).toBeInTheDocument();
-      expect(divider).toHaveAttribute("inert");
+      expect(divider).not.toHaveAttribute("inert");
     });
   });
 
@@ -1107,12 +1191,10 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      // Expand sidebar to see tags
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       const tagsContainer = container.querySelector(".workspace-tags");
       expect(tagsContainer).toBeInTheDocument();
+      // The tags row is hidden when collapsed via CSS keyed on .expanded
+      expect(container.querySelector(".workspace-tags-row")).toBeInTheDocument();
 
       const pills = container.querySelectorAll(".tag-pill");
       expect(pills).toHaveLength(2);
@@ -1122,7 +1204,7 @@ describe("Sidebar component", () => {
       expect(pillTexts).toContain("wip");
     });
 
-    it("does not render tags container when workspace has no tags", async () => {
+    it("does not render tags container when workspace has no tags", () => {
       const ws = createMockWorkspace({
         path: "/test/.worktrees/ws1",
         name: "ws1",
@@ -1137,10 +1219,8 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       expect(container.querySelector(".workspace-tags")).not.toBeInTheDocument();
+      expect(container.querySelector(".workspace-tags-row")).not.toBeInTheDocument();
     });
   });
 
@@ -1175,7 +1255,7 @@ describe("Sidebar component", () => {
       deletionStore.reset();
     });
 
-    it("shows spinner when workspace is deleting (expanded layout)", async () => {
+    it("shows spinner when workspace is deleting (expanded)", async () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1189,16 +1269,11 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       // Should have progress-ring (spinner) instead of status indicator
       expect(container.querySelector("vscode-progress-ring.deletion-spinner")).toBeInTheDocument();
-      // Should NOT have regular status indicator for this workspace
-      // Note: getByRole would find the workspace-item status, but we deleted it
     });
 
-    it("shows spinner when workspace is deleting (minimized layout)", () => {
+    it("shows spinner when workspace is deleting (collapsed)", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1212,11 +1287,11 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project], totalWorkspaces: 1 },
       });
 
-      // In minimized state, should show spinner
+      // In collapsed state, should show spinner
       expect(container.querySelector("vscode-progress-ring.deletion-spinner")).toBeInTheDocument();
     });
 
-    it("shows agent status indicator when not deleting", async () => {
+    it("shows agent status indicator when not deleting", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1229,9 +1304,6 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       // Should have status indicator, NOT spinner
       expect(
         container.querySelector("vscode-progress-ring.deletion-spinner")
@@ -1239,7 +1311,7 @@ describe("Sidebar component", () => {
       expect(screen.getByRole("status")).toBeInTheDocument();
     });
 
-    it("minimized layout aria-label shows Deleting when workspace is being deleted", () => {
+    it("status cell aria-label shows Deleting when workspace is being deleted", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1259,7 +1331,7 @@ describe("Sidebar component", () => {
       expect(statusButton).toBeInTheDocument();
     });
 
-    it("shows spinner for deleting workspace and status for non-deleting", async () => {
+    it("shows spinner for deleting workspace and status for non-deleting", () => {
       const ws1 = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const ws2 = createMockWorkspace({ path: "/test/.worktrees/ws2", name: "ws2" });
       const project = createMockProject({
@@ -1274,15 +1346,12 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       // Should have one spinner (ws1) and one status indicator (ws2)
       expect(container.querySelectorAll("vscode-progress-ring.deletion-spinner")).toHaveLength(1);
       expect(screen.getAllByRole("status")).toHaveLength(1);
     });
 
-    it("hides X button when deletion status is in-progress (expanded layout)", async () => {
+    it("hides X button when deletion status is in-progress", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1292,18 +1361,15 @@ describe("Sidebar component", () => {
       // Set deletion state (in-progress: completed=false)
       deletionStore.setDeletionState(createDeletionProgress("/test/.worktrees/ws1"));
 
-      const { container } = render(Sidebar, {
+      render(Sidebar, {
         props: { ...defaultProps, projects: [project] },
       });
-
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
 
       // X button should NOT be rendered for workspace being deleted
       expect(screen.queryByLabelText("Remove workspace")).not.toBeInTheDocument();
     });
 
-    it("hides X button when deletion status is error (expanded layout)", async () => {
+    it("hides X button when deletion status is error", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1316,18 +1382,15 @@ describe("Sidebar component", () => {
       errorState.hasErrors = true;
       deletionStore.setDeletionState(errorState);
 
-      const { container } = render(Sidebar, {
+      render(Sidebar, {
         props: { ...defaultProps, projects: [project] },
       });
-
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
 
       // X button should NOT be rendered for workspace with deletion error
       expect(screen.queryByLabelText("Remove workspace")).not.toBeInTheDocument();
     });
 
-    it("shows warning triangle when deletion status is error (expanded layout)", async () => {
+    it("shows warning triangle when deletion status is error", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1343,9 +1406,6 @@ describe("Sidebar component", () => {
       const { container } = render(Sidebar, {
         props: { ...defaultProps, projects: [project] },
       });
-
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
 
       // Warning triangle should be visible - Icon component renders vscode-icon
       const warning = container.querySelector(".deletion-error");
@@ -1353,7 +1413,7 @@ describe("Sidebar component", () => {
       expect(warning!.querySelector("vscode-icon")).toBeInTheDocument();
     });
 
-    it("warning triangle has accessible attributes", async () => {
+    it("warning triangle has accessible attributes", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1370,16 +1430,13 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project] },
       });
 
-      const sidebar = container.querySelector(".sidebar");
-      await fireEvent.mouseEnter(sidebar!);
-
       // Warning should have role="img" and aria-label
       const warning = container.querySelector(".deletion-error");
       expect(warning).toHaveAttribute("role", "img");
       expect(warning).toHaveAttribute("aria-label", "Deletion failed");
     });
 
-    it("minimized layout shows warning when deletion status is error", () => {
+    it("collapsed mode shows warning when deletion status is error", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,
@@ -1397,7 +1454,7 @@ describe("Sidebar component", () => {
         props: { ...defaultProps, projects: [project], totalWorkspaces: 1 },
       });
 
-      // In minimized state, should show warning - Icon component renders vscode-icon
+      // In collapsed state, should show warning - Icon component renders vscode-icon
       const warning = container.querySelector(".deletion-error");
       expect(warning).toBeInTheDocument();
       expect(warning!.querySelector("vscode-icon")).toBeInTheDocument();
@@ -1410,7 +1467,7 @@ describe("Sidebar component", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("minimized layout aria-label shows Deletion failed when status is error", () => {
+    it("status cell aria-label shows Deletion failed when status is error", () => {
       const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
       const project = createMockProject({
         path: "/test" as ProjectPath,

--- a/src/renderer/lib/stores/ui-mode.svelte.test.ts
+++ b/src/renderer/lib/stores/ui-mode.svelte.test.ts
@@ -21,9 +21,11 @@ import {
   uiMode,
   desiredMode,
   shortcutModeActive,
+  hoverExpansionEligible,
   setModeFromMain,
   setDialogOpen,
   setSidebarExpanded,
+  setNewWorkspaceViewOpen,
   computeDesiredMode,
   syncMode,
   reset,
@@ -238,6 +240,50 @@ describe("ui-mode store", () => {
 
       syncMode();
       expect(mockApi.ui.setMode).toHaveBeenCalledWith("hover");
+    });
+  });
+
+  describe("hoverExpansionEligible", () => {
+    it("is true in plain workspace mode", () => {
+      expect(hoverExpansionEligible.value).toBe(true);
+    });
+
+    it("is false while shortcut mode is active", () => {
+      setModeFromMain("shortcut");
+      flushSync();
+
+      expect(hoverExpansionEligible.value).toBe(false);
+    });
+
+    it("is false while a dialog is open", () => {
+      setDialogOpen(true);
+      flushSync();
+
+      expect(hoverExpansionEligible.value).toBe(false);
+    });
+
+    it("is false while the New workspace view is open", () => {
+      setNewWorkspaceViewOpen(true);
+      flushSync();
+
+      expect(hoverExpansionEligible.value).toBe(false);
+    });
+
+    it("stays true when hover itself is the only expansion cause", () => {
+      setSidebarExpanded(true);
+      flushSync();
+
+      expect(hoverExpansionEligible.value).toBe(true);
+    });
+
+    it("becomes true again when the forcing mode exits", () => {
+      setModeFromMain("shortcut");
+      flushSync();
+      expect(hoverExpansionEligible.value).toBe(false);
+
+      setModeFromMain("workspace");
+      flushSync();
+      expect(hoverExpansionEligible.value).toBe(true);
     });
   });
 

--- a/src/renderer/lib/stores/ui-mode.svelte.ts
+++ b/src/renderer/lib/stores/ui-mode.svelte.ts
@@ -66,6 +66,15 @@ const _desiredMode = $derived(
   computeDesiredMode(_modeFromMain, _dialogOpen, _sidebarExpanded, _newWorkspaceViewOpen)
 );
 
+// True when hover may initiate sidebar expansion: nothing else (shortcut
+// mode, a dialog, the New workspace view) is already forcing the UI on top.
+// Derived by computing the mode with the hover input blanked out — otherwise
+// the sidebar expanding into a parked cursor would latch hover and keep the
+// sidebar open after that mode exits.
+const _hoverExpansionEligible = $derived(
+  computeDesiredMode(_modeFromMain, _dialogOpen, false, _newWorkspaceViewOpen) === "workspace"
+);
+
 // ============ Getters (follow store pattern) ============
 
 /**
@@ -96,6 +105,16 @@ export const desiredMode = {
 export const shortcutModeActive = {
   get value(): boolean {
     return _modeFromMain === "shortcut";
+  },
+};
+
+/**
+ * Whether hover may initiate sidebar expansion (no other input is already
+ * forcing the UI on top). Consumed by the Sidebar's hover tracking.
+ */
+export const hoverExpansionEligible = {
+  get value(): boolean {
+    return _hoverExpansionEligible;
   },
 };
 

--- a/src/renderer/lib/styles/global.css
+++ b/src/renderer/lib/styles/global.css
@@ -58,3 +58,32 @@ textarea {
   white-space: nowrap;
   border: 0;
 }
+
+/* ============================================================================
+ * Sidebar two-column row cells
+ * Every sidebar row is [flexible label cell | fixed icon cell at the right
+ * edge]; the collapsed sidebar shows only the icon column. Shared between
+ * Sidebar and NotificationStack (Svelte scoping would otherwise force each
+ * component to duplicate these rules). `.ch-sidebar-expanded` is set on the
+ * sidebar root alongside its scoped `expanded` class.
+ * ============================================================================ */
+
+.ch-icon-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ch-sidebar-minimized-width, 20px);
+  min-width: var(--ch-sidebar-minimized-width, 20px);
+  flex-shrink: 0;
+}
+
+/* Collapsed label cells are out of the tab order and accessibility tree.
+   No transition: collapse snaps (see Sidebar.svelte), and during the expand
+   animation the labels are revealed by the growing width. */
+.ch-label-cell {
+  visibility: hidden;
+}
+
+.ch-sidebar-expanded .ch-label-cell {
+  visibility: visible;
+}


### PR DESCRIPTION
- Replace the duplicated expanded/minimized markup branches in Sidebar and NotificationStack with one two-column row layout: [flexible label cell | fixed 20px icon cell at the right edge]; collapsing hides the label cells, so the icon column IS the collapsed sidebar
- Status-indicator block (pending/deleting/error/hibernated/normal) now exists once, preparing the upcoming interactive hibernation-icon work
- Shared `.ch-icon-cell` / `.ch-label-cell` utilities in global.css; CSS keys off the existing `.expanded` class; `inert` plumbing on project headers/dividers removed
- Status cell is a real `<button>` in both modes (clicks bubble to the row's switch handler)
- Expansion state machine consolidated: `isExpanded` derives from the ui-mode store's synchronous `desiredMode`; hover lock-in guard generalized to all forced-expanded modes via new `hoverExpansionEligible`
- Deliberate-hover gating: 150ms open delay + depth threshold (cursor must pass the outer quarter of the gutter)
- Expand animates; collapse snaps (ending hover instantly drops the UI view below the workspace views, so an animated collapse only reads as icon flicker)
- Left-edge exits: leave at clientX <= 0 while the window sits at the screen's left edge is a pinned cursor (slams deliver only a shallow enter + that leave) and arms/holds expansion; in windowed mode it collapses normally
- Debug logging for hover state transitions under the [ui] logger