### PR TITLE
feat: workspaces can be woken up from the sidebar

### DIFF
--- a/src/renderer/lib/components/HibernatedOverlay.svelte
+++ b/src/renderer/lib/components/HibernatedOverlay.svelte
@@ -47,7 +47,8 @@
     aria-label="Wake workspace"
     onclick={() => void handleHibernateToggle()}
   >
-    <Icon name="debug-start" size={48} />
+    <span class="icon-pause"><Icon name="debug-pause" size={48} /></span>
+    <span class="icon-play"><Icon name="debug-start" size={48} /></span>
     <span class="label">Hibernated</span>
     <span class="hint">Click or press Alt+X H to wake up</span>
   </button>
@@ -102,6 +103,23 @@
   .indicator:hover,
   .indicator:focus-visible {
     opacity: 1;
+  }
+
+  /* Pause at rest, play while hovering the indicator (= "click to wake"). */
+  .icon-pause {
+    display: flex;
+  }
+
+  .icon-play {
+    display: none;
+  }
+
+  .indicator:hover .icon-pause {
+    display: none;
+  }
+
+  .indicator:hover .icon-play {
+    display: flex;
   }
 
   .label {

--- a/src/renderer/lib/components/HibernatedOverlay.test.ts
+++ b/src/renderer/lib/components/HibernatedOverlay.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the HibernatedOverlay component.
+ *
+ * The overlay shows a pause icon at rest; CSS swaps it to a play icon while
+ * the indicator button is hovered (the swap itself is CSS-only and not
+ * observable in happy-dom — the tests assert both icons are in the DOM).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import type { Api } from "@shared/electron-api";
+import { createMockApi } from "../test-utils";
+
+// Must be set before component import because $lib/api checks window.api
+const mockApi: Api = createMockApi();
+window.api = mockApi;
+
+vi.mock("$lib/api", () => ({
+  workspaces: {
+    getScreenshot: vi.fn().mockResolvedValue({ url: null }),
+  },
+}));
+
+vi.mock("$lib/stores/shortcuts.svelte", () => ({
+  handleHibernateToggle: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import after mock setup
+import HibernatedOverlay from "./HibernatedOverlay.svelte";
+import { handleHibernateToggle } from "$lib/stores/shortcuts.svelte";
+import type { WorkspaceRef } from "@shared/api/types";
+
+const workspaceRef = {
+  projectId: "test-12345678",
+  workspaceName: "ws1",
+  path: "/test/.worktrees/ws1",
+} as WorkspaceRef;
+
+describe("HibernatedOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("renders both pause and play icons inside the wake button", () => {
+    const { container } = render(HibernatedOverlay, { props: { workspaceRef } });
+
+    const indicator = container.querySelector(".indicator");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator!.querySelector(".icon-pause vscode-icon")).toBeInTheDocument();
+    expect(indicator!.querySelector(".icon-play vscode-icon")).toBeInTheDocument();
+  });
+
+  it("shows the hibernated label and wake hint", () => {
+    render(HibernatedOverlay, { props: { workspaceRef } });
+
+    expect(screen.getByText("Hibernated")).toBeInTheDocument();
+    expect(screen.getByText(/Alt\+X H/)).toBeInTheDocument();
+  });
+
+  it("clicking the indicator wakes the workspace", async () => {
+    render(HibernatedOverlay, { props: { workspaceRef } });
+
+    const button = screen.getByRole("button", { name: /wake workspace/i });
+    await fireEvent.click(button);
+
+    expect(handleHibernateToggle).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
+  import * as api from "$lib/api";
   import type { ProjectId, WorkspaceRef, WorkspaceName } from "$lib/api";
   import AgentStatusIndicator from "./AgentStatusIndicator.svelte";
   import WorkspaceTags from "./WorkspaceTags.svelte";
@@ -166,6 +167,12 @@
   function handleRemoveWorkspace(workspaceRef: WorkspaceRef): void {
     onOpenRemoveDialog(workspaceRef);
   }
+
+  function handleWakeWorkspace(path: string): void {
+    api.workspaces.wake(path).catch((error: unknown) => {
+      logger.error("Failed to wake workspace", { path, error: String(error) });
+    });
+  }
 </script>
 
 <!--
@@ -298,12 +305,16 @@
                   </div>
                   <!-- Status cell: a button in both modes (clicks bubble to the
                        row's switch handler); the collapsed sidebar shows only
-                       this cell. -->
+                       this cell. For hibernated workspaces it also wakes —
+                       the click bubbles on, so the row switches too. -->
                   <button
                     type="button"
                     class="ch-icon-cell status-cell"
-                    aria-label={`${workspace.name} in ${project.name} - ${pending ? "Creating" : deletionStatus === "in-progress" ? "Deleting" : deletionStatus === "error" ? "Deletion failed" : hibernated ? "Hibernated" : statusText}`}
+                    aria-label={`${workspace.name} in ${project.name} - ${pending ? "Creating" : deletionStatus === "in-progress" ? "Deleting" : deletionStatus === "error" ? "Deletion failed" : hibernated ? "Hibernated - click to wake" : statusText}`}
                     aria-current={isActive ? "true" : undefined}
+                    onclick={() => {
+                      if (hibernated) handleWakeWorkspace(workspace.path);
+                    }}
                   >
                     {#if pending}
                       <!-- Creating: show red "busy" immediately (work is queued) -->
@@ -316,7 +327,8 @@
                       </span>
                     {:else if hibernated}
                       <span class="hibernation-indicator" role="img" aria-label="Hibernated">
-                        <Icon name="debug-pause" size={14} />
+                        <span class="icon-pause"><Icon name="debug-pause" size={14} /></span>
+                        <span class="icon-play"><Icon name="debug-start" size={14} /></span>
                       </span>
                     {:else}
                       <AgentStatusIndicator
@@ -606,10 +618,10 @@
   }
 
   .status-cell:hover {
-    background: var(--ch-input-bg);
+    background: var(--ch-list-hover-bg);
   }
 
-  .status-cell:focus {
+  .status-cell:focus-visible {
     outline: 1px solid var(--ch-focus-border);
     outline-offset: -1px;
   }
@@ -642,7 +654,9 @@
     background: var(--ch-list-active-bg);
   }
 
-  .workspace-item:focus-within {
+  /* Keyboard-only: mouse clicks focus the inner buttons too, and the active
+     row highlight already covers that case. */
+  .workspace-item:has(:focus-visible) {
     outline: 1px solid var(--ch-focus-border);
     outline-offset: -1px;
   }
@@ -690,6 +704,27 @@
     justify-content: center;
     opacity: 0.55;
     flex-shrink: 0;
+  }
+
+  /* Pause at rest, play while hovering the status cell (= "click to wake"). */
+  .hibernation-indicator .icon-pause {
+    display: flex;
+  }
+
+  .hibernation-indicator .icon-play {
+    display: none;
+  }
+
+  .status-cell:hover .icon-pause {
+    display: none;
+  }
+
+  .status-cell:hover .icon-play {
+    display: flex;
+  }
+
+  .status-cell:hover .hibernation-indicator {
+    opacity: 1;
   }
 
   .workspace-item.hibernated .workspace-btn {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -25,9 +25,13 @@ window.api = mockApi;
 vi.mock("$lib/api", () => ({
   sendNotificationEvent: vi.fn(),
   on: vi.fn(() => () => {}),
+  workspaces: {
+    wake: vi.fn().mockResolvedValue(null),
+  },
 }));
 
 // Import after mock setup
+import { workspaces as apiWorkspaces } from "$lib/api";
 import Sidebar from "./Sidebar.svelte";
 import { createMockProject, createMockWorkspace } from "$lib/test-fixtures";
 import type { ProjectPath, WorkspacePath } from "@shared/ipc";
@@ -1221,6 +1225,93 @@ describe("Sidebar component", () => {
 
       expect(container.querySelector(".workspace-tags")).not.toBeInTheDocument();
       expect(container.querySelector(".workspace-tags-row")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("hibernation indicator", () => {
+    const hibernatedSetup = () => {
+      const ws = createMockWorkspace({
+        path: "/test/.worktrees/ws1",
+        name: "ws1",
+        metadata: { hibernated: "true" },
+      });
+      const project = createMockProject({
+        path: "/test" as ProjectPath,
+        name: "test",
+        workspaces: [ws],
+      });
+      return {
+        ws,
+        project,
+        props: { ...defaultProps, projects: [project], totalWorkspaces: 1 },
+      };
+    };
+
+    it("renders both pause and play icons for a hibernated workspace", () => {
+      const { props } = hibernatedSetup();
+      const { container } = render(Sidebar, { props });
+
+      // Both icons are in the DOM; CSS swaps them on :hover (not testable here).
+      const indicator = container.querySelector(".hibernation-indicator");
+      expect(indicator).toBeInTheDocument();
+      expect(indicator!.querySelector(".icon-pause vscode-icon")).toBeInTheDocument();
+      expect(indicator!.querySelector(".icon-play vscode-icon")).toBeInTheDocument();
+    });
+
+    it("status cell aria-label announces the wake action when hibernated", () => {
+      const { props } = hibernatedSetup();
+      render(Sidebar, { props });
+
+      const statusButton = screen.getByRole("button", {
+        name: /ws1 in test - Hibernated - click to wake/i,
+      });
+      expect(statusButton).toBeInTheDocument();
+    });
+
+    it("clicking the status cell wakes the workspace and switches to it", async () => {
+      const onSwitchWorkspace = vi.fn();
+      const { ws, project, props } = hibernatedSetup();
+      render(Sidebar, { props: { ...props, onSwitchWorkspace } });
+
+      const statusButton = screen.getByRole("button", { name: /Hibernated - click to wake/i });
+      await fireEvent.click(statusButton);
+
+      expect(apiWorkspaces.wake).toHaveBeenCalledWith(ws.path);
+      // The click bubbles to the row's switch handler.
+      expect(onSwitchWorkspace).toHaveBeenCalledWith({
+        projectId: project.id,
+        workspaceName: ws.name,
+        path: ws.path,
+      });
+    });
+
+    it("clicking the status cell of a non-hibernated workspace does not wake", async () => {
+      const onSwitchWorkspace = vi.fn();
+      const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
+      const project = createMockProject({
+        path: "/test" as ProjectPath,
+        name: "test",
+        workspaces: [ws],
+      });
+      render(Sidebar, {
+        props: { ...defaultProps, projects: [project], totalWorkspaces: 1, onSwitchWorkspace },
+      });
+
+      const statusButton = screen.getByRole("button", { name: /ws1 in test/i });
+      await fireEvent.click(statusButton);
+
+      expect(apiWorkspaces.wake).not.toHaveBeenCalled();
+      expect(onSwitchWorkspace).toHaveBeenCalled();
+    });
+
+    it("does not render the hibernation indicator when not hibernated", () => {
+      const ws = createMockWorkspace({ path: "/test/.worktrees/ws1", name: "ws1" });
+      const project = createMockProject({ path: "/test" as ProjectPath, workspaces: [ws] });
+      const { container } = render(Sidebar, {
+        props: { ...defaultProps, projects: [project] },
+      });
+
+      expect(container.querySelector(".hibernation-indicator")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
- Unified hibernation icon semantics: pause at rest, play on hover, clickable to wake — in both the sidebar and the hibernated overlay
- Clicking a hibernated workspace's sidebar status cell wakes it and switches to it (click bubbles to the row's switch handler)
- Pause/play swap is CSS-only (both icons rendered, toggled on hover of the status cell / overlay indicator)
- Sidebar status cell hover is now flat like the trash action button
- Focus outlines in the sidebar are keyboard-only (:focus-visible), so mouse clicks leave just the active-row highlight
- Renderer tests for the wake click wiring and icon markup (Sidebar + new HibernatedOverlay tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)