### PR TITLE
chore(agents): unify Claude/OpenCode module providers via shared spec core

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,16 +1,16 @@
 # Agent System Documentation
 
-This document describes the agent integration layer, provider interface, and how to implement new agent types.
+This document describes the agent integration layer, provider interfaces, and how to implement new agent types.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Architecture](#architecture)
 - [Core Components](#core-components)
-  - [AgentSetupInfo](#agentsetupinfo)
+  - [AgentModuleProvider](#agentmoduleprovider)
+  - [AgentModuleSpec and the core factory](#agentmodulespec-and-the-core-factory)
   - [AgentServerManager](#agentservermanager)
   - [AgentProvider](#agentprovider)
-  - [AgentStatusManager](#agentstatusmanager)
 - [Status Flow](#status-flow)
 - [MCP Integration](#mcp-integration)
 - [OpenCode Implementation](#opencode-implementation)
@@ -22,18 +22,20 @@ This document describes the agent integration layer, provider interface, and how
 
 ## Overview
 
-CodeHydra uses an abstraction layer to support multiple AI coding agents. The architecture consists of three main components:
+CodeHydra uses an abstraction layer to support multiple AI coding agents. Everything lives under `src/modules/agent-module/`:
 
-| Component            | Purpose                                     | Scope                    |
-| -------------------- | ------------------------------------------- | ------------------------ |
-| `AgentSetupInfo`     | Binary distribution, config file generation | Singleton per type       |
-| `AgentServerManager` | Server lifecycle (start, stop, restart)     | Shared across workspaces |
-| `AgentProvider`      | Connection and status tracking              | One per workspace        |
+| Component                   | Purpose                                                               | Scope                    |
+| --------------------------- | --------------------------------------------------------------------- | ------------------------ |
+| `createAgentModule`         | Generic intent module; delegates every hook to an AgentModuleProvider | One per agent type       |
+| `AgentModuleProvider`       | Unified per-agent surface (binary, lifecycle, status, sessions)       | One per agent type       |
+| `createAgentModuleProvider` | Generic provider-tracking core, parameterized by an `AgentModuleSpec` | One per agent type       |
+| `AgentServerManager`        | Server lifecycle (start, stop, restart)                               | Shared across workspaces |
+| `AgentProvider`             | Connection and status tracking                                        | One per workspace        |
 
 **Existing implementations:**
 
-- **OpenCode** (`src/agents/opencode/`) - SSE-based SDK client, one server per workspace
-- **Claude Code** (`src/agents/claude-code/`) - HTTP hook server, shared across all workspaces
+- **OpenCode** (`src/modules/agent-module/opencode/`) - SSE-based SDK client, one server per workspace
+- **Claude Code** (`src/modules/agent-module/claude/`) - HTTP hook server, shared across all workspaces
 
 ---
 
@@ -43,27 +45,27 @@ CodeHydra uses an abstraction layer to support multiple AI coding agents. The ar
 ┌─────────────────────────────────────────────────────────────────┐
 │                        MAIN PROCESS                              │
 │                                                                  │
-│  AgentServerManager ──► spawns agent server(s)                   │
+│  AgentServerManager ──► spawns/tracks agent server(s)            │
 │         │                      port stored in memory             │
-│         │ onServerStarted(path, port)                            │
+│         │ onServerStarted(path, port, ...)                       │
 │         ▼                                                        │
-│  AgentStatusManager ◄── AgentProvider (status events)            │
+│  module-provider core ◄── AgentProvider (status events)          │
+│  (registry + status cache)                                       │
 │         │                                                        │
-│         │ onStatusChanged callback                               │
+│         │ onStatusChange callback (wired by createAgentModule)   │
 │         ▼                                                        │
 │  Dispatcher.dispatch(agent:update-status intent)                 │
 │         │                                                        │
-│         │ UpdateAgentStatusOperation emits domain event           │
+│         │ UpdateAgentStatusOperation emits domain event          │
 │         ▼                                                        │
 │  agent:status-updated domain event                               │
 │         │                                                        │
-│         ├──► UiIpcModule subscriber                            │
+│         ├──► UI IPC subscriber                                   │
 │         │      converts AggregatedAgentStatus → WorkspaceStatus  │
-│         │      emits workspace:status-changed via registry        │
+│         │      emits workspace:status-changed                    │
 │         │                                                        │
-│         └──► BadgeModule subscriber                               │
-│                updates internal map, re-aggregates badge state    │
-│                calls badgeManager.updateBadge()                   │
+│         └──► Badge module subscriber                             │
+│                updates internal map, re-aggregates badge state   │
 │                                                                  │
 └──────────────────────────┬──────────────────────────────────────┘
                            │
@@ -81,108 +83,100 @@ CodeHydra uses an abstraction layer to support multiple AI coding agents. The ar
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-### AgentModule
+### Generic agent module
 
-`AgentModule` (`src/main/modules/agent-module.ts`) is the consolidated lifecycle owner for all agent concerns. It is a factory function (`createAgentModule`) returning an `IntentModule` with hooks across multiple operations:
+`createAgentModule(provider, deps)` (`src/modules/agent-module/agent-module.ts`) returns an `IntentModule` that is a thin adapter: every hook handler delegates to the `AgentModuleProvider`. One module instance is registered per agent type in the composition root (`src/main.ts`).
 
-| Operation              | Hook Points                                       | Responsibility                                                                          |
-| ---------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `app:start`            | `check-config`, `check-deps`, `start`, `activate` | Config check, binary preflight, server callback wiring, status subscription, MCP config |
-| `app:shutdown`         | `stop`                                            | Dispose ServerManager, AgentStatusManager, cleanup callbacks                            |
-| `app:setup`            | `agent-selection`, `save-agent`, `binary`         | Agent selection UI, config persistence, binary download                                 |
-| `open-workspace`       | `setup`                                           | Start server, wait for provider, set initial prompt, get env vars                       |
-| `delete-workspace`     | `shutdown`                                        | Kill terminals, stop server, clear TUI tracking                                         |
-| `get-workspace-status` | `get`                                             | Return agent status                                                                     |
-| `get-agent-session`    | `get`                                             | Return session info                                                                     |
-| `restart-agent`        | `restart`                                         | Restart agent server                                                                    |
+| Operation              | Hook Points                               | Responsibility                                             |
+| ---------------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| `app:start`            | `before-ready`, `check-deps`, `start`     | Script declarations, binary preflight, MCP port capture    |
+| `app:ready`            | `available-agents`                        | Report agent availability for the picker                   |
+| `app:shutdown`         | `stop`                                    | Dispose provider, cleanup status subscription              |
+| `setup`                | `register-agents`, `save-agent`, `binary` | Agent selection UI, config persistence, binary download    |
+| `open-workspace`       | `setup`                                   | Start server, wait for provider, prompt plumbing, env vars |
+| `delete-workspace`     | `shutdown`                                | Stop server, clear per-workspace tracking                  |
+| `hibernate-workspace`  | `shutdown`                                | Best-effort server stop (errors not propagated)            |
+| `get-workspace-status` | `get`                                     | Return agent status                                        |
+| `get-agent-session`    | `get`                                     | Return session info                                        |
+| `restart-agent`        | `restart`                                 | Restart agent server                                       |
+| `agent-lifecycle`      | `lifecycle`                               | Terminal open/close transitions (reported by the sidekick) |
 
-Internal closure state: `handleServerStarted()`, `waitForProvider()`, `serverStartedPromises`, server callback wiring.
+Provider initialization is lazy: it happens on the first `open-workspace` for the configured agent, using the MCP port captured during `app:start`.
 
 ### File Structure
 
 ```
-src/agents/
-  types.ts              # Shared interfaces (AgentSetupInfo, AgentServerManager, AgentProvider)
-  index.ts              # Factory functions and exports
-  status-manager.ts     # AgentStatusManager (aggregates status across workspaces)
+src/modules/agent-module/
+  types.ts                  # Shared interfaces (AgentServerManager, AgentProvider, McpConfig, ...)
+  agent-module.ts           # createAgentModule (generic intent adapter)
+  agent-module-provider.ts  # AgentModuleProvider interface
+  module-provider.ts        # createAgentModuleProvider core + AgentModuleSpec
+  status-utils.ts           # Pure status conversion helpers
   opencode/
-    setup-info.ts       # OpenCodeSetupInfo (version, URLs)
-    server-manager.ts   # OpenCodeServerManager (one server per workspace)
-    provider.ts         # OpenCodeProvider (SSE client)
-    client.ts           # OpenCodeClient (SSE/HTTP)
-    types.ts            # OpenCode-specific types
-  claude-code/
-    setup-info.ts       # ClaudeCodeSetupInfo
-    server-manager.ts   # ClaudeCodeServerManager (shared HTTP server)
-    provider.ts         # ClaudeCodeProvider
-src/main/modules/
-  agent-module.ts       # AgentModule (consolidated lifecycle owner)
+    setup-info.ts           # Version/URL/bundle-dir helper functions
+    server-manager.ts       # OpenCodeServerManager (one server per workspace)
+    provider.ts             # OpenCodeProvider (SSE client wrapper)
+    client.ts               # OpenCodeClient (official SDK + SSE)
+    module-provider.ts      # createOpenCodeModuleProvider (spec definition)
+    wrapper.ts              # CLI wrapper (redirects to `opencode attach`)
+  claude/
+    setup-info.ts           # Version/URL/sub-path helper functions
+    server-manager.ts       # ClaudeCodeServerManager (shared HTTP hook server)
+    provider.ts             # ClaudeCodeProvider (env vars + hook subscription)
+    module-provider.ts      # createClaudeModuleProvider (spec definition)
+    hook-handler.ts         # Hook POST script run by the Claude CLI
+    wrapper.ts              # CLI wrapper (session resume, initial prompt)
 ```
 
 ---
 
 ## Core Components
 
-### AgentSetupInfo
+### AgentModuleProvider
 
-Static information about an agent type. One instance per agent type (singleton).
+The unified per-agent surface consumed by the generic module (`agent-module-provider.ts`). Covers identity constants (`type`, `displayName`, `icon`, `scripts`, ...), binary management (`preflight`, `downloadBinary`), lifecycle (`initialize`, `dispose`), per-workspace operations (`startWorkspace`, `stopWorkspace`, `restartWorkspace`, `applyTerminalLifecycle`), queries (`getStatus`, `getSession`), the cross-workspace `onStatusChange` event, and `clearWorkspaceTracking`.
 
-```typescript
-interface AgentSetupInfo {
-  /** Version string (e.g., "0.1.0-beta.43") */
-  readonly version: string;
+### AgentModuleSpec and the core factory
 
-  /** Binary filename relative to bin directory (e.g., "opencode" or "opencode.exe") */
-  readonly binaryPath: string;
+`createAgentModuleProvider(spec, deps)` (`module-provider.ts`) implements `AgentModuleProvider` once. It owns the shared machinery:
 
-  /** Entry point for wrapper script (e.g., "agents/opencode-wrapper.cjs") */
-  readonly wrapperEntryPoint: string;
+- per-workspace provider registry and status cache (with change deduplication)
+- `onServerStarted`/`onServerStopped` wiring, including the restart path (disconnect → reconnect)
+- binary preflight/download scaffolding
+- disposal
 
-  /** VS Code marketplace extension ID (e.g., "anthropic.claude-code") */
-  readonly extensionId?: string;
+Per-agent behavior is supplied via `AgentModuleSpec<P>` (generic over the concrete provider class):
 
-  /** Get download URL for the binary for current platform */
-  getBinaryUrl(): string;
-
-  /**
-   * Generate config file with environment variable substitution
-   * @param targetPath - Path where config file should be written
-   * @param variables - Variables to substitute (e.g., { MCP_PORT: "3000" })
-   */
-  generateConfigFile(targetPath: Path, variables: Record<string, string>): Promise<void>;
-}
-```
-
-**Implementation notes:**
-
-- `getBinaryUrl()` returns platform-specific download URL
-- `generateConfigFile()` creates workspace-specific config (e.g., MCP server configuration)
-- Use template files with `${VARIABLE}` placeholders for config generation
+| Spec member              | Claude                                        | OpenCode                                       |
+| ------------------------ | --------------------------------------------- | ---------------------------------------------- |
+| `resolveBinary()`        | `null` when no version override (bundled)     | always resolves from `version.opencode`        |
+| `createProvider`         | `new ClaudeCodeProvider({serverManager,...})` | `new OpenCodeProvider(path, logger)`           |
+| `connectProvider`        | `connect(port)`                               | `connect(port)` + `fetchStatus()`              |
+| `initialStatus`          | always `"none"` (status arrives via hooks)    | derived from `getEffectiveCounts()`            |
+| `onProviderRegistered`   | —                                             | sends the pending initial prompt               |
+| `startServer`            | `startServer(path)`                           | `startServer(path, {initialPrompt})`           |
+| `afterProviderReady`     | writes prompt file + no-session marker        | —                                              |
+| `applyTerminalLifecycle` | WrapperStart/WrapperEnd via server manager    | `triggerWrapperStart` / TUI detach             |
+| `wireExtraCallbacks`     | —                                             | `setMarkActiveHandler` (TUI-attached tracking) |
+| `clearWorkspaceTracking` | — (no per-workspace tracking)                 | clears the TUI-attached entry                  |
 
 ### AgentServerManager
 
-Manages server lifecycle. One manager handles all workspaces.
+Manages server lifecycle (`types.ts`). One manager handles all workspaces.
 
 ```typescript
 interface AgentServerManager {
-  /** Start server for a workspace, returns allocated port */
   startServer(workspacePath: string): Promise<number>;
-
-  /** Stop server for a workspace */
   stopServer(workspacePath: string): Promise<StopServerResult>;
-
-  /** Restart server for a workspace, preserving the same port */
   restartServer(workspacePath: string): Promise<RestartServerResult>;
-
-  /** Callback when server starts successfully */
   onServerStarted(
-    callback: (workspacePath: string, port: number, ...args: unknown[]) => void
+    cb: (workspacePath: string, port: number, ...args: unknown[]) => void
   ): () => void;
-
-  /** Callback when server stops */
-  onServerStopped(callback: (workspacePath: string, ...args: unknown[]) => void): () => void;
-
-  /** Dispose the manager, stopping all servers */
+  onServerStopped(cb: (workspacePath: string, ...args: unknown[]) => void): () => void;
+  setMarkActiveHandler(handler: (workspacePath: string) => void): void;
+  setInitialPrompt?(workspacePath: string, config: NormalizedInitialPrompt): Promise<void>; // Claude only
+  setNoSessionMarker?(workspacePath: string): Promise<void>; // Claude only
+  setMcpConfig(config: McpConfig): void;
   dispose(): Promise<void>;
 }
 ```
@@ -203,72 +197,27 @@ interface AgentServerManager {
 
 ### AgentProvider
 
-Per-workspace connection and status tracking.
+Per-workspace connection and status tracking (`types.ts`).
 
 ```typescript
 interface AgentProvider {
-  /** VS Code commands to execute on workspace activation */
-  readonly startupCommands: readonly string[];
-
-  /** Connect to agent server at given port */
   connect(port: number): Promise<void>;
-
-  /** Disconnect from agent server (for restart, preserves session info) */
-  disconnect(): void;
-
-  /** Reconnect to agent server after restart */
+  disconnect(): void; // for restart, preserves session info
   reconnect(): Promise<void>;
-
-  /** Subscribe to status changes - callback receives computed status */
   onStatusChange(callback: (status: AgentStatus) => void): () => void;
-
-  /** Get session info for TUI attachment */
   getSession(): AgentSessionInfo | null;
-
-  /** Get environment variables needed for terminal integration */
   getEnvironmentVariables(): Record<string, string>;
-
-  /** Mark agent as active (first MCP request received) */
   markActive(): void;
-
-  /** Dispose the provider completely */
+  detachTui?(): void; // only providers with a TUI-attached status gate (OpenCode)
   dispose(): void;
 }
 ```
 
 **Implementation notes:**
 
-- `startupCommands` are VS Code commands executed when workspace becomes active
 - `disconnect()` preserves state for reconnection; `dispose()` is final cleanup
 - Status changes should be emitted as soon as they occur
-- `getEnvironmentVariables()` provides env vars for terminal/extension integration
-
-### AgentStatusManager
-
-Aggregates status across all workspaces:
-
-```typescript
-interface AgentStatusManager {
-  /** Register a provider for a workspace */
-  registerProvider(workspacePath: string, provider: AgentProvider): void;
-
-  /** Unregister a provider when workspace is removed */
-  unregisterProvider(workspacePath: string): void;
-
-  /** Get current status for a workspace */
-  getStatus(workspacePath: string): AgentStatus;
-
-  /** Subscribe to status changes for any workspace */
-  onStatusChange(callback: (workspacePath: string, status: AgentStatus) => void): () => void;
-}
-```
-
-**Key responsibilities:**
-
-1. Maintains registry of workspace → provider mappings
-2. Subscribes to each provider's status changes
-3. Aggregates and emits unified status events
-4. Cleans up subscriptions when providers are unregistered
+- `getEnvironmentVariables()` provides env vars the sidekick sets for all new terminals
 
 ---
 
@@ -298,29 +247,14 @@ interface AgentSessionInfo {
 
 ### Permission State Override
 
-For agents like OpenCode, sessions waiting for user permission are displayed as "idle" (green indicator) rather than "busy":
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                      AgentProvider                               │
-│                                                                  │
-│  sessionStatuses: Map<sessionId, SessionStatus>                  │
-│  pendingPermissions: Map<sessionId, Set<permissionId>>          │
-│                                                                  │
-│  getAdjustedStatus():                                           │
-│    for each session:                                            │
-│      if pendingPermissions.has(sessionId) → count as idle       │
-│      else if status.type === "idle" → count as idle             │
-│      else if status.type === "busy" → count as busy             │
-└─────────────────────────────────────────────────────────────────┘
-```
+For agents like OpenCode, sessions waiting for user permission are displayed as "idle" (green indicator) rather than "busy". The provider tracks `pendingPermissions: Map<sessionId, Set<permissionId>>`; any pending permission makes `getEffectiveCounts()` report idle.
 
 **Event handling:**
 
-- `permission.updated`: Adds permission to `pendingPermissions` Set
-- `permission.replied`: Removes permission from `pendingPermissions` Set
+- `permission.updated`: Adds permission to `pendingPermissions`
+- `permission.replied`: Removes permission from `pendingPermissions`
 - `session.deleted`: Clears pending permissions for that session
-- Connection disconnect: Clears all pending permissions (reconnection safety)
+- Disconnect: Clears all pending permissions (reconnection safety)
 
 ### Background Shell Handling (Claude Code)
 
@@ -340,61 +274,45 @@ which happens automatically when a background shell exits) or the session ends.
 
 ## MCP Integration
 
-Agent servers are configured to connect to CodeHydra's MCP server for workspace API access.
-
-### Environment Variables
-
-When spawning agent servers, the following environment variables are set:
-
-| Variable             | Set for     | Purpose                                                      |
-| -------------------- | ----------- | ------------------------------------------------------------ |
-| `_CH_WORKSPACE_PATH` | Agents      | Absolute path to the workspace (for X-Workspace-Path header) |
-| `_CH_MCP_PORT`       | Agents      | Port of CodeHydra's MCP server                               |
-| `_CH_PLUGIN_PORT`    | code-server | Port of CodeHydra's Plugin server (for VS Code extensions)   |
+Agent servers are configured to connect to CodeHydra's MCP server for workspace API access. The MCP port is captured during `app:start` and passed to the provider via `initialize()`.
 
 ### OpenCode MCP Configuration
 
-OpenCode servers receive a config file path via `OPENCODE_CONFIG` env var:
+OpenCode servers receive the MCP config inline via the `OPENCODE_CONFIG_CONTENT` environment variable at spawn time:
 
 ```json
 {
-  "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "codehydra": {
       "type": "remote",
-      "url": "http://127.0.0.1:{env:_CH_MCP_PORT}",
-      "headers": {
-        "X-Workspace-Path": "{env:_CH_WORKSPACE_PATH}"
-      },
+      "url": "http://127.0.0.1:<mcp-port>/mcp",
+      "headers": { "X-Workspace-Path": "<workspace-path>" },
       "enabled": true
     }
   }
 }
 ```
 
+### Claude Code MCP Configuration
+
+The server manager generates per-workspace config files (`codehydra-hooks.json`, `codehydra-mcp.json`) from JSON templates with `${VARIABLE}` substitution, stored under `<data>/claude/configs/<workspace-hash>/`. The provider exposes their paths via environment variables (`_CH_CLAUDE_SETTINGS`, `_CH_CLAUDE_MCP_CONFIG`).
+
 ### MCP Tools Available to Agents
 
-The MCP server exposes workspace management tools:
-
-| Tool                       | Description                           |
-| -------------------------- | ------------------------------------- |
-| `workspace.getStatus`      | Get workspace dirty/agent status      |
-| `workspace.getMetadata`    | Get all workspace metadata            |
-| `workspace.setMetadata`    | Set or delete metadata key            |
-| `workspace.delete`         | Delete the current workspace          |
-| `workspace.create`         | Create a new workspace in the project |
-| `workspace.executeCommand` | Execute a VS Code command             |
+The MCP server exposes workspace management tools (`workspace.getStatus`, `workspace.getMetadata`, `workspace.setMetadata`, `workspace.delete`, `workspace.create`, `workspace.executeCommand`, ...). See docs/API.md.
 
 ### Port Discovery for CLI
 
-The sidekick extension calls `api.workspace.getAgentSession()` on connect and sets environment variables for all new terminals:
+The sidekick extension applies the env vars from `getEnvironmentVariables()` to all new terminals:
 
 | Variable                  | Purpose                            |
 | ------------------------- | ---------------------------------- |
 | `_CH_OPENCODE_PORT`       | OpenCode server port               |
 | `_CH_OPENCODE_SESSION_ID` | OpenCode session ID for attachment |
+| `_CH_BRIDGE_PORT`         | Claude hook bridge port            |
+| `_CH_WORKSPACE_PATH`      | Workspace path (both agents)       |
 
-The wrapper script (`<app-data>/bin/opencode`) reads these env vars to redirect `opencode` invocations to `opencode attach http://127.0.0.1:$PORT --session $SESSION_ID`.
+The OpenCode wrapper script reads these to redirect `opencode` invocations to `opencode attach http://127.0.0.1:$PORT --session $SESSION_ID`.
 
 ---
 
@@ -407,10 +325,10 @@ OpenCode uses SSE (Server-Sent Events) for real-time status updates.
 ```
 1. startServer(workspacePath) called
 2. Allocate port via PortManager
-3. Spawn `opencode serve --port N --dir path`
-4. HTTP probe to `/app` confirms server is ready
-5. Fire onServerStarted callback
-6. Provider.connect(port) establishes SSE connection
+3. Spawn `opencode serve --port N` (cwd = workspace)
+4. HTTP probe to `/path` confirms server is ready
+5. Fire onServerStarted(path, port, pendingPrompt)
+6. Provider.connect(port) finds/creates a session and connects SSE
 ```
 
 ### SSE Event Types
@@ -442,24 +360,15 @@ import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk";
 export type SdkClientFactory = (baseUrl: string) => OpencodeClient;
 
 export class OpenCodeClient implements IDisposable {
-  constructor(port: number, sdkFactory: SdkClientFactory = defaultFactory) {
-    this.baseUrl = `http://localhost:${port}`;
-    this.sdk = sdkFactory(this.baseUrl);
-  }
-
-  async connect(timeoutMs = 5000): Promise<void> {
-    const events = await this.sdk.event.subscribe();
-    this.processEvents(events.stream);
+  constructor(port: number, logger: Logger, sdkFactory: SdkClientFactory = defaultSdkFactory) {
+    // ...
   }
 }
 ```
 
-### Error Handling
+### TUI-Attached Gate
 
-- **Connection Failures**: Exponential backoff reconnection (1s, 2s, 4s... max 30s)
-- **Port Reuse**: PID comparison detects when different process reuses a port
-- **Concurrent Scans**: Mutex flag prevents overlapping scan operations
-- **Resource Cleanup**: `IDisposable` pattern ensures proper cleanup on shutdown
+OpenCode status reports `"none"` until the TUI attaches (first MCP request or terminal open). The module provider keeps a `tuiAttachedWorkspaces` set that survives provider recreation across server restarts; terminal close detaches the TUI (`detachTui()`) without stopping the server.
 
 ---
 
@@ -469,178 +378,82 @@ Claude Code uses a shared HTTP server with a hook-based integration model.
 
 ### Architecture
 
-Unlike OpenCode (one server per workspace), Claude Code uses a single HTTP server that handles requests for all workspaces. The workspace is identified via request headers.
+Unlike OpenCode (one server per workspace), Claude Code uses a single HTTP bridge server that handles hook notifications for all workspaces. The workspace is identified by the `workspacePath` field in the hook payload.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  ClaudeCodeServerManager                                         │
-│  - Single HTTP server on dynamic port                           │
-│  - Routes: POST /hook                                           │
-│  - Workspace identified by X-Workspace-Path header              │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │
-            ┌───────────────┼───────────────┐
-            │               │               │
-            ▼               ▼               ▼
-┌───────────────┐ ┌───────────────┐ ┌───────────────┐
-│ Workspace A   │ │ Workspace B   │ │ Workspace C   │
-│ Provider      │ │ Provider      │ │ Provider      │
-└───────────────┘ └───────────────┘ └───────────────┘
-```
-
-### Hook Integration
-
-Claude Code sends hooks to the CodeHydra server:
-
-```typescript
-// Hook request from Claude Code
-POST /hook
-X-Workspace-Path: /path/to/workspace
+POST /hook/<HookName>
 Content-Type: application/json
 
-{
-  "type": "status",
-  "status": "busy"
-}
+{ "workspacePath": "/path/to/workspace", "session_id": "..." }
 ```
 
 ### Status Derivation
 
-Since Claude Code doesn't provide explicit status events, status is derived from hook activity:
-
-- **First hook received**: `none` → `idle`
-- **Prompt submitted**: `idle` → `busy`
-- **Response completed**: `busy` → `idle`
-- **Inactivity timeout**: `busy` → `idle` (safety fallback)
+Status is driven by the Claude CLI's hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PermissionRequest`, ...) routed through a per-workspace state machine in the server manager (see `claude/types.ts` for the hook → status mapping). It also handles compaction, sub-agent tracking, and permission-resolution edge cases. `WrapperStart`/`WrapperEnd` are not accepted over HTTP — they are driven by the sidekick via the `agent:lifecycle` intent (`triggerWrapperLifecycle`).
 
 ### Session Resumption
 
 The Claude wrapper automatically attempts to resume previous sessions using the `--continue` flag:
 
 1. On launch, checks if user passed `--continue`, `-c`, or `--resume` flags
-2. If not, prepends `--continue` to attempt resuming the most recent session for this directory
+2. If not, prepends `--continue` to attempt resuming the most recent session for this directory (unless the no-session marker for a brand-new workspace is present)
 3. If continuation fails (no session exists), automatically retries without `--continue`
 4. This enables seamless session continuity across CodeHydra restarts
 
-**How `--continue` works**: The Claude CLI `--continue` flag loads the most recent conversation from the current project directory. Sessions are stored in `~/.claude/projects/` and are per-directory.
-
 **Flag precedence**: If user passes `--resume <session-id>`, it takes precedence over `--continue`. The wrapper detects this and skips adding `--continue` to avoid conflicts.
-
-Users can still use their own flags:
-
-- `--resume <session>` - Resume a specific named session
-- `--continue` or `-c` - Explicitly continue most recent session
 
 ---
 
 ## Implementing a New Agent
 
-### 1. Create Setup Info Class
+### 1. Create setup-info helpers
 
 ```typescript
-// src/agents/my-agent/setup-info.ts
-export class MyAgentSetupInfo implements AgentSetupInfo {
-  readonly version = "1.0.0";
-  readonly binaryPath = process.platform === "win32" ? "my-agent.exe" : "my-agent";
-  readonly wrapperEntryPoint = "agents/my-agent-wrapper.cjs";
-  readonly extensionId = "publisher.my-agent-extension";
+// src/modules/agent-module/my-agent/setup-info.ts
+export function getMyAgentUrlForVersion(version, platform, arch): string { ... }
+export function getMyAgentBundleDir(pathProvider, version): Path { ... }
+```
 
-  constructor(private deps: { fileSystem: FileSystemBoundary; platform: string }) {}
+### 2. Create the server manager and provider
 
-  getBinaryUrl(): string {
-    // Return platform-specific download URL
-  }
+Implement `AgentServerManager` (server lifecycle) and `AgentProvider` (per-workspace connection + status), following the per-workspace (OpenCode) or shared (Claude) pattern.
 
-  async generateConfigFile(targetPath: Path, variables: Record<string, string>): Promise<void> {
-    // Generate config with variable substitution
-  }
+### 3. Define the module provider spec
+
+```typescript
+// src/modules/agent-module/my-agent/module-provider.ts
+export function createMyAgentModuleProvider(deps: MyAgentModuleProviderDeps): AgentModuleProvider {
+  return createAgentModuleProvider<MyAgentProvider>(
+    {
+      type: "my-agent",
+      configKey: "version.my-agent",
+      displayName: "My Agent",
+      icon: "rocket",
+      serverName: "My Agent",
+      scripts: ["ch-my-agent"],
+      serverManager: deps.serverManager,
+      resolveBinary() { ... },
+      createProvider: (path) => new MyAgentProvider(path, deps.logger),
+      connectProvider: (provider, port) => provider.connect(port),
+      initialStatus: () => "none",
+      startServer: (path) => deps.serverManager.startServer(path).then(() => undefined),
+      applyTerminalLifecycle: (path, event, ctx) => { ... },
+    },
+    { logger: deps.logger, downloadDeps: deps.downloadDeps, binaryName: deps.binaryConfig.name }
+  );
 }
 ```
 
-### 2. Create Server Manager Class
+### 4. Register in the composition root
+
+In `src/main.ts`, construct the module provider and register a module:
 
 ```typescript
-// src/agents/my-agent/server-manager.ts
-export class MyAgentServerManager implements AgentServerManager {
-  private servers = new Map<string, ServerState>();
-  private startedCallbacks: Array<(...args: unknown[]) => void> = [];
-  private stoppedCallbacks: Array<(...args: unknown[]) => void> = [];
-
-  async startServer(workspacePath: string): Promise<number> {
-    const port = await this.deps.portManager.acquirePort();
-    // Start server, wait for ready
-    this.notifyStarted(workspacePath, port);
-    return port;
-  }
-
-  // ... implement remaining methods
-}
+const myAgentProvider = createMyAgentModuleProvider({ ... });
+dispatcher.registerModule(createAgentModule(myAgentProvider, { dispatcher, logger, agentConfig }));
 ```
 
-### 3. Create Provider Class
-
-```typescript
-// src/agents/my-agent/provider.ts
-export class MyAgentProvider implements AgentProvider {
-  readonly startupCommands = ["my-agent.openTerminal"] as const;
-  private statusCallbacks: Array<(status: AgentStatus) => void> = [];
-  private status: AgentStatus = "none";
-  private port: number | null = null;
-  private sessionId: string | null = null;
-
-  async connect(port: number): Promise<void> {
-    this.port = port;
-    // Establish connection, subscribe to events
-  }
-
-  onStatusChange(callback: (status: AgentStatus) => void): () => void {
-    this.statusCallbacks.push(callback);
-    callback(this.status); // Emit current status immediately
-    return () => {
-      const idx = this.statusCallbacks.indexOf(callback);
-      if (idx >= 0) this.statusCallbacks.splice(idx, 1);
-    };
-  }
-
-  // ... implement remaining methods
-}
-```
-
-### 4. Register in Factory Functions
-
-Update `src/agents/index.ts`:
-
-```typescript
-// Add to AgentType union in src/agents/types.ts
-export type AgentType = "opencode" | "claude-code" | "my-agent";
-
-// Add imports
-import { MyAgentSetupInfo } from "./my-agent/setup-info";
-import { MyAgentServerManager } from "./my-agent/server-manager";
-import { MyAgentProvider } from "./my-agent/provider";
-
-// Add cases to factory functions
-export function getAgentSetupInfo(type: AgentType, deps: SetupInfoDeps): AgentSetupInfo {
-  switch (type) {
-    // ... existing cases
-    case "my-agent":
-      return new MyAgentSetupInfo({ fileSystem: deps.fileSystem, platform: deps.platform });
-  }
-}
-```
-
-### Dependencies
-
-Providers receive dependencies through factory functions:
-
-```typescript
-/** Dependencies for AgentSetupInfo */
-interface SetupInfoDeps {
-  readonly fileSystem: FileSystemBoundary;
-  readonly platform: "darwin" | "linux" | "win32";
-  readonly arch: SupportedArch;
-}
-```
+Also extend the `AgentType` union (`src/shared/plugin-protocol`) — this is an interface change requiring approval (see CLAUDE.md).
 
 ---
 
@@ -648,63 +461,24 @@ interface SetupInfoDeps {
 
 ### Integration Test Coverage
 
-Tests should cover:
+The primary suites are `claude/module-provider.integration.test.ts` and `opencode/module-provider.integration.test.ts`. They exercise the full `AgentModuleProvider` surface against a stubbed server manager and a `vi.mock`ed provider class, covering:
 
-1. **Connect/disconnect/reconnect cycle**
-2. **Status change propagation**
-3. **Session retrieval**
-4. **Environment variables**
-5. **Multiple subscribers**
+1. **Identity constants and binary management** (preflight/download)
+2. **Server started/stopped callbacks** (first start, restart-reconnect, full stop)
+3. **Status change propagation and deduplication**
+4. **Session retrieval and environment variables**
+5. **Prompt plumbing** (Claude prompt file / OpenCode pending prompt)
 6. **Disposal cleanup**
 
-### Example Test Structure
+### Testing the OpenCode Client
 
 ```typescript
-describe("MyAgentProvider", () => {
-  it("should emit status changes to subscribers", async () => {
-    const provider = new MyAgentProvider(deps);
-    const statuses: AgentStatus[] = [];
-
-    provider.onStatusChange((status) => statuses.push(status));
-    await provider.connect(3000);
-
-    // Trigger status change
-    // ...
-
-    expect(statuses).toContain("idle");
-  });
-
-  it("should preserve session across disconnect/reconnect", async () => {
-    const provider = new MyAgentProvider(deps);
-    await provider.connect(3000);
-
-    // Establish session
-    // ...
-
-    provider.disconnect();
-    await provider.reconnect();
-
-    expect(provider.getSession()).not.toBeNull();
-  });
-});
-```
-
-### Testing OpenCode Client
-
-```typescript
-import { createMockSdkClient, createMockSdkFactory, createTestSession } from "./sdk-test-utils";
-
 const mockSdk = createMockSdkClient({
   sessions: [createTestSession({ id: "ses-1", directory: "/test" })],
   sessionStatuses: { "ses-1": { type: "idle" } },
 });
 const factory = createMockSdkFactory(mockSdk);
-const client = new OpenCodeClient(8080, factory);
+const client = new OpenCodeClient(8080, SILENT_LOGGER, factory);
 ```
 
-### Reference Implementations
-
-| Agent       | Setup Info                             | Server Manager                             | Provider                             |
-| ----------- | -------------------------------------- | ------------------------------------------ | ------------------------------------ |
-| OpenCode    | `src/agents/opencode/setup-info.ts`    | `src/agents/opencode/server-manager.ts`    | `src/agents/opencode/provider.ts`    |
-| Claude Code | `src/agents/claude-code/setup-info.ts` | `src/agents/claude-code/server-manager.ts` | `src/agents/claude-code/provider.ts` |
+See `opencode/sdk-client.state-mock.ts` and docs/TESTING.md for conventions.

--- a/src/modules/agent-module/claude/module-provider.ts
+++ b/src/modules/agent-module/claude/module-provider.ts
@@ -1,40 +1,22 @@
 /**
  * Claude Module Provider - AgentModuleProvider implementation for Claude Code.
  *
- * Wraps ClaudeCodeServerManager and ClaudeCodeProvider to implement the
- * unified AgentModuleProvider interface. Absorbs all per-workspace provider
- * management, status tracking, and server lifecycle coordination that was
- * previously scattered across the intent module closure.
- *
- * The generic agent module factory delegates all Claude-specific behavior
- * to this provider, keeping the module itself a thin intent adapter.
+ * Defines the Claude-specific AgentModuleSpec consumed by the generic
+ * createAgentModuleProvider() core: provider construction, prompt-file
+ * plumbing (initial prompt + no-session marker), and wrapper lifecycle
+ * routing. All provider-tracking machinery lives in the core.
  */
 
-import type {
-  AgentModuleProvider,
-  WorkspaceStartOptions,
-  WorkspaceStartResult,
-} from "../agent-module-provider";
-import type { AgentProvider, AgentSessionInfo, AgentStatus, McpConfig } from "../types";
-import type { AgentLifecycleEvent } from "../../../shared/plugin-protocol";
-import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
-import type {
-  ArchiveExtension,
-  DownloadDeps,
-  DownloadProgressCallback,
-  DownloadRequest,
-} from "../../../utils/binary-download";
-import { downloadBinary, isBinaryInstalled } from "../../../utils/binary-download";
-import type { BinaryType } from "../../../utils/binary-resolution/types";
-import { AgentBinaryError, getErrorMessage } from "../../../shared/errors/service-errors";
+import type { AgentModuleProvider } from "../agent-module-provider";
+import type { ArchiveExtension, DownloadDeps } from "../../../utils/binary-download";
 import type { PersistedAccessor } from "../../../boundaries/platform/store-definition";
-import type { StopServerResult, RestartServerResult } from "../types";
 import type { Logger } from "../../../boundaries/platform/logging";
 import type { ClaudeCodeServerManager } from "./server-manager";
 import { ClaudeCodeProvider } from "./provider";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
 import { getClaudeUrlForVersion, getClaudeSubPath } from "./setup-info";
+import { createAgentModuleProvider } from "../module-provider";
 
 // =============================================================================
 // Dependency Interface
@@ -64,9 +46,6 @@ export interface ClaudeModuleProviderDeps {
 
 /**
  * Create an AgentModuleProvider for Claude Code.
- *
- * Uses factory function pattern (not a class) to keep state in a closure,
- * consistent with the existing module pattern.
  */
 export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): AgentModuleProvider {
   const {
@@ -80,324 +59,68 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
     logger,
   } = deps;
 
-  // ===========================================================================
-  // Internal closure state
-  // ===========================================================================
+  return createAgentModuleProvider<ClaudeCodeProvider>(
+    {
+      // --- Identity ---
+      type: "claude",
+      configKey: "version.claude",
+      displayName: "Claude Code",
+      icon: "sparkle",
+      serverName: "Claude Code hook",
+      scripts: ["ch-claude", "ch-claude.cjs", "ch-claude.cmd", "claude-code-hook-handler.cjs"],
 
-  /** Per-workspace provider instances. */
-  const providers = new Map<WorkspacePath, AgentProvider>();
+      serverManager,
 
-  /** Cached aggregated status per workspace (for deduplication and queries). */
-  const statusCache = new Map<WorkspacePath, AggregatedAgentStatus>();
-
-  /** Tracks pending handleServerStarted() promises for waitForProvider(). */
-  const serverStartedPromises = new Map<string, Promise<void>>();
-
-  /** Cleanup functions for onServerStarted/onServerStopped callbacks. */
-  let serverStartedCleanupFn: (() => void) | null = null;
-  let serverStoppedCleanupFn: (() => void) | null = null;
-
-  /** Registered status change callbacks. */
-  const statusChangeCallbacks: Array<
-    (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
-  > = [];
-
-  // ===========================================================================
-  // Provider management helpers
-  // ===========================================================================
-
-  function createNoneStatus(): AggregatedAgentStatus {
-    return { status: "none", counts: { idle: 0, busy: 0 } };
-  }
-
-  function convertToAggregatedStatus(status: AgentStatus): AggregatedAgentStatus {
-    switch (status) {
-      case "none":
-        return { status: "none", counts: { idle: 0, busy: 0 } };
-      case "idle":
-        return { status: "idle", counts: { idle: 1, busy: 0 } };
-      case "busy":
-        return { status: "busy", counts: { idle: 0, busy: 1 } };
-    }
-  }
-
-  function notifyStatusChange(path: WorkspacePath, status: AggregatedAgentStatus): void {
-    for (const callback of statusChangeCallbacks) {
-      callback(path, status);
-    }
-  }
-
-  function handleStatusUpdate(path: WorkspacePath, agentStatus: AgentStatus): void {
-    const status = convertToAggregatedStatus(agentStatus);
-    const previous = statusCache.get(path);
-    const hasChanged =
-      !previous ||
-      previous.status !== status.status ||
-      previous.counts.idle !== status.counts.idle ||
-      previous.counts.busy !== status.counts.busy;
-
-    if (hasChanged) {
-      statusCache.set(path, status);
-      notifyStatusChange(path, status);
-    }
-  }
-
-  function addProvider(path: WorkspacePath, provider: AgentProvider): void {
-    if (providers.has(path)) return;
-
-    provider.onStatusChange((status) => handleStatusUpdate(path, status));
-
-    providers.set(path, provider);
-    // ClaudeCodeProvider: initial status is "none" (status comes via onStatusChange from ServerManager)
-    handleStatusUpdate(path, "none");
-  }
-
-  function removeProvider(path: WorkspacePath): void {
-    const provider = providers.get(path);
-    if (provider) {
-      provider.dispose();
-      providers.delete(path);
-      statusCache.delete(path);
-      notifyStatusChange(path, createNoneStatus());
-    }
-  }
-
-  function disconnectProvider(path: WorkspacePath): void {
-    const provider = providers.get(path);
-    if (provider) {
-      provider.disconnect();
-    }
-  }
-
-  async function reconnectProvider(path: WorkspacePath): Promise<void> {
-    const provider = providers.get(path);
-    if (provider) {
-      await provider.reconnect();
-      // ClaudeCodeProvider: status comes via onStatusChange, initial reconnect status is "none"
-      handleStatusUpdate(path, "none");
-    }
-  }
-
-  // ===========================================================================
-  // Server callback wiring
-  // ===========================================================================
-
-  async function handleServerStarted(workspacePath: WorkspacePath, port: number): Promise<void> {
-    try {
-      // Check if this is a restart (provider already exists from disconnect)
-      if (providers.has(workspacePath)) {
-        try {
-          await reconnectProvider(workspacePath);
-          logger.info("Reconnected agent provider after restart", {
-            workspacePath,
-            port,
-            agentType: "claude",
-          });
-        } catch (error) {
-          logger.error(
-            "Failed to reconnect agent provider",
-            { workspacePath, port, agentType: "claude" },
-            error instanceof Error ? error : undefined
-          );
-        }
-        return;
-      }
-
-      // First start: create Claude-specific provider directly
-      const provider = new ClaudeCodeProvider({
-        serverManager,
-        workspacePath,
-        logger,
-      });
-
-      try {
-        await provider.connect(port);
-        addProvider(workspacePath, provider);
-      } catch (error) {
-        logger.error(
-          "Failed to initialize agent provider",
-          { workspacePath, port, agentType: "claude" },
-          error instanceof Error ? error : undefined
-        );
-      }
-    } finally {
-      serverStartedPromises.delete(workspacePath);
-    }
-  }
-
-  function wireServerCallbacks(): void {
-    serverStartedCleanupFn = serverManager.onServerStarted((workspacePath, port) => {
-      const promise = handleServerStarted(workspacePath as WorkspacePath, port);
-      serverStartedPromises.set(workspacePath, promise);
-    });
-
-    serverStoppedCleanupFn = serverManager.onServerStopped((workspacePath, isRestart) => {
-      if (isRestart) {
-        disconnectProvider(workspacePath as WorkspacePath);
-      } else {
-        removeProvider(workspacePath as WorkspacePath);
-      }
-    });
-  }
-
-  // ===========================================================================
-  // AgentModuleProvider implementation
-  // ===========================================================================
-
-  return {
-    // --- Identity ---
-
-    type: "claude",
-    configKey: "version.claude",
-    displayName: "Claude Code",
-    icon: "sparkle",
-    serverName: "Claude Code hook",
-    scripts: [
-      "ch-claude",
-      "ch-claude.cjs",
-      "ch-claude.cmd",
-      "claude-code-hook-handler.cjs",
-    ] as const,
-
-    // --- Binary ---
-
-    get binaryType(): BinaryType {
-      return binaryConfig.name as BinaryType;
-    },
-
-    async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
-      const version = versionConfig.get();
-      if (version === null) {
-        return { success: true, needsDownload: false };
-      }
-      try {
+      // --- Binary: version null = bundled binary, nothing to download ---
+      resolveBinary() {
+        const version = versionConfig.get();
+        if (version === null) return null;
         const destDir = pathProvider.bundlePath(`claude/${version}`).toNative();
-        const installed = await isBinaryInstalled(destDir, downloadDeps);
-        return { success: true, needsDownload: !installed };
-      } catch {
-        return { success: false, needsDownload: false };
-      }
-    },
+        return {
+          destDir,
+          request: () => ({
+            name: binaryConfig.name,
+            url: getClaudeUrlForVersion(version, platform, arch),
+            destDir,
+            archiveExtension: binaryConfig.archiveExtension,
+            executablePath: binaryConfig.executablePath,
+            subPath: getClaudeSubPath(platform, arch),
+          }),
+        };
+      },
 
-    async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
-      const version = versionConfig.get();
-      if (version === null) return;
-      const destDir = pathProvider.bundlePath(`claude/${version}`).toNative();
-      const request: DownloadRequest = {
-        name: binaryConfig.name,
-        url: getClaudeUrlForVersion(version, platform, arch),
-        destDir,
-        archiveExtension: binaryConfig.archiveExtension,
-        executablePath: binaryConfig.executablePath,
-        subPath: getClaudeSubPath(platform, arch),
-      };
-      try {
-        await downloadBinary(request, downloadDeps, onProgress);
-      } catch (error) {
-        throw new AgentBinaryError(
-          `Failed to download ${binaryConfig.name}: ${getErrorMessage(error)}`
-        );
-      }
-    },
+      // --- Provider lifecycle ---
+      createProvider: (workspacePath) =>
+        new ClaudeCodeProvider({ serverManager, workspacePath, logger }),
 
-    // --- Lifecycle ---
+      connectProvider: (provider, port) => provider.connect(port),
 
-    initialize(mcpConfig: McpConfig | null): void {
-      wireServerCallbacks();
-      if (mcpConfig) {
-        serverManager.setMcpConfig(mcpConfig);
-      }
-    },
+      // Status comes via onStatusChange from the ServerManager hooks; the
+      // registration/reconnect seed is always "none".
+      initialStatus: () => "none",
 
-    async dispose(): Promise<void> {
-      if (serverStartedCleanupFn) {
-        serverStartedCleanupFn();
-        serverStartedCleanupFn = null;
-      }
-      if (serverStoppedCleanupFn) {
-        serverStoppedCleanupFn();
-        serverStoppedCleanupFn = null;
-      }
+      // --- Workspace start ---
+      startServer: async (workspacePath) => {
+        await serverManager.startServer(workspacePath);
+      },
 
-      await serverManager.dispose();
-
-      for (const provider of providers.values()) {
-        provider.dispose();
-      }
-      providers.clear();
-      statusCache.clear();
-    },
-
-    // --- Per-workspace ---
-
-    async startWorkspace(
-      workspacePath: string,
-      options?: WorkspaceStartOptions
-    ): Promise<WorkspaceStartResult> {
-      await serverManager.startServer(workspacePath);
-
-      // Wait for the handleServerStarted callback to complete
-      const promise = serverStartedPromises.get(workspacePath);
-      if (promise) {
-        await promise;
-      }
-
-      if (options?.initialPrompt) {
-        await serverManager.setInitialPrompt(workspacePath, options.initialPrompt);
-      }
-
-      if (options?.isNewWorkspace) {
-        await serverManager.setNoSessionMarker(workspacePath);
-      }
-
-      return {
-        envVars: providers.get(workspacePath as WorkspacePath)?.getEnvironmentVariables() ?? {},
-      };
-    },
-
-    async stopWorkspace(workspacePath: string): Promise<StopServerResult> {
-      return serverManager.stopServer(workspacePath);
-    },
-
-    async restartWorkspace(workspacePath: string): Promise<RestartServerResult> {
-      return serverManager.restartServer(workspacePath);
-    },
-
-    applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void {
-      serverManager.triggerWrapperLifecycle(
-        workspacePath,
-        event === "open" ? "WrapperStart" : "WrapperEnd"
-      );
-    },
-
-    // --- Query ---
-
-    getStatus(workspacePath: WorkspacePath): AggregatedAgentStatus {
-      return statusCache.get(workspacePath) ?? createNoneStatus();
-    },
-
-    getSession(workspacePath: WorkspacePath): AgentSessionInfo | null {
-      return providers.get(workspacePath)?.getSession() ?? null;
-    },
-
-    // --- Events ---
-
-    onStatusChange(
-      callback: (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
-    ): () => void {
-      statusChangeCallbacks.push(callback);
-      return () => {
-        const index = statusChangeCallbacks.indexOf(callback);
-        if (index >= 0) {
-          statusChangeCallbacks.splice(index, 1);
+      afterProviderReady: async (workspacePath, options) => {
+        if (options?.initialPrompt) {
+          await serverManager.setInitialPrompt(workspacePath, options.initialPrompt);
         }
-      };
-    },
+        if (options?.isNewWorkspace) {
+          await serverManager.setNoSessionMarker(workspacePath);
+        }
+      },
 
-    // --- Cleanup ---
-
-    clearWorkspaceTracking(): void {
-      // No-op for Claude: no per-workspace tracking state to clear
+      // --- Terminal lifecycle ---
+      applyTerminalLifecycle: (workspacePath, event) => {
+        serverManager.triggerWrapperLifecycle(
+          workspacePath,
+          event === "open" ? "WrapperStart" : "WrapperEnd"
+        );
+      },
     },
-  };
+    { logger, downloadDeps, binaryName: binaryConfig.name }
+  );
 }

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -22,6 +22,7 @@ import type {
   StopServerResult,
   RestartServerResult,
   AgentStatus,
+  McpConfig,
 } from "../types";
 import { Path } from "../../../utils/path/path";
 import {
@@ -81,14 +82,6 @@ export type ServerStoppedCallback = (workspacePath: string, isRestart: boolean) 
 export interface ClaudeCodeServerManagerConfig {
   /** Path to the hook-handler.js script */
   readonly hookHandlerPath?: string;
-}
-
-/**
- * MCP server configuration for Claude Code integration.
- */
-export interface McpConfig {
-  /** MCP server port */
-  readonly port: number;
 }
 
 /**
@@ -838,11 +831,11 @@ export class ClaudeCodeServerManager implements AgentServerManager {
 
     // Generate hooks config
     const hooksConfigPath = new Path(workspaceConfigDir, "codehydra-hooks.json");
-    await this.generateHooksConfig(hooksConfigPath, variables);
+    await this.generateConfigFromTemplate(hooksConfigTemplate, hooksConfigPath, variables);
 
     // Generate MCP config
     const mcpConfigPath = new Path(workspaceConfigDir, "codehydra-mcp.json");
-    await this.generateMcpConfig(mcpConfigPath, variables);
+    await this.generateConfigFromTemplate(mcpConfigTemplate, mcpConfigPath, variables);
 
     this.logger.debug("Config files generated", {
       workspacePath,
@@ -872,13 +865,14 @@ export class ClaudeCodeServerManager implements AgentServerManager {
   }
 
   /**
-   * Generate hooks config file from template.
+   * Generate a config file from a JSON template with variable substitution.
    */
-  private async generateHooksConfig(
+  private async generateConfigFromTemplate(
+    template: unknown,
     targetPath: Path,
     variables: Record<string, string>
   ): Promise<void> {
-    let content = JSON.stringify(hooksConfigTemplate, null, 2);
+    let content = JSON.stringify(template, null, 2);
 
     // Substitute variables
     for (const [key, value] of Object.entries(variables)) {
@@ -890,21 +884,12 @@ export class ClaudeCodeServerManager implements AgentServerManager {
   }
 
   /**
-   * Generate MCP config file from template.
+   * Get the path to a config file in the workspace's config directory.
    */
-  private async generateMcpConfig(
-    targetPath: Path,
-    variables: Record<string, string>
-  ): Promise<void> {
-    let content = JSON.stringify(mcpConfigTemplate, null, 2);
-
-    // Substitute variables
-    for (const [key, value] of Object.entries(variables)) {
-      const pattern = new RegExp(`\\$\\{${key}\\}`, "g");
-      content = content.replace(pattern, value);
-    }
-
-    await this.fileSystem.writeFile(targetPath, content);
+  private configFilePath(workspacePath: string, filename: string): Path {
+    const normalizedPath = new Path(workspacePath).toString();
+    const safeWorkspaceName = this.getConfigDirName(normalizedPath);
+    return new Path(this.pathProvider.dataPath("claude/configs"), safeWorkspaceName, filename);
   }
 
   /**
@@ -912,13 +897,7 @@ export class ClaudeCodeServerManager implements AgentServerManager {
    * This is used by the Provider to set environment variables.
    */
   getHooksConfigPath(workspacePath: string): Path {
-    const normalizedPath = new Path(workspacePath).toString();
-    const safeWorkspaceName = this.getConfigDirName(normalizedPath);
-    return new Path(
-      this.pathProvider.dataPath("claude/configs"),
-      safeWorkspaceName,
-      "codehydra-hooks.json"
-    );
+    return this.configFilePath(workspacePath, "codehydra-hooks.json");
   }
 
   /**
@@ -926,12 +905,6 @@ export class ClaudeCodeServerManager implements AgentServerManager {
    * This is used by the Provider to set environment variables.
    */
   getMcpConfigPath(workspacePath: string): Path {
-    const normalizedPath = new Path(workspacePath).toString();
-    const safeWorkspaceName = this.getConfigDirName(normalizedPath);
-    return new Path(
-      this.pathProvider.dataPath("claude/configs"),
-      safeWorkspaceName,
-      "codehydra-mcp.json"
-    );
+    return this.configFilePath(workspacePath, "codehydra-mcp.json");
   }
 }

--- a/src/modules/agent-module/module-provider.ts
+++ b/src/modules/agent-module/module-provider.ts
@@ -1,0 +1,461 @@
+/**
+ * Generic agent module provider factory.
+ *
+ * Owns all provider-tracking machinery shared by the Claude and OpenCode
+ * module providers: the per-workspace provider registry, status cache with
+ * deduplication, server started/stopped callback wiring, restart-reconnect
+ * handling, binary preflight/download scaffolding, and disposal.
+ *
+ * Per-agent behavior is supplied through an AgentModuleSpec: identity
+ * constants, binary resolution, provider construction/connection, the
+ * initial status seed, prompt plumbing, and terminal lifecycle routing.
+ */
+
+import type {
+  AgentModuleProvider,
+  WorkspaceStartOptions,
+  WorkspaceStartResult,
+} from "./agent-module-provider";
+import type {
+  AgentProvider,
+  AgentServerManager,
+  AgentSessionInfo,
+  AgentStatus,
+  McpConfig,
+  StopServerResult,
+  RestartServerResult,
+} from "./types";
+import type { AgentType, AgentLifecycleEvent } from "../../shared/plugin-protocol";
+import type { AggregatedAgentStatus, WorkspacePath } from "../../shared/ipc";
+import type {
+  DownloadDeps,
+  DownloadProgressCallback,
+  DownloadRequest,
+} from "../../utils/binary-download";
+import { downloadBinary, isBinaryInstalled } from "../../utils/binary-download";
+import type { BinaryType } from "../../utils/binary-resolution/types";
+import { AgentBinaryError, getErrorMessage } from "../../shared/errors/service-errors";
+import type { Logger } from "../../boundaries/platform/logging";
+import { createNoneStatus, convertToAggregatedStatus } from "./status-utils";
+
+// =============================================================================
+// Spec Interface
+// =============================================================================
+
+/**
+ * Access to the core's per-workspace provider registry, handed to spec hooks
+ * that need to reach a registered provider (e.g. terminal lifecycle routing).
+ */
+export interface SpecContext<P extends AgentProvider> {
+  getProvider(path: WorkspacePath): P | undefined;
+}
+
+/**
+ * Per-agent behavior consumed by createAgentModuleProvider().
+ *
+ * Generic over the concrete provider type so spec hooks can use
+ * agent-specific provider methods without casts.
+ */
+export interface AgentModuleSpec<P extends AgentProvider> {
+  // --- Identity ---
+
+  /** Agent type identifier (e.g., "claude", "opencode") */
+  readonly type: AgentType;
+
+  /** Config key used for version overrides (e.g., "version.claude") */
+  readonly configKey: string;
+
+  /** Human-readable display name (e.g., "Claude Code") */
+  readonly displayName: string;
+
+  /** Icon name for UI display */
+  readonly icon: string;
+
+  /** MCP server name registered by this agent */
+  readonly serverName: string;
+
+  /** Script filenames to copy into workspaces */
+  readonly scripts: readonly string[];
+
+  // --- Binary ---
+
+  /**
+   * Resolve the binary install location and (lazily) the download request.
+   * Returns null when there is nothing to download (e.g. Claude with no
+   * version override uses the bundled binary).
+   */
+  resolveBinary(): { destDir: string; request: () => DownloadRequest } | null;
+
+  // --- Server manager ---
+
+  /** The agent's server manager (common subset used by the core). */
+  readonly serverManager: Pick<
+    AgentServerManager,
+    | "stopServer"
+    | "restartServer"
+    | "onServerStarted"
+    | "onServerStopped"
+    | "setMcpConfig"
+    | "dispose"
+  >;
+
+  // --- Provider lifecycle ---
+
+  /** Construct the per-workspace provider (not yet connected). */
+  createProvider(workspacePath: WorkspacePath): P;
+
+  /** Connect the provider to the server (plus any initial fetch). */
+  connectProvider(provider: P, port: number): Promise<void>;
+
+  /** Status seed used on registration and after reconnect. */
+  initialStatus(provider: P): AgentStatus;
+
+  /**
+   * Called after the provider is registered on first start. `extra` is the
+   * third argument of the server manager's onServerStarted callback
+   * (e.g. OpenCode's pending prompt), untyped at this boundary.
+   */
+  onProviderRegistered?(path: WorkspacePath, provider: P, extra: unknown): Promise<void>;
+
+  // --- Workspace start ---
+
+  /** Start the agent server for a workspace. */
+  startServer(workspacePath: string, options: WorkspaceStartOptions | undefined): Promise<void>;
+
+  /** Called after the provider is ready (e.g. Claude's prompt file plumbing). */
+  afterProviderReady?(
+    workspacePath: string,
+    options: WorkspaceStartOptions | undefined
+  ): Promise<void>;
+
+  // --- Terminal lifecycle + per-workspace tracking ---
+
+  /** Apply an agent terminal lifecycle transition (reported by the sidekick). */
+  applyTerminalLifecycle(
+    workspacePath: string,
+    event: AgentLifecycleEvent,
+    ctx: SpecContext<P>
+  ): void;
+
+  /** Wire agent-specific server callbacks (called once, alongside core wiring). */
+  wireExtraCallbacks?(ctx: SpecContext<P>): void;
+
+  /** Called when a provider is registered, before the status seed is emitted. */
+  onProviderAdded?(path: WorkspacePath, provider: P): void;
+
+  /** Remove agent-specific tracking state for a workspace. */
+  clearWorkspaceTracking?(path: WorkspacePath): void;
+
+  /** Clear agent-specific state on dispose. */
+  onDispose?(): void;
+}
+
+/**
+ * Shared dependencies of the core factory.
+ */
+export interface AgentModuleCoreDeps {
+  readonly logger: Logger;
+  readonly downloadDeps: DownloadDeps;
+  /** Binary name used for binaryType and download error messages. */
+  readonly binaryName: string;
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+/**
+ * Create an AgentModuleProvider from a per-agent spec.
+ *
+ * Uses factory function pattern (not a class) to keep state in a closure,
+ * consistent with the existing module pattern.
+ */
+export function createAgentModuleProvider<P extends AgentProvider>(
+  spec: AgentModuleSpec<P>,
+  deps: AgentModuleCoreDeps
+): AgentModuleProvider {
+  const { logger, downloadDeps, binaryName } = deps;
+
+  // ===========================================================================
+  // Internal closure state
+  // ===========================================================================
+
+  /** Per-workspace provider instances. */
+  const providers = new Map<WorkspacePath, P>();
+
+  /** Cached aggregated status per workspace (for deduplication and queries). */
+  const statusCache = new Map<WorkspacePath, AggregatedAgentStatus>();
+
+  /** Tracks pending handleServerStarted() promises for startWorkspace(). */
+  const serverStartedPromises = new Map<string, Promise<void>>();
+
+  /** Status change subscribers. */
+  const statusChangeListeners = new Set<
+    (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
+  >();
+
+  /** Cleanup functions for onServerStarted/onServerStopped callbacks. */
+  let serverStartedCleanupFn: (() => void) | null = null;
+  let serverStoppedCleanupFn: (() => void) | null = null;
+
+  /** Whether server callbacks have been wired. */
+  let callbacksWired = false;
+
+  const ctx: SpecContext<P> = {
+    getProvider: (path) => providers.get(path),
+  };
+
+  // ===========================================================================
+  // Provider management helpers
+  // ===========================================================================
+
+  function notifyStatusChange(path: WorkspacePath, status: AggregatedAgentStatus): void {
+    for (const listener of statusChangeListeners) {
+      listener(path, status);
+    }
+  }
+
+  function handleStatusUpdate(path: WorkspacePath, agentStatus: AgentStatus): void {
+    const status = convertToAggregatedStatus(agentStatus);
+    const previous = statusCache.get(path);
+    const hasChanged =
+      !previous ||
+      previous.status !== status.status ||
+      previous.counts.idle !== status.counts.idle ||
+      previous.counts.busy !== status.counts.busy;
+
+    if (hasChanged) {
+      statusCache.set(path, status);
+      notifyStatusChange(path, status);
+    }
+  }
+
+  function addProvider(path: WorkspacePath, provider: P): void {
+    if (providers.has(path)) return;
+
+    provider.onStatusChange((status) => handleStatusUpdate(path, status));
+
+    spec.onProviderAdded?.(path, provider);
+
+    providers.set(path, provider);
+    handleStatusUpdate(path, spec.initialStatus(provider));
+  }
+
+  function removeProvider(path: WorkspacePath): void {
+    const provider = providers.get(path);
+    if (provider) {
+      provider.dispose();
+      providers.delete(path);
+      statusCache.delete(path);
+      notifyStatusChange(path, createNoneStatus());
+    }
+  }
+
+  function disconnectProvider(path: WorkspacePath): void {
+    const provider = providers.get(path);
+    if (provider) {
+      provider.disconnect();
+    }
+  }
+
+  async function reconnectProvider(path: WorkspacePath): Promise<void> {
+    const provider = providers.get(path);
+    if (provider) {
+      await provider.reconnect();
+      handleStatusUpdate(path, spec.initialStatus(provider));
+    }
+  }
+
+  // ===========================================================================
+  // Server callback wiring
+  // ===========================================================================
+
+  async function handleServerStarted(
+    workspacePath: WorkspacePath,
+    port: number,
+    extra: unknown
+  ): Promise<void> {
+    try {
+      // Check if this is a restart (provider already exists from disconnect)
+      if (providers.has(workspacePath)) {
+        try {
+          await reconnectProvider(workspacePath);
+          logger.info("Reconnected agent provider after restart", {
+            workspacePath,
+            port,
+            agentType: spec.type,
+          });
+        } catch (error) {
+          logger.error(
+            "Failed to reconnect agent provider",
+            { workspacePath, port, agentType: spec.type },
+            error instanceof Error ? error : undefined
+          );
+        }
+        return;
+      }
+
+      // First start: create the agent-specific provider
+      const provider = spec.createProvider(workspacePath);
+
+      try {
+        await spec.connectProvider(provider, port);
+        addProvider(workspacePath, provider);
+        await spec.onProviderRegistered?.(workspacePath, provider, extra);
+      } catch (error) {
+        logger.error(
+          "Failed to initialize agent provider",
+          { workspacePath, port, agentType: spec.type },
+          error instanceof Error ? error : undefined
+        );
+      }
+    } finally {
+      serverStartedPromises.delete(workspacePath);
+    }
+  }
+
+  function wireServerCallbacks(): void {
+    if (callbacksWired) return;
+    callbacksWired = true;
+
+    spec.wireExtraCallbacks?.(ctx);
+
+    serverStartedCleanupFn = spec.serverManager.onServerStarted((workspacePath, port, ...extra) => {
+      const promise = handleServerStarted(workspacePath as WorkspacePath, port, extra[0]);
+      serverStartedPromises.set(workspacePath, promise);
+    });
+
+    serverStoppedCleanupFn = spec.serverManager.onServerStopped((workspacePath, ...args) => {
+      const isRestart = args[0] === true;
+      if (isRestart) {
+        disconnectProvider(workspacePath as WorkspacePath);
+      } else {
+        removeProvider(workspacePath as WorkspacePath);
+      }
+    });
+  }
+
+  // ===========================================================================
+  // AgentModuleProvider implementation
+  // ===========================================================================
+
+  return {
+    // --- Identity ---
+    type: spec.type,
+    configKey: spec.configKey,
+    displayName: spec.displayName,
+    icon: spec.icon,
+    serverName: spec.serverName,
+    scripts: spec.scripts,
+
+    // --- Binary ---
+    binaryType: binaryName as BinaryType,
+
+    async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
+      try {
+        const resolved = spec.resolveBinary();
+        if (resolved === null) {
+          return { success: true, needsDownload: false };
+        }
+        const installed = await isBinaryInstalled(resolved.destDir, downloadDeps);
+        return { success: true, needsDownload: !installed };
+      } catch {
+        return { success: false, needsDownload: false };
+      }
+    },
+
+    async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
+      const resolved = spec.resolveBinary();
+      if (resolved === null) return;
+      try {
+        await downloadBinary(resolved.request(), downloadDeps, onProgress);
+      } catch (error) {
+        throw new AgentBinaryError(`Failed to download ${binaryName}: ${getErrorMessage(error)}`);
+      }
+    },
+
+    // --- Lifecycle ---
+    initialize(mcpConfig: McpConfig | null): void {
+      wireServerCallbacks();
+      if (mcpConfig !== null) {
+        spec.serverManager.setMcpConfig(mcpConfig);
+      }
+    },
+
+    async dispose(): Promise<void> {
+      if (serverStartedCleanupFn) {
+        serverStartedCleanupFn();
+        serverStartedCleanupFn = null;
+      }
+      if (serverStoppedCleanupFn) {
+        serverStoppedCleanupFn();
+        serverStoppedCleanupFn = null;
+      }
+      callbacksWired = false;
+
+      await spec.serverManager.dispose();
+
+      for (const provider of providers.values()) {
+        provider.dispose();
+      }
+      providers.clear();
+      statusCache.clear();
+      statusChangeListeners.clear();
+      spec.onDispose?.();
+    },
+
+    // --- Per-workspace ---
+    async startWorkspace(
+      workspacePath: string,
+      options?: WorkspaceStartOptions
+    ): Promise<WorkspaceStartResult> {
+      await spec.startServer(workspacePath, options);
+
+      // Wait for the handleServerStarted callback to complete
+      const promise = serverStartedPromises.get(workspacePath);
+      if (promise) {
+        await promise;
+      }
+
+      await spec.afterProviderReady?.(workspacePath, options);
+
+      return {
+        envVars: providers.get(workspacePath as WorkspacePath)?.getEnvironmentVariables() ?? {},
+      };
+    },
+
+    async stopWorkspace(workspacePath: string): Promise<StopServerResult> {
+      return spec.serverManager.stopServer(workspacePath);
+    },
+
+    async restartWorkspace(workspacePath: string): Promise<RestartServerResult> {
+      return spec.serverManager.restartServer(workspacePath);
+    },
+
+    applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void {
+      spec.applyTerminalLifecycle(workspacePath, event, ctx);
+    },
+
+    // --- Query ---
+    getStatus(workspacePath: WorkspacePath): AggregatedAgentStatus {
+      return statusCache.get(workspacePath) ?? createNoneStatus();
+    },
+
+    getSession(workspacePath: WorkspacePath): AgentSessionInfo | null {
+      return providers.get(workspacePath)?.getSession() ?? null;
+    },
+
+    // --- Events ---
+    onStatusChange(
+      callback: (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
+    ): () => void {
+      statusChangeListeners.add(callback);
+      return () => statusChangeListeners.delete(callback);
+    },
+
+    // --- Cleanup ---
+    clearWorkspaceTracking(workspacePath: WorkspacePath): void {
+      spec.clearWorkspaceTracking?.(workspacePath);
+    },
+  };
+}

--- a/src/modules/agent-module/opencode/module-provider.ts
+++ b/src/modules/agent-module/opencode/module-provider.ts
@@ -1,45 +1,26 @@
 /**
  * OpenCode agent module provider implementation.
  *
- * Implements the AgentModuleProvider interface by wrapping OpenCodeServerManager
- * and OpenCodeProvider. Absorbs all closure state and helper functions that were
- * previously in opencode-agent-module.ts into a reusable provider that the
- * generic module factory can delegate to.
+ * Defines the OpenCode-specific AgentModuleSpec consumed by the generic
+ * createAgentModuleProvider() core: provider construction (+ initial status
+ * fetch), pending-prompt delivery after registration, and TUI-attached
+ * tracking that survives provider recreation across server restarts. All
+ * provider-tracking machinery lives in the core.
  */
 
-import type {
-  AgentModuleProvider,
-  WorkspaceStartOptions,
-  WorkspaceStartResult,
-} from "../agent-module-provider";
-import type {
-  AgentProvider,
-  AgentStatus,
-  McpConfig,
-  StopServerResult,
-  RestartServerResult,
-} from "../types";
-import type { AgentSessionInfo } from "../types";
-import type { AgentLifecycleEvent } from "../../../shared/plugin-protocol";
-import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
+import type { AgentModuleProvider } from "../agent-module-provider";
+import type { WorkspacePath } from "../../../shared/ipc";
 import { Path } from "../../../utils/path/path";
-import type {
-  ArchiveExtension,
-  DownloadProgressCallback,
-  DownloadRequest,
-} from "../../../utils/binary-download";
-import { downloadBinary, isBinaryInstalled } from "../../../utils/binary-download";
-import type { DownloadDeps } from "../../../utils/binary-download";
-import type { BinaryType } from "../../../utils/binary-resolution/types";
-import { AgentBinaryError, getErrorMessage } from "../../../shared/errors/service-errors";
+import type { ArchiveExtension, DownloadDeps } from "../../../utils/binary-download";
 import type { PersistedAccessor } from "../../../boundaries/platform/store-definition";
 import type { Logger } from "../../../boundaries/platform/logging";
-import type { Unsubscribe } from "../../../shared/api/interfaces";
 import type { OpenCodeServerManager, PendingPrompt } from "./server-manager";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
 import { getOpencodeBundleDir, getOpencodeUrlForVersion } from "./setup-info";
 import { OpenCodeProvider } from "./provider";
+import { countsToStatus } from "../status-utils";
+import { createAgentModuleProvider } from "../module-provider";
 
 // =============================================================================
 // Dependency Interfaces
@@ -85,23 +66,6 @@ export function createOpenCodeModuleProvider(
     logger,
   } = deps;
 
-  // ===========================================================================
-  // Internal closure state
-  // ===========================================================================
-
-  /** Tracks pending handleServerStarted() promises for waitForProvider(). */
-  const serverStartedPromises = new Map<string, Promise<void>>();
-
-  /** Cleanup functions for onServerStarted/onServerStopped callbacks. */
-  let serverStartedCleanupFn: Unsubscribe | null = null;
-  let serverStoppedCleanupFn: Unsubscribe | null = null;
-
-  /** Per-workspace provider instances. */
-  const providers = new Map<WorkspacePath, AgentProvider>();
-
-  /** Cached aggregated status per workspace (for deduplication and queries). */
-  const statusCache = new Map<WorkspacePath, AggregatedAgentStatus>();
-
   /**
    * Track workspaces that have had TUI attached.
    * Persists across provider recreations (e.g., server restart) so we can
@@ -109,359 +73,119 @@ export function createOpenCodeModuleProvider(
    */
   const tuiAttachedWorkspaces = new Set<WorkspacePath>();
 
-  /** Status change subscribers. */
-  const statusChangeListeners = new Set<
-    (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
-  >();
+  return createAgentModuleProvider<OpenCodeProvider>(
+    {
+      // --- Identity ---
+      type: "opencode",
+      configKey: "version.opencode",
+      displayName: "OpenCode",
+      icon: "terminal",
+      serverName: "OpenCode",
+      scripts: ["ch-opencode", "ch-opencode.cjs", "ch-opencode.cmd"],
 
-  /** Whether server callbacks have been wired. */
-  let callbacksWired = false;
+      serverManager,
 
-  // ===========================================================================
-  // Provider management helpers
-  // ===========================================================================
+      // --- Binary ---
+      resolveBinary() {
+        const version = versionConfig.get();
+        const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
+        return {
+          destDir,
+          request: () => ({
+            name: binaryConfig.name,
+            url: getOpencodeUrlForVersion(version, platform, arch),
+            destDir,
+            archiveExtension: binaryConfig.archiveExtension,
+            executablePath: binaryConfig.executablePath,
+          }),
+        };
+      },
 
-  function createNoneStatus(): AggregatedAgentStatus {
-    return { status: "none", counts: { idle: 0, busy: 0 } };
-  }
+      // --- Provider lifecycle ---
+      createProvider: (workspacePath) => new OpenCodeProvider(workspacePath, logger),
 
-  function convertToAggregatedStatus(status: AgentStatus): AggregatedAgentStatus {
-    switch (status) {
-      case "none":
-        return { status: "none", counts: { idle: 0, busy: 0 } };
-      case "idle":
-        return { status: "idle", counts: { idle: 1, busy: 0 } };
-      case "busy":
-        return { status: "busy", counts: { idle: 0, busy: 1 } };
-    }
-  }
-
-  function getProviderStatus(provider: AgentProvider): AgentStatus {
-    if (provider instanceof OpenCodeProvider) {
-      const counts = provider.getEffectiveCounts();
-      if (counts.idle === 0 && counts.busy === 0) return "none";
-      if (counts.busy > 0) return "busy";
-      return "idle";
-    }
-    return "none";
-  }
-
-  function handleStatusUpdate(path: WorkspacePath, agentStatus: AgentStatus): void {
-    const status = convertToAggregatedStatus(agentStatus);
-    const previous = statusCache.get(path);
-    const hasChanged =
-      !previous ||
-      previous.status !== status.status ||
-      previous.counts.idle !== status.counts.idle ||
-      previous.counts.busy !== status.counts.busy;
-
-    if (hasChanged) {
-      statusCache.set(path, status);
-      for (const listener of statusChangeListeners) {
-        listener(path, status);
-      }
-    }
-  }
-
-  function addProvider(path: WorkspacePath, provider: AgentProvider): void {
-    if (providers.has(path)) return;
-
-    provider.onStatusChange((status) => handleStatusUpdate(path, status));
-
-    if (tuiAttachedWorkspaces.has(path)) {
-      provider.markActive();
-    }
-
-    providers.set(path, provider);
-    handleStatusUpdate(path, getProviderStatus(provider));
-  }
-
-  function removeProvider(path: WorkspacePath): void {
-    const provider = providers.get(path);
-    if (provider) {
-      provider.dispose();
-      providers.delete(path);
-      statusCache.delete(path);
-      for (const listener of statusChangeListeners) {
-        listener(path, createNoneStatus());
-      }
-    }
-  }
-
-  function disconnectProvider(path: WorkspacePath): void {
-    const provider = providers.get(path);
-    if (provider) {
-      provider.disconnect();
-    }
-  }
-
-  async function reconnectProvider(path: WorkspacePath): Promise<void> {
-    const provider = providers.get(path);
-    if (provider) {
-      await provider.reconnect();
-      handleStatusUpdate(path, getProviderStatus(provider));
-    }
-  }
-
-  function markProviderActive(path: WorkspacePath): void {
-    tuiAttachedWorkspaces.add(path);
-    const provider = providers.get(path);
-    if (provider) {
-      provider.markActive();
-    }
-  }
-
-  function markProviderInactive(path: WorkspacePath): void {
-    tuiAttachedWorkspaces.delete(path);
-    const provider = providers.get(path);
-    if (provider) {
-      provider.detachTui?.();
-    }
-  }
-
-  // ===========================================================================
-  // Internal functions
-  // ===========================================================================
-
-  async function waitForProvider(workspacePath: string): Promise<void> {
-    const promise = serverStartedPromises.get(workspacePath);
-    if (promise) {
-      await promise;
-    }
-  }
-
-  async function handleServerStarted(
-    workspacePath: WorkspacePath,
-    port: number,
-    pendingPrompt: PendingPrompt | undefined
-  ): Promise<void> {
-    try {
-      // Check if this is a restart (provider already exists from disconnect)
-      if (providers.has(workspacePath)) {
-        try {
-          await reconnectProvider(workspacePath);
-          logger.info("Reconnected agent provider after restart", {
-            workspacePath,
-            port,
-            agentType: "opencode",
-          });
-        } catch (error) {
-          logger.error(
-            "Failed to reconnect agent provider",
-            { workspacePath, port, agentType: "opencode" },
-            error instanceof Error ? error : undefined
-          );
-        }
-        return;
-      }
-
-      // First start: create OpenCode-specific provider directly
-      const provider = new OpenCodeProvider(workspacePath, logger);
-
-      try {
+      connectProvider: async (provider, port) => {
         await provider.connect(port);
         await provider.fetchStatus();
+      },
 
-        addProvider(workspacePath, provider);
+      initialStatus: (provider) => countsToStatus(provider.getEffectiveCounts()),
 
-        // Send initial prompt if provided
-        if (pendingPrompt) {
-          const sessionResult = await provider.createSession();
-          if (sessionResult.ok) {
-            const promptResult = await provider.sendPrompt(
-              sessionResult.value.id,
-              pendingPrompt.prompt,
-              {
-                ...(pendingPrompt.agent !== undefined && { agent: pendingPrompt.agent }),
-                ...(pendingPrompt.model !== undefined && { model: pendingPrompt.model }),
-              }
-            );
-            if (!promptResult.ok) {
-              logger.error("Failed to send initial prompt", {
-                workspacePath,
-                error: promptResult.error.message,
-              });
+      onProviderAdded: (path, provider) => {
+        if (tuiAttachedWorkspaces.has(path)) {
+          provider.markActive();
+        }
+      },
+
+      // Send the initial prompt (if any) once the provider is registered.
+      onProviderRegistered: async (workspacePath, provider, extra) => {
+        const pendingPrompt = extra as PendingPrompt | undefined;
+        if (!pendingPrompt) return;
+
+        const sessionResult = await provider.createSession();
+        if (sessionResult.ok) {
+          const promptResult = await provider.sendPrompt(
+            sessionResult.value.id,
+            pendingPrompt.prompt,
+            {
+              ...(pendingPrompt.agent !== undefined && { agent: pendingPrompt.agent }),
+              ...(pendingPrompt.model !== undefined && { model: pendingPrompt.model }),
             }
-          } else {
-            logger.error("Failed to create session for initial prompt", {
+          );
+          if (!promptResult.ok) {
+            logger.error("Failed to send initial prompt", {
               workspacePath,
-              error: sessionResult.error.message,
+              error: promptResult.error.message,
             });
           }
+        } else {
+          logger.error("Failed to create session for initial prompt", {
+            workspacePath,
+            error: sessionResult.error.message,
+          });
         }
-      } catch (error) {
-        logger.error(
-          "Failed to initialize agent provider",
-          { workspacePath, port, agentType: "opencode" },
-          error instanceof Error ? error : undefined
-        );
-      }
-    } finally {
-      serverStartedPromises.delete(workspacePath);
-    }
-  }
+      },
 
-  function wireServerCallbacks(): void {
-    if (callbacksWired) return;
-    callbacksWired = true;
+      // --- Workspace start ---
+      startServer: async (workspacePath, options) => {
+        if (options?.initialPrompt) {
+          await serverManager.startServer(workspacePath, {
+            initialPrompt: options.initialPrompt,
+          });
+        } else {
+          await serverManager.startServer(workspacePath);
+        }
+      },
 
-    serverManager.setMarkActiveHandler((wp) => markProviderActive(wp as WorkspacePath));
-
-    serverStartedCleanupFn = serverManager.onServerStarted((workspacePath, port, pendingPrompt) => {
-      const promise = handleServerStarted(
-        workspacePath as WorkspacePath,
-        port,
-        pendingPrompt as PendingPrompt | undefined
-      );
-      serverStartedPromises.set(workspacePath, promise);
-    });
-
-    serverStoppedCleanupFn = serverManager.onServerStopped((workspacePath, isRestart) => {
-      if (isRestart) {
-        disconnectProvider(workspacePath as WorkspacePath);
-      } else {
-        removeProvider(workspacePath as WorkspacePath);
-      }
-    });
-  }
-
-  // ===========================================================================
-  // AgentModuleProvider implementation
-  // ===========================================================================
-
-  return {
-    // --- Identity ---
-    type: "opencode",
-    configKey: "version.opencode",
-    displayName: "OpenCode",
-    icon: "terminal",
-    serverName: "OpenCode",
-    scripts: ["ch-opencode", "ch-opencode.cjs", "ch-opencode.cmd"],
-
-    // --- Binary ---
-    binaryType: binaryConfig.name as BinaryType,
-
-    async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
-      const version = versionConfig.get();
-      try {
-        const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
-        const installed = await isBinaryInstalled(destDir, downloadDeps);
-        return { success: true, needsDownload: !installed };
-      } catch {
-        return { success: false, needsDownload: false };
-      }
-    },
-
-    async downloadBinary(onProgress?: DownloadProgressCallback): Promise<void> {
-      const version = versionConfig.get();
-      const destDir = getOpencodeBundleDir(pathProvider, version).toNative();
-      const request: DownloadRequest = {
-        name: binaryConfig.name,
-        url: getOpencodeUrlForVersion(version, platform, arch),
-        destDir,
-        archiveExtension: binaryConfig.archiveExtension,
-        executablePath: binaryConfig.executablePath,
-      };
-      try {
-        await downloadBinary(request, downloadDeps, onProgress);
-      } catch (error) {
-        throw new AgentBinaryError(
-          `Failed to download ${binaryConfig.name}: ${getErrorMessage(error)}`
-        );
-      }
-    },
-
-    // --- Lifecycle ---
-    initialize(mcpConfig: McpConfig | null): void {
-      wireServerCallbacks();
-      if (mcpConfig !== null) {
-        serverManager.setMcpConfig(mcpConfig);
-      }
-    },
-
-    async dispose(): Promise<void> {
-      if (serverStartedCleanupFn) {
-        serverStartedCleanupFn();
-        serverStartedCleanupFn = null;
-      }
-      if (serverStoppedCleanupFn) {
-        serverStoppedCleanupFn();
-        serverStoppedCleanupFn = null;
-      }
-      callbacksWired = false;
-
-      await serverManager.dispose();
-
-      for (const provider of providers.values()) {
-        provider.dispose();
-      }
-      providers.clear();
-      statusCache.clear();
-      tuiAttachedWorkspaces.clear();
-      statusChangeListeners.clear();
-    },
-
-    // --- Per-workspace ---
-    async startWorkspace(
-      workspacePath: string,
-      options?: WorkspaceStartOptions
-    ): Promise<WorkspaceStartResult> {
-      // Start with initial prompt options for OpenCode
-      if (options?.initialPrompt) {
-        await serverManager.startServer(workspacePath, {
-          initialPrompt: options.initialPrompt,
+      // --- Terminal lifecycle + TUI tracking ---
+      wireExtraCallbacks: (ctx) => {
+        serverManager.setMarkActiveHandler((wp) => {
+          const path = wp as WorkspacePath;
+          tuiAttachedWorkspaces.add(path);
+          ctx.getProvider(path)?.markActive();
         });
-      } else {
-        await serverManager.startServer(workspacePath);
-      }
+      },
 
-      await waitForProvider(workspacePath);
+      applyTerminalLifecycle: (workspacePath, event, ctx) => {
+        if (event === "open") {
+          // Clears the loading screen (workspace-ready) and marks active (TUI attached),
+          // mirroring the old WrapperStart bridge route.
+          serverManager.triggerWrapperStart(workspacePath);
+        } else {
+          const path = new Path(workspacePath).toString() as WorkspacePath;
+          tuiAttachedWorkspaces.delete(path);
+          ctx.getProvider(path)?.detachTui();
+        }
+      },
 
-      const envVars: Record<string, string> = {
-        ...(providers.get(workspacePath as WorkspacePath)?.getEnvironmentVariables() ?? {}),
-      };
+      clearWorkspaceTracking: (path) => {
+        tuiAttachedWorkspaces.delete(path);
+      },
 
-      return { envVars };
+      onDispose: () => {
+        tuiAttachedWorkspaces.clear();
+      },
     },
-
-    async stopWorkspace(workspacePath: string): Promise<StopServerResult> {
-      return serverManager.stopServer(workspacePath);
-    },
-
-    async restartWorkspace(workspacePath: string): Promise<RestartServerResult> {
-      return serverManager.restartServer(workspacePath);
-    },
-
-    applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void {
-      if (event === "open") {
-        // Clears the loading screen (workspace-ready) and marks active (TUI attached),
-        // mirroring the old WrapperStart bridge route.
-        serverManager.triggerWrapperStart(workspacePath);
-      } else {
-        markProviderInactive(new Path(workspacePath).toString() as WorkspacePath);
-      }
-    },
-
-    // --- Query ---
-    getStatus(workspacePath: WorkspacePath): AggregatedAgentStatus {
-      return statusCache.get(workspacePath) ?? createNoneStatus();
-    },
-
-    getSession(workspacePath: WorkspacePath): AgentSessionInfo | null {
-      return providers.get(workspacePath)?.getSession() ?? null;
-    },
-
-    // --- Events ---
-    onStatusChange(
-      callback: (workspacePath: WorkspacePath, status: AggregatedAgentStatus) => void
-    ): () => void {
-      statusChangeListeners.add(callback);
-      return () => statusChangeListeners.delete(callback);
-    },
-
-    // --- Cleanup ---
-    clearWorkspaceTracking(workspacePath: WorkspacePath): void {
-      tuiAttachedWorkspaces.delete(workspacePath);
-    },
-  };
+    { logger, downloadDeps, binaryName: binaryConfig.name }
+  );
 }

--- a/src/modules/agent-module/opencode/provider.ts
+++ b/src/modules/agent-module/opencode/provider.ts
@@ -14,6 +14,7 @@ import { OpenCodeClient, type PermissionEvent } from "./client";
 import { OpenCodeError } from "../../../shared/errors/service-errors";
 import { findMatchingSession } from "./session-utils";
 import { err } from "./types";
+import { countsToStatus } from "../status-utils";
 import type { Logger } from "../../../boundaries/platform/logging";
 
 /**
@@ -189,19 +190,7 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
           });
         } else {
           // No matching session found, create a new one
-          const createResult = await client.createSession();
-          if (createResult.ok) {
-            this._primarySessionId = createResult.value.id;
-            this.logger.info("Created new session", {
-              workspacePath: this.workspacePath,
-              sessionId: createResult.value.id,
-            });
-          } else {
-            this.logger.error("Failed to create session", {
-              workspacePath: this.workspacePath,
-              error: createResult.error.message,
-            });
-          }
+          await this.createNewSession(client);
         }
       } else {
         // listSessions failed, try to create a new session instead
@@ -209,19 +198,7 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
           workspacePath: this.workspacePath,
           error: sessionsResult.error.message,
         });
-        const createResult = await client.createSession();
-        if (createResult.ok) {
-          this._primarySessionId = createResult.value.id;
-          this.logger.info("Created new session", {
-            workspacePath: this.workspacePath,
-            sessionId: createResult.value.id,
-          });
-        } else {
-          this.logger.error("Failed to create session", {
-            workspacePath: this.workspacePath,
-            error: createResult.error.message,
-          });
-        }
+        await this.createNewSession(client);
       }
 
       // Connect to SSE for real-time updates
@@ -233,6 +210,26 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
       this.logger.warn("Failed to initialize client", {
         workspacePath: this.workspacePath,
         error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Create a new session and store it as the primary session.
+   * Logs the outcome; failures are non-fatal (provider works without a session).
+   */
+  private async createNewSession(client: OpenCodeClient): Promise<void> {
+    const createResult = await client.createSession();
+    if (createResult.ok) {
+      this._primarySessionId = createResult.value.id;
+      this.logger.info("Created new session", {
+        workspacePath: this.workspacePath,
+        sessionId: createResult.value.id,
+      });
+    } else {
+      this.logger.error("Failed to create session", {
+        workspacePath: this.workspacePath,
+        error: createResult.error.message,
       });
     }
   }
@@ -428,24 +425,10 @@ export class OpenCodeProvider implements AgentProvider, IDisposable {
   }
 
   /**
-   * Calculate the current status from effective counts.
-   */
-  private calculateStatus(): AgentStatus {
-    const counts = this.getEffectiveCounts();
-    if (counts.idle === 0 && counts.busy === 0) {
-      return "none";
-    }
-    if (counts.busy > 0) {
-      return "busy";
-    }
-    return "idle";
-  }
-
-  /**
-   * Notify status change listeners with calculated status.
+   * Notify status change listeners with the status derived from effective counts.
    */
   private notifyStatusChange(): void {
-    const status = this.calculateStatus();
+    const status = countsToStatus(this.getEffectiveCounts());
     for (const listener of this.statusChangeListeners) {
       listener(status);
     }

--- a/src/modules/agent-module/opencode/server-manager.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.test.ts
@@ -449,21 +449,6 @@ describe("OpenCodeServerManager", () => {
   });
 
   describe("MCP configuration", () => {
-    it("setMcpConfig stores configuration", () => {
-      manager.setMcpConfig({
-        port: 12345,
-      });
-
-      const config = manager.getMcpConfig();
-      expect(config).toEqual({
-        port: 12345,
-      });
-    });
-
-    it("getMcpConfig returns null before setMcpConfig", () => {
-      expect(manager.getMcpConfig()).toBeNull();
-    });
-
     it("passes OPENCODE_CONFIG_CONTENT env var when config is set", async () => {
       manager.setMcpConfig({
         port: 12345,

--- a/src/modules/agent-module/opencode/server-manager.ts
+++ b/src/modules/agent-module/opencode/server-manager.ts
@@ -19,7 +19,12 @@ import type { IDisposable, Unsubscribe } from "./types";
 import { waitForHealthy } from "../../../utils/health-check";
 import { Path } from "../../../utils/path/path";
 import type { PromptModel } from "../../../shared/api/types";
-import type { AgentServerManager, StopServerResult, RestartServerResult } from "../types";
+import type {
+  AgentServerManager,
+  StopServerResult,
+  RestartServerResult,
+  McpConfig,
+} from "../types";
 import { getOpencodeBundleDir, getOpencodeExecutablePath } from "./setup-info";
 import type { SupportedPlatform } from "../../../boundaries/platform/platform-info";
 import type { PersistedAccessor } from "../../../boundaries/platform/store-definition";
@@ -82,14 +87,6 @@ export interface StartServerOptions {
     readonly agent?: string;
     readonly model?: PromptModel;
   };
-}
-
-/**
- * MCP server configuration for OpenCode integration.
- */
-export interface McpConfig {
-  /** MCP server port */
-  readonly port: number;
 }
 
 /**
@@ -506,13 +503,6 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
   setMcpConfig(config: McpConfig): void {
     this.mcpConfig = config;
     this.logger.debug("MCP config set", { port: config.port });
-  }
-
-  /**
-   * Get the current MCP configuration.
-   */
-  getMcpConfig(): McpConfig | null {
-    return this.mcpConfig;
   }
 
   /**

--- a/src/modules/agent-module/status-utils.ts
+++ b/src/modules/agent-module/status-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure status conversion helpers shared by the agent module providers.
+ */
+
+import type { AggregatedAgentStatus } from "../../shared/ipc";
+import type { AgentStatus } from "./types";
+
+/**
+ * The "no agent" aggregated status.
+ */
+export function createNoneStatus(): AggregatedAgentStatus {
+  return { status: "none", counts: { idle: 0, busy: 0 } };
+}
+
+/**
+ * Convert a single-workspace agent status to its aggregated representation.
+ */
+export function convertToAggregatedStatus(status: AgentStatus): AggregatedAgentStatus {
+  switch (status) {
+    case "none":
+      return { status: "none", counts: { idle: 0, busy: 0 } };
+    case "idle":
+      return { status: "idle", counts: { idle: 1, busy: 0 } };
+    case "busy":
+      return { status: "busy", counts: { idle: 0, busy: 1 } };
+  }
+}
+
+/**
+ * Derive an agent status from idle/busy counts.
+ */
+export function countsToStatus(counts: { idle: number; busy: number }): AgentStatus {
+  if (counts.idle === 0 && counts.busy === 0) {
+    return "none";
+  }
+  if (counts.busy > 0) {
+    return "busy";
+  }
+  return "idle";
+}


### PR DESCRIPTION
- Introduce `createAgentModuleProvider(spec)` core owning the shared provider-tracking machinery (registry, status cache with dedupe, server callback wiring incl. restart-reconnect, binary preflight/download scaffold, disposal)
- Shrink `claude/module-provider.ts` (403 → 126 lines) and `opencode/module-provider.ts` (467 → 191 lines) to `AgentModuleSpec` definitions; exported factory names unchanged
- Consolidate `McpConfig` to `agent-module/types.ts` (was defined three times)
- Remove production-dead `OpenCodeServerManager.getMcpConfig`
- Extract duplicate create-session fallback in `OpenCodeProvider.connect`
- Collapse template/config-path twins in `ClaudeCodeServerManager`
- Share counts→status mapping via `status-utils.ts`
- Drift fixes for Claude: callback re-wire guard, Set-based listeners, listener clearing on dispose
- Rewrite stale `docs/AGENTS.md` to match the current architecture

Both module-provider integration suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)