### PR TITLE
fix(notifications): buffer notification commands until the renderer is ready

### DIFF
--- a/src/modules/debug-module.integration.test.ts
+++ b/src/modules/debug-module.integration.test.ts
@@ -256,10 +256,10 @@ describe("DebugModule Integration", () => {
   });
 
   describe("update (active)", () => {
-    it("start hook opens 'Update available' notification when debug.update is on", async () => {
+    it("start hook opens 'Update available' notification when debug.update is 'pending'", async () => {
       const { manager, notifications } = createMockNotificationManager();
       const module = createDebugModule({
-        configService: createMockConfig({ defaults: { "debug.update": true } }),
+        configService: createMockConfig({ defaults: { "debug.update": "pending" } }),
         notificationManager: manager,
       });
       const hook = getHook(module, APP_START_OPERATION_ID, "start");
@@ -270,12 +270,39 @@ describe("DebugModule Integration", () => {
       expect(notifications[0]!.opened.actions).toEqual([{ id: "install", label: "Install" }]);
     });
 
+    it("bare flag value 'true' behaves like 'pending'", async () => {
+      const { manager, notifications } = createMockNotificationManager();
+      const module = createDebugModule({
+        configService: createMockConfig({ defaults: { "debug.update": "true" } }),
+        notificationManager: manager,
+      });
+      const hook = getHook(module, APP_START_OPERATION_ID, "start");
+      await hook.handler(makeHookContext());
+
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]!.opened.title).toBe("Update available");
+    });
+
+    it("start hook opens 'Update ready' notification when debug.update is 'downloaded'", async () => {
+      const { manager, notifications } = createMockNotificationManager();
+      const module = createDebugModule({
+        configService: createMockConfig({ defaults: { "debug.update": "downloaded" } }),
+        notificationManager: manager,
+      });
+      const hook = getHook(module, APP_START_OPERATION_ID, "start");
+      await hook.handler(makeHookContext());
+
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]!.opened.title).toBe("Update ready");
+      expect(notifications[0]!.opened.actions).toEqual([{ id: "restart", label: "Restart Now" }]);
+    });
+
     it("clicking Install transitions to downloading then ready", async () => {
       vi.useFakeTimers();
       try {
         const { manager, notifications, emitEvent } = createMockNotificationManager();
         const module = createDebugModule({
-          configService: createMockConfig({ defaults: { "debug.update": true } }),
+          configService: createMockConfig({ defaults: { "debug.update": "pending" } }),
           notificationManager: manager,
         });
         const hook = getHook(module, APP_START_OPERATION_ID, "start");
@@ -304,7 +331,7 @@ describe("DebugModule Integration", () => {
     it("check-deps returns missingBinaries when debug.setup is on", async () => {
       const module = createDebugModule({
         configService: createMockConfig({
-          defaults: { "debug.setup": true, "debug.update": true },
+          defaults: { "debug.setup": true, "debug.update": "pending" },
         }),
       });
       const hook = getHook(module, APP_START_OPERATION_ID, "check-deps");

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -4,7 +4,9 @@
  * Controlled by config keys (env vars / CLI flags):
  * - debug.blocking-pids: Simulate blocking processes during workspace deletion
  * - debug.setup: Force setup flow with simulated binary download progress
- * - debug.update: Simulate available update with download progress
+ * - debug.update: Simulate an update notification. "pending" (or bare flag)
+ *   shows "Update available" with the full install → download → ready flow;
+ *   "downloaded" jumps straight to "Update ready".
  *
  * Only active in development mode (requires: { development: true }).
  */
@@ -12,7 +14,7 @@
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext } from "../intents/lib/operation";
 import type { Config } from "../boundaries/platform/config";
-import { storeBoolean } from "../boundaries/platform/store-definition";
+import { storeBoolean, storeEnum } from "../boundaries/platform/store-definition";
 import { APP_START_OPERATION_ID, type CheckDepsResult } from "../intents/app-start";
 import type { BinaryType } from "../utils/binary-resolution/types";
 import {
@@ -54,16 +56,24 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
         description: "Force setup flow with simulated binary download progress",
         ...storeBoolean(),
       }),
-      configService.register("debug.update", {
-        default: false,
-        description: "Simulate available update with download progress",
-        ...storeBoolean(),
-      }),
     ].map((accessor) => [accessor.name, accessor] as const)
   );
 
+  // "true" is what a bare --debug.update CLI flag parses to; treat it as "pending".
+  const updateModeConfig = configService.register("debug.update", {
+    default: null,
+    description:
+      "Simulate update notification: pending = available + install flow, downloaded = ready to install",
+    ...storeEnum(["true", "pending", "downloaded"], { nullable: true }),
+  });
+
   function isActive(key: string): boolean {
     return debugConfigs.get(key)?.get() === true;
+  }
+
+  function updateMode(): "pending" | "downloaded" | null {
+    const value = updateModeConfig.get();
+    return value === "true" ? "pending" : value;
   }
 
   // Workspaces kept alive by debug.blocking-pids after deletion
@@ -129,9 +139,14 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
         },
         start: {
           handler: async (): Promise<void> => {
-            if (!isActive("debug.update") || !deps.notificationManager) return;
+            const mode = updateMode();
+            if (mode === null || !deps.notificationManager) return;
             const version = "99.0.0-debug";
-            simulateUpdateNotification(deps.notificationManager, version);
+            if (mode === "downloaded") {
+              deps.notificationManager.open(readyConfig(version));
+            } else {
+              simulateUpdateNotification(deps.notificationManager, version);
+            }
           },
         },
       },
@@ -152,6 +167,16 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
         },
       },
     },
+  };
+}
+
+function readyConfig(version: string): NotificationConfig {
+  return {
+    type: "info",
+    title: "Update ready",
+    message: `Version ${version} is ready to install.`,
+    dismissible: false,
+    actions: [{ id: "restart", label: "Restart Now" }],
   };
 }
 
@@ -182,13 +207,7 @@ async function simulateDownload(handle: NotificationHandle, version: string): Pr
     });
     await delay(150);
   }
-  handle.update({
-    type: "info",
-    title: "Update ready",
-    message: `Version ${version} is ready to install.`,
-    dismissible: false,
-    actions: [{ id: "restart", label: "Restart Now" }],
-  });
+  handle.update(readyConfig(version));
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/modules/notification-manager.integration.test.ts
+++ b/src/modules/notification-manager.integration.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+/**
+ * Integration tests for NotificationManager command buffering.
+ *
+ * The renderer's NotificationHost only subscribes once MainView mounts, so
+ * commands sent earlier must be buffered and flushed on markUIReady().
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { NotificationManager } from "./notification-manager";
+import { ApiIpcChannels } from "../shared/ipc";
+import type { IViewManager } from "../boundaries/shell/view-manager.interface";
+import type { NotificationConfig } from "../shared/notification-types";
+
+const CONFIG: NotificationConfig = {
+  type: "info",
+  title: "Test",
+  message: "Test message",
+  dismissible: true,
+};
+
+function createManager() {
+  const sendToUI = vi.fn<(channel: string, ...args: unknown[]) => void>();
+  const manager = new NotificationManager({ sendToUI } as unknown as IViewManager);
+  return { manager, sendToUI };
+}
+
+describe("NotificationManager buffering", () => {
+  it("buffers commands until markUIReady, then flushes in order", () => {
+    const { manager, sendToUI } = createManager();
+
+    const handle = manager.open(CONFIG);
+    const updated: NotificationConfig = { ...CONFIG, title: "Updated" };
+    handle.update(updated);
+
+    expect(sendToUI).not.toHaveBeenCalled();
+
+    manager.markUIReady();
+
+    expect(sendToUI.mock.calls).toEqual([
+      [
+        ApiIpcChannels.NOTIFICATION_COMMAND,
+        { action: "open", notificationId: handle.id, config: CONFIG },
+      ],
+      [
+        ApiIpcChannels.NOTIFICATION_COMMAND,
+        { action: "update", notificationId: handle.id, config: updated },
+      ],
+    ]);
+  });
+
+  it("skips notifications opened and closed while buffered", () => {
+    const { manager, sendToUI } = createManager();
+
+    const transient = manager.open(CONFIG);
+    transient.close();
+    const survivor = manager.open(CONFIG);
+
+    manager.markUIReady();
+
+    expect(sendToUI).toHaveBeenCalledTimes(1);
+    expect(sendToUI).toHaveBeenCalledWith(ApiIpcChannels.NOTIFICATION_COMMAND, {
+      action: "open",
+      notificationId: survivor.id,
+      config: CONFIG,
+    });
+  });
+
+  it("sends directly after markUIReady", () => {
+    const { manager, sendToUI } = createManager();
+    manager.markUIReady();
+
+    const handle = manager.open(CONFIG);
+    handle.close();
+
+    expect(sendToUI.mock.calls).toEqual([
+      [
+        ApiIpcChannels.NOTIFICATION_COMMAND,
+        { action: "open", notificationId: handle.id, config: CONFIG },
+      ],
+      [ApiIpcChannels.NOTIFICATION_COMMAND, { action: "close", notificationId: handle.id }],
+    ]);
+  });
+
+  it("markUIReady is idempotent", () => {
+    const { manager, sendToUI } = createManager();
+
+    manager.open(CONFIG);
+    manager.markUIReady();
+    manager.markUIReady();
+
+    expect(sendToUI).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/notification-manager.state-mock.ts
+++ b/src/modules/notification-manager.state-mock.ts
@@ -73,6 +73,8 @@ export function createMockNotificationManager(): MockNotificationManager {
       } satisfies NotificationHandle;
     },
     routeEvent() {},
+    // The mock has no buffering — notifications are tracked immediately.
+    markUIReady() {},
   } as unknown as NotificationManager;
 
   return {

--- a/src/modules/notification-manager.ts
+++ b/src/modules/notification-manager.ts
@@ -36,12 +36,20 @@ export interface NotificationHandle {
 
 /**
  * NotificationManager sends typed commands to the renderer for notification lifecycle.
+ *
+ * Commands are buffered until markUIReady() is called: the renderer's
+ * NotificationHost only subscribes to notification commands once MainView
+ * mounts, so anything sent earlier (e.g. from app:start hooks) would be
+ * silently dropped. The buffer is flushed in order when the renderer
+ * dispatches lifecycle.ready().
  */
 export class NotificationManager {
   private readonly viewManager: IViewManager;
   private readonly handles = new Map<string, NotificationHandleImpl>();
   private readonly logger: Logger | undefined;
   private nextId = 1;
+  private uiReady = false;
+  private pendingCommands: NotificationCommand[] = [];
 
   constructor(viewManager: IViewManager, logger?: Logger) {
     this.viewManager = viewManager;
@@ -53,15 +61,45 @@ export class NotificationManager {
    */
   open(config: NotificationConfig): NotificationHandle {
     const notificationId = `ntf-${this.nextId++}`;
-    const handle = new NotificationHandleImpl(notificationId, this.viewManager, () => {
-      this.handles.delete(notificationId);
-    });
+    const handle = new NotificationHandleImpl(
+      notificationId,
+      (command) => this.send(command),
+      () => {
+        this.handles.delete(notificationId);
+      }
+    );
     this.handles.set(notificationId, handle);
 
-    const command: NotificationCommand = { action: "open", notificationId, config };
-    this.viewManager.sendToUI(ApiIpcChannels.NOTIFICATION_COMMAND, command);
+    this.send({ action: "open", notificationId, config });
 
     return handle;
+  }
+
+  /**
+   * Flush buffered commands and switch to direct delivery. Idempotent.
+   * Called once the renderer's NotificationHost is mounted (lifecycle.ready()).
+   * Notifications that were already closed while buffered are skipped entirely.
+   */
+  markUIReady(): void {
+    if (this.uiReady) return;
+    this.uiReady = true;
+    const buffered = this.pendingCommands;
+    this.pendingCommands = [];
+    const closedIds = new Set(
+      buffered.filter((c) => c.action === "close").map((c) => c.notificationId)
+    );
+    for (const command of buffered) {
+      if (closedIds.has(command.notificationId)) continue;
+      this.viewManager.sendToUI(ApiIpcChannels.NOTIFICATION_COMMAND, command);
+    }
+  }
+
+  private send(command: NotificationCommand): void {
+    if (!this.uiReady) {
+      this.pendingCommands.push(command);
+      return;
+    }
+    this.viewManager.sendToUI(ApiIpcChannels.NOTIFICATION_COMMAND, command);
   }
 
   /**
@@ -88,15 +126,15 @@ class NotificationHandleImpl implements NotificationHandle {
   readonly id: string;
   readonly closed: Promise<void>;
 
-  private readonly viewManager: IViewManager;
+  private readonly send: (command: NotificationCommand) => void;
   private readonly onRemove: () => void;
   private readonly listeners = new Set<(event: NotificationUserEvent) => void>();
   private resolveClosed!: () => void;
   private isClosed = false;
 
-  constructor(id: string, viewManager: IViewManager, onRemove: () => void) {
+  constructor(id: string, send: (command: NotificationCommand) => void, onRemove: () => void) {
     this.id = id;
-    this.viewManager = viewManager;
+    this.send = send;
     this.onRemove = onRemove;
     this.closed = new Promise<void>((resolve) => {
       this.resolveClosed = resolve;
@@ -105,15 +143,13 @@ class NotificationHandleImpl implements NotificationHandle {
 
   update(config: NotificationConfig): void {
     if (this.isClosed) return;
-    const command: NotificationCommand = { action: "update", notificationId: this.id, config };
-    this.viewManager.sendToUI(ApiIpcChannels.NOTIFICATION_COMMAND, command);
+    this.send({ action: "update", notificationId: this.id, config });
   }
 
   close(): void {
     if (this.isClosed) return;
     this.isClosed = true;
-    const command: NotificationCommand = { action: "close", notificationId: this.id };
-    this.viewManager.sendToUI(ApiIpcChannels.NOTIFICATION_COMMAND, command);
+    this.send({ action: "close", notificationId: this.id });
     this.resolveClosed();
     this.listeners.clear();
     this.onRemove();

--- a/src/modules/ui-ipc-module.integration.test.ts
+++ b/src/modules/ui-ipc-module.integration.test.ts
@@ -53,6 +53,7 @@ import {
 import type { AppShutdownIntent } from "../intents/app-shutdown";
 import type { Operation, OperationContext } from "../intents/lib/operation";
 import { createUiIpcModule, type UiIpcModuleDeps } from "./ui-ipc-module";
+import type { NotificationManager } from "./notification-manager";
 import { createMockLogging } from "../boundaries/platform/logging";
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext } from "../intents/lib/operation";
@@ -445,6 +446,30 @@ describe("UiIpcModule - IPC handlers", () => {
       type: "app:ready",
       payload: {},
     });
+  });
+
+  it("lifecycle.ready releases buffered notifications before dispatching app:ready", async () => {
+    const ipcLayer = createBehavioralIpcBoundary();
+    const markUIReady = vi.fn();
+    const dispatch = vi.fn().mockImplementation(async () => {
+      // markUIReady must run before app:ready so notifications opened during
+      // app:start hooks render as soon as the renderer is mounted.
+      expect(markUIReady).toHaveBeenCalledTimes(1);
+    });
+    const deps = createBridgeDeps({
+      ipcLayer,
+      dispatcher: { dispatch } as unknown as UiIpcModuleDeps["dispatcher"],
+      notificationManager: {
+        markUIReady,
+        routeEvent: vi.fn(),
+      } as unknown as NotificationManager,
+    });
+    createUiIpcModule(deps);
+
+    await ipcLayer._invoke(ApiIpcChannels.LIFECYCLE_READY, undefined);
+
+    expect(markUIReady).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ type: "app:ready", payload: {} });
   });
 });
 

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -339,6 +339,9 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
   // ---------------------------------------------------------------------------
 
   registerIpc(ApiIpcChannels.LIFECYCLE_READY, async () => {
+    // The renderer calls lifecycle.ready() once MainView (and its
+    // NotificationHost) is mounted — buffered notifications can now render.
+    deps.notificationManager?.markUIReady();
     return await dispatcher.dispatch({
       type: INTENT_APP_READY,
       payload: {},


### PR DESCRIPTION
- NotificationManager now buffers open/update/close commands until the renderer's NotificationHost is mounted (released via lifecycle.ready() in ui-ipc-module), fixing notifications sent during app:start hooks being silently dropped — including the auto-updater's latent race where a check finishing before renderer mount lost its notification permanently
- Notifications opened and closed entirely while buffered are skipped on flush
- debug.update is now a nullable enum: bare --debug.update / =pending shows the full "Update available" → install → download → ready flow; =downloaded jumps straight to "Update ready / Restart Now"
- New integration tests for the buffering behavior, the markUIReady release point, and the debug.update modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)