### PR TITLE
feat: Unified Enter/Escape handling in forms

### DIFF
--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -914,6 +914,67 @@ describe("CreationModule", () => {
       await flush();
       expect(clone.closed).toBe(true);
     });
+
+    it("Escape (dismiss) closes the dialog when not cloning", async () => {
+      const s = setup();
+      const panel = await s.start();
+      panel.emitAction("clone", {});
+      await flush();
+      const clone = s.dialogs.modalHandles()[0]!;
+
+      clone.emitDismiss();
+      await flush();
+      expect(clone.closed).toBe(true);
+    });
+
+    it("Escape (dismiss) after a failed clone closes the dialog", async () => {
+      const s = setup();
+      const panel = await s.start();
+      panel.emitAction("clone", {});
+      await flush();
+      const clone = s.dialogs.modalHandles()[0]!;
+      s.dispatcher.results.set(INTENT_OPEN_PROJECT, () => Promise.reject(new Error("nope")));
+
+      clone.emitChange("url", { url: "org/repo" });
+      await flush();
+      clone.emitAction("do-clone", { url: "org/repo" });
+      await flush();
+      await flush();
+
+      clone.emitDismiss();
+      await flush();
+      expect(clone.closed).toBe(true);
+    });
+
+    it("Escape (dismiss) mid-clone detaches like 'Continue in background'", async () => {
+      const s = setup({ projects: [PROJECT_A, PROJECT_B] });
+      const panel = await s.start();
+      const seededProject = field(panel.config, "project")["value"];
+
+      panel.emitAction("clone", {});
+      await flush();
+      const clone = s.dialogs.modalHandles()[0]!;
+
+      let resolveClone: (value: Project) => void = () => {};
+      s.dispatcher.results.set(
+        INTENT_OPEN_PROJECT,
+        () => new Promise<Project>((resolve) => (resolveClone = resolve))
+      );
+      clone.emitChange("url", { url: "org/repo" });
+      await flush();
+      clone.emitAction("do-clone", { url: "org/repo" });
+      await flush();
+
+      clone.emitDismiss();
+      await flush();
+      expect(clone.closed).toBe(true);
+
+      // The detached clone completing must NOT hijack the form selection.
+      resolveClone(PROJECT_B);
+      await flush();
+      await flush();
+      expect(field(panel.config, "project")["value"]).toBe(seededProject);
+    });
   });
 
   describe("seeding from domain events", () => {

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -842,6 +842,16 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       }
     });
 
+    cloneHandle.onDismiss(() => {
+      if (cloneDialog !== state) return;
+      if (state.cloneUrl !== null) {
+        // Mid-clone, Escape detaches like "Continue in background": the clone
+        // keeps running and project:opened lands silently.
+        logger.debug("Clone continuing in background", { url: state.cloneUrl });
+      }
+      closeCloneDialog();
+    });
+
     cloneHandle.onEvent((event) => {
       if (cloneDialog !== state) return;
       state.url = event.data?.[CLONE_FIELD_URL] ?? state.url;

--- a/src/modules/deletion-dialog-module.integration.test.ts
+++ b/src/modules/deletion-dialog-module.integration.test.ts
@@ -48,6 +48,7 @@ interface MockHandle {
   closed: boolean;
   eventListeners: Set<(event: DialogUserEvent) => void>;
   emitEvent(event: DialogUserEvent): void;
+  emitDismiss(): void;
 }
 
 interface MockDialogManager {
@@ -66,6 +67,7 @@ function createMockDialogManager(): MockDialogManager {
     },
     open: vi.fn((config: DialogConfig) => {
       const listeners = new Set<(event: DialogUserEvent) => void>();
+      const dismissListeners = new Set<() => void>();
       const handle: MockHandle = {
         id: `dlg-test-${handles.length + 1}`,
         config,
@@ -73,6 +75,9 @@ function createMockDialogManager(): MockDialogManager {
         eventListeners: listeners,
         emitEvent(event) {
           for (const l of listeners) l(event);
+        },
+        emitDismiss() {
+          for (const l of dismissListeners) l();
         },
       };
       handles.push(handle);
@@ -89,7 +94,10 @@ function createMockDialogManager(): MockDialogManager {
           return () => listeners.delete(handler);
         }),
         onChange: vi.fn(() => () => {}),
-        onDismiss: vi.fn(() => () => {}),
+        onDismiss: vi.fn((handler: () => void) => {
+          dismissListeners.add(handler);
+          return () => dismissListeners.delete(handler);
+        }),
         nextEvent: vi.fn(),
         closed: new Promise<void>(() => {}),
       } as DialogHandle;
@@ -440,6 +448,45 @@ describe("DeletionDialogModule", () => {
     expect(payload.workspacePath).toBe(WS_PATH_A);
     expect(payload.force).toBe(true);
     expect(payload.ignoreWarnings).toBe(true);
+  });
+
+  it("Escape (dismiss event) acts like the Dismiss button when completed with errors", async () => {
+    const { dialogManager, dispatcher, fireProgress, fireSwitched } = setup;
+
+    await fireSwitched(WS_PATH_A);
+    await fireProgress(
+      makeProgress({
+        completed: true,
+        hasErrors: true,
+        operations: [
+          { id: "cleanup-workspace", label: "Removing workspace", status: "error", error: "EBUSY" },
+        ],
+      })
+    );
+
+    const handle = dialogManager.lastHandle!;
+    handle.emitDismiss();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.closed).toBe(true);
+    const forceIntent = dispatcher.dispatched.find((d) => d.type === INTENT_DELETE_WORKSPACE);
+    expect(forceIntent).toBeDefined();
+    expect((forceIntent!.payload as Record<string, unknown>).force).toBe(true);
+  });
+
+  it("Escape (dismiss event) is a no-op while deletion is in progress", async () => {
+    const { dialogManager, dispatcher, fireProgress, fireSwitched } = setup;
+
+    await fireSwitched(WS_PATH_A);
+    // In progress: no Dismiss button is rendered.
+    await fireProgress(makeProgress());
+
+    const handle = dialogManager.lastHandle!;
+    handle.emitDismiss();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.closed).toBe(false);
+    expect(dispatcher.dispatched.find((d) => d.type === INTENT_DELETE_WORKSPACE)).toBeUndefined();
   });
 
   it("should clean up on EVENT_WORKSPACE_DELETED", async () => {

--- a/src/modules/deletion-dialog-module.ts
+++ b/src/modules/deletion-dialog-module.ts
@@ -160,6 +160,20 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
 
   /** Wire retry/dismiss event handlers on a dialog handle. */
   function wireEvents(handle: DialogHandle, workspacePath: string): void {
+    function dismiss(): void {
+      deps.logger.debug("Deletion dismiss", { workspace: workspacePath });
+      handle.close();
+      activeDialog = null;
+      progressMap.delete(workspacePath);
+      dispatchDelete(deps.dispatcher, {
+        workspacePath,
+        keepBranch: false,
+        force: true,
+        removeWorktree: true,
+        ignoreWarnings: true,
+      });
+    }
+
     handle.onEvent((evt) => {
       const progress = progressMap.get(workspacePath);
       if (!progress) return;
@@ -177,18 +191,16 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
           ...(pids && { blockingPids: pids }),
         });
       } else if (evt.actionId === "dismiss") {
-        deps.logger.debug("Deletion dismiss", { workspace: workspacePath });
-        handle.close();
-        activeDialog = null;
-        progressMap.delete(workspacePath);
-        dispatchDelete(deps.dispatcher, {
-          workspacePath,
-          keepBranch: false,
-          force: true,
-          removeWorktree: true,
-          ignoreWarnings: true,
-        });
+        dismiss();
       }
+    });
+
+    // Escape acts like the Dismiss button, but only in the states where that
+    // button is rendered (completed with errors); mid-deletion it's a no-op.
+    handle.onDismiss(() => {
+      const progress = progressMap.get(workspacePath);
+      if (!progress || !progress.completed || !progress.hasErrors) return;
+      dismiss();
     });
   }
 

--- a/src/modules/dialog-manager.integration.test.ts
+++ b/src/modules/dialog-manager.integration.test.ts
@@ -223,8 +223,7 @@ describe("DialogManager", () => {
       manager.routeEvent({ dialogId: handle.id, actionId: "first" });
       manager.routeEvent({ dialogId: handle.id, actionId: "second" });
 
-      const result = await promise;
-      expect(result.actionId).toBe("first");
+      await expect(promise).resolves.toMatchObject({ actionId: "first" });
     });
 
     it("should reject after timeout when no event arrives", async () => {
@@ -241,8 +240,7 @@ describe("DialogManager", () => {
       const promise = handle.nextEvent(5000);
       manager.routeEvent({ dialogId: handle.id, actionId: "ok" });
 
-      const result = await promise;
-      expect(result.actionId).toBe("ok");
+      await expect(promise).resolves.toMatchObject({ actionId: "ok" });
     });
 
     it("should not timeout when no timeout is specified", async () => {
@@ -318,8 +316,7 @@ describe("DialogManager", () => {
       manager.routeEvent({ kind: "change", dialogId: handle.id, fieldId: "f", data: { f: "x" } });
       manager.routeEvent({ dialogId: handle.id, actionId: "go" });
 
-      const result = await promise;
-      expect(result.actionId).toBe("go");
+      await expect(promise).resolves.toMatchObject({ actionId: "go" });
     });
   });
 
@@ -363,15 +360,27 @@ describe("DialogManager", () => {
       expect(onDismiss).not.toHaveBeenCalled();
     });
 
-    it("nextEvent ignores dismiss events and resolves on the next action", async () => {
+    it("nextEvent resolves on a dismiss event (callers loop if they need an action)", async () => {
       const handle = manager.open(createConfig("Test"));
 
       const promise = handle.nextEvent();
       manager.routeEvent({ kind: "dismiss", dialogId: handle.id });
-      manager.routeEvent({ dialogId: handle.id, actionId: "go" });
 
       const result = await promise;
-      expect(result.actionId).toBe("go");
+      expect(result.kind).toBe("dismiss");
+    });
+
+    it("nextEvent unsubscribes both channels once settled", async () => {
+      const handle = manager.open(createConfig("Test"));
+
+      const first = handle.nextEvent();
+      manager.routeEvent({ dialogId: handle.id, actionId: "go" });
+      await expect(first).resolves.toMatchObject({ actionId: "go" });
+
+      // A later dismiss only settles the NEW wait, not stale listeners.
+      const second = handle.nextEvent();
+      manager.routeEvent({ kind: "dismiss", dialogId: handle.id });
+      expect((await second).kind).toBe("dismiss");
     });
   });
 

--- a/src/modules/dialog-manager.ts
+++ b/src/modules/dialog-manager.ts
@@ -42,8 +42,13 @@ export interface DialogHandle {
    * function.
    */
   onDismiss(handler: (event: DialogDismissEvent) => void): () => void;
-  /** Await next action event (for sequential hook flows). Rejects on timeout if specified. */
-  nextEvent(timeoutMs?: number): Promise<DialogActionEvent>;
+  /**
+   * Await the next user response: an action (button click) or a dismiss
+   * (Escape). For sequential hook flows. Callers that require a specific
+   * action must loop until they get it (e.g. a mandatory selection ignoring
+   * dismisses). Rejects on timeout if specified.
+   */
+  nextEvent(timeoutMs?: number): Promise<DialogActionEvent | DialogDismissEvent>;
   /** Promise that resolves when the dialog closes. */
   readonly closed: Promise<void>;
 }
@@ -170,12 +175,15 @@ class DialogHandleImpl implements DialogHandle {
     };
   }
 
-  nextEvent(timeoutMs?: number): Promise<DialogActionEvent> {
-    const eventPromise = new Promise<DialogActionEvent>((resolve) => {
-      const unsub = this.onEvent((event) => {
-        unsub();
+  nextEvent(timeoutMs?: number): Promise<DialogActionEvent | DialogDismissEvent> {
+    const eventPromise = new Promise<DialogActionEvent | DialogDismissEvent>((resolve) => {
+      const settle = (event: DialogActionEvent | DialogDismissEvent): void => {
+        unsubAction();
+        unsubDismiss();
         resolve(event);
-      });
+      };
+      const unsubAction = this.onEvent(settle);
+      const unsubDismiss = this.onDismiss(settle);
     });
     if (timeoutMs === undefined) return eventPromise;
     return Promise.race([

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -40,8 +40,12 @@ import type { DialogUserEvent, DialogConfig } from "../shared/dialog-types";
 // Helpers
 // =============================================================================
 
-function createMockHandle(): DialogHandle & { _emitEvent(event: DialogUserEvent): void } {
+function createMockHandle(): DialogHandle & {
+  _emitEvent(event: DialogUserEvent): void;
+  _emitDismiss(): void;
+} {
   const listeners = new Set<(event: DialogUserEvent) => void>();
+  const dismissListeners = new Set<() => void>();
   let closedResolve!: () => void;
   const closedPromise = new Promise<void>((resolve) => {
     closedResolve = resolve;
@@ -57,10 +61,16 @@ function createMockHandle(): DialogHandle & { _emitEvent(event: DialogUserEvent)
       return () => listeners.delete(handler);
     }),
     onChange: vi.fn(() => () => {}),
-    onDismiss: vi.fn(() => () => {}),
+    onDismiss: vi.fn((handler: () => void) => {
+      dismissListeners.add(handler);
+      return () => dismissListeners.delete(handler);
+    }),
     nextEvent: vi.fn(),
     _emitEvent(event: DialogUserEvent) {
       for (const listener of listeners) listener(event);
+    },
+    _emitDismiss() {
+      for (const listener of dismissListeners) listener();
     },
   };
 }
@@ -222,6 +232,18 @@ describe("ErrorReportModule — bug report dialog", () => {
     handle._emitEvent({ dialogId: "dlg-test", actionId: "cancel" });
     expect(handle.close).toHaveBeenCalled();
     expect(deps.dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("Escape (dismiss) discards the draft like Cancel and allows reopening", async () => {
+    const { module, deps, handle } = setup();
+    await emitKey(module, "b");
+    handle._emitDismiss();
+    expect(handle.close).toHaveBeenCalled();
+    expect(deps.dispatcher.dispatch).not.toHaveBeenCalled();
+
+    // The active-handle guard is cleared — 'b' opens a fresh dialog.
+    await emitKey(module, "b");
+    expect(deps.dialogManager.open).toHaveBeenCalledTimes(2);
   });
 
   it("includes rotated archive log alongside the current log", async () => {

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -403,6 +403,12 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
       }
     });
 
+    // Escape discards the draft, same as Cancel.
+    handle.onDismiss(() => {
+      handle.close();
+      activeHandle = null;
+    });
+
     void handle.closed.then(() => {
       activeHandle = null;
     });

--- a/src/modules/local-project-module.integration.test.ts
+++ b/src/modules/local-project-module.integration.test.ts
@@ -74,9 +74,11 @@ interface MockDialogHandle {
   closed: boolean;
   eventListeners: Array<(event: { dialogId: string; actionId: string }) => void>;
   close(): void;
-  nextEvent(): Promise<{ dialogId: string; actionId: string }>;
+  nextEvent(): Promise<{ dialogId: string; actionId?: string; kind?: string }>;
   onEvent(handler: (event: { dialogId: string; actionId: string }) => void): () => void;
+  onDismiss(handler: () => void): () => void;
   emitEvent(event: { dialogId: string; actionId: string }): void;
+  emitDismiss(): void;
   readonly closed_promise: Promise<void>;
 }
 
@@ -91,6 +93,7 @@ function createMockDialogManager(): {
   const dialogManager = {
     open: vi.fn().mockImplementation((config: unknown) => {
       const listeners: Array<(event: { dialogId: string; actionId: string }) => void> = [];
+      const dismissListeners: Array<() => void> = [];
       let resolveClosed: () => void;
       const closedPromise = new Promise<void>((resolve) => {
         resolveClosed = resolve;
@@ -106,8 +109,10 @@ function createMockDialogManager(): {
           resolveClosed();
         },
         nextEvent() {
+          // Mirrors DialogHandle.nextEvent: settles on an action OR a dismiss.
           return new Promise((resolve) => {
             listeners.push((event) => resolve(event));
+            dismissListeners.push(() => resolve({ dialogId: handle.id, kind: "dismiss" }));
           });
         },
         onEvent(handler: (event: { dialogId: string; actionId: string }) => void) {
@@ -117,9 +122,21 @@ function createMockDialogManager(): {
             if (idx >= 0) listeners.splice(idx, 1);
           };
         },
+        onDismiss(handler: () => void) {
+          dismissListeners.push(handler);
+          return () => {
+            const idx = dismissListeners.indexOf(handler);
+            if (idx >= 0) dismissListeners.splice(idx, 1);
+          };
+        },
         emitEvent(event: { dialogId: string; actionId: string }) {
           for (const listener of [...listeners]) {
             listener(event);
+          }
+        },
+        emitDismiss() {
+          for (const listener of [...dismissListeners]) {
+            listener();
           }
         },
         get closed_promise() {
@@ -845,6 +862,28 @@ describe("LocalProjectModule Integration", () => {
         dialogId: dialogManager.lastHandle!.id,
         actionId: "cancel",
       });
+
+      const { results, errors } = await preparePromise;
+
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({ canceled: true });
+      expect(gitClient.init).not.toHaveBeenCalled();
+      expect(dialogManager.lastHandle!.closed).toBe(true);
+    });
+
+    it("returns canceled on Escape (dismiss), same as Cancel", async () => {
+      const { openHooks, dialogManager, gitClient } = createTestSetup();
+      vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
+
+      // Start the prepare hook (will block on the dialog)
+      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+        intent: openLocalIntent(PROJECT_PATH),
+      });
+
+      // Simulate the user pressing Escape
+      await vi.waitFor(() => expect(dialogManager.lastHandle).not.toBeNull());
+      dialogManager.lastHandle!.emitDismiss();
 
       const { results, errors } = await preparePromise;
 

--- a/src/modules/local-project-module.ts
+++ b/src/modules/local-project-module.ts
@@ -355,10 +355,11 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               modal: true,
             });
 
+            // Escape (dismiss) cancels, same as the Cancel button.
             const event = await dialog.nextEvent();
             dialog.close();
 
-            if (event.actionId !== "init") {
+            if (event.kind === "dismiss" || event.actionId !== "init") {
               return { canceled: true };
             }
 

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -503,6 +503,61 @@ describe("ViewModule Integration", () => {
       expect(result.selectedAgent).toBe("opencode");
       expect(dialogManager.open).toHaveBeenCalled();
     });
+
+    it("ignores dismiss (Escape) and keeps waiting for a selection", async () => {
+      const availableAgents: RegisterAgentResult[] = [
+        { agent: "claude", label: "Claude", icon: "sparkle" },
+        { agent: "opencode", label: "OpenCode", icon: "terminal" },
+      ];
+
+      const dispatcher = createMockDispatcher();
+      const viewManager = createMockViewManager();
+
+      dispatcher.registerOperation(
+        INTENT_SETUP,
+        new MinimalAgentSelectionOperation(availableAgents)
+      );
+
+      // Selection is mandatory: a dismiss response must not pick a fallback
+      // agent — the module re-awaits until an action arrives.
+      const nextEvent = vi
+        .fn()
+        .mockResolvedValueOnce({ kind: "dismiss", dialogId: "dlg-agent" })
+        .mockResolvedValueOnce({
+          dialogId: "dlg-agent",
+          actionId: "select",
+          data: { agent: "opencode" },
+        });
+      const dialogManager = {
+        open: vi.fn(() => ({
+          id: "dlg-agent",
+          update: vi.fn(),
+          close: vi.fn(),
+          onEvent: vi.fn(() => () => {}),
+          nextEvent,
+          closed: Promise.resolve(),
+        })),
+      };
+
+      const module = createViewModule({
+        viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
+        logger: SILENT_LOGGER,
+        viewLayer: null,
+        windowLayer: null,
+        sessionLayer: null,
+        dialogManager: dialogManager as unknown as NonNullable<ViewModuleDeps["dialogManager"]>,
+      });
+
+      dispatcher.registerModule(module);
+
+      const result = (await dispatcher.dispatch({
+        type: INTENT_SETUP,
+        payload: {},
+      } as SetupIntent)) as unknown as AgentSelectionResult;
+
+      expect(result.selectedAgent).toBe("opencode");
+      expect(nextEvent).toHaveBeenCalledTimes(2);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -472,7 +472,12 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             };
 
             const handle = deps.dialogManager.open(config);
-            const event = await handle.nextEvent(5 * 60_000);
+            // Agent selection is mandatory: Escape (dismiss) is ignored — keep
+            // waiting until the user confirms a selection.
+            let event = await handle.nextEvent(5 * 60_000);
+            while (event.kind === "dismiss") {
+              event = await handle.nextEvent(5 * 60_000);
+            }
             handle.close();
 
             const selectedAgent = event.data?.["agent"] ?? availableAgents[0]?.agent;

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -3,14 +3,14 @@
 
   Modal surface for the declarative dialog framework.
   Renders the chrome — faded logo backdrop + centered card — and delegates the
-  sections + actions to <Form>. One DialogView is rendered per active dialog by
-  DialogHost.
+  sections + actions to <Form>, which owns the keyboard contract (Escape ->
+  dismiss, Cmd/Ctrl+Enter -> primary, Tab trap). One DialogView is rendered
+  per active dialog by DialogHost.
 -->
 <script lang="ts">
   import type { DialogConfig } from "@shared/dialog-types";
   import Logo from "./Logo.svelte";
   import Form from "./form/Form.svelte";
-  import { trapTabKey } from "$lib/utils/focus-trap";
 
   interface Props {
     dialogId: string;
@@ -21,30 +21,14 @@
 
   const { dialogId, config, workspaceArea = false }: Props = $props();
 
-  let rootRef: HTMLElement | undefined = $state();
-
   /** Derive heading text from sections for aria-label. */
   const heading = $derived.by(() => {
     const headingSection = config.sections.find((s) => s.type === "text" && s.style === "heading");
     return headingSection?.type === "text" ? headingSection.content : "Dialog";
   });
-
-  // Tab/Shift+Tab cycles within the dialog so focus never leaves the form.
-  function handleKeydown(event: KeyboardEvent): void {
-    if (rootRef) {
-      trapTabKey(event, rootRef);
-    }
-  }
 </script>
 
-<div
-  bind:this={rootRef}
-  class="dialog-view"
-  class:workspace-area={workspaceArea}
-  role="dialog"
-  aria-label={heading}
-  onkeydowncapture={handleKeydown}
->
+<div class="dialog-view" class:workspace-area={workspaceArea} role="dialog" aria-label={heading}>
   <div class="backdrop" aria-hidden="true">
     <Logo size={128} />
   </div>

--- a/src/renderer/lib/components/DialogView.test.ts
+++ b/src/renderer/lib/components/DialogView.test.ts
@@ -127,6 +127,42 @@ describe("DialogView component (modal surface)", () => {
     });
   });
 
+  describe("keyboard (owned by the wrapped Form)", () => {
+    const config: DialogConfig = {
+      sections: [
+        { type: "text", content: "Clone from Git Repository", style: "heading" },
+        { type: "input", id: "url" },
+        {
+          type: "group",
+          items: [
+            { type: "button", id: "do-clone", label: "Clone", variant: "primary" },
+            { type: "button", id: "cancel", label: "Cancel", variant: "secondary" },
+          ],
+        },
+      ],
+    };
+
+    it("Escape emits a dismiss event for the modal session", async () => {
+      renderDialog(config, { dialogId: "clone-1" });
+
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Escape" });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({ kind: "dismiss", dialogId: "clone-1" });
+    });
+
+    it("Cmd/Ctrl+Enter fires the primary action", async () => {
+      renderDialog(config, { dialogId: "clone-1" });
+
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Enter", metaKey: true });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({
+        dialogId: "clone-1",
+        actionId: "do-clone",
+        data: { url: "" },
+      });
+    });
+  });
+
   describe("tab trap", () => {
     const config: DialogConfig = {
       sections: [

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -35,7 +35,6 @@
     newWorkspaceView,
     openNewWorkspaceView,
     closeNewWorkspaceView,
-    registerSubmitHandler,
   } from "$lib/stores/new-workspace-view.svelte.js";
   import {
     shortcutModeActive,
@@ -165,15 +164,6 @@
       showDismissPending = false;
       api.sendDialogEvent({ kind: "dismiss", dialogId: session.dialogId });
     }
-  });
-
-  // Expose Create to keyboard shortcuts (Alt+X+Enter) while the panel is
-  // shown: forward to the panel form's primary action.
-  let panelViewRef: PanelView | undefined = $state();
-  $effect(() => {
-    if (!newWorkspaceView.isOpen || !panelDialog.value) return;
-    registerSubmitHandler(() => panelViewRef?.submitPrimary());
-    return () => registerSubmitHandler(null);
   });
 
   // Auto-open the New workspace view as the empty state: when no workspaces
@@ -369,11 +359,7 @@
        the empty state). The creation form is the only panel-surface session
        today; revisit the gating if another panel session appears. -->
   {#if newWorkspaceView.isOpen && panelDialog.value}
-    <PanelView
-      bind:this={panelViewRef}
-      dialogId={panelDialog.value.dialogId}
-      config={panelDialog.value.config}
-    />
+    <PanelView dialogId={panelDialog.value.dialogId} config={panelDialog.value.config} />
   {/if}
 
   <!-- Backdrop shown when no workspace is active and the panel is closed -->

--- a/src/renderer/lib/components/PanelView.svelte
+++ b/src/renderer/lib/components/PanelView.svelte
@@ -9,19 +9,18 @@
   Shell behaviour (renderer-owned; the backend owns the form session):
   - Docked over the content area (sidebar stays visible), z-index 1 so modal
     dialogs (z 900) stack above.
-  - Escape emits a "dismiss" event; the backend decides what dismissing means
-    (typically close + reopen with fresh config = clear).
-  - Cmd/Ctrl+Enter fires the primary action; Enter in fields does not submit.
-  - Tab/Shift+Tab is trapped at the panel boundaries so focus doesn't leak
-    into the sidebar.
+  - Keyboard (Escape -> dismiss, Cmd/Ctrl+Enter -> primary, Tab trap) is owned
+    by Form — shared with the modal surface.
+  - When the last modal stacked above the panel closes, the panel re-places
+    focus on the form's autofocus control (focus would otherwise be lost to
+    <body>, leaving the keyboard flow dead).
   - Form is keyed by dialogId: a backend close + reopen remounts it with fresh
     field values (the reset gesture).
 -->
 <script lang="ts">
-  import type { DialogConfig, DialogUserEvent } from "@shared/dialog-types";
+  import type { DialogConfig } from "@shared/dialog-types";
   import Form from "./form/Form.svelte";
-  import { sendDialogEvent } from "$lib/api";
-  import { trapTabKey } from "$lib/utils/focus-trap";
+  import { dialogs } from "$lib/stores/dialog-framework.svelte";
 
   interface Props {
     dialogId: string;
@@ -30,7 +29,6 @@
 
   const { dialogId, config }: Props = $props();
 
-  let sectionRef: HTMLElement | undefined = $state();
   let formRef: Form | undefined = $state();
 
   /** Derive heading text from sections for the accessible name. */
@@ -39,42 +37,19 @@
     return headingSection?.type === "text" ? headingSection.content : "Panel";
   });
 
-  /**
-   * Activate the form's primary action. Exposed so hosting code can bind
-   * keyboard shortcuts (e.g. Alt+X+Enter) to the panel form's submit.
-   */
-  export function submitPrimary(): void {
-    formRef?.submitPrimary();
-  }
-
-  // Escape -> dismiss intent to the backend; Cmd/Ctrl+Enter -> primary action;
-  // Tab/Shift+Tab trapped at the panel boundaries (shared focus-trap util,
-  // including vscode-elements).
-  function handleKeydown(event: KeyboardEvent): void {
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault();
-      formRef?.submitPrimary();
-      return;
-    }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      event.stopPropagation();
-      const dismiss: DialogUserEvent = { kind: "dismiss", dialogId };
-      sendDialogEvent(dismiss);
-      return;
-    }
-    if (sectionRef) {
-      trapTabKey(event, sectionRef);
-    }
-  }
+  // Refocus the form when the last modal above the panel closes (modals steal
+  // focus while open; on close the panel is the active surface again).
+  const modalAbove = $derived(
+    [...dialogs.value.values()].some((entry) => entry.surface === "modal")
+  );
+  let hadModalAbove = false;
+  $effect(() => {
+    if (hadModalAbove && !modalAbove) formRef?.refocus();
+    hadModalAbove = modalAbove;
+  });
 </script>
 
-<section
-  bind:this={sectionRef}
-  class="panel-view"
-  aria-label={heading}
-  onkeydowncapture={handleKeydown}
->
+<section class="panel-view" aria-label={heading}>
   <div class="panel-card">
     {#key dialogId}
       <Form bind:this={formRef} {dialogId} {config} />

--- a/src/renderer/lib/components/PanelView.test.ts
+++ b/src/renderer/lib/components/PanelView.test.ts
@@ -1,13 +1,13 @@
 /**
  * Tests for PanelView component (the persistent panel surface).
- * Section/action rendering lives in Form.test.ts — these cover only the
- * panel shell: accessible name, Escape -> dismiss event, Cmd/Ctrl+Enter ->
- * primary action, the Tab trap at the panel boundaries, and the
- * dialogId-keyed Form remount (the reset gesture).
+ * Section/action rendering and the keyboard contract (Escape, Cmd/Ctrl+Enter,
+ * Tab trap) live in Form.test.ts — these cover only the panel shell:
+ * accessible name, the dialogId-keyed Form remount (the reset gesture), and
+ * refocusing the form when the last modal stacked above the panel closes.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/svelte";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
 import type { DialogConfig } from "@shared/dialog-types";
 
 // Mock setup - must be hoisted
@@ -24,6 +24,7 @@ vi.mock("$lib/api", () => ({
 
 // Import after mock setup
 import PanelView from "./PanelView.svelte";
+import { processCommand, reset as resetDialogs } from "$lib/stores/dialog-framework.svelte";
 
 function createConfig(overrides?: Partial<DialogConfig>): DialogConfig {
   return {
@@ -50,6 +51,7 @@ function renderPanel(config: DialogConfig, dialogId = "panel-1") {
 describe("PanelView component (panel surface)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetDialogs();
   });
 
   afterEach(() => {
@@ -77,109 +79,65 @@ describe("PanelView component (panel surface)", () => {
     });
   });
 
-  describe("Escape", () => {
-    it("emits a dismiss event for the session", async () => {
-      renderPanel(createConfig(), "panel-42");
-
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Escape",
-      });
-
-      expect(mockSendDialogEvent).toHaveBeenCalledWith({
-        kind: "dismiss",
-        dialogId: "panel-42",
-      });
-    });
-  });
-
-  describe("Cmd/Ctrl+Enter", () => {
-    it("fires the primary action with the field-values snapshot", async () => {
-      renderPanel(createConfig(), "panel-1");
-
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Enter",
-        ctrlKey: true,
-      });
-
-      expect(mockSendDialogEvent).toHaveBeenCalledWith({
-        dialogId: "panel-1",
-        actionId: "create",
-        data: { name: "" },
-      });
-    });
-
-    it("plain Enter on the shell does not submit", async () => {
-      renderPanel(createConfig());
-
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Enter",
-      });
-
-      expect(mockSendDialogEvent).not.toHaveBeenCalled();
-    });
-
-    it("does nothing when the config has no actions", async () => {
-      renderPanel({
-        layout: "form",
-        sections: [{ type: "text", content: "New Workspace", style: "heading" }],
-      });
-
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Enter",
-        metaKey: true,
-      });
-
-      expect(mockSendDialogEvent).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("Tab trap", () => {
-    // Multiline inputs render as native <textarea>s — focusable in happy-dom,
-    // unlike the vscode-elements web components whose internals aren't wired.
-    const trapConfig: DialogConfig = {
-      layout: "form",
+  describe("refocus on modal close", () => {
+    // A multiline autofocus input renders as a native <textarea> with
+    // data-autofocus — focusable in happy-dom, unlike vscode-elements.
+    const autofocusConfig = createConfig({
       sections: [
         { type: "text", content: "New Workspace", style: "heading" },
-        { type: "input", id: "first", label: "First", multiline: true },
-        { type: "input", id: "last", label: "Last", multiline: true },
+        { type: "input", id: "note", label: "Note", multiline: true, autofocus: true },
       ],
-    };
-
-    function getTextareas(): [HTMLTextAreaElement, HTMLTextAreaElement] {
-      const areas = document.querySelectorAll("textarea");
-      return [areas[0] as HTMLTextAreaElement, areas[1] as HTMLTextAreaElement];
-    }
-
-    it("Tab on the last control wraps to the first", async () => {
-      renderPanel(trapConfig);
-      const [first, last] = getTextareas();
-
-      last.focus();
-      await fireEvent.keyDown(last, { key: "Tab" });
-
-      expect(document.activeElement).toBe(first);
     });
 
-    it("Shift+Tab on the first control wraps to the last", async () => {
-      renderPanel(trapConfig);
-      const [first, last] = getTextareas();
+    it("re-places focus on the autofocus control when the last modal above closes", async () => {
+      renderPanel(autofocusConfig);
+      const textarea = document.querySelector("textarea")!;
+      await waitFor(() => expect(document.activeElement).toBe(textarea));
 
-      first.focus();
-      await fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+      // A modal opens above the panel and takes focus elsewhere.
+      processCommand({ action: "open", dialogId: "modal-1", config: { sections: [] } });
+      textarea.blur();
+      await waitFor(() => expect(document.activeElement).not.toBe(textarea));
 
-      expect(document.activeElement).toBe(last);
+      // Modal closes — the panel is the active surface again.
+      processCommand({ action: "close", dialogId: "modal-1" });
+
+      await waitFor(() => expect(document.activeElement).toBe(textarea));
     });
 
-    it("Tab pulls focus back in when it sits outside the panel", async () => {
-      renderPanel(trapConfig);
-      const [first] = getTextareas();
+    it("does not refocus while a modal is still open above", async () => {
+      renderPanel(autofocusConfig);
+      const textarea = document.querySelector("textarea")!;
+      await waitFor(() => expect(document.activeElement).toBe(textarea));
 
-      (document.activeElement as HTMLElement | null)?.blur();
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Tab",
+      processCommand({ action: "open", dialogId: "modal-1", config: { sections: [] } });
+      processCommand({ action: "open", dialogId: "modal-2", config: { sections: [] } });
+      textarea.blur();
+
+      // Only one of the two modals closes.
+      processCommand({ action: "close", dialogId: "modal-1" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(document.activeElement).not.toBe(textarea);
+    });
+
+    it("a panel-surface session does not count as a modal above", async () => {
+      renderPanel(autofocusConfig);
+      const textarea = document.querySelector("textarea")!;
+      await waitFor(() => expect(document.activeElement).toBe(textarea));
+
+      processCommand({
+        action: "open",
+        dialogId: "panel-x",
+        config: { sections: [] },
+        surface: "panel",
       });
+      textarea.blur();
+      processCommand({ action: "close", dialogId: "panel-x" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
-      expect(document.activeElement).toBe(first);
+      // No modal ever closed above the panel — focus is left alone.
+      expect(document.activeElement).not.toBe(textarea);
     });
   });
 
@@ -202,10 +160,7 @@ describe("PanelView component (panel surface)", () => {
 
       const textarea = document.querySelector("textarea")!;
       await fireEvent.input(textarea, { target: { value: "draft text" } });
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Enter",
-        ctrlKey: true,
-      });
+      await fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
       expect(mockSendDialogEvent).toHaveBeenCalledWith(
         expect.objectContaining({ data: { note: "draft text" } })
       );
@@ -214,10 +169,7 @@ describe("PanelView component (panel surface)", () => {
       // Backend reset: close + reopen arrives as a new dialogId.
       await rerender({ dialogId: "panel-2", config });
 
-      await fireEvent.keyDown(screen.getByRole("region", { name: "New Workspace" }), {
-        key: "Enter",
-        ctrlKey: true,
-      });
+      await fireEvent.keyDown(document.querySelector("textarea")!, { key: "Enter", ctrlKey: true });
       expect(mockSendDialogEvent).toHaveBeenCalledWith(
         expect.objectContaining({ dialogId: "panel-2", data: { note: "" } })
       );

--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -10,6 +10,9 @@
   - the field-change channel (per-field debounce, cancel-on-submit)
   - autofocus placement and focus-follow on config updates
   - primary-action resolution (Enter submit) and action/change event emission
+  - the form-global keyboard contract: Escape emits a "dismiss" event (the
+    session owner decides what dismissing means), Cmd/Ctrl+Enter fires the
+    primary action, Tab/Shift+Tab is trapped at the form boundary
 
   Leaves are controlled components: they receive their narrowed section config
   plus current value and report raw interactions back via callbacks; Form
@@ -26,6 +29,7 @@
   import type { DialogConfig, DialogSection, DialogUserEvent } from "@shared/dialog-types";
   import { onMount, onDestroy, untrack } from "svelte";
   import { sendDialogEvent } from "$lib/api";
+  import { trapTabKey } from "$lib/utils/focus-trap";
   import Section from "./Section.svelte";
   import type { ButtonItem, DropdownSectionConfig, FieldSectionConfig } from "./types";
 
@@ -232,6 +236,15 @@
     }, 0);
   }
 
+  /**
+   * Re-place focus on the autofocus control. Exposed for hosting surfaces
+   * that regain focus ownership (e.g. the panel when the last modal stacked
+   * above it closes and focus would otherwise be lost to <body>).
+   */
+  export function refocus(): void {
+    focusAutofocusTarget();
+  }
+
   /** The id of the control carrying the autofocus flag, or null. */
   function autofocusIdOf(cfg: DialogConfig): string | null {
     for (const section of cfg.sections) {
@@ -339,16 +352,6 @@
     if (primaryButton) handleButton(primaryButton);
   }
 
-  /**
-   * Activate the form's primary button as if clicked. Exposed for hosting
-   * surfaces that bind keyboard submit shortcuts (e.g. the panel shell's
-   * Cmd/Ctrl+Enter); same selection rule as Enter on a radio card. No-op
-   * without an explicit primary button.
-   */
-  export function submitPrimary(): void {
-    triggerPrimaryAction();
-  }
-
   /** Handle a button click: emit an action event with the values snapshot. */
   function handleButton(button: ButtonItem): void {
     if (button.disabled || button.busy) return;
@@ -377,9 +380,50 @@
     }
     return undefined;
   }
+
+  /**
+   * Form-global keyboard contract, on the bubble phase so field-level handlers
+   * run first — e.g. an open dropdown consumes Escape (stopPropagation) to
+   * close itself; only a second Escape reaches the form and dismisses the
+   * session. Must be a template handler: Svelte delegates template keydowns to
+   * the app root and replays them target-to-root, so only a delegated handler
+   * keeps that ordering with the field components' handlers.
+   * - Escape emits a "dismiss" event; the session owner decides what
+   *   dismissing means (owners without a dismiss listener ignore it).
+   * - Cmd/Ctrl+Enter activates the primary button from anywhere in the form.
+   * - Tab/Shift+Tab is trapped at the form boundary so focus never leaks out.
+   */
+  function handleKeydown(event: KeyboardEvent): void {
+    // A field-level handler that consumed the key (dropdown Enter/Escape,
+    // input Enter, radio Enter) marks it defaultPrevented — stay out.
+    if (event.defaultPrevented) return;
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      triggerPrimaryAction();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      const dismiss: DialogUserEvent = { kind: "dismiss", dialogId };
+      sendDialogEvent(dismiss);
+      return;
+    }
+    if (formRef) {
+      trapTabKey(event, formRef);
+    }
+  }
 </script>
 
-<div class="form" class:layout-form={layout === "form"} bind:this={formRef}>
+<!-- role="none": the form root is pure layout; the keydown handler is the
+     form-global keyboard contract, not a widget interaction. -->
+<div
+  class="form"
+  class:layout-form={layout === "form"}
+  role="none"
+  bind:this={formRef}
+  onkeydown={handleKeydown}
+>
   <!-- The recursive section snippet: GroupSection renders its items through
        it, re-entering the dispatcher without importing it (acyclic imports). -->
   {#snippet renderSection(section: DialogSection | ButtonItem)}

--- a/src/renderer/lib/components/form/Form.test.ts
+++ b/src/renderer/lib/components/form/Form.test.ts
@@ -863,6 +863,152 @@ describe("Form component", () => {
     });
   });
 
+  // ---- Form-global keyboard contract ----
+
+  describe("keyboard contract", () => {
+    const keyConfig: DialogConfig = {
+      sections: [
+        { type: "input", id: "name", label: "Name" },
+        {
+          type: "group",
+          items: [
+            { type: "button", id: "cancel", label: "Cancel", variant: "secondary" },
+            { type: "button", id: "create", label: "Create", variant: "primary" },
+          ],
+        },
+      ],
+    };
+
+    it("Escape emits a dismiss event for the session", async () => {
+      renderForm(keyConfig, { dialogId: "kb-1" });
+
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Escape" });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({ kind: "dismiss", dialogId: "kb-1" });
+    });
+
+    it("Escape bubbles up from inside a field to dismiss", async () => {
+      renderForm(keyConfig, { dialogId: "kb-2" });
+
+      await fireEvent.keyDown(document.getElementById("name")!, { key: "Escape" });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({ kind: "dismiss", dialogId: "kb-2" });
+    });
+
+    it("an open dropdown consumes the first Escape; the second dismisses", async () => {
+      renderForm(
+        {
+          sections: [
+            {
+              type: "dropdown",
+              id: "region",
+              suggestions: [{ items: [{ value: "us-east", label: "US East" }] }],
+            },
+          ],
+        },
+        { dialogId: "kb-3" }
+      );
+
+      const input = screen.getByRole("combobox");
+      await fireEvent.focus(input);
+      expect(input).toHaveAttribute("aria-expanded", "true");
+
+      // First Escape closes the dropdown without dismissing the session.
+      await fireEvent.keyDown(input, { key: "Escape" });
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(mockSendDialogEvent).not.toHaveBeenCalled();
+
+      // Second Escape reaches the form and dismisses.
+      await fireEvent.keyDown(input, { key: "Escape" });
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({ kind: "dismiss", dialogId: "kb-3" });
+    });
+
+    it("Cmd/Ctrl+Enter activates the primary button with the values snapshot", async () => {
+      renderForm(keyConfig, { dialogId: "kb-4" });
+
+      const field = document.getElementById("name")!;
+      await fireEvent.input(field, { target: { value: "ws" } });
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Enter", ctrlKey: true });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({
+        dialogId: "kb-4",
+        actionId: "create",
+        data: { name: "ws" },
+      });
+    });
+
+    it("Ctrl+Enter inside a single-line input submits exactly once", async () => {
+      renderForm(keyConfig, { dialogId: "kb-5" });
+
+      // The input's own Enter handler consumes the key (defaultPrevented);
+      // the form-level handler must not fire a second action.
+      await fireEvent.keyDown(document.getElementById("name")!, { key: "Enter", ctrlKey: true });
+
+      expect(mockSendDialogEvent).toHaveBeenCalledTimes(1);
+      expect(mockSendDialogEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ actionId: "create" })
+      );
+    });
+
+    it("Cmd/Ctrl+Enter does nothing without an explicit primary button", async () => {
+      renderForm({
+        sections: [
+          { type: "text", content: "Working", style: "heading" },
+          { type: "group", items: [{ type: "button", id: "go", label: "Go" }] },
+        ],
+      });
+
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Enter", metaKey: true });
+
+      expect(mockSendDialogEvent).not.toHaveBeenCalled();
+    });
+
+    it("plain Enter on the form root does not submit", async () => {
+      renderForm(keyConfig);
+
+      await fireEvent.keyDown(document.querySelector(".form")!, { key: "Enter" });
+
+      expect(mockSendDialogEvent).not.toHaveBeenCalled();
+    });
+
+    describe("Tab trap", () => {
+      // Multiline inputs render as native <textarea>s — focusable in happy-dom,
+      // unlike the vscode-elements web components whose internals aren't wired.
+      const trapConfig: DialogConfig = {
+        sections: [
+          { type: "input", id: "first", label: "First", multiline: true },
+          { type: "input", id: "last", label: "Last", multiline: true },
+        ],
+      };
+
+      function getTextareas(): [HTMLTextAreaElement, HTMLTextAreaElement] {
+        const areas = document.querySelectorAll("textarea");
+        return [areas[0] as HTMLTextAreaElement, areas[1] as HTMLTextAreaElement];
+      }
+
+      it("Tab on the last control wraps to the first", async () => {
+        renderForm(trapConfig);
+        const [first, last] = getTextareas();
+
+        last.focus();
+        await fireEvent.keyDown(last, { key: "Tab" });
+
+        expect(document.activeElement).toBe(first);
+      });
+
+      it("Shift+Tab on the first control wraps to the last", async () => {
+        renderForm(trapConfig);
+        const [first, last] = getTextareas();
+
+        first.focus();
+        await fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+
+        expect(document.activeElement).toBe(last);
+      });
+    });
+  });
+
   // ---- Autofocus ----
 
   describe("autofocus", () => {

--- a/src/renderer/lib/stores/new-workspace-view.svelte.ts
+++ b/src/renderer/lib/stores/new-workspace-view.svelte.ts
@@ -19,10 +19,6 @@ import { setActiveWorkspace } from "./projects.svelte.js";
 
 let _isOpen = $state(false);
 
-// Submit handler registered by MainView while the panel is shown, so keyboard
-// shortcuts (Alt+X+Enter) can trigger the panel form's primary action.
-let _submitHandler: (() => void) | null = null;
-
 // ============ Getters ============
 
 export const newWorkspaceView = {
@@ -52,24 +48,8 @@ export function closeNewWorkspaceView(): void {
 }
 
 /**
- * Register (or clear with null) the submit handler from the mounted view.
- */
-export function registerSubmitHandler(handler: (() => void) | null): void {
-  _submitHandler = handler;
-}
-
-/**
- * Trigger the view's Create action (used by Alt+X+Enter while the view is open).
- * No-op if the view isn't mounted/registered or the form is invalid.
- */
-export function requestSubmit(): void {
-  _submitHandler?.();
-}
-
-/**
  * Reset store to initial state. Used for testing.
  */
 export function reset(): void {
   _isOpen = false;
-  _submitHandler = null;
 }

--- a/src/renderer/lib/stores/shortcuts.svelte.ts
+++ b/src/renderer/lib/stores/shortcuts.svelte.ts
@@ -15,7 +15,6 @@ import {
   newWorkspaceView,
   openNewWorkspaceView,
   closeNewWorkspaceView,
-  requestSubmit,
 } from "./new-workspace-view.svelte";
 import { getLifecycle } from "./workspace-lifecycle.svelte";
 import {
@@ -343,14 +342,14 @@ export async function handleHibernateToggle(): Promise<void> {
 /**
  * Handle dialog opening keys (Enter, Delete, Backspace).
  * Sets mode to "workspace" locally for immediate UI feedback.
- * - Enter opens the New workspace view, or creates the workspace if it's already open.
+ * - Enter opens the New workspace view.
  * - Delete/Backspace opens the remove dialog for the active workspace.
  */
 function handleDialog(key: DialogKey): void {
   if (key === "Enter") {
     if (newWorkspaceView.isOpen) {
-      // Already on the New workspace view: Alt+X+Enter creates the workspace.
-      requestSubmit();
+      // Already on the New workspace view: nothing to open. Keyboard submit
+      // is Cmd/Ctrl+Enter, owned by the form itself.
       return;
     }
     // Deactivate shortcut mode locally for immediate UI feedback. The New

--- a/src/renderer/lib/stores/shortcuts.test.ts
+++ b/src/renderer/lib/stores/shortcuts.test.ts
@@ -36,7 +36,6 @@ const mockNewWorkspaceView = vi.hoisted(() => ({
   newWorkspaceView: { isOpen: false as boolean },
   openNewWorkspaceView: vi.fn(),
   closeNewWorkspaceView: vi.fn(),
-  requestSubmit: vi.fn(),
 }));
 
 // Create mock workspace type for testing
@@ -885,18 +884,17 @@ describe("shortcuts store", () => {
 
         // Opens the New workspace view with no project pre-fill (no args).
         expect(mockNewWorkspaceView.openNewWorkspaceView).toHaveBeenCalledWith();
-        expect(mockNewWorkspaceView.requestSubmit).not.toHaveBeenCalled();
         expect(shortcutModeActive.value).toBe(false);
       });
 
-      it("should-create-workspace-on-enter-when-view-already-open", () => {
-        // Already on the New workspace view: Alt+X+Enter triggers Create.
+      it("should-do-nothing-on-enter-when-view-already-open", () => {
+        // Already on the New workspace view: keyboard submit is Cmd/Ctrl+Enter
+        // (owned by the form), not Alt+X+Enter.
         mockNewWorkspaceView.newWorkspaceView.isOpen = true;
 
         enableShortcutMode();
         handleShortcutKey("enter");
 
-        expect(mockNewWorkspaceView.requestSubmit).toHaveBeenCalled();
         expect(mockNewWorkspaceView.openNewWorkspaceView).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
- Form.svelte now owns the form-global keyboard contract for both surfaces (panel + modal): Escape emits a dismiss event, Cmd/Ctrl+Enter fires the primary action, Tab is trapped at the form boundary
- Escape now works in modal dialogs: the git clone dialog closes (or detaches like "Continue in background" mid-clone), bug report and init-git cancel, the deletion dialog dismisses only when its Dismiss button is shown; setup/splash dialogs stay ESC-inert
- An open dropdown consumes the first Escape (closes just the dropdown); only a second Escape dismisses the session — fixes a latent panel bug
- DialogHandle.nextEvent() resolves on dismiss as well as actions; mandatory agent selection loops until a real selection arrives
- Removed the Alt+X+Enter submit path — Cmd/Ctrl+Enter is the uniform keyboard submit (Alt+X+Enter still opens the New workspace view)
- The create panel refocuses its autofocus control when the last modal above it closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)