### PR TITLE
chore(plugin-protocol): replace hand-rolled validators with zod schemas

### DIFF
--- a/src/shared/plugin-protocol.test.ts
+++ b/src/shared/plugin-protocol.test.ts
@@ -7,6 +7,10 @@ import {
   validateSetMetadataRequest,
   validateExecuteCommandRequest,
   validateOpenSystemPathRequest,
+  validateWorkspaceCreateRequest,
+  validateDeleteWorkspaceRequest,
+  validateGetWorkspaceStatusRequest,
+  validateAgentLifecycleRequest,
   validateLogRequest,
   COMMAND_TIMEOUT_MS,
   type ServerToClientEvents,
@@ -68,7 +72,7 @@ describe("validateSetMetadataRequest", () => {
 
     it("rejects array payload", () => {
       const result = validateSetMetadataRequest([]);
-      expect(result).toEqual({ valid: false, error: "Missing required field: key" });
+      expect(result).toEqual({ valid: false, error: "Request must be an object" });
     });
   });
 
@@ -345,6 +349,192 @@ describe("validateOpenSystemPathRequest", () => {
   });
 });
 
+describe("validateWorkspaceCreateRequest", () => {
+  describe("valid requests", () => {
+    it("accepts name and base", () => {
+      const result = validateWorkspaceCreateRequest({ name: "feature-x", base: "main" });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts string initialPrompt", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: "Implement the feature",
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts whitespace-only initialPrompt string (no trim, by design)", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: "   ",
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts initialPrompt object with agent and model", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: {
+          prompt: "Implement the feature",
+          agent: "build",
+          model: { providerID: "anthropic", modelID: "claude-sonnet" },
+        },
+        stealFocus: false,
+      });
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("invalid requests", () => {
+    it("rejects non-object payload", () => {
+      expect(validateWorkspaceCreateRequest(null)).toEqual({
+        valid: false,
+        error: "Request must be an object",
+      });
+    });
+
+    it("rejects missing name", () => {
+      const result = validateWorkspaceCreateRequest({ base: "main" });
+      expect(result).toEqual({ valid: false, error: "Missing required field: name" });
+    });
+
+    it("rejects empty base", () => {
+      const result = validateWorkspaceCreateRequest({ name: "feature-x", base: "  " });
+      expect(result).toEqual({ valid: false, error: "Field 'base' cannot be empty" });
+    });
+
+    it("rejects empty initialPrompt string", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: "",
+      });
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+      });
+    });
+
+    it("rejects initialPrompt object without prompt", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: { agent: "build" },
+      });
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+      });
+    });
+
+    it("rejects malformed initialPrompt model", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        initialPrompt: { prompt: "Implement", model: { providerID: "anthropic" } },
+      });
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+      });
+    });
+
+    it("rejects non-boolean stealFocus", () => {
+      const result = validateWorkspaceCreateRequest({
+        name: "feature-x",
+        base: "main",
+        stealFocus: "yes",
+      });
+      expect(result).toEqual({ valid: false, error: "Field 'stealFocus' must be a boolean" });
+    });
+  });
+});
+
+describe("validateDeleteWorkspaceRequest", () => {
+  it("normalizes undefined and null to an empty request", () => {
+    expect(validateDeleteWorkspaceRequest(undefined)).toEqual({ valid: true, request: {} });
+    expect(validateDeleteWorkspaceRequest(null)).toEqual({ valid: true, request: {} });
+  });
+
+  it("passes keepBranch through", () => {
+    expect(validateDeleteWorkspaceRequest({ keepBranch: true })).toEqual({
+      valid: true,
+      request: { keepBranch: true },
+    });
+  });
+
+  it("rejects non-boolean keepBranch", () => {
+    expect(validateDeleteWorkspaceRequest({ keepBranch: "yes" })).toEqual({
+      valid: false,
+      error: "Field 'keepBranch' must be a boolean",
+    });
+  });
+
+  it("rejects non-object payload", () => {
+    expect(validateDeleteWorkspaceRequest("delete")).toEqual({
+      valid: false,
+      error: "Request must be an object",
+    });
+  });
+});
+
+describe("validateGetWorkspaceStatusRequest", () => {
+  it("normalizes undefined and null to an empty request", () => {
+    expect(validateGetWorkspaceStatusRequest(undefined)).toEqual({ valid: true, request: {} });
+    expect(validateGetWorkspaceStatusRequest(null)).toEqual({ valid: true, request: {} });
+  });
+
+  it("passes refresh through and strips explicit undefined", () => {
+    expect(validateGetWorkspaceStatusRequest({ refresh: true })).toEqual({
+      valid: true,
+      request: { refresh: true },
+    });
+    expect(validateGetWorkspaceStatusRequest({ refresh: undefined })).toEqual({
+      valid: true,
+      request: {},
+    });
+  });
+
+  it("rejects non-boolean refresh", () => {
+    expect(validateGetWorkspaceStatusRequest({ refresh: 1 })).toEqual({
+      valid: false,
+      error: "Field 'refresh' must be a boolean",
+    });
+  });
+});
+
+describe("validateAgentLifecycleRequest", () => {
+  it("accepts open and close events", () => {
+    expect(validateAgentLifecycleRequest({ event: "open" })).toEqual({ valid: true });
+    expect(validateAgentLifecycleRequest({ event: "close" })).toEqual({ valid: true });
+  });
+
+  it("rejects unknown events with the received value", () => {
+    expect(validateAgentLifecycleRequest({ event: "pause" })).toEqual({
+      valid: false,
+      error: "Invalid agent lifecycle event: pause",
+    });
+  });
+
+  it("rejects missing event", () => {
+    expect(validateAgentLifecycleRequest({})).toEqual({
+      valid: false,
+      error: "Missing required field: event",
+    });
+  });
+
+  it("rejects non-object payload", () => {
+    expect(validateAgentLifecycleRequest(null)).toEqual({
+      valid: false,
+      error: "Request must be an object",
+    });
+  });
+});
+
 describe("COMMAND_TIMEOUT_MS constant", () => {
   it("exports default timeout of 10 seconds", () => {
     expect(COMMAND_TIMEOUT_MS).toBe(10_000);
@@ -442,7 +632,7 @@ describe("validateLogRequest", () => {
 
     it("rejects non-string level", () => {
       const result = validateLogRequest({ level: 123, message: "test" });
-      expect(result).toEqual({ valid: false, error: "Field 'level' must be a string" });
+      expect(result).toEqual({ valid: false, error: "Invalid log level: 123" });
     });
   });
 
@@ -479,9 +669,10 @@ describe("validateLogRequest", () => {
         message: "test",
         context: { fn: () => {} },
       });
-      expect(result.valid).toBe(false);
-      expect((result as { error: string }).error).toContain("Invalid context value type");
-      expect((result as { error: string }).error).toContain("function");
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'context.fn' must be a string, number, boolean, or null",
+      });
     });
 
     it("rejects invalid context value (nested object)", () => {
@@ -490,9 +681,10 @@ describe("validateLogRequest", () => {
         message: "test",
         context: { nested: { deep: 1 } },
       });
-      expect(result.valid).toBe(false);
-      expect((result as { error: string }).error).toContain("Invalid context value type");
-      expect((result as { error: string }).error).toContain("object");
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'context.nested' must be a string, number, boolean, or null",
+      });
     });
 
     it("rejects invalid context value (array)", () => {
@@ -501,9 +693,10 @@ describe("validateLogRequest", () => {
         message: "test",
         context: { arr: [1, 2] },
       });
-      expect(result.valid).toBe(false);
-      expect((result as { error: string }).error).toContain("Invalid context value type");
-      expect((result as { error: string }).error).toContain("array");
+      expect(result).toEqual({
+        valid: false,
+        error: "Field 'context.arr' must be a string, number, boolean, or null",
+      });
     });
   });
 

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -5,8 +5,9 @@
  * CodeHydra (server) and VS Code extensions (clients).
  */
 
+import { z } from "zod/v4";
 import type { WorkspaceStatus, Workspace, InitialPrompt, AgentSession } from "./api/types";
-import { METADATA_KEY_REGEX, isValidMetadataKey } from "./api/types";
+import { METADATA_KEY_REGEX, isValidMetadataKey, initialPromptSchema } from "./api/types";
 
 // ============================================================================
 // Result Types
@@ -19,6 +20,74 @@ import { METADATA_KEY_REGEX, isValidMetadataKey } from "./api/types";
 export type PluginResult<T> =
   | { readonly success: true; readonly data: T }
   | { readonly success: false; readonly error: string };
+
+// ============================================================================
+// Validation Infrastructure
+// ============================================================================
+
+/** A string field that must be non-empty after trimming. */
+function nonEmptyString(field: string) {
+  return z.string().refine((value) => value.trim().length > 0, `Field '${field}' cannot be empty`);
+}
+
+/**
+ * Map a zod issue to the protocol's error-message style. Custom messages from
+ * enum/refine checks pass through verbatim; union messages are written without
+ * the field prefix so the path can be prepended here.
+ */
+function formatIssue(issue: z.core.$ZodIssue | undefined): string {
+  if (!issue) {
+    return "Invalid request";
+  }
+  if (issue.path.length === 0) {
+    return issue.code === "invalid_type" ? "Request must be an object" : issue.message;
+  }
+  const field = issue.path.join(".");
+  if (issue.input === undefined) {
+    return `Missing required field: ${field}`;
+  }
+  if (issue.code === "invalid_type") {
+    const expected = issue.expected === "record" ? "object" : issue.expected;
+    const article = expected === "object" || expected === "array" ? "an" : "a";
+    return `Field '${field}' must be ${article} ${expected}`;
+  }
+  if (issue.code === "invalid_union") {
+    return `Field '${field}' ${issue.message}`;
+  }
+  return issue.message;
+}
+
+/**
+ * Adapt a zod schema to a validator returning the parsed (normalized) request.
+ * Only the first issue is reported, matching the fail-fast style of the
+ * previous hand-rolled validators.
+ */
+function parseWith<T>(
+  schema: z.ZodType<T>
+): (payload: unknown) => { valid: true; request: T } | { valid: false; error: string } {
+  return (payload) => {
+    const result = schema.safeParse(payload, { reportInput: true });
+    return result.success
+      ? { valid: true, request: result.data }
+      : { valid: false, error: formatIssue(result.error.issues[0]) };
+  };
+}
+
+/**
+ * Adapt a zod schema to a check-only validator; callers keep using the raw
+ * payload. Used where the schema's inferred output (`field?: T | undefined`)
+ * is not assignable to the hand-written interface (`field?: T`) under
+ * exactOptionalPropertyTypes — those schemas also carry no `satisfies` guard.
+ */
+function validateWith(
+  schema: z.ZodType
+): (payload: unknown) => { valid: true } | { valid: false; error: string } {
+  const parse = parseWith(schema);
+  return (payload) => {
+    const result = parse(payload);
+    return result.valid ? { valid: true } : result;
+  };
+}
 
 // ============================================================================
 // Command Types
@@ -162,40 +231,16 @@ export interface ExecuteCommandRequest {
   readonly args?: readonly unknown[];
 }
 
+const executeCommandRequestSchema = z.object({
+  command: nonEmptyString("command"),
+  args: z.array(z.unknown()).optional(),
+});
+
 /**
  * Runtime validation for ExecuteCommandRequest.
  * Validates that command is a non-empty string and args is an array if present.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
  */
-export function validateExecuteCommandRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  if (!("command" in request)) {
-    return { valid: false, error: "Missing required field: command" };
-  }
-
-  if (typeof request.command !== "string") {
-    return { valid: false, error: "Field 'command' must be a string" };
-  }
-
-  if (request.command.trim().length === 0) {
-    return { valid: false, error: "Field 'command' cannot be empty" };
-  }
-
-  if ("args" in request && !Array.isArray(request.args)) {
-    return { valid: false, error: "Field 'args' must be an array" };
-  }
-
-  return { valid: true };
-}
+export const validateExecuteCommandRequest = validateWith(executeCommandRequestSchema);
 
 /**
  * The action to perform on a system path.
@@ -214,44 +259,18 @@ export interface OpenSystemPathRequest {
   readonly path: string;
 }
 
+const openSystemPathRequestSchema = z.object({
+  app: z.enum(["default", "explorer"], {
+    error: "Field 'app' must be 'default' or 'explorer'",
+  }),
+  path: nonEmptyString("path"),
+}) satisfies z.ZodType<OpenSystemPathRequest>;
+
 /**
  * Runtime validation for OpenSystemPathRequest.
  * Validates that app is a valid action and path is a non-empty string.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
  */
-export function validateOpenSystemPathRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  if (!("app" in request)) {
-    return { valid: false, error: "Missing required field: app" };
-  }
-
-  if (request.app !== "default" && request.app !== "explorer") {
-    return { valid: false, error: "Field 'app' must be 'default' or 'explorer'" };
-  }
-
-  if (!("path" in request)) {
-    return { valid: false, error: "Missing required field: path" };
-  }
-
-  if (typeof request.path !== "string") {
-    return { valid: false, error: "Field 'path' must be a string" };
-  }
-
-  if (request.path.trim().length === 0) {
-    return { valid: false, error: "Field 'path' cannot be empty" };
-  }
-
-  return { valid: true };
-}
+export const validateOpenSystemPathRequest = validateWith(openSystemPathRequestSchema);
 
 /**
  * Request payload for deleting a workspace.
@@ -284,154 +303,51 @@ export interface WorkspaceCreateRequest {
   readonly stealFocus?: boolean;
 }
 
+const workspaceCreateRequestSchema = z.object({
+  name: nonEmptyString("name"),
+  base: nonEmptyString("base"),
+  initialPrompt: z
+    .unknown()
+    .refine(
+      (value) => initialPromptSchema.safeParse(value).success,
+      "Field 'initialPrompt' must be a non-empty string or a prompt object"
+    )
+    .optional(),
+  stealFocus: z.boolean().optional(),
+});
+
 /**
  * Runtime validation for WorkspaceCreateRequest.
- * Validates structure and required fields.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
+ * Validates structure and required fields. The optional initialPrompt is
+ * checked against initialPromptSchema (including the model field), keeping
+ * this path in sync with the MCP server's validation.
  */
-export function validateWorkspaceCreateRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
+export const validateWorkspaceCreateRequest = validateWith(workspaceCreateRequestSchema);
 
-  const request = payload as Record<string, unknown>;
-
-  // Validate name
-  if (!("name" in request)) {
-    return { valid: false, error: "Missing required field: name" };
-  }
-
-  if (typeof request.name !== "string") {
-    return { valid: false, error: "Field 'name' must be a string" };
-  }
-
-  if (request.name.trim().length === 0) {
-    return { valid: false, error: "Field 'name' cannot be empty" };
-  }
-
-  // Validate base
-  if (!("base" in request)) {
-    return { valid: false, error: "Missing required field: base" };
-  }
-
-  if (typeof request.base !== "string") {
-    return { valid: false, error: "Field 'base' must be a string" };
-  }
-
-  if (request.base.trim().length === 0) {
-    return { valid: false, error: "Field 'base' cannot be empty" };
-  }
-
-  // Validate initialPrompt (optional)
-  if ("initialPrompt" in request && request.initialPrompt !== undefined) {
-    const prompt = request.initialPrompt;
-    if (typeof prompt === "string") {
-      if (prompt.length === 0) {
-        return { valid: false, error: "Field 'initialPrompt' cannot be empty string" };
-      }
-    } else if (typeof prompt === "object" && prompt !== null) {
-      const promptObj = prompt as Record<string, unknown>;
-      if (typeof promptObj.prompt !== "string" || promptObj.prompt.length === 0) {
-        return { valid: false, error: "Field 'initialPrompt.prompt' must be a non-empty string" };
-      }
-      if ("agent" in promptObj && typeof promptObj.agent !== "string") {
-        return { valid: false, error: "Field 'initialPrompt.agent' must be a string" };
-      }
-    } else {
-      return { valid: false, error: "Field 'initialPrompt' must be a string or object" };
-    }
-  }
-
-  // Validate stealFocus (optional)
-  if ("stealFocus" in request && typeof request.stealFocus !== "boolean") {
-    return { valid: false, error: "Field 'stealFocus' must be a boolean" };
-  }
-
-  return { valid: true };
-}
+const setMetadataRequestSchema = z.object({
+  key: z
+    .string()
+    .refine((key) => key.length > 0, "Field 'key' cannot be empty")
+    .refine(isValidMetadataKey, `Invalid key format: must match ${METADATA_KEY_REGEX.toString()}`),
+  value: z.union([z.string(), z.null()], { error: "must be a string or null" }),
+}) satisfies z.ZodType<SetMetadataRequest>;
 
 /**
  * Runtime validation for SetMetadataRequest.
  * Validates structure and key format against METADATA_KEY_REGEX.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
  */
-export function validateSetMetadataRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
+export const validateSetMetadataRequest = validateWith(setMetadataRequestSchema);
 
-  const request = payload as Record<string, unknown>;
-
-  if (!("key" in request)) {
-    return { valid: false, error: "Missing required field: key" };
-  }
-
-  if (typeof request.key !== "string") {
-    return { valid: false, error: "Field 'key' must be a string" };
-  }
-
-  if (request.key.length === 0) {
-    return { valid: false, error: "Field 'key' cannot be empty" };
-  }
-
-  if (!isValidMetadataKey(request.key)) {
-    return {
-      valid: false,
-      error: `Invalid key format: must match ${METADATA_KEY_REGEX.toString()}`,
-    };
-  }
-
-  if (!("value" in request)) {
-    return { valid: false, error: "Missing required field: value" };
-  }
-
-  if (request.value !== null && typeof request.value !== "string") {
-    return { valid: false, error: "Field 'value' must be a string or null" };
-  }
-
-  return { valid: true };
-}
+const deleteWorkspaceRequestSchema = z
+  .object({ keepBranch: z.boolean().optional() })
+  .nullish()
+  .transform((value): DeleteWorkspaceRequest => value ?? {});
 
 /**
  * Runtime validation for DeleteWorkspaceRequest.
- * Validates structure and keepBranch is boolean if present.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
+ * Accepts undefined/null (optional request) and normalizes it to {}.
  */
-export function validateDeleteWorkspaceRequest(
-  payload: unknown
-): { valid: true; request: DeleteWorkspaceRequest } | { valid: false; error: string } {
-  // Allow empty object or undefined (optional request)
-  if (payload === undefined || payload === null) {
-    return { valid: true, request: {} };
-  }
-
-  if (typeof payload !== "object") {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  if ("keepBranch" in request && typeof request.keepBranch !== "boolean") {
-    return { valid: false, error: "Field 'keepBranch' must be a boolean" };
-  }
-
-  return {
-    valid: true,
-    request: {
-      keepBranch: request.keepBranch as boolean | undefined,
-    },
-  };
-}
+export const validateDeleteWorkspaceRequest = parseWith(deleteWorkspaceRequestSchema);
 
 /**
  * Request to get workspace status.
@@ -443,33 +359,19 @@ export interface GetWorkspaceStatusRequest {
   readonly refresh?: boolean;
 }
 
+const getWorkspaceStatusRequestSchema = z
+  .object({ refresh: z.boolean().optional() })
+  .nullish()
+  .transform(
+    (value): GetWorkspaceStatusRequest =>
+      value?.refresh === undefined ? {} : { refresh: value.refresh }
+  );
+
 /**
  * Runtime validation for GetWorkspaceStatusRequest.
+ * Accepts undefined/null (optional request) and normalizes it to {}.
  */
-export function validateGetWorkspaceStatusRequest(
-  payload: unknown
-): { valid: true; request: GetWorkspaceStatusRequest } | { valid: false; error: string } {
-  if (payload === undefined || payload === null) {
-    return { valid: true, request: {} };
-  }
-
-  if (typeof payload !== "object") {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  if ("refresh" in request && typeof request.refresh !== "boolean") {
-    return { valid: false, error: "Field 'refresh' must be a boolean" };
-  }
-
-  return {
-    valid: true,
-    request: {
-      ...(typeof request.refresh === "boolean" && { refresh: request.refresh }),
-    },
-  };
-}
+export const validateGetWorkspaceStatusRequest = parseWith(getWorkspaceStatusRequestSchema);
 
 // ============================================================================
 // UI Request/Response Types
@@ -572,27 +474,16 @@ export interface AgentLifecycleRequest {
   readonly event: AgentLifecycleEvent;
 }
 
+const agentLifecycleRequestSchema = z.object({
+  event: z.enum(["open", "close"], {
+    error: (issue) => `Invalid agent lifecycle event: ${String(issue.input)}`,
+  }),
+}) satisfies z.ZodType<AgentLifecycleRequest>;
+
 /**
  * Runtime validation for AgentLifecycleRequest.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
  */
-export function validateAgentLifecycleRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  if (request.event !== "open" && request.event !== "close") {
-    return { valid: false, error: `Invalid agent lifecycle event: ${String(request.event)}` };
-  }
-
-  return { valid: true };
-}
+export const validateAgentLifecycleRequest = validateWith(agentLifecycleRequestSchema);
 
 // ============================================================================
 // Socket.IO Event Types
@@ -757,75 +648,24 @@ export interface LogRequest {
   readonly context?: LogContext;
 }
 
-/**
- * Valid log levels array for validation.
- * Note: Duplicated from services/logging/types.ts because shared/ cannot import from services/.
- */
-const VALID_LOG_LEVELS = ["silly", "debug", "info", "warn", "error"];
+const logRequestSchema = z.object({
+  // Note: levels duplicated from services/logging/types.ts because shared/ cannot import from services/.
+  level: z.enum(["silly", "debug", "info", "warn", "error"], {
+    error: (issue) => `Invalid log level: ${String(issue.input)}`,
+  }),
+  message: z.string().refine((value) => value.length > 0, "Field 'message' cannot be empty"),
+  context: z
+    .record(
+      z.string(),
+      z.union([z.string(), z.number(), z.boolean(), z.null()], {
+        error: "must be a string, number, boolean, or null",
+      })
+    )
+    .optional(),
+});
 
 /**
  * Runtime validation for LogRequest.
  * Validates structure, level, message, and context value types.
- *
- * @param payload - The payload to validate
- * @returns Object with valid boolean and optional error message
  */
-export function validateLogRequest(
-  payload: unknown
-): { valid: true } | { valid: false; error: string } {
-  if (typeof payload !== "object" || payload === null) {
-    return { valid: false, error: "Request must be an object" };
-  }
-
-  const request = payload as Record<string, unknown>;
-
-  // Validate level
-  if (!("level" in request)) {
-    return { valid: false, error: "Missing required field: level" };
-  }
-
-  if (typeof request.level !== "string") {
-    return { valid: false, error: "Field 'level' must be a string" };
-  }
-
-  if (!VALID_LOG_LEVELS.includes(request.level)) {
-    return { valid: false, error: `Invalid log level: ${request.level}` };
-  }
-
-  // Validate message
-  if (!("message" in request)) {
-    return { valid: false, error: "Missing required field: message" };
-  }
-
-  if (typeof request.message !== "string") {
-    return { valid: false, error: "Field 'message' must be a string" };
-  }
-
-  if (request.message.length === 0) {
-    return { valid: false, error: "Field 'message' cannot be empty" };
-  }
-
-  // Validate context (optional)
-  if ("context" in request && request.context !== undefined) {
-    if (typeof request.context !== "object" || request.context === null) {
-      return { valid: false, error: "Field 'context' must be an object" };
-    }
-
-    // Validate each context value is a primitive
-    const contextObj = request.context as Record<string, unknown>;
-    for (const [key, value] of Object.entries(contextObj)) {
-      if (value === null) {
-        continue; // null is valid
-      }
-      const valueType = typeof value;
-      if (valueType !== "string" && valueType !== "number" && valueType !== "boolean") {
-        return {
-          valid: false,
-          error: `Invalid context value type for key '${key}': expected primitive, got ${valueType === "object" ? (Array.isArray(value) ? "array" : "object") : valueType}`,
-        };
-      }
-    }
-  }
-
-  return { valid: true };
-}
+export const validateLogRequest = validateWith(logRequestSchema);


### PR DESCRIPTION
- Replace the eight hand-rolled Socket.IO request validators in `src/shared/plugin-protocol.ts` with zod/v4 schemas behind two small adapters: `validateWith` (check-only) and `parseWith` (returns the normalized request, used by delete/getStatus); a shared `formatIssue` formatter keeps the established error-message style
- Exported interfaces and validator signatures are unchanged, so `plugin-server-module.ts` and its integration/boundary tests needed no changes; `satisfies z.ZodType<X>` guards catch schema/interface drift where `exactOptionalPropertyTypes` allows
- `initialPrompt` is now checked against `initialPromptSchema`, closing the gap where `initialPrompt.model` was accepted unvalidated and unifying the plugin and MCP validation paths
- Add previously-missing test coverage for the workspaceCreate, delete, getStatus, and agentLifecycle validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)