### PR TITLE
refactor(intents): deduplicate operation boilerplate via shared hook helpers

### DIFF
--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -32,7 +32,7 @@ Concrete reference for the intent-based architecture. For conceptual overview an
 
 ### Intent and DomainEvent
 
-Source: `src/main/intents/infrastructure/types.ts`
+Source: `src/intents/lib/types.ts`
 
 ```typescript
 /**
@@ -69,7 +69,7 @@ export interface DomainEvent {
 
 ### DispatchFn, HookContext, HookHandler, HookResult, and ResolvedHooks
 
-Source: `src/main/intents/infrastructure/operation.ts`
+Source: `src/intents/lib/operation.ts`
 
 ```typescript
 /**
@@ -136,7 +136,7 @@ export interface ResolvedHooks {
 
 ### OperationContext and Operation
 
-Source: `src/main/intents/infrastructure/operation.ts`
+Source: `src/intents/lib/operation.ts`
 
 ```typescript
 /**
@@ -165,7 +165,7 @@ export interface Operation<I extends Intent = Intent, R = void> {
 
 ### HookDeclarations, EventDeclarations, and IntentModule
 
-Source: `src/main/intents/infrastructure/module.ts`
+Source: `src/intents/lib/module.ts`
 
 ```typescript
 /**
@@ -200,7 +200,7 @@ export interface IntentModule {
 
 ### IntentHandle, IntentInterceptor, and IDispatcher
 
-Source: `src/main/intents/infrastructure/dispatcher.ts`
+Source: `src/intents/lib/dispatcher.ts`
 
 ```typescript
 /**
@@ -271,9 +271,53 @@ Capabilities accumulate across handlers within a single `collect()` call and are
 
 ---
 
+## Hook Result Policies
+
+Source: `src/intents/lib/hook-helpers.ts`, `src/intents/lib/workspace-operation.ts`
+
+Operations apply a small set of shared policies to `collect()` results. Use these helpers instead of hand-rolling the loops:
+
+| Helper                 | Policy                                                                                                                                                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `throwHookErrors`      | Standard guard for fatal hook points: a lone error is rethrown raw (its message reaches IPC/MCP callers), multiple errors aggregate in an `AggregateError` with the given label    |
+| `lastDefined`          | Last-write-wins extraction of one field across handler results (`null` is a valid value; only `undefined` means "not provided")                                                    |
+| `requireResult`        | Throws the given message when a required hook result is missing                                                                                                                    |
+| `mergeHookResults`     | Conflict-throwing field merge — handlers contribute disjoint field subsets; the same field from two handlers is an error (used by open-workspace, get-project-bases)               |
+| `collectErrorMessages` | Folds thrown handler errors plus per-result `error` strings into one message list for best-effort pipelines that report via progress events instead of throwing (delete-workspace) |
+
+Best-effort hook points (app-shutdown `stop`/`quit`, app-resume `resume`, hibernate/wake teardown, switch-workspace auto-select) intentionally ignore or collect errors — that is documented in each operation header, not a missing guard.
+
+### WorkspaceHookOperation
+
+Workspace-scoped operations that run a single hook point share one skeleton: resolve workspace → optionally resolve project → collect hook → `throwHookErrors` → extract result → optionally emit a domain event. `WorkspaceHookOperation` (in `src/intents/lib/workspace-operation.ts`) implements it; concrete operations subclass with a spec:
+
+```typescript
+export class GetMetadataOperation extends WorkspaceHookOperation<
+  GetMetadataIntent,
+  GetMetadataHookResult,
+  Readonly<Record<string, string>>
+> {
+  constructor() {
+    super(GET_METADATA_OPERATION_ID, {
+      hookPoint: "get",
+      errorLabel: "get-metadata get hooks failed",
+      extract: (results) =>
+        requireResult(
+          lastDefined(results, (r) => r.metadata),
+          "Get metadata hook did not provide metadata result"
+        ),
+    });
+  }
+}
+```
+
+Spec options: `resolveProject` (dispatch `project:resolve` — only needed when the event payload wants `projectId`) and `onSuccess` (build a domain event from `{ intent, resolved, project, result }`). Subclasses: get-agent-session, get-metadata, restart-agent, set-metadata, vscode-command, vscode-show-message.
+
+---
+
 ## Idempotency
 
-Source: `src/main/intents/infrastructure/idempotency-module.ts`
+Source: `src/intents/lib/idempotency-module.ts`
 
 The idempotency module prevents duplicate intent dispatches using a single interceptor that covers multiple rules.
 
@@ -379,29 +423,43 @@ Non-IPC consumers (MCP Server, Plugin API) dispatch intents directly through the
 
 ## Operations Reference
 
-All operations use the intent dispatcher (`Dispatcher` + `HookRegistry`). Intents are dispatched through operations that run hook points, with hook modules contributing behavior. This pattern decouples orchestration from implementation.
+All operations use the intent dispatcher. Intents are dispatched through operations that run hook points, with hook modules contributing behavior. This pattern decouples orchestration from implementation.
 
-| Operation              | Intent Type              | Hook Points                                              | Domain Event        |
-| ---------------------- | ------------------------ | -------------------------------------------------------- | ------------------- |
-| `set-metadata`         | `workspace:setMetadata`  | `set`                                                    | --                  |
-| `get-metadata`         | `workspace:getMetadata`  | `get`                                                    | --                  |
-| `get-workspace-status` | `workspace:getStatus`    | `get`                                                    | --                  |
-| `get-agent-session`    | `workspace:getSession`   | `get`                                                    | --                  |
-| `restart-agent`        | `workspace:restartAgent` | `restart`                                                | --                  |
-| `set-mode`             | `ui:setMode`             | `set`                                                    | --                  |
-| `get-active-workspace` | `ui:getActiveWorkspace`  | `get`                                                    | --                  |
-| `create-workspace`     | `workspace:create`       | `create`, `setup`, `finalize`                            | `workspace:created` |
-| `delete-workspace`     | `workspace:delete`       | `shutdown`, `release`, `delete`                          | `workspace:deleted` |
-| `open-project`         | `project:open`           | `open`                                                   | `project:opened`    |
-| `close-project`        | `project:close`          | `close`                                                  | `project:closed`    |
-| `app-start`            | `app:start`              | `before-ready`, `init`, `show-ui`, `check-deps`, `start` | --                  |
-| `app-shutdown`         | `app:shutdown`           | `stop`                                                   | --                  |
-| `app-setup`            | `app:setup`              | `setup`                                                  | --                  |
-| `app-resume`           | `app:resume`             | `resume`                                                 | --                  |
+| Operation              | Intent Type               | Hook Points                                                                                      | Domain Events                                                                 |
+| ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `set-metadata`         | `workspace:set-metadata`  | `set`                                                                                            | `workspace:metadata-changed`                                                  |
+| `get-metadata`         | `workspace:get-metadata`  | `get`                                                                                            | --                                                                            |
+| `get-workspace-status` | `workspace:get-status`    | `get`                                                                                            | --                                                                            |
+| `get-agent-session`    | `agent:get-session`       | `get`                                                                                            | --                                                                            |
+| `restart-agent`        | `agent:restart`           | `restart`                                                                                        | `agent:restarted`                                                             |
+| `agent-lifecycle`      | `agent:lifecycle`         | `lifecycle`                                                                                      | --                                                                            |
+| `update-agent-status`  | `agent:update-status`     | --                                                                                               | `agent:status-updated`                                                        |
+| `set-mode`             | `ui:set-mode`             | `set`                                                                                            | `ui:mode-changed`                                                             |
+| `get-active-workspace` | `ui:get-active-workspace` | `get`                                                                                            | --                                                                            |
+| `vscode-command`       | `vscode:command`          | `execute`                                                                                        | --                                                                            |
+| `vscode-show-message`  | `vscode:show-message`     | `show`                                                                                           | --                                                                            |
+| `resolve-workspace`    | `workspace:resolve`       | `resolve`                                                                                        | --                                                                            |
+| `resolve-project`      | `project:resolve`         | `resolve`                                                                                        | --                                                                            |
+| `open-workspace`       | `workspace:open`          | `create`, `setup`, `finalize`                                                                    | `workspace:loading`, `workspace:created`, `workspace:create-failed`           |
+| `delete-workspace`     | `workspace:delete`        | `preflight`, `shutdown`, `release`, `flush`, `delete`, `detect`                                  | `workspace:deleted`, `workspace:delete-failed`, `workspace:deletion-progress` |
+| `hibernate-workspace`  | `workspace:hibernate`     | `capture`, `shutdown`, `release`                                                                 | `workspace:hibernated`, `workspace:hibernate-failed`                          |
+| `wake-workspace`       | `workspace:wake`          | `cleanup`                                                                                        | `workspace:woken`, `workspace:wake-failed`                                    |
+| `switch-workspace`     | `workspace:switch`        | `activate`, `find-candidates`, `select-next`                                                     | `workspace:switched`                                                          |
+| `open-project`         | `project:open`            | `select-folder`, `prepare`, `resolve`, `register`, `discover`                                    | `clone:progress`, `project:opened`, `project:open-failed`                     |
+| `close-project`        | `project:close`           | `resolve`, `close`                                                                               | `project:closed`, `workspace:switched(null)`                                  |
+| `list-projects`        | `project:list`            | `list-projects`, `list-workspaces`                                                               | --                                                                            |
+| `get-project-bases`    | `project:get-bases`       | `list`, `refresh`                                                                                | `bases:updated`                                                               |
+| `app-start`            | `app:start`               | `before-ready`, `init`, `show-ui`, `check-deps`, `start`                                         | --                                                                            |
+| `app-ready`            | `app:ready`               | `available-agents`, `load-projects`                                                              | `app:started`                                                                 |
+| `app-shutdown`         | `app:shutdown`            | `stop`, `quit`                                                                                   | --                                                                            |
+| `setup`                | `app:setup`               | `show-ui`, `register-agents`, `agent-selection`, `save-agent`, `binary`, `extensions`, `hide-ui` | `setup:progress`, `setup:error`                                               |
+| `app-resume`           | `app:resume`              | `resume`                                                                                         | `app:resumed`                                                                 |
+| `shortcut-key`         | `shortcut:key`            | --                                                                                               | `shortcut:key-pressed`                                                        |
+| `submit-bug-report`    | `bug-report:submit`       | --                                                                                               | `bug-report:submitted`                                                        |
 
 IPC handlers in `UiIpcModule` create typed intents and dispatch them. Domain events (e.g., `workspace:created`) are subscribed to by event handlers in modules (UiIpcModule, BadgeModule, WindowTitleModule) which forward them to the renderer via `sendToUI()` or react internally.
 
-The `create-workspace` operation uses these hook modules:
+The `open-workspace` operation uses these hook modules:
 
 - **create**: WorktreeModule (creates git worktree, or populates context from `existingWorkspace` data when activating discovered workspaces)
 - **setup**: KeepFilesModule (copies .keepfiles), AgentModule (starts agent server) -- both best-effort with internal try/catch
@@ -415,11 +473,9 @@ The `delete-workspace` operation uses these hook modules:
 
 The delete operation uses an `IdempotencyInterceptor` to prevent duplicate deletions of the same workspace. Force mode (`force: true`) bypasses the interceptor and wraps hook errors in try/catch. The `workspace:deleted` domain event triggers StateModule (removes workspace from state), UiIpcModule (emits `workspace:removed` IPC event), and clears the idempotency flag. When `removeWorktree` is false, only the shutdown hooks run (runtime teardown without deleting the git worktree).
 
-The `open-project` operation uses these hook modules:
+The `open-project` operation runs `select-folder` (when no path/URL given), `prepare` (e.g. git init), then `resolve` (clone if URL, validate git), `register` (generate ID, store state, persist), and `discover` (find existing workspaces).
 
-- **open**: ProjectResolverModule (clone if URL, validate git, create provider), ProjectDiscoveryModule (discover workspaces, orphan cleanup), ProjectRegistryModule (generate ID, load config, register state, persist)
-
-After the open hook, the operation dispatches `workspace:create` per discovered workspace (best-effort, continues on failure), sets the first workspace as active, and emits `project:opened`. A `ProjectOpenIdempotencyInterceptor` prevents concurrent/duplicate opens of the same project path.
+After the hooks, the operation dispatches `workspace:open` per discovered workspace (best-effort, continues on failure), sets the first workspace as active, and emits `project:opened`. A per-key idempotency rule prevents concurrent/duplicate opens of the same project path.
 
 The `close-project` operation uses these hook modules:
 

--- a/src/intents/agent-lifecycle.ts
+++ b/src/intents/agent-lifecycle.ts
@@ -16,6 +16,7 @@
 import type { Intent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { AgentLifecycleEvent } from "../shared/plugin-protocol";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -61,11 +62,6 @@ export class AgentLifecycleOperation implements Operation<AgentLifecycleIntent, 
       event: payload.event,
     };
     const { errors } = await ctx.hooks.collect<void>("lifecycle", lifecycleCtx);
-    if (errors.length === 1) {
-      throw errors[0]!;
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "agent-lifecycle lifecycle hooks failed");
-    }
+    throwHookErrors(errors, "agent-lifecycle lifecycle hooks failed");
   }
 }

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -19,6 +19,7 @@ import { Path } from "../utils/path/path";
 import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
 import type { ConfigAgentType } from "../boundaries/platform/config";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -97,7 +98,7 @@ export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResu
       ctx.hooks.collect<AvailableAgentsResult>("available-agents", hookCtx),
       ctx.hooks.collect<LoadProjectsResult>("load-projects", hookCtx),
     ]);
-    if (projectsResult.errors.length > 0) throw projectsResult.errors[0]!;
+    throwHookErrors(projectsResult.errors, "app:ready load-projects hooks failed");
     // available-agents errors are best-effort: an agent that fails preflight just
     // doesn't appear in the list.
 

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -592,8 +592,10 @@ describe("AppStart Operation", () => {
         createCodeServerModule(state),
       ]);
 
+      // A lone failing handler surfaces its raw error (multiple would aggregate
+      // under "check-deps hooks failed").
       await expect(dispatcher.dispatch(appStartIntent())).rejects.toThrow(
-        "check-deps hooks failed"
+        "Binary preflight failed"
       );
       expect(state.codeServerStarted).toBe(false);
     });

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -59,6 +59,7 @@ export interface ExtensionInstallEntry {
   readonly vsixPath: string;
 }
 import { INTENT_SETUP } from "./setup";
+import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -154,7 +155,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // Script declarations, noAsar, data paths, electron flags. All independent.
     const { results: configResults, errors: configErrors } =
       await ctx.hooks.collect<ConfigureResult>("before-ready", hookCtx);
-    if (configErrors.length > 0) throw configErrors[0]!;
+    throwHookErrors(configErrors, "app:start before-ready hooks failed");
     const requiredScripts = configResults.flatMap((r) => r.scripts ?? []);
 
     // --- Hook 2: "init" ---
@@ -166,7 +167,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       "init",
       initCtx
     );
-    if (initErrors.length > 0) throw initErrors[0]!;
+    throwHookErrors(initErrors, "app:start init hooks failed");
 
     // Extract extensionRequirements from init results
     const extensionRequirements: ExtensionRequirement[] = [];
@@ -180,13 +181,8 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // Hook 3: "show-ui" -- Show starting screen, capture waitForRetry
     const { results: showUiResults, errors: showUiErrors } =
       await ctx.hooks.collect<ShowUIHookResult>("show-ui", hookCtx);
-    if (showUiErrors.length > 0) {
-      throw showUiErrors[0]!;
-    }
-    let waitForRetry: (() => Promise<void>) | undefined;
-    for (const result of showUiResults) {
-      if (result.waitForRetry !== undefined) waitForRetry = result.waitForRetry;
-    }
+    throwHookErrors(showUiErrors, "app:start show-ui hooks failed");
+    const waitForRetry = lastDefined(showUiResults, (r) => r.waitForRetry);
 
     // Hook 4: "check-deps" (collect, isolated contexts)
     let checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
@@ -234,9 +230,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // read from ctx.capabilities. Capability-based ordering replaces the former
     // separate "activate" hook point.
     const { errors: startErrors } = await ctx.hooks.collect<void>("start", hookCtx);
-    if (startErrors.length > 0) {
-      throw startErrors[0]!;
-    }
+    throwHookErrors(startErrors, "app:start start hooks failed");
   }
 
   /**
@@ -258,9 +252,7 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       "check-deps",
       depsCtx
     );
-    if (depsErrors.length > 0) {
-      throw new AggregateError(depsErrors, "check-deps hooks failed");
-    }
+    throwHookErrors(depsErrors, "check-deps hooks failed");
 
     // Merge dep results (concatenate arrays from all handlers)
     const missingBinaries: BinaryType[] = [];

--- a/src/intents/close-project.ts
+++ b/src/intents/close-project.ts
@@ -18,6 +18,7 @@ import type { ProjectId } from "../shared/api/types";
 import { INTENT_DELETE_WORKSPACE, type DeleteWorkspaceIntent } from "./delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -105,18 +106,12 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
     };
     const { results: resolveResults, errors: resolveErrors } =
       await ctx.hooks.collect<CloseResolveHookResult>("resolve", hookCtx);
-    if (resolveErrors.length > 0) {
-      throw resolveErrors[0]!;
-    }
+    throwHookErrors(resolveErrors, "close-project resolve hooks failed");
 
     // Merge resolve results — last-write-wins
-    let remoteUrl: string | undefined;
     const removeLocalRepo = payload.removeLocalRepo ?? false;
-    let workspaces: ReadonlyArray<{ path: string }> = [];
-    for (const result of resolveResults) {
-      if (result.remoteUrl !== undefined) remoteUrl = result.remoteUrl;
-      if (result.workspaces !== undefined) workspaces = result.workspaces;
-    }
+    const remoteUrl = lastDefined(resolveResults, (r) => r.remoteUrl);
+    const workspaces = lastDefined(resolveResults, (r) => r.workspaces) ?? [];
 
     // 3. Dispatch workspace:delete per workspace (removeWorktree=false, skipSwitch=true)
     for (const workspace of workspaces) {
@@ -148,15 +143,10 @@ export class CloseProjectOperation implements Operation<CloseProjectIntent, void
       "close",
       closeHookInput
     );
-    if (closeErrors.length > 0) {
-      throw new AggregateError(closeErrors, "close-project close hooks failed");
-    }
+    throwHookErrors(closeErrors, "close-project close hooks failed");
 
     // Merge close results — last-write-wins for otherProjectsExist
-    let otherProjectsExist: boolean | undefined;
-    for (const result of closeResults) {
-      if (result.otherProjectsExist !== undefined) otherProjectsExist = result.otherProjectsExist;
-    }
+    const otherProjectsExist = lastDefined(closeResults, (r) => r.otherProjectsExist);
 
     // 5. Emit workspace:switched(null) if no other projects remain
     if (otherProjectsExist === false) {

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -39,6 +39,7 @@ import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-wo
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
+import { throwHookErrors, collectErrorMessages } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -181,20 +182,13 @@ interface MergedShutdown {
   readonly errors: readonly string[];
 }
 
-interface MergedRelease {
-  readonly errors: readonly string[];
-}
-
-interface MergedDelete {
+/** Shared shape for hook points that only report errors (release, delete, flush). */
+interface MergedErrors {
   readonly errors: readonly string[];
 }
 
 interface MergedDetect {
   readonly blockingProcesses?: readonly BlockingProcess[];
-  readonly errors: readonly string[];
-}
-
-interface MergedFlush {
   readonly errors: readonly string[];
 }
 
@@ -208,44 +202,18 @@ function mergeShutdown(
 ): MergedShutdown {
   let wasActive = false;
   let serverName: string | undefined;
-  const errors: string[] = [];
-
-  for (const e of collectErrors) errors.push(e.message);
   for (const r of results) {
     if (r.wasActive) wasActive = true;
     if (r.serverName && !serverName) serverName = r.serverName;
-    if (r.error) errors.push(r.error);
   }
-
-  return { wasActive, serverName, errors };
+  return { wasActive, serverName, errors: collectErrorMessages(results, collectErrors) };
 }
 
-function mergeRelease(
-  results: readonly ReleaseHookResult[],
+function mergeErrors(
+  results: readonly { readonly error?: string }[],
   collectErrors: readonly Error[]
-): MergedRelease {
-  const errors: string[] = [];
-
-  for (const e of collectErrors) errors.push(e.message);
-  for (const r of results) {
-    if (r.error) errors.push(r.error);
-  }
-
-  return { errors };
-}
-
-function mergeDelete(
-  results: readonly DeleteHookResult[],
-  collectErrors: readonly Error[]
-): MergedDelete {
-  const errors: string[] = [];
-
-  for (const e of collectErrors) errors.push(e.message);
-  for (const r of results) {
-    if (r.error) errors.push(r.error);
-  }
-
-  return { errors };
+): MergedErrors {
+  return { errors: collectErrorMessages(results, collectErrors) };
 }
 
 function mergeDetect(
@@ -253,32 +221,13 @@ function mergeDetect(
   collectErrors: readonly Error[]
 ): MergedDetect {
   let blockingProcesses: readonly BlockingProcess[] | undefined;
-  const errors: string[] = [];
-
-  for (const e of collectErrors) errors.push(e.message);
   for (const r of results) {
     if (r.blockingProcesses !== undefined) blockingProcesses = r.blockingProcesses;
-    if (r.error) errors.push(r.error);
   }
-
   return {
     ...(blockingProcesses !== undefined && { blockingProcesses }),
-    errors,
+    errors: collectErrorMessages(results, collectErrors),
   };
-}
-
-function mergeFlush(
-  results: readonly FlushHookResult[],
-  collectErrors: readonly Error[]
-): MergedFlush {
-  const errors: string[] = [];
-
-  for (const e of collectErrors) errors.push(e.message);
-  for (const r of results) {
-    if (r.error) errors.push(r.error);
-  }
-
-  return { errors };
 }
 
 // =============================================================================
@@ -293,10 +242,10 @@ type EmitFn = (event: DomainEvent) => Promise<void>;
 
 interface PipelineState {
   readonly shutdown?: MergedShutdown;
-  readonly release?: MergedRelease;
-  readonly del?: MergedDelete;
+  readonly release?: MergedErrors;
+  readonly del?: MergedErrors;
   readonly detect?: MergedDetect;
-  readonly flush?: MergedFlush;
+  readonly flush?: MergedErrors;
 }
 
 // =============================================================================
@@ -437,7 +386,7 @@ export class DeleteWorkspaceOperation implements Operation<
 
       let isDirty = false;
       let unmergedCommits = 0;
-      for (const e of preflightCollectErrors) throw e;
+      throwHookErrors(preflightCollectErrors, "workspace:delete preflight hooks failed");
       for (const r of preflightResults) {
         if (r.isDirty) isDirty = true;
         if (r.unmergedCommits !== undefined && r.unmergedCommits > unmergedCommits)
@@ -500,7 +449,7 @@ export class DeleteWorkspaceOperation implements Operation<
     // --- Release (CWD scan + kill) ---
     const { results: releaseResults, errors: releaseCollectErrors } =
       await ctx.hooks.collect<ReleaseHookResult>("release", pipelineCtx);
-    const release = mergeRelease(releaseResults, releaseCollectErrors);
+    const release = mergeErrors(releaseResults, releaseCollectErrors);
     this.emitPipelineProgress(
       emit,
       identity,
@@ -512,7 +461,7 @@ export class DeleteWorkspaceOperation implements Operation<
     );
 
     // --- Flush (kill provided PIDs from previous attempt) ---
-    let flush: MergedFlush | undefined;
+    let flush: MergedErrors | undefined;
     if (payload.blockingPids && payload.blockingPids.length > 0) {
       this.emitPipelineProgress(
         emit,
@@ -529,13 +478,13 @@ export class DeleteWorkspaceOperation implements Operation<
       };
       const { results: flushResults, errors: flushCollectErrors } =
         await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);
-      flush = mergeFlush(flushResults, flushCollectErrors);
+      flush = mergeErrors(flushResults, flushCollectErrors);
     }
 
     // --- Delete ---
     const { results: deleteResults, errors: deleteCollectErrors } =
       await ctx.hooks.collect<DeleteHookResult>("delete", pipelineCtx);
-    const del = mergeDelete(deleteResults, deleteCollectErrors);
+    const del = mergeErrors(deleteResults, deleteCollectErrors);
 
     const deleteFailed = del.errors.length > 0;
     if (!deleteFailed) {

--- a/src/intents/get-active-workspace.ts
+++ b/src/intents/get-active-workspace.ts
@@ -11,6 +11,7 @@
 import type { Intent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { WorkspaceRef } from "../shared/api/types";
+import { throwHookErrors, lastDefined, requireResult } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -54,20 +55,12 @@ export class GetActiveWorkspaceOperation implements Operation<
       "get",
       hookCtx
     );
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
+    throwHookErrors(errors, "get-active-workspace get hooks failed");
 
     // Merge results — last-write-wins for workspaceRef
-    let workspaceRef: WorkspaceRef | null | undefined;
-    for (const result of results) {
-      if (result.workspaceRef !== undefined) workspaceRef = result.workspaceRef;
-    }
-
-    if (workspaceRef === undefined) {
-      throw new Error("Get active workspace hook did not provide workspaceRef result");
-    }
-
-    return workspaceRef;
+    return requireResult(
+      lastDefined(results, (r) => r.workspaceRef),
+      "Get active workspace hook did not provide workspaceRef result"
+    );
   }
 }

--- a/src/intents/get-agent-session.ts
+++ b/src/intents/get-agent-session.ts
@@ -10,9 +10,10 @@
  */
 
 import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import type { HookContext } from "./lib/operation";
 import type { AgentSession } from "../shared/api/types";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
+import { lastDefined, requireResult } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -53,44 +54,20 @@ export interface GetAgentSessionHookResult {
 // Operation
 // =============================================================================
 
-export class GetAgentSessionOperation implements Operation<
+export class GetAgentSessionOperation extends WorkspaceHookOperation<
   GetAgentSessionIntent,
+  GetAgentSessionHookResult,
   AgentSession | null
 > {
-  readonly id = GET_AGENT_SESSION_OPERATION_ID;
-
-  async execute(ctx: OperationContext<GetAgentSessionIntent>): Promise<AgentSession | null> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. get — handler retrieves session info
-    const getCtx: GetAgentSessionHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<GetAgentSessionHookResult>("get", getCtx);
-    if (errors.length === 1) {
-      throw errors[0]!;
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "get-agent-session get hooks failed");
-    }
-
-    // Merge results — last-write-wins for session
-    let session: AgentSession | null | undefined;
-    for (const result of results) {
-      if (result.session !== undefined) session = result.session;
-    }
-
-    if (session === undefined) {
-      throw new Error("Get agent session hook did not provide session result");
-    }
-
-    return session;
+  constructor() {
+    super(GET_AGENT_SESSION_OPERATION_ID, {
+      hookPoint: "get",
+      errorLabel: "get-agent-session get hooks failed",
+      extract: (results) =>
+        requireResult(
+          lastDefined(results, (r) => r.session),
+          "Get agent session hook did not provide session result"
+        ),
+    });
   }
 }

--- a/src/intents/get-metadata.ts
+++ b/src/intents/get-metadata.ts
@@ -10,8 +10,9 @@
  */
 
 import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import type { HookContext } from "./lib/operation";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
+import { lastDefined, requireResult } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -53,43 +54,20 @@ export interface GetMetadataHookResult {
 // Operation
 // =============================================================================
 
-export class GetMetadataOperation implements Operation<
+export class GetMetadataOperation extends WorkspaceHookOperation<
   GetMetadataIntent,
+  GetMetadataHookResult,
   Readonly<Record<string, string>>
 > {
-  readonly id = GET_METADATA_OPERATION_ID;
-
-  async execute(
-    ctx: OperationContext<GetMetadataIntent>
-  ): Promise<Readonly<Record<string, string>>> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. get — handler performs the actual provider read
-    const getCtx: GetHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<GetMetadataHookResult>("get", getCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-
-    // Merge results — last-write-wins for metadata
-    let metadata: Readonly<Record<string, string>> | undefined;
-    for (const result of results) {
-      if (result.metadata !== undefined) metadata = result.metadata;
-    }
-
-    if (metadata === undefined) {
-      throw new Error("Get metadata hook did not provide metadata result");
-    }
-
-    return metadata;
+  constructor() {
+    super(GET_METADATA_OPERATION_ID, {
+      hookPoint: "get",
+      errorLabel: "get-metadata get hooks failed",
+      extract: (results) =>
+        requireResult(
+          lastDefined(results, (r) => r.metadata),
+          "Get metadata hook did not provide metadata result"
+        ),
+    });
   }
 }

--- a/src/intents/get-project-bases.ts
+++ b/src/intents/get-project-bases.ts
@@ -20,6 +20,7 @@ import type { Intent, DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { ProjectId, BaseInfo } from "../shared/api/types";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { throwHookErrors, mergeHookResults } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -88,22 +89,6 @@ export interface RefreshBasesHookInput extends HookContext {
 
 export const GET_PROJECT_BASES_OPERATION_ID = "get-project-bases";
 
-/** Merge hook results field-by-field. Throws if two handlers contribute the same field. */
-function mergeHookResults<T extends object>(results: readonly T[], hookPoint: string): Partial<T> {
-  const merged: Record<string, unknown> = {};
-  for (const result of results) {
-    for (const [key, value] of Object.entries(result)) {
-      if (value !== undefined) {
-        if (key in merged) {
-          throw new Error(`${hookPoint} hook conflict: "${key}" provided by multiple handlers`);
-        }
-        merged[key] = value;
-      }
-    }
-  }
-  return merged as Partial<T>;
-}
-
 export class GetProjectBasesOperation implements Operation<
   GetProjectBasesIntent,
   GetProjectBasesResult
@@ -124,7 +109,7 @@ export class GetProjectBasesOperation implements Operation<
     const { results: listResults, errors: listErrors } =
       await ctx.hooks.collect<ListBasesHookResult>("list", listCtx);
 
-    if (listErrors.length > 0) throw listErrors[0]!;
+    throwHookErrors(listErrors, "project:get-bases list hooks failed");
 
     const listMerged = mergeHookResults(listResults, "list");
     const bases = listMerged.bases ?? [];

--- a/src/intents/get-workspace-status.ts
+++ b/src/intents/get-workspace-status.ts
@@ -15,6 +15,7 @@ import type { WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_GET_PROJECT_BASES, type GetProjectBasesIntent } from "./get-project-bases";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -98,9 +99,7 @@ export class GetWorkspaceStatusOperation implements Operation<
       workspacePath: payload.workspacePath,
     };
     const { results, errors } = await ctx.hooks.collect<GetStatusHookResult>("get", getCtx);
-    if (errors.length > 0) {
-      throw new AggregateError(errors, "get-workspace-status get hooks failed");
-    }
+    throwHookErrors(errors, "get-workspace-status get hooks failed");
 
     // Merge results — isDirty uses OR, unmergedCommits uses max
     let isDirty = false;

--- a/src/intents/lib/hook-helpers.test.ts
+++ b/src/intents/lib/hook-helpers.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Focused tests for operation hook helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  throwHookErrors,
+  lastDefined,
+  requireResult,
+  mergeHookResults,
+  collectErrorMessages,
+} from "./hook-helpers";
+
+describe("throwHookErrors", () => {
+  it("does nothing for an empty error list", () => {
+    expect(() => throwHookErrors([], "label")).not.toThrow();
+  });
+
+  it("rethrows a lone error raw (preserves identity and message)", () => {
+    const original = new Error("provider exploded");
+    try {
+      throwHookErrors([original], "label");
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBe(original);
+    }
+  });
+
+  it("wraps multiple errors in an AggregateError with the given message", () => {
+    const a = new Error("first");
+    const b = new Error("second");
+    try {
+      throwHookErrors([a, b], "my-op hooks failed");
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AggregateError);
+      const agg = e as AggregateError;
+      expect(agg.message).toBe("my-op hooks failed");
+      expect(agg.errors).toEqual([a, b]);
+    }
+  });
+});
+
+describe("lastDefined", () => {
+  it("returns undefined for empty results", () => {
+    expect(lastDefined([], (r: { v?: number }) => r.v)).toBeUndefined();
+  });
+
+  it("returns undefined when no result provides the field", () => {
+    expect(lastDefined([{}, {}], (r: { v?: number }) => r.v)).toBeUndefined();
+  });
+
+  it("returns the last defined value (last-write-wins)", () => {
+    const results = [{ v: 1 }, {}, { v: 2 }, {}];
+    expect(lastDefined(results, (r) => r.v)).toBe(2);
+  });
+
+  it("treats null as a provided value", () => {
+    const results: { v?: string | null }[] = [{ v: "x" }, { v: null }];
+    expect(lastDefined(results, (r) => r.v)).toBeNull();
+  });
+});
+
+describe("requireResult", () => {
+  it("returns the value when defined", () => {
+    expect(requireResult(42, "msg")).toBe(42);
+  });
+
+  it("passes through null (only undefined is missing)", () => {
+    expect(requireResult<string | null>(null, "msg")).toBeNull();
+  });
+
+  it("throws the given message when undefined", () => {
+    expect(() => requireResult(undefined, "hook did not provide result")).toThrow(
+      "hook did not provide result"
+    );
+  });
+});
+
+describe("mergeHookResults", () => {
+  it("merges disjoint fields from multiple results", () => {
+    const merged = mergeHookResults([{ a: 1 }, { b: "x" }], "create");
+    expect(merged).toEqual({ a: 1, b: "x" });
+  });
+
+  it("ignores undefined fields", () => {
+    const merged = mergeHookResults([{ a: 1, b: undefined }, { b: "x" }], "create");
+    expect(merged).toEqual({ a: 1, b: "x" });
+  });
+
+  it("throws on conflicting fields, naming the hook point and field", () => {
+    expect(() => mergeHookResults([{ a: 1 }, { a: 2 }], "create")).toThrow(
+      'create hook conflict: "a" provided by multiple handlers'
+    );
+  });
+
+  it("returns empty object for no results", () => {
+    expect(mergeHookResults([], "create")).toEqual({});
+  });
+});
+
+describe("collectErrorMessages", () => {
+  it("returns empty list when nothing failed", () => {
+    expect(collectErrorMessages([{}, {}], [])).toEqual([]);
+  });
+
+  it("collects thrown-handler messages before per-result error strings", () => {
+    const messages = collectErrorMessages(
+      [{ error: "soft failure" }, {}],
+      [new Error("hard failure")]
+    );
+    expect(messages).toEqual(["hard failure", "soft failure"]);
+  });
+
+  it("skips empty error strings", () => {
+    expect(collectErrorMessages([{ error: "" }], [])).toEqual([]);
+  });
+});

--- a/src/intents/lib/hook-helpers.ts
+++ b/src/intents/lib/hook-helpers.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared helpers for operation hook handling.
+ *
+ * Operations call `hooks.collect()` and then apply one of a small set of
+ * policies to the returned results and errors. These helpers are the single
+ * source of truth for those policies:
+ *
+ * - `throwHookErrors` — the standard fatal-hook error guard: a lone error is
+ *   rethrown raw (preserving its message for IPC/MCP callers), multiple
+ *   errors are wrapped in an AggregateError.
+ * - `lastDefined` — last-write-wins extraction of a single field across
+ *   handler results.
+ * - `requireResult` — guard for hook points that must produce a result.
+ * - `mergeHookResults` — conflict-throwing field merge (multiple handlers may
+ *   each contribute a disjoint subset of fields).
+ * - `collectErrorMessages` — fold collect() errors plus per-result `error`
+ *   strings into one list (best-effort pipelines that report instead of throw).
+ */
+
+/**
+ * Standard error guard for fatal hook points.
+ * Rethrows a lone error raw; aggregates multiple errors under `message`.
+ */
+export function throwHookErrors(errors: readonly Error[], message: string): void {
+  if (errors.length === 1) throw errors[0]!;
+  if (errors.length > 1) throw new AggregateError(errors, message);
+}
+
+/**
+ * Last-write-wins extraction over hook results: returns the value picked from
+ * the last result for which `pick` returned a defined value.
+ * `null` is a valid value — only `undefined` means "not provided".
+ */
+export function lastDefined<T, V>(
+  results: readonly T[],
+  pick: (result: T) => V | undefined
+): V | undefined {
+  let value: V | undefined;
+  for (const result of results) {
+    const picked = pick(result);
+    if (picked !== undefined) value = picked;
+  }
+  return value;
+}
+
+/** Guard for hook points that must produce a result. */
+export function requireResult<V>(value: V | undefined, message: string): V {
+  if (value === undefined) throw new Error(message);
+  return value;
+}
+
+/** Merge hook results field-by-field. Throws if two handlers contribute the same field. */
+export function mergeHookResults<T extends object>(
+  results: readonly T[],
+  hookPoint: string
+): Partial<T> {
+  const merged: Record<string, unknown> = {};
+  for (const result of results) {
+    for (const [key, value] of Object.entries(result)) {
+      if (value !== undefined) {
+        if (key in merged) {
+          throw new Error(`${hookPoint} hook conflict: "${key}" provided by multiple handlers`);
+        }
+        merged[key] = value;
+      }
+    }
+  }
+  return merged as Partial<T>;
+}
+
+/**
+ * Fold collect() errors and per-result `error` strings into one message list.
+ * Used by best-effort pipelines (delete-workspace) that surface errors via
+ * progress events instead of throwing.
+ */
+export function collectErrorMessages(
+  results: readonly { readonly error?: string }[],
+  collectErrors: readonly Error[]
+): string[] {
+  const errors: string[] = collectErrors.map((e) => e.message);
+  for (const result of results) {
+    if (result.error) errors.push(result.error);
+  }
+  return errors;
+}

--- a/src/intents/lib/workspace-operation.integration.test.ts
+++ b/src/intents/lib/workspace-operation.integration.test.ts
@@ -1,0 +1,259 @@
+// @vitest-environment node
+/**
+ * Integration tests for the WorkspaceHookOperation skeleton through the Dispatcher.
+ *
+ * The six concrete subclasses (get-agent-session, get-metadata, restart-agent,
+ * set-metadata, vscode-command, vscode-show-message) are thin specs; the shared
+ * behavior lives here:
+ * - workspace:resolve failure short-circuits before the hook runs
+ * - project:resolve is dispatched only when resolveProject is set
+ * - lone hook error is rethrown raw; multiple errors aggregate under errorLabel
+ * - extract() receives results in handler order (last-write-wins via lastDefined)
+ * - onSuccess event is emitted with resolved identity and the extracted result
+ */
+
+import { describe, it, expect } from "vitest";
+import { createMockDispatcher } from "./dispatcher.test-utils";
+import { WorkspaceHookOperation } from "./workspace-operation";
+import { lastDefined, requireResult } from "./hook-helpers";
+import type { Intent, DomainEvent } from "./types";
+import type { HookHandler } from "./operation";
+import {
+  ResolveWorkspaceOperation,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "../resolve-workspace";
+import type { ResolveHookResult as ResolveWorkspaceHookResult } from "../resolve-workspace";
+import {
+  ResolveProjectOperation,
+  RESOLVE_PROJECT_OPERATION_ID,
+  INTENT_RESOLVE_PROJECT,
+} from "../resolve-project";
+import type { ResolveHookResult as ResolveProjectHookResult } from "../resolve-project";
+import type { IntentModule } from "./module";
+import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+
+// =============================================================================
+// Test operation
+// =============================================================================
+
+const PROJECT_ROOT = "/project";
+const PROJECT_ID = "proj-1" as ProjectId;
+const WORKSPACE_PATH = "/workspaces/feature-x";
+const WORKSPACE_NAME = "feature-x" as WorkspaceName;
+
+const INTENT_TEST = "test:workspace-hook" as const;
+const TEST_OPERATION_ID = "test-workspace-hook";
+const EVENT_TEST_DONE = "test:done" as const;
+
+interface TestIntent extends Intent<string> {
+  readonly type: typeof INTENT_TEST;
+  readonly payload: { readonly workspacePath: string };
+}
+
+interface TestHookResult {
+  readonly value?: string;
+}
+
+class TestOperation extends WorkspaceHookOperation<TestIntent, TestHookResult, string> {
+  constructor(opts?: { resolveProject?: boolean; emitEvent?: boolean }) {
+    super(TEST_OPERATION_ID, {
+      hookPoint: "work",
+      ...(opts?.resolveProject !== undefined && { resolveProject: opts.resolveProject }),
+      errorLabel: "test-workspace-hook work hooks failed",
+      extract: (results) =>
+        requireResult(
+          lastDefined(results, (r) => r.value),
+          "Test hook did not provide value result"
+        ),
+      ...(opts?.emitEvent && {
+        onSuccess: ({ intent, resolved, project, result }) => ({
+          type: EVENT_TEST_DONE,
+          payload: {
+            projectId: project?.projectId,
+            workspaceName: resolved.workspaceName,
+            workspacePath: intent.payload.workspacePath,
+            result,
+          },
+        }),
+      }),
+    });
+  }
+}
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+function createSetup(opts: {
+  operation: TestOperation;
+  workHandlers: readonly HookHandler[];
+  registerProject?: boolean;
+}): { dispatcher: ReturnType<typeof createMockDispatcher>; hookRuns: () => number } {
+  const dispatcher = createMockDispatcher();
+  dispatcher.registerOperation(INTENT_TEST, opts.operation);
+  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  if (opts.registerProject) {
+    dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+  }
+
+  const resolveModule: IntentModule = {
+    name: "test-resolve",
+    hooks: {
+      [RESOLVE_WORKSPACE_OPERATION_ID]: {
+        resolve: {
+          handler: async (ctx): Promise<ResolveWorkspaceHookResult> => {
+            const intent = ctx.intent as TestIntent;
+            if (intent.payload.workspacePath === WORKSPACE_PATH) {
+              return { projectPath: PROJECT_ROOT, workspaceName: WORKSPACE_NAME };
+            }
+            return {};
+          },
+        },
+      },
+      ...(opts.registerProject && {
+        [RESOLVE_PROJECT_OPERATION_ID]: {
+          resolve: {
+            handler: async (): Promise<ResolveProjectHookResult> => ({
+              projectId: PROJECT_ID,
+              projectName: "project",
+            }),
+          },
+        },
+      }),
+    },
+  };
+  dispatcher.registerModule(resolveModule);
+
+  // One module per work handler (HookDeclarations allows one handler per hook point).
+  let runs = 0;
+  opts.workHandlers.forEach((h, i) => {
+    dispatcher.registerModule({
+      name: `test-work-${i}`,
+      hooks: {
+        [TEST_OPERATION_ID]: {
+          work: {
+            ...h,
+            handler: async (ctx) => {
+              runs++;
+              return h.handler(ctx);
+            },
+          },
+        },
+      },
+    });
+  });
+
+  return { dispatcher, hookRuns: () => runs };
+}
+
+function testIntent(workspacePath: string = WORKSPACE_PATH): TestIntent {
+  return { type: INTENT_TEST, payload: { workspacePath } };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("WorkspaceHookOperation", () => {
+  it("resolve failure short-circuits before the hook runs", async () => {
+    const { dispatcher, hookRuns } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [{ handler: async () => ({ value: "x" }) }],
+    });
+
+    await expect(dispatcher.dispatch(testIntent("/unknown"))).rejects.toThrow(
+      "Workspace not found: /unknown"
+    );
+    expect(hookRuns()).toBe(0);
+  });
+
+  it("returns the extracted result on success", async () => {
+    const { dispatcher } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [{ handler: async () => ({ value: "result-1" }) }],
+    });
+
+    await expect(dispatcher.dispatch(testIntent())).resolves.toBe("result-1");
+  });
+
+  it("rethrows a lone hook error raw", async () => {
+    const { dispatcher } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [
+        {
+          handler: async () => {
+            throw new Error("provider exploded");
+          },
+        },
+      ],
+    });
+
+    await expect(dispatcher.dispatch(testIntent())).rejects.toThrow("provider exploded");
+  });
+
+  it("aggregates multiple hook errors under the errorLabel", async () => {
+    const { dispatcher } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [
+        {
+          handler: async () => {
+            throw new Error("first");
+          },
+        },
+        {
+          handler: async () => {
+            throw new Error("second");
+          },
+        },
+      ],
+    });
+
+    await expect(dispatcher.dispatch(testIntent())).rejects.toThrow(
+      "test-workspace-hook work hooks failed"
+    );
+  });
+
+  it("throws the extract guard when no handler provides a result", async () => {
+    const { dispatcher } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [{ handler: async () => ({}) }],
+    });
+
+    await expect(dispatcher.dispatch(testIntent())).rejects.toThrow(
+      "Test hook did not provide value result"
+    );
+  });
+
+  it("emits the onSuccess event with resolved identity, project, and result", async () => {
+    const { dispatcher } = createSetup({
+      operation: new TestOperation({ resolveProject: true, emitEvent: true }),
+      workHandlers: [{ handler: async () => ({ value: "done" }) }],
+      registerProject: true,
+    });
+
+    const events: DomainEvent[] = [];
+    dispatcher.subscribe(EVENT_TEST_DONE, (e) => events.push(e));
+
+    await dispatcher.dispatch(testIntent());
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload).toEqual({
+      projectId: PROJECT_ID,
+      workspaceName: WORKSPACE_NAME,
+      workspacePath: WORKSPACE_PATH,
+      result: "done",
+    });
+  });
+
+  it("does not dispatch project:resolve unless resolveProject is set", async () => {
+    // No project:resolve operation registered — dispatch would throw
+    // "No operation registered" if the skeleton tried to resolve the project.
+    const { dispatcher } = createSetup({
+      operation: new TestOperation(),
+      workHandlers: [{ handler: async () => ({ value: "ok" }) }],
+    });
+
+    await expect(dispatcher.dispatch(testIntent())).resolves.toBe("ok");
+  });
+});

--- a/src/intents/lib/workspace-operation.ts
+++ b/src/intents/lib/workspace-operation.ts
@@ -1,0 +1,102 @@
+/**
+ * WorkspaceHookOperation — shared skeleton for workspace-scoped operations.
+ *
+ * Six operations (get-agent-session, get-metadata, restart-agent,
+ * set-metadata, vscode-command, vscode-show-message) follow the same shape:
+ *
+ * 1. Dispatch workspace:resolve to validate workspacePath (and obtain
+ *    workspaceName for event payloads)
+ * 2. Optionally dispatch project:resolve (only needed when a post-hook
+ *    domain event wants projectId)
+ * 3. Run a single hook point with `{ intent, workspacePath }` input
+ * 4. Throw hook errors via the standard guard (lone error raw, multiple
+ *    aggregated)
+ * 5. Extract the operation result from the hook results
+ * 6. Optionally emit a domain event built from the resolved identity
+ *
+ * Concrete operations subclass this with a spec — they keep their exported
+ * class names so registration in main.ts and tests is unchanged.
+ */
+
+import type { Intent, DomainEvent } from "./types";
+import type { Operation, OperationContext, HookContext } from "./operation";
+import { throwHookErrors } from "./hook-helpers";
+import {
+  INTENT_RESOLVE_WORKSPACE,
+  type ResolveWorkspaceIntent,
+  type ResolveWorkspaceResult,
+} from "../resolve-workspace";
+import {
+  INTENT_RESOLVE_PROJECT,
+  type ResolveProjectIntent,
+  type ResolveProjectResult,
+} from "../resolve-project";
+
+/** An intent whose payload carries the target workspace path. */
+export type WorkspaceScopedIntent<R> = Intent<R> & {
+  readonly payload: { readonly workspacePath: string };
+};
+
+/** Input context passed to the hook point — matches the per-op input interfaces. */
+interface WorkspaceHookInput extends HookContext {
+  readonly workspacePath: string;
+}
+
+export interface WorkspaceHookSpec<I extends WorkspaceScopedIntent<R>, THook, R> {
+  /** Hook point to collect (e.g. "get", "restart"). */
+  readonly hookPoint: string;
+  /** Also dispatch project:resolve — needed only when onSuccess wants projectId. */
+  readonly resolveProject?: boolean;
+  /** AggregateError message when multiple handlers fail. */
+  readonly errorLabel: string;
+  /** Merge hook results into the operation result. May throw (missing required result). */
+  readonly extract: (results: readonly THook[]) => R;
+  /** Optional post-hook domain event. `project` is set iff `resolveProject` is true. */
+  readonly onSuccess?: (args: {
+    readonly intent: I;
+    readonly resolved: ResolveWorkspaceResult;
+    readonly project: ResolveProjectResult | undefined;
+    readonly result: R;
+  }) => DomainEvent;
+}
+
+export abstract class WorkspaceHookOperation<
+  I extends WorkspaceScopedIntent<R>,
+  THook,
+  R,
+> implements Operation<I, R> {
+  protected constructor(
+    readonly id: string,
+    private readonly spec: WorkspaceHookSpec<I, THook, R>
+  ) {}
+
+  async execute(ctx: OperationContext<I>): Promise<R> {
+    const { workspacePath } = ctx.intent.payload;
+
+    // 1. Dispatch shared workspace resolution
+    const resolved = await ctx.dispatch({
+      type: INTENT_RESOLVE_WORKSPACE,
+      payload: { workspacePath },
+    } as ResolveWorkspaceIntent);
+
+    // 2. Dispatch shared project resolution (event payloads only)
+    const project = this.spec.resolveProject
+      ? await ctx.dispatch({
+          type: INTENT_RESOLVE_PROJECT,
+          payload: { projectPath: resolved.projectPath },
+        } as ResolveProjectIntent)
+      : undefined;
+
+    // 3. Run the hook point — handlers do the actual work
+    const hookCtx: WorkspaceHookInput = { intent: ctx.intent, workspacePath };
+    const { results, errors } = await ctx.hooks.collect<THook>(this.spec.hookPoint, hookCtx);
+    throwHookErrors(errors, this.spec.errorLabel);
+
+    // 4. Extract result and emit optional domain event
+    const result = this.spec.extract(results);
+    if (this.spec.onSuccess) {
+      ctx.emit(this.spec.onSuccess({ intent: ctx.intent, resolved, project, result }));
+    }
+    return result;
+  }
+}

--- a/src/intents/list-projects.ts
+++ b/src/intents/list-projects.ts
@@ -14,6 +14,7 @@ import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { Project, ProjectId } from "../shared/api/types";
 import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
 import { toIpcWorkspaces } from "../utils/workspace-conversion";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 /** Re-exported for use by operation integration tests (avoids direct service import). */
 export type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
@@ -71,24 +72,14 @@ export class ListProjectsOperation implements Operation<ListProjectsIntent, Proj
       "list-projects",
       hookCtx
     );
-    if (projectsResult.errors.length > 0) {
-      if (projectsResult.errors.length === 1) {
-        throw projectsResult.errors[0]!;
-      }
-      throw new AggregateError(projectsResult.errors, "Multiple errors listing projects");
-    }
+    throwHookErrors(projectsResult.errors, "Multiple errors listing projects");
 
     // Collect workspace data from "list-workspaces" hook
     const workspacesResult = await ctx.hooks.collect<ListWorkspacesHookResult>(
       "list-workspaces",
       hookCtx
     );
-    if (workspacesResult.errors.length > 0) {
-      if (workspacesResult.errors.length === 1) {
-        throw workspacesResult.errors[0]!;
-      }
-      throw new AggregateError(workspacesResult.errors, "Multiple errors listing workspaces");
-    }
+    throwHookErrors(workspacesResult.errors, "Multiple errors listing workspaces");
 
     // Build workspace lookup by projectPath
     const workspaceMap = new Map<string, InternalWorkspace[]>();

--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -28,6 +28,7 @@ import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./ge
 import { HIBERNATED_METADATA_KEY } from "./hibernate-workspace";
 import { toIpcWorkspaces } from "../utils/workspace-conversion";
 import { Path } from "../utils/path/path";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -182,12 +183,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       const selectCtx: HookContext = { intent };
       const { results: selectResults, errors: selectErrors } =
         await ctx.hooks.collect<SelectFolderHookResult>("select-folder", selectCtx);
-      if (selectErrors.length === 1) {
-        throw selectErrors[0]!;
-      }
-      if (selectErrors.length > 1) {
-        throw new AggregateError(selectErrors, "project:open select-folder hooks failed");
-      }
+      throwHookErrors(selectErrors, "project:open select-folder hooks failed");
       let folderPath: string | null = null;
       for (const r of selectResults) {
         if (r.folderPath) folderPath = r.folderPath;
@@ -208,12 +204,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       const prepareCtx: HookContext = { intent: effectiveIntent };
       const { results: prepareResults, errors: prepareErrors } =
         await ctx.hooks.collect<PrepareHookResult>("prepare", prepareCtx);
-      if (prepareErrors.length === 1) {
-        throw prepareErrors[0]!;
-      }
-      if (prepareErrors.length > 1) {
-        throw new AggregateError(prepareErrors, "project:open prepare hooks failed");
-      }
+      throwHookErrors(prepareErrors, "project:open prepare hooks failed");
       for (const r of prepareResults) {
         if (r.canceled) return null;
       }
@@ -233,12 +224,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       const resolveCtx: ResolveHookInput = { intent: effectiveIntent, report };
       const { results: resolveResults, errors: resolveErrors } =
         await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-      if (resolveErrors.length === 1) {
-        throw resolveErrors[0]!;
-      }
-      if (resolveErrors.length > 1) {
-        throw new AggregateError(resolveErrors, "project:open resolve hooks failed");
-      }
+      throwHookErrors(resolveErrors, "project:open resolve hooks failed");
       let projectPath: string | undefined;
       let resolvedRemoteUrl: string | undefined;
       let alreadyOpen = false;
@@ -259,12 +245,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       };
       const { results: registerResults, errors: registerErrors } =
         await ctx.hooks.collect<RegisterHookResult>("register", registerCtx);
-      if (registerErrors.length === 1) {
-        throw registerErrors[0]!;
-      }
-      if (registerErrors.length > 1) {
-        throw new AggregateError(registerErrors, "project:open register hooks failed");
-      }
+      throwHookErrors(registerErrors, "project:open register hooks failed");
       let projectId: ProjectId | undefined;
       let name: string | undefined;
       for (const r of registerResults) {
@@ -280,12 +261,7 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
       const discoverCtx: DiscoverHookInput = { intent: effectiveIntent, projectPath };
       const { results: discoverResults, errors: discoverErrors } =
         await ctx.hooks.collect<DiscoverHookResult>("discover", discoverCtx);
-      if (discoverErrors.length === 1) {
-        throw discoverErrors[0]!;
-      }
-      if (discoverErrors.length > 1) {
-        throw new AggregateError(discoverErrors, "project:open discover hooks failed");
-      }
+      throwHookErrors(discoverErrors, "project:open discover hooks failed");
       const workspaces: InternalWorkspace[] = [];
       let defaultBaseBranch: string | undefined;
       for (const r of discoverResults) {

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -31,6 +31,7 @@ import { normalizeInitialPrompt } from "../shared/api/types";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
+import { throwHookErrors, mergeHookResults } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -186,22 +187,6 @@ export interface FinalizeHookInput extends HookContext {
   readonly agentType: AgentType | null;
 }
 
-/** Merge hook results field-by-field. Throws if two handlers contribute the same field. */
-function mergeHookResults<T extends object>(results: readonly T[], hookPoint: string): Partial<T> {
-  const merged: Record<string, unknown> = {};
-  for (const result of results) {
-    for (const [key, value] of Object.entries(result)) {
-      if (value !== undefined) {
-        if (key in merged) {
-          throw new Error(`${hookPoint} hook conflict: "${key}" provided by multiple handlers`);
-        }
-        merged[key] = value;
-      }
-    }
-  }
-  return merged as Partial<T>;
-}
-
 export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, OpenWorkspaceResult> {
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
 
@@ -257,7 +242,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
     const { results: createResults, errors: createErrors } =
       await ctx.hooks.collect<CreateHookResult>("create", createCtx);
 
-    if (createErrors.length > 0) throw createErrors[0]!;
+    throwHookErrors(createErrors, "workspace:open create hooks failed");
 
     const create = mergeHookResults(createResults, "create");
     const { workspacePath, branch, metadata, resolvedBase } = create;
@@ -273,7 +258,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
     };
     const setupResult = await ctx.hooks.collect<SetupHookResult>("setup", setupCtx);
 
-    if (setupResult.errors.length > 0) throw setupResult.errors[0]!;
+    throwHookErrors(setupResult.errors, "workspace:open setup hooks failed");
 
     // Accumulate env vars from all setup hook results (multiple modules can contribute)
     const envVars: Record<string, string> = {};
@@ -298,7 +283,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
       finalizeCtx
     );
 
-    if (finalizeErrors.length > 0) throw finalizeErrors[0]!;
+    throwHookErrors(finalizeErrors, "workspace:open finalize hooks failed");
 
     const workspaceUrl = finalizeCaps.workspaceUrl as string | undefined;
     if (!workspaceUrl) {

--- a/src/intents/resolve-project.ts
+++ b/src/intents/resolve-project.ts
@@ -14,6 +14,7 @@
 import type { Intent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { ProjectId } from "../shared/api/types";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -70,12 +71,7 @@ export class ResolveProjectOperation implements Operation<
       projectPath: payload.projectPath,
     };
     const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-    if (errors.length === 1) {
-      throw errors[0]!;
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "project:resolve hooks failed");
-    }
+    throwHookErrors(errors, "project:resolve hooks failed");
 
     let projectId: ProjectId | undefined;
     let projectName: string | undefined;

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -14,6 +14,7 @@
 import type { Intent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { WorkspaceName } from "../shared/api/types";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -75,12 +76,7 @@ export class ResolveWorkspaceOperation implements Operation<
       workspacePath: payload.workspacePath,
     };
     const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
-    if (errors.length === 1) {
-      throw errors[0]!;
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "workspace:resolve hooks failed");
-    }
+    throwHookErrors(errors, "workspace:resolve hooks failed");
 
     let projectPath: string | undefined;
     let workspaceName: WorkspaceName | undefined;

--- a/src/intents/restart-agent.ts
+++ b/src/intents/restart-agent.ts
@@ -12,10 +12,10 @@
  */
 
 import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import type { HookContext } from "./lib/operation";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
-import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
+import { lastDefined, requireResult } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -73,62 +73,31 @@ export interface RestartAgentHookResult {
 // Operation
 // =============================================================================
 
-export class RestartAgentOperation implements Operation<RestartAgentIntent, number> {
-  readonly id = RESTART_AGENT_OPERATION_ID;
-
-  async execute(ctx: OperationContext<RestartAgentIntent>): Promise<number> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    const { projectPath, workspaceName } = await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. Dispatch shared project resolution
-    const { projectId } = await ctx.dispatch({
-      type: INTENT_RESOLVE_PROJECT,
-      payload: { projectPath },
-    } as ResolveProjectIntent);
-
-    // 3. restart — handler restarts the server
-    const restartCtx: RestartAgentHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<RestartAgentHookResult>(
-      "restart",
-      restartCtx
-    );
-    if (errors.length === 1) {
-      throw errors[0]!;
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "restart-agent restart hooks failed");
-    }
-
-    // Merge results — last-write-wins for port
-    let port: number | undefined;
-    for (const result of results) {
-      if (result.port !== undefined) port = result.port;
-    }
-
-    if (port === undefined) {
-      throw new Error("Restart agent hook did not provide port result");
-    }
-
-    // Emit domain event for subscribers (e.g., UiIpcModule)
-    const event: AgentRestartedEvent = {
-      type: EVENT_AGENT_RESTARTED,
-      payload: {
-        projectId,
-        workspaceName,
-        path: payload.workspacePath,
-        port,
-      },
-    };
-    ctx.emit(event);
-
-    return port;
+export class RestartAgentOperation extends WorkspaceHookOperation<
+  RestartAgentIntent,
+  RestartAgentHookResult,
+  number
+> {
+  constructor() {
+    super(RESTART_AGENT_OPERATION_ID, {
+      hookPoint: "restart",
+      resolveProject: true,
+      errorLabel: "restart-agent restart hooks failed",
+      extract: (results) =>
+        requireResult(
+          lastDefined(results, (r) => r.port),
+          "Restart agent hook did not provide port result"
+        ),
+      onSuccess: ({ intent, resolved, project, result }) =>
+        ({
+          type: EVENT_AGENT_RESTARTED,
+          payload: {
+            projectId: project!.projectId,
+            workspaceName: resolved.workspaceName,
+            path: intent.payload.workspacePath,
+            port: result,
+          },
+        }) satisfies AgentRestartedEvent,
+    });
   }
 }

--- a/src/intents/set-metadata.ts
+++ b/src/intents/set-metadata.ts
@@ -10,10 +10,9 @@
  */
 
 import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import type { HookContext } from "./lib/operation";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
-import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
 
 // =============================================================================
 // Intent + Event Types
@@ -63,45 +62,24 @@ export interface SetHookInput extends HookContext {
 // Operation
 // =============================================================================
 
-export class SetMetadataOperation implements Operation<SetMetadataIntent, void> {
-  readonly id = SET_METADATA_OPERATION_ID;
-
-  async execute(ctx: OperationContext<SetMetadataIntent>): Promise<void> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    const { projectPath, workspaceName } = await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. Dispatch shared project resolution
-    const { projectId } = await ctx.dispatch({
-      type: INTENT_RESOLVE_PROJECT,
-      payload: { projectPath },
-    } as ResolveProjectIntent);
-
-    // 3. set — handler performs the actual provider write
-    const setCtx: SetHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { errors } = await ctx.hooks.collect<void>("set", setCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-
-    // Emit domain event for subscribers (e.g., UiIpcModule)
-    const event: MetadataChangedEvent = {
-      type: EVENT_METADATA_CHANGED,
-      payload: {
-        projectId,
-        workspaceName,
-        workspacePath: payload.workspacePath,
-        key: payload.key,
-        value: payload.value,
-      },
-    };
-    ctx.emit(event);
+export class SetMetadataOperation extends WorkspaceHookOperation<SetMetadataIntent, void, void> {
+  constructor() {
+    super(SET_METADATA_OPERATION_ID, {
+      hookPoint: "set",
+      resolveProject: true,
+      errorLabel: "set-metadata set hooks failed",
+      extract: () => undefined,
+      onSuccess: ({ intent, resolved, project }) =>
+        ({
+          type: EVENT_METADATA_CHANGED,
+          payload: {
+            projectId: project!.projectId,
+            workspaceName: resolved.workspaceName,
+            workspacePath: intent.payload.workspacePath,
+            key: intent.payload.key,
+            value: intent.payload.value,
+          },
+        }) satisfies MetadataChangedEvent,
+    });
   }
 }

--- a/src/intents/set-mode.ts
+++ b/src/intents/set-mode.ts
@@ -11,6 +11,7 @@
 import type { Intent, DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
 import type { UIMode } from "../shared/ipc";
+import { throwHookErrors, lastDefined, requireResult } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -67,19 +68,13 @@ export class SetModeOperation implements Operation<SetModeIntent, void> {
 
     // Run "set" hook -- handler captures previousMode and applies new mode
     const { results, errors } = await ctx.hooks.collect<SetModeHookResult>("set", hookCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
+    throwHookErrors(errors, "set-mode set hooks failed");
 
     // Merge results — last-write-wins for previousMode
-    let previousMode: UIMode | undefined;
-    for (const result of results) {
-      if (result.previousMode !== undefined) previousMode = result.previousMode;
-    }
-
-    if (previousMode === undefined) {
-      throw new Error("Set mode hook did not provide previousMode result");
-    }
+    const previousMode = requireResult(
+      lastDefined(results, (r) => r.previousMode),
+      "Set mode hook did not provide previousMode result"
+    );
 
     // Emit domain event only when mode actually changed (defense against oscillation)
     if (ctx.intent.payload.mode !== previousMode) {

--- a/src/intents/setup.ts
+++ b/src/intents/setup.ts
@@ -22,6 +22,7 @@ import type { ConfigAgentType, SetupRowId, SetupRowStatus } from "../shared/api/
 import type { BinaryType } from "../utils/binary-resolution/types";
 import type { ExtensionInstallEntry } from "./app-start";
 import type { LifecycleAgentType } from "../shared/ipc";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -158,9 +159,7 @@ export class SetupOperation implements Operation<SetupIntent, void> {
     try {
       // Hook 1: "show-ui" -- Show setup screen
       const { errors: showUiErrors } = await ctx.hooks.collect<void>("show-ui", hookCtx);
-      if (showUiErrors.length > 0) {
-        throw showUiErrors[0]!;
-      }
+      throwHookErrors(showUiErrors, "app:setup show-ui hooks failed");
 
       // Hook 2: "agent-selection" -- (conditional) Collect agent info + show UI
       let selectedAgent: ConfigAgentType | undefined;
@@ -168,9 +167,7 @@ export class SetupOperation implements Operation<SetupIntent, void> {
         // 2a: Collect available agents from per-agent modules
         const { results: agentInfos, errors: registerErrors } =
           await ctx.hooks.collect<RegisterAgentResult>("register-agents", hookCtx);
-        if (registerErrors.length > 0) {
-          throw registerErrors[0]!;
-        }
+        throwHookErrors(registerErrors, "app:setup register-agents hooks failed");
 
         // 2b: Show agent selection UI with collected agents
         const selectionCtx: AgentSelectionHookContext = { ...hookCtx, availableAgents: agentInfos };
@@ -178,9 +175,7 @@ export class SetupOperation implements Operation<SetupIntent, void> {
           "agent-selection",
           selectionCtx
         );
-        if (agentErrors.length > 0) {
-          throw agentErrors[0]!;
-        }
+        throwHookErrors(agentErrors, "app:setup agent-selection hooks failed");
         selectedAgent = agentCaps.agentType as ConfigAgentType | undefined;
       }
 
@@ -191,9 +186,7 @@ export class SetupOperation implements Operation<SetupIntent, void> {
           selectedAgent,
         };
         const { errors: saveErrors } = await ctx.hooks.collect<void>("save-agent", saveAgentInput);
-        if (saveErrors.length > 0) {
-          throw saveErrors[0]!;
-        }
+        throwHookErrors(saveErrors, "app:setup save-agent hooks failed");
       }
 
       // Create progress reporter that emits domain events
@@ -217,9 +210,7 @@ export class SetupOperation implements Operation<SetupIntent, void> {
         ...(payload.missingBinaries !== undefined && { missingBinaries: payload.missingBinaries }),
       };
       const { errors: binaryErrors } = await ctx.hooks.collect<void>("binary", binaryInput);
-      if (binaryErrors.length > 0) {
-        throw binaryErrors[0]!;
-      }
+      throwHookErrors(binaryErrors, "app:setup binary hooks failed");
 
       // Hook 5: "extensions" -- Update extension progress (installs if needed)
       const extensionsInput: ExtensionsHookInput = {
@@ -233,15 +224,11 @@ export class SetupOperation implements Operation<SetupIntent, void> {
         "extensions",
         extensionsInput
       );
-      if (extensionsErrors.length > 0) {
-        throw extensionsErrors[0]!;
-      }
+      throwHookErrors(extensionsErrors, "app:setup extensions hooks failed");
 
       // Hook 6: "hide-ui" -- Hide setup screen (return to starting screen)
       const { errors: hideUiErrors } = await ctx.hooks.collect<void>("hide-ui", hookCtx);
-      if (hideUiErrors.length > 0) {
-        throw hideUiErrors[0]!;
-      }
+      throwHookErrors(hideUiErrors, "app:setup hide-ui hooks failed");
 
       // Control returns to AppStartOperation (no dispatch)
     } catch (error) {

--- a/src/intents/switch-workspace.ts
+++ b/src/intents/switch-workspace.ts
@@ -25,6 +25,7 @@ import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import type { WorkspacePath } from "../shared/ipc";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
+import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -252,18 +253,10 @@ export class SwitchWorkspaceOperation implements Operation<SwitchWorkspaceIntent
     };
     const { results: activateResults, errors: activateErrors } =
       await ctx.hooks.collect<SwitchWorkspaceHookResult>("activate", activateCtx);
-    if (activateErrors.length === 1) {
-      throw activateErrors[0]!;
-    }
-    if (activateErrors.length > 1) {
-      throw new AggregateError(activateErrors, "workspace:switch activate hooks failed");
-    }
+    throwHookErrors(activateErrors, "workspace:switch activate hooks failed");
 
     // Merge results — last-write-wins for resolvedPath
-    let resolvedPath: string | undefined;
-    for (const result of activateResults) {
-      if (result.resolvedPath !== undefined) resolvedPath = result.resolvedPath;
-    }
+    const resolvedPath = lastDefined(activateResults, (r) => r.resolvedPath);
 
     // No-op: hook resolved workspace but it was already active
     // (resolvedPath left unset intentionally)

--- a/src/intents/vscode-command.ts
+++ b/src/intents/vscode-command.ts
@@ -10,8 +10,9 @@
  */
 
 import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import type { HookContext } from "./lib/operation";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
+import { lastDefined } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -50,34 +51,17 @@ export interface ExecuteHookResult {
 // Operation
 // =============================================================================
 
-export class VscodeCommandOperation implements Operation<VscodeCommandIntent, unknown> {
-  readonly id = VSCODE_COMMAND_OPERATION_ID;
-
-  async execute(ctx: OperationContext<VscodeCommandIntent>): Promise<unknown> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. execute — handler performs the actual command
-    const executeCtx: ExecuteHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<ExecuteHookResult>("execute", executeCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-
-    // Extract result — last-write-wins
-    let result: unknown;
-    for (const r of results) {
-      if (r.result !== undefined) result = r.result;
-    }
-
-    return result;
+export class VscodeCommandOperation extends WorkspaceHookOperation<
+  VscodeCommandIntent,
+  ExecuteHookResult,
+  unknown
+> {
+  constructor() {
+    super(VSCODE_COMMAND_OPERATION_ID, {
+      hookPoint: "execute",
+      errorLabel: "vscode-command execute hooks failed",
+      // No required result — a command may legitimately return undefined.
+      extract: (results) => lastDefined(results, (r) => r.result),
+    });
   }
 }

--- a/src/intents/vscode-show-message.ts
+++ b/src/intents/vscode-show-message.ts
@@ -13,8 +13,9 @@
  */
 
 import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
+import type { HookContext } from "./lib/operation";
+import { WorkspaceHookOperation } from "./lib/workspace-operation";
+import { lastDefined } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -62,37 +63,16 @@ export interface ShowHookResult {
 // Operation
 // =============================================================================
 
-export class VscodeShowMessageOperation implements Operation<
+export class VscodeShowMessageOperation extends WorkspaceHookOperation<
   VscodeShowMessageIntent,
+  ShowHookResult,
   string | null
 > {
-  readonly id = VSCODE_SHOW_MESSAGE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<VscodeShowMessageIntent>): Promise<string | null> {
-    const { payload } = ctx.intent;
-
-    // 1. Dispatch shared workspace resolution
-    await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
-
-    // 2. show — handler performs the actual VS Code UI call
-    const showCtx: ShowHookInput = {
-      intent: ctx.intent,
-      workspacePath: payload.workspacePath,
-    };
-    const { results, errors } = await ctx.hooks.collect<ShowHookResult>("show", showCtx);
-    if (errors.length > 0) {
-      throw errors[0]!;
-    }
-
-    // Extract result — last-write-wins
-    let result: string | null | undefined;
-    for (const r of results) {
-      if (r.result !== undefined) result = r.result;
-    }
-
-    return result ?? null;
+  constructor() {
+    super(VSCODE_SHOW_MESSAGE_OPERATION_ID, {
+      hookPoint: "show",
+      errorLabel: "vscode-show-message show hooks failed",
+      extract: (results) => lastDefined(results, (r) => r.result) ?? null,
+    });
   }
 }


### PR DESCRIPTION
- Add `src/intents/lib/hook-helpers.ts`: `throwHookErrors` (lone error rethrown raw, multiple aggregated), `lastDefined`, `requireResult`, `mergeHookResults`, `collectErrorMessages` — single source of truth for the hook-result policies previously copy-pasted across operations
- Add `src/intents/lib/workspace-operation.ts`: `WorkspaceHookOperation` base class for the resolve → hook → guard → extract → emit skeleton; get-agent-session, get-metadata, restart-agent, set-metadata, vscode-command, and vscode-show-message become thin subclasses (exported class names unchanged)
- Converge all 40 fatal hook-error guard sites on `throwHookErrors`; behavior change: a lone failing handler now surfaces its raw error to IPC/MCP callers (get-workspace-status, close-project close hook, and app-start check-deps previously wrapped even a single error in a generic AggregateError, masking the cause)
- Dedupe the byte-identical `mergeHookResults` copies (open-workspace, get-project-bases) and collapse delete-workspace's three identical merge functions/interfaces into one
- Refresh stale `docs/INTENTS.md` sections (lib paths, operations reference) and document the new conventions under "Hook Result Policies"
- New tests: focused hook-helpers suite and a WorkspaceHookOperation integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)