### PR TITLE
test: deduplicate test infrastructure across the suite

### DIFF
--- a/src/boundaries/platform/archive-extractor.state-mock.ts
+++ b/src/boundaries/platform/archive-extractor.state-mock.ts
@@ -21,6 +21,7 @@ import type {
   MatcherResult,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Type Definitions
@@ -118,10 +119,7 @@ export function createArchiveExtractorMock(
       return extractions;
     },
     snapshot(): Snapshot {
-      return {
-        __brand: "Snapshot" as const,
-        value: this.toString(),
-      };
+      return createSnapshot(this);
     },
     toString(): string {
       const count = extractions.length;

--- a/src/boundaries/platform/filesystem.state-mock.ts
+++ b/src/boundaries/platform/filesystem.state-mock.ts
@@ -28,6 +28,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Entry Types
@@ -276,7 +277,7 @@ class FileSystemMockStateImpl implements FileSystemMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/platform/git-client.state-mock.ts
+++ b/src/boundaries/platform/git-client.state-mock.ts
@@ -36,6 +36,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Internal State Types
@@ -213,7 +214,7 @@ class GitClientMockStateImpl implements GitClientMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/platform/http-client.state-mock.ts
+++ b/src/boundaries/platform/http-client.state-mock.ts
@@ -19,6 +19,7 @@ import type {
   MatcherResult,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { countMatcher, createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Type Definitions
@@ -182,10 +183,7 @@ export function createMockHttpClient(options?: MockHttpClientOptions): MockHttpC
       return networkError;
     },
     snapshot(): Snapshot {
-      return {
-        __brand: "Snapshot" as const,
-        value: this.toString(),
-      };
+      return createSnapshot(this);
     },
     toString(): string {
       const count = requests.length;
@@ -312,18 +310,7 @@ export const httpClientMatchers: MatcherImplementationsFor<MockHttpClient, HttpC
     } satisfies MatcherResult;
   },
 
-  toHaveRequestCount(received, count) {
-    const actual = received.$.requests.length;
-    const pass = actual === count;
-
-    return {
-      pass,
-      message: (): string =>
-        pass
-          ? `Expected not to have ${count} request(s), but did`
-          : `Expected ${count} request(s), but got ${actual}`,
-    } satisfies MatcherResult;
-  },
+  toHaveRequestCount: countMatcher<MockHttpClient>("request", (mock) => mock.$.requests.length),
 
   toHaveNoRequests(received) {
     const count = received.$.requests.length;

--- a/src/boundaries/platform/port-manager.state-mock.ts
+++ b/src/boundaries/platform/port-manager.state-mock.ts
@@ -7,6 +7,7 @@
 
 import type { PortManager } from "./network";
 import type { MockState, MockWithState, Snapshot } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 /**
  * Configuration options for the PortManager mock.
@@ -91,10 +92,7 @@ export class PortManagerMockState implements MockState {
   }
 
   snapshot(): Snapshot {
-    return {
-      __brand: "Snapshot",
-      value: this.toString(),
-    };
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/platform/posthog.state-mock.ts
+++ b/src/boundaries/platform/posthog.state-mock.ts
@@ -22,6 +22,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Types
@@ -101,7 +102,7 @@ class PostHogBoundaryMockStateImpl implements PostHogBoundaryMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/platform/process.state-mock.ts
+++ b/src/boundaries/platform/process.state-mock.ts
@@ -9,6 +9,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // Types and Interfaces
@@ -124,7 +125,7 @@ class SpawnedProcessMockStateImpl implements SpawnedProcessMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() };
+    return createSnapshot(this);
   }
 
   toString(): string {
@@ -206,7 +207,7 @@ class ProcessRunnerMockStateImpl implements ProcessRunnerMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() };
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/shell/app.state-mock.ts
+++ b/src/boundaries/shell/app.state-mock.ts
@@ -17,6 +17,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { CallbackSet, countMatcher, createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // State Implementation
@@ -36,19 +37,14 @@ class AppBoundaryMockStateImpl implements MockState {
   sleepBlockerStarts = 0;
   /** Number of times a blocker transitioned from active → inactive. */
   sleepBlockerStops = 0;
-  readonly themeUpdatedCallbacks: Set<() => void> = new Set();
+  readonly themeUpdatedCallbacks = new CallbackSet();
 
   triggerThemeUpdated(): void {
-    for (const cb of this.themeUpdatedCallbacks) {
-      cb();
-    }
+    this.themeUpdatedCallbacks.trigger();
   }
 
   snapshot(): Snapshot {
-    return {
-      __brand: "Snapshot",
-      value: this.toString(),
-    };
+    return createSnapshot(this);
   }
 
   toString(): string {
@@ -173,10 +169,7 @@ export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): Moc
     },
 
     onThemeUpdated(callback: () => void) {
-      state.themeUpdatedCallbacks.add(callback);
-      return () => {
-        state.themeUpdatedCallbacks.delete(callback);
-      };
+      return state.themeUpdatedCallbacks.add(callback);
     },
   };
 }
@@ -240,18 +233,10 @@ const appBoundaryMatchers: MatcherImplementationsFor<
     };
   },
 
-  toHaveBadgeCount(received, count) {
-    const actual = received.$.badgeCount;
-    const pass = actual === count;
-
-    return {
-      pass,
-      message: () =>
-        pass
-          ? `Expected badge count NOT to be ${count}`
-          : `Expected badge count to be ${count}, but got ${actual}`,
-    };
-  },
+  toHaveBadgeCount: countMatcher<MockAppBoundary & { $: AppBoundaryMockStateImpl }>(
+    "badge",
+    (mock) => mock.$.badgeCount
+  ),
 
   toBePreventingSleep(received) {
     const actual = received.$.preventingSleep;
@@ -264,17 +249,10 @@ const appBoundaryMatchers: MatcherImplementationsFor<
     };
   },
 
-  toHaveSleepBlockerStartCount(received, count) {
-    const actual = received.$.sleepBlockerStarts;
-    const pass = actual === count;
-    return {
-      pass,
-      message: () =>
-        pass
-          ? `Expected sleep blocker start count NOT to be ${count}`
-          : `Expected sleep blocker start count to be ${count}, but got ${actual}`,
-    };
-  },
+  toHaveSleepBlockerStartCount: countMatcher<MockAppBoundary & { $: AppBoundaryMockStateImpl }>(
+    "sleep blocker start",
+    (mock) => mock.$.sleepBlockerStarts
+  ),
 };
 
 // Register matchers with vitest

--- a/src/boundaries/shell/image.state-mock.ts
+++ b/src/boundaries/shell/image.state-mock.ts
@@ -29,6 +29,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // State Types
@@ -91,7 +92,7 @@ export class ImageBoundaryMockState implements MockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/boundaries/shell/session.state-mock.ts
+++ b/src/boundaries/shell/session.state-mock.ts
@@ -24,6 +24,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { countMatcher, createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // State Types
@@ -113,7 +114,7 @@ class SessionBoundaryMockStateImpl implements SessionBoundaryMockState {
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() };
+    return createSnapshot(this);
   }
 
   toString(): string {
@@ -371,21 +372,7 @@ export const sessionBoundaryMatchers: MatcherImplementationsFor<
     };
   },
 
-  toHaveSessionCount(received, count) {
-    const actual = received.$.sessions.size;
-
-    if (actual !== count) {
-      return {
-        pass: false,
-        message: () => `Expected ${count} sessions but found ${actual}`,
-      };
-    }
-
-    return {
-      pass: true,
-      message: () => `Expected not to have ${count} sessions`,
-    };
-  },
+  toHaveSessionCount: countMatcher<MockSessionBoundary>("session", (mock) => mock.$.sessions.size),
 };
 
 // Register matchers with expect

--- a/src/boundaries/shell/view.state-mock.ts
+++ b/src/boundaries/shell/view.state-mock.ts
@@ -31,6 +31,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { CallbackRegistry, createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // State Types
@@ -146,28 +147,16 @@ interface ViewState {
 class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
   private readonly _views: Map<string, ViewState>;
   private readonly _windowChildren: Map<string, string[]>;
-  private readonly _beforeInputEventCallbacks: Map<
-    string,
-    Set<(input: KeyboardInput, preventDefault: () => void) => void>
-  >;
-  private readonly _destroyedCallbacks: Map<string, Set<() => void>>;
-  private readonly _uncaughtExceptionCallbacks: Map<
-    string,
-    Set<(details: UncaughtExceptionDetails) => void>
-  >;
-  private readonly _renderProcessGoneCallbacks: Map<
-    string,
-    Set<(details: RenderProcessGoneDetails) => void>
-  >;
   private readonly _devToolsOpen: Set<string>;
+
+  readonly beforeInputEventCallbacks = new CallbackRegistry<[KeyboardInput, () => void]>();
+  readonly destroyedCallbacks = new CallbackRegistry();
+  readonly uncaughtExceptionCallbacks = new CallbackRegistry<[UncaughtExceptionDetails]>();
+  readonly renderProcessGoneCallbacks = new CallbackRegistry<[RenderProcessGoneDetails]>();
 
   constructor() {
     this._views = new Map();
     this._windowChildren = new Map();
-    this._beforeInputEventCallbacks = new Map();
-    this._destroyedCallbacks = new Map();
-    this._uncaughtExceptionCallbacks = new Map();
-    this._renderProcessGoneCallbacks = new Map();
     this._devToolsOpen = new Set();
   }
 
@@ -180,25 +169,6 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
     return this._windowChildren;
   }
 
-  get beforeInputEventCallbacks(): Map<
-    string,
-    Set<(input: KeyboardInput, preventDefault: () => void) => void>
-  > {
-    return this._beforeInputEventCallbacks;
-  }
-
-  get destroyedCallbacks(): Map<string, Set<() => void>> {
-    return this._destroyedCallbacks;
-  }
-
-  get uncaughtExceptionCallbacks(): Map<string, Set<(details: UncaughtExceptionDetails) => void>> {
-    return this._uncaughtExceptionCallbacks;
-  }
-
-  get renderProcessGoneCallbacks(): Map<string, Set<(details: RenderProcessGoneDetails) => void>> {
-    return this._renderProcessGoneCallbacks;
-  }
-
   get devToolsOpen(): Set<string> {
     return this._devToolsOpen;
   }
@@ -208,47 +178,32 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
     const preventDefault = () => {
       defaultPrevented = true;
     };
-    const callbacks = this._beforeInputEventCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback(input, preventDefault);
-      }
-    }
+    this.beforeInputEventCallbacks.trigger(handle.id, input, preventDefault);
     return { defaultPrevented };
   }
 
   triggerDestroyed(handle: ViewHandle): void {
-    const callbacks = this._destroyedCallbacks.get(handle.id);
+    const callbacks = this.destroyedCallbacks.get(handle.id);
     if (callbacks) {
       for (const callback of [...callbacks]) {
         callback();
       }
     }
     // Clean up callbacks for the destroyed view
-    this._beforeInputEventCallbacks.delete(handle.id);
-    this._destroyedCallbacks.delete(handle.id);
+    this.beforeInputEventCallbacks.delete(handle.id);
+    this.destroyedCallbacks.delete(handle.id);
   }
 
   triggerUncaughtException(handle: ViewHandle, details: UncaughtExceptionDetails): void {
-    const callbacks = this._uncaughtExceptionCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback(details);
-      }
-    }
+    this.uncaughtExceptionCallbacks.trigger(handle.id, details);
   }
 
   triggerRenderProcessGone(handle: ViewHandle, details: RenderProcessGoneDetails): void {
-    const callbacks = this._renderProcessGoneCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback(details);
-      }
-    }
+    this.renderProcessGoneCallbacks.trigger(handle.id, details);
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {
@@ -336,6 +291,12 @@ class ViewBoundaryMockStateImpl implements ViewBoundaryMockState {
  */
 export function createViewBoundaryMock(): MockViewBoundary {
   const state = new ViewBoundaryMockStateImpl();
+  const registries = [
+    state.beforeInputEventCallbacks,
+    state.destroyedCallbacks,
+    state.uncaughtExceptionCallbacks,
+    state.renderProcessGoneCallbacks,
+  ];
   let nextId = 1;
 
   function getView(handle: ViewHandle): ViewState {
@@ -367,10 +328,9 @@ export function createViewBoundaryMock(): MockViewBoundary {
         hasWindowOpenHandler: false,
         focused: false,
       });
-      state.beforeInputEventCallbacks.set(id, new Set());
-      state.destroyedCallbacks.set(id, new Set());
-      state.uncaughtExceptionCallbacks.set(id, new Set());
-      state.renderProcessGoneCallbacks.set(id, new Set());
+      for (const registry of registries) {
+        registry.init(id);
+      }
       return { id, __brand: "ViewHandle" };
     },
 
@@ -390,18 +350,16 @@ export function createViewBoundaryMock(): MockViewBoundary {
         }
       }
       state.views.delete(handle.id);
-      state.beforeInputEventCallbacks.delete(handle.id);
-      state.destroyedCallbacks.delete(handle.id);
-      state.uncaughtExceptionCallbacks.delete(handle.id);
-      state.renderProcessGoneCallbacks.delete(handle.id);
+      for (const registry of registries) {
+        registry.delete(handle.id);
+      }
     },
 
     destroyAll(): void {
       state.views.clear();
-      state.beforeInputEventCallbacks.clear();
-      state.destroyedCallbacks.clear();
-      state.uncaughtExceptionCallbacks.clear();
-      state.renderProcessGoneCallbacks.clear();
+      for (const registry of registries) {
+        registry.clear();
+      }
       state.windowChildren.clear();
     },
 
@@ -468,20 +426,12 @@ export function createViewBoundaryMock(): MockViewBoundary {
       callback: (input: KeyboardInput, preventDefault: () => void) => void
     ): Unsubscribe {
       getView(handle); // Validate handle exists
-      const callbacks = state.beforeInputEventCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return state.beforeInputEventCallbacks.add(handle.id, callback);
     },
 
     onDestroyed(handle: ViewHandle, callback: () => void): Unsubscribe {
       getView(handle); // Validate handle exists
-      const callbacks = state.destroyedCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return state.destroyedCallbacks.add(handle.id, callback);
     },
 
     onUncaughtException(
@@ -489,11 +439,7 @@ export function createViewBoundaryMock(): MockViewBoundary {
       callback: (details: UncaughtExceptionDetails) => void
     ): Unsubscribe {
       getView(handle); // Validate handle exists
-      const callbacks = state.uncaughtExceptionCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return state.uncaughtExceptionCallbacks.add(handle.id, callback);
     },
 
     onRenderProcessGone(
@@ -501,11 +447,7 @@ export function createViewBoundaryMock(): MockViewBoundary {
       callback: (details: RenderProcessGoneDetails) => void
     ): Unsubscribe {
       getView(handle); // Validate handle exists
-      const callbacks = state.renderProcessGoneCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return state.renderProcessGoneCallbacks.add(handle.id, callback);
     },
 
     onUnresponsive(handle: ViewHandle, _callback: () => void): Unsubscribe {
@@ -534,10 +476,9 @@ export function createViewBoundaryMock(): MockViewBoundary {
 
     async dispose(): Promise<void> {
       state.views.clear();
-      state.beforeInputEventCallbacks.clear();
-      state.destroyedCallbacks.clear();
-      state.uncaughtExceptionCallbacks.clear();
-      state.renderProcessGoneCallbacks.clear();
+      for (const registry of registries) {
+        registry.clear();
+      }
       state.windowChildren.clear();
     },
   };

--- a/src/boundaries/shell/window.state-mock.ts
+++ b/src/boundaries/shell/window.state-mock.ts
@@ -29,6 +29,7 @@ import type {
   Snapshot,
   MatcherImplementationsFor,
 } from "../../test/state-mock";
+import { CallbackRegistry, countMatcher, createSnapshot } from "../../test/state-mock";
 
 // =============================================================================
 // State Types
@@ -145,11 +146,11 @@ interface WindowStateInternal {
 class WindowBoundaryMockStateImpl implements WindowBoundaryMockState {
   constructor(
     private readonly _windows: Map<string, WindowStateInternal>,
-    private readonly _resizeCallbacks: Map<string, Set<() => void>>,
-    private readonly _maximizeCallbacks: Map<string, Set<() => void>>,
-    private readonly _unmaximizeCallbacks: Map<string, Set<() => void>>,
-    private readonly _closeCallbacks: Map<string, Set<() => void>>,
-    private readonly _blurCallbacks: Map<string, Set<() => void>>
+    private readonly _resizeCallbacks: CallbackRegistry,
+    private readonly _maximizeCallbacks: CallbackRegistry,
+    private readonly _unmaximizeCallbacks: CallbackRegistry,
+    private readonly _closeCallbacks: CallbackRegistry,
+    private readonly _blurCallbacks: CallbackRegistry
   ) {}
 
   get windows(): ReadonlyMap<string, WindowMockState> {
@@ -169,12 +170,7 @@ class WindowBoundaryMockStateImpl implements WindowBoundaryMockState {
   }
 
   triggerResize(handle: WindowHandle): void {
-    const callbacks = this._resizeCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback();
-      }
-    }
+    this._resizeCallbacks.trigger(handle.id);
   }
 
   triggerMaximize(handle: WindowHandle): void {
@@ -182,12 +178,7 @@ class WindowBoundaryMockStateImpl implements WindowBoundaryMockState {
     if (window) {
       window.isMaximized = true;
     }
-    const callbacks = this._maximizeCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback();
-      }
-    }
+    this._maximizeCallbacks.trigger(handle.id);
   }
 
   triggerUnmaximize(handle: WindowHandle): void {
@@ -195,34 +186,19 @@ class WindowBoundaryMockStateImpl implements WindowBoundaryMockState {
     if (window) {
       window.isMaximized = false;
     }
-    const callbacks = this._unmaximizeCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback();
-      }
-    }
+    this._unmaximizeCallbacks.trigger(handle.id);
   }
 
   triggerClose(handle: WindowHandle): void {
-    const callbacks = this._closeCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback();
-      }
-    }
+    this._closeCallbacks.trigger(handle.id);
   }
 
   triggerBlur(handle: WindowHandle): void {
-    const callbacks = this._blurCallbacks.get(handle.id);
-    if (callbacks) {
-      for (const callback of callbacks) {
-        callback();
-      }
-    }
+    this._blurCallbacks.trigger(handle.id);
   }
 
   snapshot(): Snapshot {
-    return { __brand: "Snapshot", value: this.toString() } as Snapshot;
+    return createSnapshot(this);
   }
 
   toString(): string {
@@ -261,11 +237,18 @@ class WindowBoundaryMockStateImpl implements WindowBoundaryMockState {
  */
 export function createWindowBoundaryMock(): MockWindowBoundary {
   const windows = new Map<string, WindowStateInternal>();
-  const resizeCallbacks = new Map<string, Set<() => void>>();
-  const maximizeCallbacks = new Map<string, Set<() => void>>();
-  const unmaximizeCallbacks = new Map<string, Set<() => void>>();
-  const closeCallbacks = new Map<string, Set<() => void>>();
-  const blurCallbacks = new Map<string, Set<() => void>>();
+  const resizeCallbacks = new CallbackRegistry();
+  const maximizeCallbacks = new CallbackRegistry();
+  const unmaximizeCallbacks = new CallbackRegistry();
+  const closeCallbacks = new CallbackRegistry();
+  const blurCallbacks = new CallbackRegistry();
+  const registries = [
+    resizeCallbacks,
+    maximizeCallbacks,
+    unmaximizeCallbacks,
+    closeCallbacks,
+    blurCallbacks,
+  ];
   const contentViews = new Map<string, ContentView>();
   let nextId = 1;
 
@@ -336,11 +319,9 @@ export function createWindowBoundaryMock(): MockWindowBoundary {
         options,
       });
       contentViews.set(id, createContentView());
-      resizeCallbacks.set(id, new Set());
-      maximizeCallbacks.set(id, new Set());
-      unmaximizeCallbacks.set(id, new Set());
-      closeCallbacks.set(id, new Set());
-      blurCallbacks.set(id, new Set());
+      for (const registry of registries) {
+        registry.init(id);
+      }
       return { id, __brand: "WindowHandle" };
     },
 
@@ -389,47 +370,27 @@ export function createWindowBoundaryMock(): MockWindowBoundary {
 
     onResize(handle: WindowHandle, callback: () => void): Unsubscribe {
       getWindow(handle); // Validate handle exists
-      const callbacks = resizeCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return resizeCallbacks.add(handle.id, callback);
     },
 
     onMaximize(handle: WindowHandle, callback: () => void): Unsubscribe {
       getWindow(handle); // Validate handle exists
-      const callbacks = maximizeCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return maximizeCallbacks.add(handle.id, callback);
     },
 
     onUnmaximize(handle: WindowHandle, callback: () => void): Unsubscribe {
       getWindow(handle); // Validate handle exists
-      const callbacks = unmaximizeCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return unmaximizeCallbacks.add(handle.id, callback);
     },
 
     onClose(handle: WindowHandle, callback: () => void): Unsubscribe {
       getWindow(handle); // Validate handle exists
-      const callbacks = closeCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return closeCallbacks.add(handle.id, callback);
     },
 
     onBlur(handle: WindowHandle, callback: () => void): Unsubscribe {
       getWindow(handle); // Validate handle exists
-      const callbacks = blurCallbacks.get(handle.id);
-      callbacks?.add(callback);
-      return () => {
-        callbacks?.delete(callback);
-      };
+      return blurCallbacks.add(handle.id, callback);
     },
 
     getContentView(handle: WindowHandle): ContentView {
@@ -452,11 +413,9 @@ export function createWindowBoundaryMock(): MockWindowBoundary {
       }
       windows.clear();
       contentViews.clear();
-      resizeCallbacks.clear();
-      maximizeCallbacks.clear();
-      unmaximizeCallbacks.clear();
-      closeCallbacks.clear();
-      blurCallbacks.clear();
+      for (const registry of registries) {
+        registry.clear();
+      }
     },
   };
 
@@ -538,19 +497,7 @@ export const windowBoundaryMatchers: MatcherImplementationsFor<
     };
   },
 
-  toHaveWindowCount(received, count) {
-    const actualCount = received.$.windows.size;
-    if (actualCount !== count) {
-      return {
-        pass: false,
-        message: () => `Expected ${count} windows but found ${actualCount}`,
-      };
-    }
-    return {
-      pass: true,
-      message: () => `Expected not to have ${count} windows`,
-    };
-  },
+  toHaveWindowCount: countMatcher<MockWindowBoundary>("window", (mock) => mock.$.windows.size),
 
   toHaveWindowTitle(received, id, title) {
     const window = received.$.windows.get(id);

--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -49,23 +49,11 @@ import type {
   DeletePipelineHookInput,
 } from "./delete-workspace";
 import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type {
-  ResolveHookResult as ResolveWorkspaceHookResult,
-  ResolveHookInput as ResolveWorkspaceHookInput,
-} from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type {
-  ResolveHookResult as ResolveProjectHookResult,
-  ResolveHookInput as ResolveProjectHookInput,
-} from "./resolve-project";
+  createTestViewManager,
+  registerTestInfrastructure,
+  workspacesFromProjects,
+} from "./operations.test-utils";
+import type { TestViewManager } from "./operations.test-utils";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
 import type { ProjectId, WorkspaceName, Project } from "../shared/api/types";
 import { Path } from "../utils/path/path";
@@ -106,11 +94,7 @@ interface TestState {
 interface TestHarness {
   dispatcher: Dispatcher;
   state: TestState;
-  viewManager: {
-    getActiveWorkspacePath(): string;
-    setActiveWorkspace(path: string | null, focus?: boolean): void;
-    destroyWorkspaceView(path: string): Promise<void>;
-  };
+  viewManager: TestViewManager;
 }
 
 function createTestHarness(options?: {
@@ -121,14 +105,17 @@ function createTestHarness(options?: {
 }): TestHarness {
   const dispatcher = createMockDispatcher();
 
+  const vmHarness = createTestViewManager(WORKSPACE_A_PATH);
+  const viewManager = vmHarness.viewManager;
+
   const state: TestState = {
     serversStoppedForWorkspaces: [],
-    destroyedViews: [],
+    destroyedViews: vmHarness.destroyedViews,
     deregisteredProjects: [],
     removedProjectsFromStore: [],
     deletedProjectDirectories: [],
     unregisteredProjects: [],
-    setActiveWorkspaceCalls: [],
+    setActiveWorkspaceCalls: vmHarness.setActiveWorkspaceCalls,
   };
 
   const workspaces = options?.emptyProject
@@ -159,29 +146,6 @@ function createTestHarness(options?: {
         workspaces,
         ...(options?.withRemoteUrl && { remoteUrl: "https://github.com/org/repo.git" }),
       };
-
-  const viewManager = {
-    getActiveWorkspacePath: vi.fn().mockReturnValue(WORKSPACE_A_PATH),
-    setActiveWorkspace: vi.fn().mockImplementation((path: string | null, focus?: boolean) => {
-      state.setActiveWorkspaceCalls.push({
-        path,
-        ...(focus !== undefined && { focus }),
-      });
-    }),
-    destroyWorkspaceView: vi.fn().mockImplementation(async (path: string) => {
-      state.destroyedViews.push(path);
-    }),
-    getUIView: vi.fn(),
-    createWorkspaceView: vi.fn(),
-    getWorkspaceView: vi.fn(),
-    updateBounds: vi.fn(),
-    focus: vi.fn(),
-    setMode: vi.fn(),
-    getMode: vi.fn().mockReturnValue("workspace"),
-    onWorkspaceChange: vi.fn().mockReturnValue(() => {}),
-    updateCodeServerPort: vi.fn(),
-    preloadWorkspaceUrl: vi.fn(),
-  } as TestHarness["viewManager"];
 
   const remoteUrl = options?.withRemoteUrl
     ? "https://github.com/org/repo.git"
@@ -228,51 +192,13 @@ function createTestHarness(options?: {
   // Register operations
   dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
   dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  // Resolve modules (shared workspace:resolve and project:resolve operations)
-  const deleteResolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath: wsPath } = ctx as ResolveWorkspaceHookInput;
-            // Reverse lookup: find which project owns this workspace path
-            const projects: Project[] = await appState.getAllProjects();
-            for (const p of projects) {
-              const workspace = p.workspaces?.find((w: { path: string }) => w.path === wsPath);
-              if (workspace) {
-                const workspaceName = wsPath.slice(wsPath.lastIndexOf("/") + 1);
-                return {
-                  projectPath: p.path,
-                  workspaceName: workspaceName as WorkspaceName,
-                  active: viewManager.getActiveWorkspacePath() === wsPath,
-                };
-              }
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
-
-  const deleteResolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const { projectPath } = ctx as ResolveProjectHookInput;
-            const projectId = testProjectId(projectPath);
-            return { projectId };
-          },
-        },
-      },
-    },
-  };
+  // Shared workspace:resolve (reverse lookup over the project) and project:resolve
+  registerTestInfrastructure(dispatcher, {
+    workspaces: workspacesFromProjects(() => (project ? [project] : [])),
+    projects: (projectPath) => ({ projectId: testProjectId(projectPath) }),
+    viewManager,
+  });
 
   // Delete-workspace hook modules (simplified for close-project testing)
   const deleteViewModule: IntentModule = {
@@ -460,8 +386,6 @@ function createTestHarness(options?: {
   };
 
   for (const m of [
-    deleteResolveModule,
-    deleteResolveProjectModule,
     deleteViewModule,
     deleteAgentModule,
     deleteStateModule,

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -51,6 +51,9 @@ import type {
   WorkspaceName,
 } from "../shared/api/types";
 import { getErrorMessage } from "../shared/error-utils";
+import { createTestViewManager } from "./operations.test-utils";
+import type { TestViewManager } from "./operations.test-utils";
+import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
 import {
   SwitchWorkspaceOperation,
@@ -247,42 +250,6 @@ function createTestAppState(initial?: Partial<TestAppState>): {
   return { appState, state };
 }
 
-interface TestViewManager {
-  getActiveWorkspacePath(): string | null;
-  setActiveWorkspace(path: string | null, focus?: boolean): void;
-  destroyWorkspaceView(path: string): Promise<void>;
-}
-
-function createTestViewManager(activeWorkspacePath: string | null = WORKSPACE_PATH): {
-  viewManager: TestViewManager;
-  activeWorkspace: { path: string | null };
-  destroyedViews: string[];
-} {
-  const activeWorkspace = { path: activeWorkspacePath };
-  const destroyedViews: string[] = [];
-
-  const viewManager = {
-    getActiveWorkspacePath: vi.fn().mockImplementation(() => activeWorkspace.path),
-    setActiveWorkspace: vi.fn().mockImplementation((path: string | null) => {
-      activeWorkspace.path = path;
-    }),
-    destroyWorkspaceView: vi.fn().mockImplementation(async (path: string) => {
-      destroyedViews.push(path);
-    }),
-    getUIView: vi.fn(),
-    createWorkspaceView: vi.fn(),
-    getWorkspaceView: vi.fn(),
-    updateBounds: vi.fn(),
-    focus: vi.fn(),
-    setMode: vi.fn(),
-    getMode: vi.fn().mockReturnValue("workspace"),
-    onWorkspaceChange: vi.fn().mockReturnValue(() => {}),
-    updateCodeServerPort: vi.fn(),
-  } as TestViewManager;
-
-  return { viewManager, activeWorkspace, destroyedViews };
-}
-
 function createTestSendToUI(): {
   sendToUI: (channel: string, payload: unknown) => void;
   emittedEvents: Array<{ event: string; payload: unknown }>;
@@ -362,8 +329,7 @@ function createTestHarness(options?: {
     options?.activeWorkspacePath ?? WORKSPACE_PATH
   );
   const { sendToUI, emittedEvents } = createTestSendToUI();
-  const noop: (...args: unknown[]) => void = () => {};
-  const logger = { silly: noop, debug: noop, info: noop, warn: noop, error: noop };
+  const logger = SILENT_LOGGER;
   const workspaceFileService = createTestWorkspaceFileService();
 
   // Register operations

--- a/src/intents/get-agent-session.integration.test.ts
+++ b/src/intents/get-agent-session.integration.test.ts
@@ -20,14 +20,8 @@ import {
   INTENT_GET_AGENT_SESSION,
 } from "./get-agent-session";
 import type { GetAgentSessionIntent, GetAgentSessionHookResult } from "./get-agent-session";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult } from "./resolve-workspace";
+import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceName, AgentSession } from "../shared/api/types";
 
@@ -62,25 +56,10 @@ function createTestSetup(opts: { session?: AgentSessionInfo | null }): TestSetup
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 
-  // Resolve module: validates workspacePath → returns projectPath + workspaceName
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            const intent = ctx.intent as { payload: { workspacePath: string } };
-            if (intent.payload.workspacePath === WORKSPACE_PATH) {
-              return { projectPath: PROJECT_ROOT, workspaceName };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
+  registerTestInfrastructure(dispatcher, {
+    workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },
+  });
 
   // Agent session hook handler module (returns session from test data)
   const agentSessionModule: IntentModule = {
@@ -96,7 +75,6 @@ function createTestSetup(opts: { session?: AgentSessionInfo | null }): TestSetup
     },
   };
 
-  dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(agentSessionModule);
 
   return { dispatcher, workspaceName };

--- a/src/intents/get-workspace-status.integration.test.ts
+++ b/src/intents/get-workspace-status.integration.test.ts
@@ -25,12 +25,7 @@ import type {
   GetStatusHookResult,
   GetStatusHookInput,
 } from "./get-workspace-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult } from "./resolve-workspace";
+import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
 import type { HookContext } from "./lib/operation";
 import type { Intent } from "./lib/types";
@@ -80,25 +75,10 @@ function createTestSetup(opts: {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 
-  // resolve module: validates workspacePath → returns projectPath + workspaceName
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            const intent = ctx.intent as { payload: { workspacePath: string } };
-            if (intent.payload.workspacePath === WORKSPACE_PATH) {
-              return { projectPath: PROJECT_ROOT, workspaceName };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
+  registerTestInfrastructure(dispatcher, {
+    workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },
+  });
 
   // get module: returns isDirty from mock provider (reads workspacePath from enriched context)
   const getStatusModule: IntentModule = {
@@ -135,7 +115,6 @@ function createTestSetup(opts: {
     },
   };
 
-  dispatcher.registerModule(resolveModule);
   dispatcher.registerModule(getStatusModule);
   dispatcher.registerModule(agentStatusModule);
 
@@ -242,21 +221,10 @@ describe("GetWorkspaceStatus Operation", () => {
       const workspaceName = "feature-x" as WorkspaceName;
 
       dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
-      dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
 
-      const resolveModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [RESOLVE_WORKSPACE_OPERATION_ID]: {
-            resolve: {
-              handler: async (): Promise<ResolveHookResult> => ({
-                projectPath: PROJECT_ROOT,
-                workspaceName,
-              }),
-            },
-          },
-        },
-      };
+      registerTestInfrastructure(dispatcher, {
+        workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },
+      });
 
       const unmergedModule: IntentModule = {
         name: "test",
@@ -272,7 +240,6 @@ describe("GetWorkspaceStatus Operation", () => {
         },
       };
 
-      dispatcher.registerModule(resolveModule);
       dispatcher.registerModule(unmergedModule);
 
       const result = (await dispatcher.dispatch(statusIntent(WORKSPACE_PATH))) as WorkspaceStatus;

--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -36,18 +36,7 @@ import {
   type CleanupHookResult,
   type WakePipelineHookInput,
 } from "./wake-workspace";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "./resolve-project";
+import { registerTestInfrastructure } from "./operations.test-utils";
 import {
   SetMetadataOperation,
   INTENT_SET_METADATA,
@@ -55,11 +44,7 @@ import {
   EVENT_METADATA_CHANGED,
   type MetadataChangedEvent,
 } from "./set-metadata";
-import {
-  SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
-  SWITCH_WORKSPACE_OPERATION_ID,
-} from "./switch-workspace";
+import { SWITCH_WORKSPACE_OPERATION_ID } from "./switch-workspace";
 import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "./get-metadata";
 import {
   INTENT_OPEN_WORKSPACE,
@@ -104,32 +89,6 @@ function createRecorder(): Recorder {
     callOrder: [],
     metadataWrites: [],
     events: [],
-  };
-}
-
-function createResolveModule(active: boolean): IntentModule {
-  return {
-    name: "test-resolve",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveWorkspaceHookResult> => ({
-            projectPath: PROJECT_PATH,
-            workspaceName: WORKSPACE_NAME,
-            active,
-            branch: BRANCH,
-          }),
-        },
-      },
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveProjectHookResult> => ({
-            projectId: PROJECT_ID,
-            projectName: "test-project",
-          }),
-        },
-      },
-    },
   };
 }
 
@@ -251,10 +210,7 @@ function buildHarness(
   const recorder = createRecorder();
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
   dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
   dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());
   dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, new WakeWorkspaceOperation());
 
@@ -274,7 +230,17 @@ function buildHarness(
     },
   });
 
-  dispatcher.registerModule(createResolveModule(opts.active ?? false));
+  // Every workspace path resolves to the test workspace; `active` comes from opts.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: () => ({
+      projectPath: PROJECT_PATH,
+      workspaceName: WORKSPACE_NAME,
+      active: opts.active ?? false,
+      branch: BRANCH,
+    }),
+    projects: () => ({ projectId: PROJECT_ID, projectName: "test-project" }),
+  });
+
   dispatcher.registerModule(createMetadataModule(recorder));
   dispatcher.registerModule(createSwitchModule(recorder));
   for (const m of buildHookModules(recorder)) dispatcher.registerModule(m);

--- a/src/intents/lib/operation.test-utils.ts
+++ b/src/intents/lib/operation.test-utils.ts
@@ -8,17 +8,22 @@
 
 import type { Intent } from "./types";
 import type { Operation, OperationContext, HookContext } from "./operation";
+import { DELETE_WORKSPACE_OPERATION_ID, EVENT_WORKSPACE_DELETED } from "../delete-workspace";
+import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../delete-workspace";
+import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 
 /**
  * Options for `createMinimalOperation`.
  *
  * @template TIntent - The intent type the operation handles.
  */
-export interface MinimalOperationOptions<TIntent extends Intent> {
+export interface MinimalOperationOptions<TIntent extends Intent, TResult = void> {
   /** Whether to throw `errors[0]` when the hook returns errors. Default: `true`. */
   throwOnError?: boolean;
   /** Custom hook context builder. Default: `{ intent: ctx.intent }`. */
   hookContext?: (ctx: OperationContext<TIntent>) => HookContext;
+  /** Fallback returned when the hook produced no result (`results[0] ?? defaultResult`). */
+  defaultResult?: TResult;
 }
 
 /**
@@ -45,7 +50,7 @@ export interface MinimalOperationOptions<TIntent extends Intent> {
 export function createMinimalOperation<TIntent extends Intent = Intent, TResult = void>(
   operationId: string,
   hookPoint: string,
-  options?: MinimalOperationOptions<TIntent>
+  options?: MinimalOperationOptions<TIntent, TResult>
 ): Operation<TIntent, TResult> {
   const throwOnError = options?.throwOnError !== false;
   const buildHookContext = options?.hookContext;
@@ -58,7 +63,41 @@ export function createMinimalOperation<TIntent extends Intent = Intent, TResult 
         : { intent: ctx.intent, capabilities: {} };
       const { results, errors } = await ctx.hooks.collect<TResult>(hookPoint, hookCtx);
       if (throwOnError && errors.length > 0) throw errors[0]!;
-      return results[0] as TResult;
+      return (results[0] ?? options?.defaultResult) as TResult;
+    },
+  };
+}
+
+/** Canned event fields for `createDeleteEventOperation`. */
+export interface DeleteEventOperationFields {
+  readonly projectId?: ProjectId;
+  readonly workspaceName?: WorkspaceName;
+  readonly projectPath?: string;
+}
+
+/**
+ * Minimal delete-workspace operation that only emits EVENT_WORKSPACE_DELETED,
+ * so tests can trigger workspace:deleted through the public dispatcher API
+ * without the full DeleteWorkspaceOperation pipeline. The workspacePath comes
+ * from the intent; the remaining event fields are canned (overridable).
+ */
+export function createDeleteEventOperation(
+  fields: DeleteEventOperationFields = {}
+): Operation<DeleteWorkspaceIntent, { started: true }> {
+  return {
+    id: DELETE_WORKSPACE_OPERATION_ID,
+    async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+      const event: WorkspaceDeletedEvent = {
+        type: EVENT_WORKSPACE_DELETED,
+        payload: {
+          projectId: fields.projectId ?? ("test-12345678" as ProjectId),
+          workspaceName: fields.workspaceName ?? ("ws" as WorkspaceName),
+          workspacePath: ctx.intent.payload.workspacePath,
+          projectPath: fields.projectPath ?? "/projects/test",
+        },
+      };
+      ctx.emit(event);
+      return { started: true };
     },
   };
 }

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -58,36 +58,14 @@ import type {
 } from "./open-workspace";
 import type { Project, ProjectId, WorkspaceName } from "../shared/api/types";
 import { Path } from "../utils/path/path";
+import { SwitchWorkspaceOperation, INTENT_SWITCH_WORKSPACE } from "./switch-workspace";
 import {
-  SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
-  SWITCH_WORKSPACE_OPERATION_ID,
-} from "./switch-workspace";
-import type {
-  SwitchWorkspaceIntent,
-  SwitchWorkspaceHookResult,
-  ActivateHookInput,
-} from "./switch-workspace";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type {
-  ResolveHookResult as SharedResolveProjectHookResult,
-  ResolveHookInput as SharedResolveProjectHookInput,
-} from "./resolve-project";
-import {
-  GetActiveWorkspaceOperation,
-  GET_ACTIVE_WORKSPACE_OPERATION_ID,
-  INTENT_GET_ACTIVE_WORKSPACE,
-} from "./get-active-workspace";
+  createTestViewManager,
+  registerTestInfrastructure,
+  workspacesFromProjects,
+} from "./operations.test-utils";
+import type { TestViewManager } from "./operations.test-utils";
+import { GET_ACTIVE_WORKSPACE_OPERATION_ID } from "./get-active-workspace";
 import type { GetActiveWorkspaceHookResult } from "./get-active-workspace";
 
 // =============================================================================
@@ -116,49 +94,6 @@ const WORKSPACE_URL = "http://127.0.0.1:8080/?folder=test";
 // =============================================================================
 // Mock Factories
 // =============================================================================
-
-interface TestViewManager {
-  getActiveWorkspacePath(): string | null;
-  setActiveWorkspace(path: string | null, focus?: boolean): void;
-  destroyWorkspaceView(path: string): Promise<void>;
-  createWorkspaceView(path: string, url: string, projectPath: string, visible: boolean): void;
-  preloadWorkspaceUrl(path: string): void;
-}
-
-function createTestViewManager(): {
-  viewManager: TestViewManager;
-  activeWorkspace: { path: string | null };
-  createdViews: Array<{ path: string; url: string }>;
-  preloadedPaths: string[];
-} {
-  const activeWorkspace = { path: null as string | null };
-  const createdViews: Array<{ path: string; url: string }> = [];
-  const preloadedPaths: string[] = [];
-
-  const viewManager = {
-    getActiveWorkspacePath: vi.fn().mockImplementation(() => activeWorkspace.path),
-    setActiveWorkspace: vi.fn().mockImplementation((path: string | null) => {
-      activeWorkspace.path = path;
-    }),
-    destroyWorkspaceView: vi.fn().mockResolvedValue(undefined),
-    getUIView: vi.fn(),
-    createWorkspaceView: vi.fn().mockImplementation((path: string, url: string) => {
-      createdViews.push({ path, url });
-    }),
-    getWorkspaceView: vi.fn(),
-    updateBounds: vi.fn(),
-    focus: vi.fn(),
-    setMode: vi.fn(),
-    getMode: vi.fn().mockReturnValue("workspace"),
-    onWorkspaceChange: vi.fn().mockReturnValue(() => {}),
-    updateCodeServerPort: vi.fn(),
-    preloadWorkspaceUrl: vi.fn().mockImplementation((path: string) => {
-      preloadedPaths.push(path);
-    }),
-  } as TestViewManager;
-
-  return { viewManager, activeWorkspace, createdViews, preloadedPaths };
-}
 
 interface TestProjectState {
   /** Projects registered via registerProject */
@@ -352,10 +287,19 @@ function createTestHarness(options?: {
   // Register operations
   dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
   dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+
+  // Shared workspace:resolve (reverse lookup over registered projects),
+  // project:resolve, switch-workspace activate, and infra operations.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: workspacesFromProjects(() => projectState.registeredProjects),
+    projects: (projectPath) => {
+      const project = projectState.registeredProjects.find((p) => p.path === projectPath);
+      return project
+        ? { projectId: testProjectId(project.path), projectName: project.name }
+        : undefined;
+    },
+    viewManager,
+  });
 
   // ---------------------------------------------------------------------------
   // Self-selecting resolve modules (local vs remote)
@@ -613,67 +557,10 @@ function createTestHarness(options?: {
     },
   };
 
-  // Resolve modules: workspace:resolve and project:resolve (shared across all operations)
-  const switchResolveModule: IntentModule = {
+  // Dynamic get-active-workspace ref derived from the view manager + registered projects
+  const activeWorkspaceModule: IntentModule = {
     name: "test",
     hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-            // Reverse lookup: find which project owns this workspace path
-            for (const project of projectState.registeredProjects) {
-              const workspace = project.workspaces.find((w) => w.path === wsPath);
-              if (workspace) {
-                const workspaceName = extractWorkspaceName(wsPath);
-                return {
-                  projectPath: project.path,
-                  workspaceName: workspaceName as WorkspaceName,
-                  active: viewManager.getActiveWorkspacePath() === wsPath,
-                };
-              }
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
-  const switchResolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<SharedResolveProjectHookResult> => {
-            const { projectPath } = ctx as SharedResolveProjectHookInput;
-            const project = projectState.registeredProjects.find((p) => p.path === projectPath);
-            return project
-              ? { projectId: testProjectId(project.path), projectName: project.name }
-              : {};
-          },
-        },
-      },
-    },
-  };
-  const switchViewModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [SWITCH_WORKSPACE_OPERATION_ID]: {
-        activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath, active } = ctx as ActivateHookInput;
-            const intent = ctx.intent as SwitchWorkspaceIntent;
-
-            if (active) {
-              return {};
-            }
-
-            const focus = intent.payload.focus ?? true;
-            viewManager.setActiveWorkspace(workspacePath, focus);
-            return { resolvedPath: workspacePath };
-          },
-        },
-      },
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
           handler: async (): Promise<GetActiveWorkspaceHookResult> => {
@@ -710,9 +597,7 @@ function createTestHarness(options?: {
     stateModule,
     viewModule,
     projectViewModule,
-    switchResolveModule,
-    switchResolveProjectModule,
-    switchViewModule,
+    activeWorkspaceModule,
   ])
     dispatcher.registerModule(m);
 

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -64,33 +64,9 @@ import type { ProjectId, Workspace, WorkspaceName } from "../shared/api/types";
 
 const PROJECT_ID = "project-ea0135bc" as ProjectId;
 import { Path } from "../utils/path/path";
-import {
-  SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
-  SWITCH_WORKSPACE_OPERATION_ID,
-} from "./switch-workspace";
+import { SWITCH_WORKSPACE_OPERATION_ID } from "./switch-workspace";
 import type { SwitchWorkspaceHookResult, ActivateHookInput } from "./switch-workspace";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type {
-  ResolveHookResult as ResolveProjectResolveHookResult,
-  ResolveHookInput as ResolveProjectHookInput,
-} from "./resolve-project";
-import {
-  GetActiveWorkspaceOperation,
-  GET_ACTIVE_WORKSPACE_OPERATION_ID,
-  INTENT_GET_ACTIVE_WORKSPACE,
-} from "./get-active-workspace";
-import type { GetActiveWorkspaceHookResult } from "./get-active-workspace";
+import { registerTestInfrastructure } from "./operations.test-utils";
 import type { WorkspaceRef } from "../shared/api/types";
 
 // =============================================================================
@@ -209,49 +185,26 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
   dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 
-  // Shared resolve modules for workspace:resolve and project:resolve
-  const resolveWorkspaceModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-            const workspaceName = wsPath.slice(wsPath.lastIndexOf("/") + 1);
-            return {
-              projectPath: PROJECT_ROOT,
-              workspaceName: workspaceName as WorkspaceName,
-            };
-          },
-        },
-      },
-    },
-  };
   // Tracks known project paths for project:resolve resolution.
   // Only PROJECT_ROOT is known by default; tests can add more.
   const knownProjectPaths = new Set<string>([PROJECT_ROOT]);
-  const resolveProjectResolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectResolveHookResult> => {
-            const { projectPath } = ctx as ResolveProjectHookInput;
-            if (knownProjectPaths.has(projectPath)) {
-              return { projectId: PROJECT_ID, projectName: "test" };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
+
+  // Shared infra: every workspace path resolves under PROJECT_ROOT with the
+  // basename as workspaceName; projects resolve from knownProjectPaths.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: (wsPath) => ({
+      projectPath: PROJECT_ROOT,
+      workspaceName: wsPath.slice(wsPath.lastIndexOf("/") + 1) as WorkspaceName,
+    }),
+    projects: (projectPath) =>
+      knownProjectPaths.has(projectPath)
+        ? { projectId: PROJECT_ID, projectName: "test" }
+        : undefined,
+    activeWorkspaceRef: opts?.activeWorkspaceRef ?? null,
+  });
+
   const switchViewModule: IntentModule = {
     name: "test",
     hooks: {
@@ -260,21 +213,6 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
           handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
             const { workspacePath } = ctx as ActivateHookInput;
             return { resolvedPath: workspacePath };
-          },
-        },
-      },
-    },
-  };
-
-  // GetActiveWorkspace module: returns configurable active workspace ref
-  const activeWorkspaceRef = opts?.activeWorkspaceRef ?? null;
-  const getActiveWorkspaceModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
-        get: {
-          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-            return { workspaceRef: activeWorkspaceRef };
           },
         },
       },
@@ -408,10 +346,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
   };
 
   const modules: IntentModule[] = [
-    resolveWorkspaceModule,
-    resolveProjectResolveModule,
     switchViewModule,
-    getActiveWorkspaceModule,
     worktreeModule,
     keepFilesModule,
     agentModule,
@@ -991,42 +926,17 @@ describe("OpenWorkspace Operation", () => {
       // Re-create setup with the extra module
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-      dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
       dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-      dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-      dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
 
-      // Shared resolve modules
-      const resolveWorkspaceModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [RESOLVE_WORKSPACE_OPERATION_ID]: {
-            resolve: {
-              handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-                const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-                const workspaceName = wsPath.slice(wsPath.lastIndexOf("/") + 1);
-                return {
-                  projectPath: PROJECT_ROOT,
-                  workspaceName: workspaceName as WorkspaceName,
-                };
-              },
-            },
-          },
-        },
-      };
-      const resolveProjectResolveModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [RESOLVE_PROJECT_OPERATION_ID]: {
-            resolve: {
-              handler: async (): Promise<ResolveProjectResolveHookResult> => {
-                return { projectId: PROJECT_ID, projectName: "test" };
-              },
-            },
-          },
-        },
-      };
+      registerTestInfrastructure(dispatcher, {
+        workspaces: (wsPath) => ({
+          projectPath: PROJECT_ROOT,
+          workspaceName: wsPath.slice(wsPath.lastIndexOf("/") + 1) as WorkspaceName,
+        }),
+        projects: () => ({ projectId: PROJECT_ID, projectName: "test" }),
+        activeWorkspaceRef: null,
+      });
+
       const switchViewModule: IntentModule = {
         name: "test",
         hooks: {
@@ -1083,23 +993,7 @@ describe("OpenWorkspace Operation", () => {
         },
       };
 
-      const getActiveWorkspaceModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
-            get: {
-              handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-                return { workspaceRef: null };
-              },
-            },
-          },
-        },
-      };
-
-      dispatcher.registerModule(resolveWorkspaceModule);
-      dispatcher.registerModule(resolveProjectResolveModule);
       dispatcher.registerModule(switchViewModule);
-      dispatcher.registerModule(getActiveWorkspaceModule);
       dispatcher.registerModule(worktreeModule);
       dispatcher.registerModule(agentModule);
       dispatcher.registerModule(extraEnvModule);

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -19,6 +19,9 @@ import type { Dispatcher } from "./lib/dispatcher";
 import type { IntentModule } from "./lib/module";
 import type { HookContext } from "./lib/operation";
 import type { ProjectId, WorkspaceName, WorkspaceRef } from "../shared/api/types";
+import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import { INTENT_UPDATE_AGENT_STATUS } from "./update-agent-status";
+import type { UpdateAgentStatusIntent } from "./update-agent-status";
 import {
   ResolveWorkspaceOperation,
   RESOLVE_WORKSPACE_OPERATION_ID,
@@ -58,6 +61,9 @@ import type {
 export interface MockWorkspaceEntry {
   readonly projectPath: string;
   readonly workspaceName: WorkspaceName;
+  readonly branch?: string | null;
+  /** Explicit active flag; when omitted, derived from the viewManager (if any). */
+  readonly active?: boolean;
 }
 
 export interface MockProjectEntry {
@@ -70,15 +76,129 @@ export interface MockViewManager {
   setActiveWorkspace(path: string | null, focus?: boolean): void;
 }
 
+/** Static map or dynamic lookup function for workspace resolution. */
+export type MockWorkspaceLookup =
+  | Readonly<Record<string, MockWorkspaceEntry>>
+  | ((workspacePath: string) => MockWorkspaceEntry | undefined);
+
+/** Static map or dynamic lookup function for project resolution. */
+export type MockProjectLookup =
+  | Readonly<Record<string, MockProjectEntry>>
+  | ((projectPath: string) => MockProjectEntry | undefined);
+
 export interface TestMockConfig {
-  /** Maps workspacePath → resolution data. */
-  readonly workspaces?: Readonly<Record<string, MockWorkspaceEntry>>;
-  /** Maps projectPath → resolution data. */
-  readonly projects?: Readonly<Record<string, MockProjectEntry>>;
+  /** Maps workspacePath → resolution data (or dynamic lookup). */
+  readonly workspaces?: MockWorkspaceLookup;
+  /** Maps projectPath → resolution data (or dynamic lookup). */
+  readonly projects?: MockProjectLookup;
   /** Active workspace ref for get-active-workspace. Default: null. */
   readonly activeWorkspaceRef?: WorkspaceRef | null;
   /** View manager for switch-workspace activate hook. Only wired if provided. */
   readonly viewManager?: MockViewManager;
+}
+
+/** Minimal project shape for {@link workspacesFromProjects}. */
+export interface ProjectWithWorkspaces {
+  readonly path: string;
+  readonly workspaces?: ReadonlyArray<{ readonly path: string }>;
+}
+
+/**
+ * Workspace lookup that reverse-looks-up the owning project from a live
+ * project list. The workspaceName derives from the path basename, matching
+ * production resolution.
+ */
+export function workspacesFromProjects(
+  getProjects: () => readonly ProjectWithWorkspaces[]
+): (workspacePath: string) => MockWorkspaceEntry | undefined {
+  return (workspacePath) => {
+    for (const project of getProjects()) {
+      if (project.workspaces?.some((w) => w.path === workspacePath)) {
+        return {
+          projectPath: project.path,
+          workspaceName: workspacePath.slice(workspacePath.lastIndexOf("/") + 1) as WorkspaceName,
+        };
+      }
+    }
+    return undefined;
+  };
+}
+
+// =============================================================================
+// Intent Builders
+// =============================================================================
+
+/** Build an agent:update-status intent. */
+export function updateStatusIntent(
+  workspacePath: string,
+  status: AggregatedAgentStatus
+): UpdateAgentStatusIntent {
+  return {
+    type: INTENT_UPDATE_AGENT_STATUS,
+    payload: {
+      workspacePath: workspacePath as WorkspacePath,
+      status,
+    },
+  };
+}
+
+// =============================================================================
+// View Manager Mock
+// =============================================================================
+
+/** ViewManager surface used by operation tests, with capture-friendly extras. */
+export interface TestViewManager extends MockViewManager {
+  destroyWorkspaceView(path: string): Promise<void>;
+  createWorkspaceView(path: string, url: string, projectPath: string, visible: boolean): void;
+  preloadWorkspaceUrl(path: string): void;
+}
+
+export interface TestViewManagerHarness {
+  readonly viewManager: TestViewManager;
+  /** Live active-workspace state; mutate `path` to simulate external changes. */
+  readonly activeWorkspace: { path: string | null };
+  readonly destroyedViews: string[];
+  readonly createdViews: Array<{ path: string; url: string }>;
+  readonly preloadedPaths: string[];
+  readonly setActiveWorkspaceCalls: Array<{ path: string | null; focus?: boolean }>;
+}
+
+/**
+ * Stateful ViewManager mock: setActiveWorkspace updates the active path and
+ * records the call; destroy/create/preload record their arguments.
+ */
+export function createTestViewManager(initialActive: string | null = null): TestViewManagerHarness {
+  const activeWorkspace = { path: initialActive };
+  const destroyedViews: string[] = [];
+  const createdViews: Array<{ path: string; url: string }> = [];
+  const preloadedPaths: string[] = [];
+  const setActiveWorkspaceCalls: Array<{ path: string | null; focus?: boolean }> = [];
+
+  const viewManager: TestViewManager = {
+    getActiveWorkspacePath: () => activeWorkspace.path,
+    setActiveWorkspace: (path, focus) => {
+      activeWorkspace.path = path;
+      setActiveWorkspaceCalls.push({ path, ...(focus !== undefined && { focus }) });
+    },
+    destroyWorkspaceView: async (path) => {
+      destroyedViews.push(path);
+    },
+    createWorkspaceView: (path, url) => {
+      createdViews.push({ path, url });
+    },
+    preloadWorkspaceUrl: (path) => {
+      preloadedPaths.push(path);
+    },
+  };
+
+  return {
+    viewManager,
+    activeWorkspace,
+    destroyedViews,
+    createdViews,
+    preloadedPaths,
+    setActiveWorkspaceCalls,
+  };
 }
 
 // =============================================================================
@@ -92,7 +212,7 @@ export interface TestMockConfig {
  * - get-active-workspace: returns config.activeWorkspaceRef
  * - switch-workspace activate: calls config.viewManager.setActiveWorkspace() (if provided)
  */
-function createTestMockModule(config: TestMockConfig): IntentModule {
+export function createTestMockModule(config: TestMockConfig): IntentModule {
   const hooks: Record<
     string,
     Record<string, { handler: (ctx: HookContext) => Promise<unknown> }>
@@ -101,16 +221,20 @@ function createTestMockModule(config: TestMockConfig): IntentModule {
   // -- resolve-workspace --
   if (config.workspaces) {
     const workspaces = config.workspaces;
+    const lookupWorkspace =
+      typeof workspaces === "function" ? workspaces : (path: string) => workspaces[path];
     const vm = config.viewManager;
     hooks[RESOLVE_WORKSPACE_OPERATION_ID] = {
       resolve: {
         handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
           const intent = ctx.intent as { payload: { workspacePath: string } };
-          const entry = workspaces[intent.payload.workspacePath];
+          const entry = lookupWorkspace(intent.payload.workspacePath);
           if (!entry) return {};
           return {
             ...entry,
-            active: vm ? vm.getActiveWorkspacePath() === intent.payload.workspacePath : false,
+            active:
+              entry.active ??
+              (vm ? vm.getActiveWorkspacePath() === intent.payload.workspacePath : false),
           };
         },
       },
@@ -120,11 +244,13 @@ function createTestMockModule(config: TestMockConfig): IntentModule {
   // -- resolve-project --
   if (config.projects) {
     const projects = config.projects;
+    const lookupProject =
+      typeof projects === "function" ? projects : (path: string) => projects[path];
     hooks[RESOLVE_PROJECT_OPERATION_ID] = {
       resolve: {
         handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
           const { projectPath } = ctx as ResolveProjectHookInput;
-          const entry = projects[projectPath];
+          const entry = lookupProject(projectPath);
           if (!entry) return {};
           const result: ResolveProjectHookResult = { projectId: entry.projectId };
           if (entry.projectName !== undefined) {
@@ -137,14 +263,18 @@ function createTestMockModule(config: TestMockConfig): IntentModule {
   }
 
   // -- get-active-workspace --
-  const activeRef = config.activeWorkspaceRef ?? null;
-  hooks[GET_ACTIVE_WORKSPACE_OPERATION_ID] = {
-    get: {
-      handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-        return { workspaceRef: activeRef };
+  // Only wired when explicitly configured, so tests can provide their own
+  // dynamic get hook without competing handlers.
+  if (config.activeWorkspaceRef !== undefined) {
+    const activeRef = config.activeWorkspaceRef;
+    hooks[GET_ACTIVE_WORKSPACE_OPERATION_ID] = {
+      get: {
+        handler: async (): Promise<GetActiveWorkspaceHookResult> => {
+          return { workspaceRef: activeRef };
+        },
       },
-    },
-  };
+    };
+  }
 
   // -- switch-workspace activate --
   if (config.viewManager) {

--- a/src/intents/restart-agent.integration.test.ts
+++ b/src/intents/restart-agent.integration.test.ts
@@ -27,21 +27,7 @@ import type {
   RestartAgentHookResult,
   AgentRestartedEvent,
 } from "./restart-agent";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type {
-  ResolveHookInput as ResolveProjectHookInput,
-  ResolveHookResult as ResolveProjectHookResult,
-} from "./resolve-project";
+import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
 import type { HookContext } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
@@ -91,44 +77,11 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  // Resolve module: validates workspacePath → returns projectPath + workspaceName
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const intent = ctx.intent as { payload: { workspacePath: string } };
-            if (intent.payload.workspacePath === WORKSPACE_PATH) {
-              return { projectPath: PROJECT_ROOT, workspaceName };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
-
-  // Resolve-project module: resolves projectPath → projectId (for domain events)
-  const resolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const { projectPath } = ctx as ResolveProjectHookInput;
-            if (projectPath === PROJECT_ROOT) {
-              return { projectId };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
+  registerTestInfrastructure(dispatcher, {
+    workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },
+    projects: { [PROJECT_ROOT]: { projectId } },
+  });
 
   // Restart hook handler module (reads from enriched context)
   const restartModule: IntentModule = {
@@ -150,8 +103,6 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
     },
   };
 
-  dispatcher.registerModule(resolveModule);
-  dispatcher.registerModule(resolveProjectModule);
   dispatcher.registerModule(restartModule);
 
   return { dispatcher, projectId, workspaceName };

--- a/src/intents/switch-workspace.integration.test.ts
+++ b/src/intents/switch-workspace.integration.test.ts
@@ -17,12 +17,11 @@
  */
 
 import { createMockDispatcher } from "./lib/dispatcher.test-utils";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 import type { IntentInterceptor } from "./lib/dispatcher";
 
 import {
-  SwitchWorkspaceOperation,
   SWITCH_WORKSPACE_OPERATION_ID,
   INTENT_SWITCH_WORKSPACE,
   EVENT_WORKSPACE_SWITCHED,
@@ -30,25 +29,16 @@ import {
 } from "./switch-workspace";
 import type {
   SwitchWorkspaceIntent,
-  SwitchWorkspaceHookResult,
-  ActivateHookInput,
   WorkspaceSwitchedEvent,
   FindCandidatesHookResult,
   SelectNextHookInput,
   SelectNextHookResult,
 } from "./switch-workspace";
 import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "./resolve-project";
+  createTestViewManager,
+  registerTestInfrastructure,
+  workspacesFromProjects,
+} from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
 import type { HookContext } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
@@ -153,95 +143,37 @@ function createTestSetup(opts?: {
   projects?: ProjectEntry[];
 }): TestSetup {
   const projects = opts?.projects ?? [createTestProject()];
-  let activePath: string | null = opts?.initialActive ?? null;
-  const setActiveWorkspace = vi.fn((path: string | null) => {
-    activePath = path;
-  });
   const appState = createMockAppState(projects);
 
   const dispatcher = createMockDispatcher();
+  const { viewManager, activeWorkspace } = createTestViewManager(opts?.initialActive ?? null);
 
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-
-  // ResolveModule: "resolve" hook -- resolves workspacePath → projectPath + workspaceName + active
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-            // Reverse lookup: find which project owns this workspace path
-            for (const project of appState.projects) {
-              const workspace = project.workspaces.find((w) => w.path === wsPath);
-              if (workspace) {
-                return {
-                  projectPath: project.path,
-                  workspaceName: wsPath.slice(wsPath.lastIndexOf("/") + 1) as WorkspaceName,
-                  active: activePath === wsPath,
-                };
-              }
-            }
-            return {};
-          },
-        },
-      },
+  registerTestInfrastructure(dispatcher, {
+    workspaces: workspacesFromProjects(() => appState.projects),
+    projects: (projectPath) => {
+      const project = appState.getProject(projectPath);
+      if (!project) return undefined;
+      return { projectId: generateProjectId(project.path), projectName: project.name };
     },
-  };
+    viewManager,
+  });
 
-  // ResolveProjectModule: "resolve" hook -- resolves projectPath → projectId + projectName
-  const resolveProjectModule: IntentModule = {
+  // Clear the active surface on workspace:switched(null) (mirrors view-module).
+  const switchedNullModule: IntentModule = {
     name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const { projectPath } = ctx as { projectPath: string } & HookContext;
-            const project = appState.getProject(projectPath);
-            if (!project) return {};
-            return { projectId: generateProjectId(project.path), projectName: project.name };
-          },
-        },
-      },
-    },
-  };
-
-  // SwitchViewModule: "activate" hook -- records the active surface
-  // (mirrors view-module's hook). Also subscribes to workspace:switched(null)
-  // to clear it.
-  const switchViewModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [SWITCH_WORKSPACE_OPERATION_ID]: {
-        activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath, active } = ctx as ActivateHookInput;
-
-            if (active) {
-              return {};
-            }
-
-            setActiveWorkspace(workspacePath);
-            return { resolvedPath: workspacePath };
-          },
-        },
-      },
-    },
     events: {
       [EVENT_WORKSPACE_SWITCHED]: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as WorkspaceSwitchedEvent).payload;
           if (payload === null) {
-            setActiveWorkspace(null);
+            viewManager.setActiveWorkspace(null);
           }
         },
       },
     },
   };
 
-  const modules: IntentModule[] = [resolveModule, resolveProjectModule, switchViewModule];
+  const modules: IntentModule[] = [switchedNullModule];
 
   if (opts?.withAutoSelect) {
     const findCandidatesModule: IntentModule = {
@@ -296,7 +228,7 @@ function createTestSetup(opts?: {
   return {
     dispatcher,
     appState,
-    getActivePath: () => activePath,
+    getActivePath: () => activeWorkspace.path,
   };
 }
 

--- a/src/intents/update-agent-status.integration.test.ts
+++ b/src/intents/update-agent-status.integration.test.ts
@@ -17,22 +17,10 @@ import {
   INTENT_UPDATE_AGENT_STATUS,
   EVENT_AGENT_STATUS_UPDATED,
 } from "./update-agent-status";
-import type { UpdateAgentStatusIntent, AgentStatusUpdatedEvent } from "./update-agent-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "./resolve-project";
+import type { AgentStatusUpdatedEvent } from "./update-agent-status";
+import { registerTestInfrastructure, updateStatusIntent } from "./operations.test-utils";
 import type { DomainEvent } from "./lib/types";
-import type { IntentModule } from "./lib/module";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
 // =============================================================================
@@ -43,68 +31,23 @@ const TEST_PROJECT_ID = "test-project-id" as ProjectId;
 const TEST_PROJECT_PATH = "/projects/test";
 const TEST_WORKSPACE_NAME = "test-workspace" as WorkspaceName;
 
-/**
- * Mock resolve modules that provide workspace + project resolution
- * for the update-agent-status operation via shared resolve intents.
- */
-function createMockResolveModules(): IntentModule[] {
-  const resolveWorkspaceModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveWorkspaceHookResult> => {
-            return {
-              projectPath: TEST_PROJECT_PATH,
-              workspaceName: TEST_WORKSPACE_NAME,
-            };
-          },
-        },
-      },
-    },
-  };
-
-  const resolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveProjectHookResult> => {
-            return { projectId: TEST_PROJECT_ID };
-          },
-        },
-      },
-    },
-  };
-
-  return [resolveWorkspaceModule, resolveProjectModule];
-}
+const TEST_WORKSPACE_ENTRY = {
+  projectPath: TEST_PROJECT_PATH,
+  workspaceName: TEST_WORKSPACE_NAME,
+};
 
 function createTestSetup(): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  for (const mod of createMockResolveModules()) {
-    dispatcher.registerModule(mod);
-  }
+  registerTestInfrastructure(dispatcher, {
+    // Every workspace path used by the tests resolves to the same project.
+    workspaces: () => TEST_WORKSPACE_ENTRY,
+    projects: { [TEST_PROJECT_PATH]: { projectId: TEST_PROJECT_ID } },
+  });
 
   return { dispatcher };
-}
-
-function updateStatusIntent(
-  workspacePath: string,
-  status: AggregatedAgentStatus
-): UpdateAgentStatusIntent {
-  return {
-    type: INTENT_UPDATE_AGENT_STATUS,
-    payload: {
-      workspacePath: workspacePath as WorkspacePath,
-      status,
-    },
-  };
 }
 
 // =============================================================================
@@ -182,27 +125,10 @@ describe("UpdateAgentStatus Operation", () => {
     it("silently returns when resolve hooks provide no projectPath", async () => {
       const dispatcher = createMockDispatcher();
       dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-      dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-      dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-      // Register resolve modules that return empty — resolve operations will throw,
-      // and update-agent-status catches the error and silently returns.
-      const emptyResolveModule: IntentModule = {
-        name: "test",
-        hooks: {
-          [RESOLVE_WORKSPACE_OPERATION_ID]: {
-            resolve: {
-              handler: async (): Promise<ResolveWorkspaceHookResult> => ({}),
-            },
-          },
-          [RESOLVE_PROJECT_OPERATION_ID]: {
-            resolve: {
-              handler: async (): Promise<ResolveProjectHookResult> => ({}),
-            },
-          },
-        },
-      };
-      dispatcher.registerModule(emptyResolveModule);
+      // Empty lookups — resolve operations will throw, and update-agent-status
+      // catches the error and silently returns.
+      registerTestInfrastructure(dispatcher, { workspaces: {}, projects: {} });
 
       const receivedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_AGENT_STATUS_UPDATED, (event) => {

--- a/src/modules/agent-module/claude/module-provider.integration.test.ts
+++ b/src/modules/agent-module/claude/module-provider.integration.test.ts
@@ -17,11 +17,13 @@ import type { ClaudeCodeServerManager } from "./server-manager";
 import type { AgentProvider, AgentStatus } from "../types";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
 import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
-import type { DownloadDeps, ArchiveExtension } from "../../../utils/binary-download";
-import { createFileSystemMock } from "../../../boundaries/platform/filesystem.state-mock";
-import { createMockHttpClient } from "../../../boundaries/platform/http-client.state-mock";
-import { createArchiveExtractorMock } from "../../../boundaries/platform/archive-extractor.state-mock";
-import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
+import type { DownloadDeps } from "../../../utils/binary-download";
+import {
+  createBinaryConfig,
+  createDownloadDeps,
+  createMockServerManager as createServerManagerBase,
+  createVersionConfig,
+} from "../module-provider.test-utils";
 import { createMockPathProvider } from "../../../boundaries/platform/path-provider.test-utils";
 
 // =============================================================================
@@ -58,37 +60,10 @@ vi.mock("./provider", () => ({
 // =============================================================================
 
 function createMockServerManager(): ClaudeCodeServerManager {
-  return {
-    startServer: vi.fn().mockResolvedValue(8080),
-    stopServer: vi.fn().mockResolvedValue({ success: true }),
-    restartServer: vi.fn().mockResolvedValue({ success: true, port: 8080 }),
-    dispose: vi.fn().mockResolvedValue(undefined),
-    setMcpConfig: vi.fn(),
+  return createServerManagerBase({
     setInitialPrompt: vi.fn().mockResolvedValue(undefined),
     setNoSessionMarker: vi.fn().mockResolvedValue(undefined),
-    onServerStarted: vi.fn().mockReturnValue(vi.fn()),
-    onServerStopped: vi.fn().mockReturnValue(vi.fn()),
-  } as unknown as ClaudeCodeServerManager;
-}
-
-function createDownloadDeps(): DownloadDeps {
-  return {
-    httpClient: createMockHttpClient(),
-    fileSystemLayer: createFileSystemMock(),
-    archiveExtractor: createArchiveExtractorMock(),
-  };
-}
-
-function createBinaryConfig() {
-  return {
-    name: "claude" as const,
-    executablePath: "claude",
-    archiveExtension: ".tar.gz" as ArchiveExtension,
-  };
-}
-
-function createVersionConfig(version: string | null = null) {
-  return createMockAccessor<string | null>("version.claude", version);
+  }) as unknown as ClaudeCodeServerManager;
 }
 
 const WS_PATH = "/workspace/feature-a" as WorkspacePath;
@@ -110,8 +85,8 @@ describe("createClaudeModuleProvider", () => {
     capturedStatusCallback = null;
     mockServerManager = createMockServerManager();
     downloadDeps = createDownloadDeps();
-    binaryConfig = createBinaryConfig();
-    versionConfig = createVersionConfig(null);
+    binaryConfig = createBinaryConfig("claude");
+    versionConfig = createVersionConfig<string | null>("version.claude", null);
     pathProvider = createMockPathProvider();
   });
 

--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -13,11 +13,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 import { join, resolve, dirname, delimiter } from "node:path";
-import { writeFile, mkdir, chmod, access } from "node:fs/promises";
-import { constants, existsSync } from "node:fs";
-import { exec as pkgExec } from "@yao-pkg/pkg";
+import { writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { createTempDir } from "../../../utils/testing/test-utils";
-import { executeScript } from "../wrapper-boundary-test-utils";
+import {
+  assertCompiledScript,
+  createFakeAgentBinary,
+  executeScript,
+} from "../wrapper-boundary-test-utils";
 
 const isWindows = process.platform === "win32";
 
@@ -74,9 +77,6 @@ function parseAllFakeClaudeOutputs(stdout: string): FakeClaudeOutput[] {
  * and CLAUDE_COUNTER_FILE for tracking invocation count across calls.
  */
 async function createFakeClaudeBinary(binDir: string): Promise<string> {
-  await mkdir(binDir, { recursive: true });
-
-  const fakeScriptPath = join(binDir, "fake-claude.cjs");
   const fakeNodeContent = `#!/usr/bin/env node
 const fs = require("node:fs");
 
@@ -116,19 +116,13 @@ if (exitCodes) {
 console.log(JSON.stringify(output));
 process.exit(isNaN(exitCode) ? 0 : exitCode);
 `;
-  await writeFile(fakeScriptPath, fakeNodeContent);
-
-  if (isWindows) {
-    // Compile to real .exe so shell:false works (no cmd.exe involvement)
-    await pkgExec([fakeScriptPath, "--target", "host", "--output", join(binDir, "claude")]);
-  } else {
-    // Unix: shell script with shebang (kernel handles it, no shell needed)
-    const shellContent = `#!/bin/sh\nexec node "\${0%/*}/fake-claude.cjs" "$@"\n`;
-    await writeFile(join(binDir, "claude"), shellContent);
-    await chmod(join(binDir, "claude"), 0o755);
-  }
-
-  return binDir;
+  // Real .exe on Windows so shell:false works (no cmd.exe involvement)
+  return createFakeAgentBinary({
+    dir: binDir,
+    binaryName: "claude",
+    scriptBody: fakeNodeContent,
+    windowsMode: "exe",
+  });
 }
 
 /**
@@ -143,13 +137,7 @@ describe("ch-claude.cjs boundary tests", () => {
   let fakeBinDir: string;
 
   beforeAll(async () => {
-    try {
-      await access(COMPILED_SCRIPT_PATH, constants.R_OK);
-    } catch {
-      throw new Error(
-        `Compiled script not found at ${COMPILED_SCRIPT_PATH}. Run 'pnpm build:wrappers' first.`
-      );
-    }
+    await assertCompiledScript(COMPILED_SCRIPT_PATH);
   });
 
   beforeEach(async () => {
@@ -518,9 +506,6 @@ describe("ch-claude.cjs boundary tests", () => {
  * global bin shims when no native .exe is present.
  */
 async function createFakeClaudeCmdShim(binDir: string): Promise<string> {
-  await mkdir(binDir, { recursive: true });
-
-  const fakeScriptPath = join(binDir, "fake-claude.cjs");
   const fakeNodeContent = `#!/usr/bin/env node
 const fs = require("node:fs");
 
@@ -553,15 +538,12 @@ if (exitCodes) {
 console.log(JSON.stringify(output));
 process.exit(isNaN(exitCode) ? 0 : exitCode);
 `;
-  await writeFile(fakeScriptPath, fakeNodeContent);
-
-  // Embed the absolute path to fake-claude.cjs rather than relying on
-  // %~dp0 — when a .cmd is invoked through a PATH lookup, %~dp0 can
-  // resolve to the caller's CWD rather than the script's directory.
-  const cmdContent = `@echo off\r\nnode "${fakeScriptPath}" %*\r\n`;
-  await writeFile(join(binDir, "claude.cmd"), cmdContent);
-
-  return binDir;
+  return createFakeAgentBinary({
+    dir: binDir,
+    binaryName: "claude",
+    scriptBody: fakeNodeContent,
+    windowsMode: "cmd-shim",
+  });
 }
 
 describe.skipIf(!isWindows)("ch-claude.cjs Windows .cmd shim (npm install)", () => {
@@ -569,13 +551,7 @@ describe.skipIf(!isWindows)("ch-claude.cjs Windows .cmd shim (npm install)", () 
   let cmdBinDir: string;
 
   beforeAll(async () => {
-    try {
-      await access(COMPILED_SCRIPT_PATH, constants.R_OK);
-    } catch {
-      throw new Error(
-        `Compiled script not found at ${COMPILED_SCRIPT_PATH}. Run 'pnpm build:wrappers' first.`
-      );
-    }
+    await assertCompiledScript(COMPILED_SCRIPT_PATH);
   });
 
   beforeEach(async () => {

--- a/src/modules/agent-module/module-provider.test-utils.ts
+++ b/src/modules/agent-module/module-provider.test-utils.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared mock factories for the claude/opencode module-provider integration
+ * tests: download deps, binary/version config, and a canned server manager
+ * with start/stop trigger capture.
+ */
+
+import { vi } from "vitest";
+import type { DownloadDeps, ArchiveExtension } from "../../utils/binary-download";
+import { createFileSystemMock } from "../../boundaries/platform/filesystem.state-mock";
+import { createMockHttpClient } from "../../boundaries/platform/http-client.state-mock";
+import { createArchiveExtractorMock } from "../../boundaries/platform/archive-extractor.state-mock";
+import { createMockAccessor } from "../../boundaries/platform/config.test-utils";
+import type { PersistedAccessor } from "../../boundaries/platform/store-definition";
+
+/** Create mock download dependencies. */
+export function createDownloadDeps(): DownloadDeps {
+  return {
+    httpClient: createMockHttpClient(),
+    fileSystemLayer: createFileSystemMock(),
+    archiveExtractor: createArchiveExtractorMock(),
+  };
+}
+
+/** Create a binary config whose executable matches the agent name. */
+export function createBinaryConfig<TName extends string>(name: TName) {
+  return {
+    name,
+    executablePath: name,
+    archiveExtension: ".tar.gz" as ArchiveExtension,
+  };
+}
+
+/**
+ * Create a version-override accessor for the given config key.
+ * Pass the type argument explicitly when the provider's deps demand a
+ * specific nullability (e.g. `createVersionConfig<string>(...)`).
+ */
+export function createVersionConfig<T extends string | null = string | null>(
+  key: string,
+  version: T
+): PersistedAccessor<T> {
+  return createMockAccessor<T>(key, version);
+}
+
+/** Fire the handlers registered via on-server-started/stopped. */
+export interface ServerManagerTriggers {
+  _triggerStarted(workspacePath: string, port: number, pendingPrompt?: unknown): void;
+  _triggerStopped(workspacePath: string, isRestart: boolean): void;
+}
+
+/**
+ * Canned server-manager mock with the members shared by both agents
+ * (startServer resolves 8080, stop/restart succeed) plus trigger capture for
+ * the started/stopped callbacks. Pass agent-specific members via `extras` and
+ * cast the result to the concrete server-manager type at the call site.
+ */
+export function createMockServerManager(
+  extras: Record<string, unknown> = {}
+): ServerManagerTriggers & Record<string, unknown> {
+  let startedHandler:
+    | ((workspacePath: string, port: number, pendingPrompt?: unknown) => void)
+    | null = null;
+  let stoppedHandler: ((workspacePath: string, isRestart: boolean) => void) | null = null;
+
+  return {
+    startServer: vi.fn().mockResolvedValue(8080),
+    stopServer: vi.fn().mockResolvedValue({ success: true }),
+    restartServer: vi.fn().mockResolvedValue({ success: true, port: 8080 }),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    setMcpConfig: vi.fn(),
+    onServerStarted: vi.fn(
+      (cb: (workspacePath: string, port: number, pendingPrompt?: unknown) => void) => {
+        startedHandler = cb;
+        return vi.fn();
+      }
+    ),
+    onServerStopped: vi.fn((cb: (workspacePath: string, isRestart: boolean) => void) => {
+      stoppedHandler = cb;
+      return vi.fn();
+    }),
+    _triggerStarted(workspacePath: string, port: number, pendingPrompt?: unknown) {
+      startedHandler?.(workspacePath, port, pendingPrompt);
+    },
+    _triggerStopped(workspacePath: string, isRestart: boolean) {
+      stoppedHandler?.(workspacePath, isRestart);
+    },
+    ...extras,
+  };
+}

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -13,11 +13,13 @@ import type { AgentModuleProvider } from "../agent-module-provider";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../../shared/ipc";
 import type { OpenCodeServerManager } from "./server-manager";
 import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
-import type { DownloadDeps, ArchiveExtension } from "../../../utils/binary-download";
-import { createFileSystemMock } from "../../../boundaries/platform/filesystem.state-mock";
-import { createMockHttpClient } from "../../../boundaries/platform/http-client.state-mock";
-import { createArchiveExtractorMock } from "../../../boundaries/platform/archive-extractor.state-mock";
-import { createMockAccessor } from "../../../boundaries/platform/config.test-utils";
+import type { DownloadDeps } from "../../../utils/binary-download";
+import {
+  createBinaryConfig,
+  createDownloadDeps,
+  createMockServerManager as createServerManagerBase,
+  createVersionConfig,
+} from "../module-provider.test-utils";
 import { createMockPathProvider } from "../../../boundaries/platform/path-provider.test-utils";
 
 // =============================================================================
@@ -113,61 +115,13 @@ function createMockServerManager(): OpenCodeServerManager & {
   _triggerStarted: ServerStartedHandler;
   _triggerStopped: ServerStoppedHandler;
 } {
-  let startedHandler: ServerStartedHandler | null = null;
-  let stoppedHandler: ServerStoppedHandler | null = null;
-
-  return {
-    startServer: vi.fn().mockResolvedValue(8080),
-    stopServer: vi.fn().mockResolvedValue({ success: true }),
-    restartServer: vi.fn().mockResolvedValue({ success: true, port: 8080 }),
-    dispose: vi.fn().mockResolvedValue(undefined),
-    setMcpConfig: vi.fn(),
+  return createServerManagerBase({
     setMarkActiveHandler: vi.fn(),
     triggerWrapperStart: vi.fn(),
-    onServerStarted: vi.fn((cb: ServerStartedHandler) => {
-      startedHandler = cb;
-      return vi.fn();
-    }),
-    onServerStopped: vi.fn((cb: ServerStoppedHandler) => {
-      stoppedHandler = cb;
-      return vi.fn();
-    }),
-    _triggerStarted(workspacePath: string, port: number, pendingPrompt: unknown) {
-      startedHandler?.(workspacePath, port, pendingPrompt);
-    },
-    _triggerStopped(workspacePath: string, isRestart: boolean) {
-      stoppedHandler?.(workspacePath, isRestart);
-    },
-  } as unknown as OpenCodeServerManager & {
+  }) as unknown as OpenCodeServerManager & {
     _triggerStarted: ServerStartedHandler;
     _triggerStopped: ServerStoppedHandler;
   };
-}
-
-/**
- * Create mock download dependencies.
- */
-function createDownloadDeps(): DownloadDeps {
-  return {
-    httpClient: createMockHttpClient(),
-    fileSystemLayer: createFileSystemMock(),
-    archiveExtractor: createArchiveExtractorMock(),
-  };
-}
-
-/**
- * Create a binary config for OpenCode.
- */
-function createBinaryConfig() {
-  return {
-    name: "opencode" as const,
-    executablePath: "opencode",
-    archiveExtension: ".tar.gz" as ArchiveExtension,
-  };
-}
-
-function createVersionConfig(version = "1.0.223") {
-  return createMockAccessor("version.opencode", version);
 }
 
 /**
@@ -201,7 +155,7 @@ describe("OpenCode module provider", () => {
   let serverManager: ReturnType<typeof createMockServerManager>;
   let downloadDeps: DownloadDeps;
   let binaryConfig: ReturnType<typeof createBinaryConfig>;
-  let versionConfig: ReturnType<typeof createVersionConfig>;
+  let versionConfig: ReturnType<typeof createVersionConfig<string>>;
   let pathProvider: ReturnType<typeof createMockPathProvider>;
   let provider: AgentModuleProvider;
 
@@ -211,8 +165,8 @@ describe("OpenCode module provider", () => {
 
     serverManager = createMockServerManager();
     downloadDeps = createDownloadDeps();
-    binaryConfig = createBinaryConfig();
-    versionConfig = createVersionConfig("1.0.223");
+    binaryConfig = createBinaryConfig("opencode");
+    versionConfig = createVersionConfig("version.opencode", "1.0.223");
     pathProvider = createMockPathProvider();
 
     const deps: OpenCodeModuleProviderDeps = {

--- a/src/modules/agent-module/opencode/sdk-client.state-mock.ts
+++ b/src/modules/agent-module/opencode/sdk-client.state-mock.ts
@@ -29,6 +29,7 @@ import type {
   MatcherResult,
   MatcherImplementationsFor,
 } from "../../../test/state-mock";
+import { createSnapshot } from "../../../test/state-mock";
 // Re-export SDK types for convenience
 export type { Session, SdkEvent, SdkSessionStatus };
 
@@ -332,10 +333,7 @@ class SdkClientMockStateImpl implements SdkClientMockState {
   // ---- MockState Implementation ----
 
   snapshot(): Snapshot {
-    return {
-      __brand: "Snapshot" as const,
-      value: this.toString(),
-    };
+    return createSnapshot(this);
   }
 
   toString(): string {

--- a/src/modules/agent-module/opencode/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/opencode/wrapper.boundary.test.ts
@@ -11,12 +11,12 @@
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 import { join, resolve } from "node:path";
-import { writeFile, mkdir, chmod, access } from "node:fs/promises";
-import { constants } from "node:fs";
 import { createTempDir } from "../../../utils/testing/test-utils";
-import { executeScript } from "../wrapper-boundary-test-utils";
-
-const isWindows = process.platform === "win32";
+import {
+  assertCompiledScript,
+  createFakeAgentBinary,
+  executeScript,
+} from "../wrapper-boundary-test-utils";
 
 /**
  * Path to the compiled ch-opencode.cjs script.
@@ -53,10 +53,6 @@ function parseFakeOpencodeOutput(stdout: string): FakeOpencodeOutput | null {
  * @param opencodeDir Directory to create the fake binary in
  */
 async function createFakeOpencodeBinary(opencodeDir: string): Promise<string> {
-  await mkdir(opencodeDir, { recursive: true });
-
-  // Create a cross-platform Node.js fake binary that outputs JSON
-  const fakeScriptPath = join(opencodeDir, "opencode-fake.cjs");
   const fakeNodeContent = `#!/usr/bin/env node
 // Fake opencode binary for testing - outputs JSON for structured assertions
 const output = {
@@ -66,29 +62,12 @@ console.log(JSON.stringify(output));
 const exitCode = parseInt(process.env.OPENCODE_EXIT_CODE || "0", 10);
 process.exit(isNaN(exitCode) ? 0 : exitCode);
 `;
-  await writeFile(fakeScriptPath, fakeNodeContent);
-
-  // Create platform-specific wrapper
-  const fakeOpencodePath = join(opencodeDir, isWindows ? "opencode.cmd" : "opencode");
-
-  if (isWindows) {
-    // Windows: batch wrapper calling node with absolute path
-    const nodePath = process.execPath;
-    const batchContent = `@echo off
-"${nodePath}" "%~dp0opencode-fake.cjs" %*
-exit /b %ERRORLEVEL%
-`;
-    await writeFile(fakeOpencodePath, batchContent);
-  } else {
-    // Unix: shell wrapper calling node
-    const shellContent = `#!/bin/sh
-exec node "$(dirname "$0")/opencode-fake.cjs" "$@"
-`;
-    await writeFile(fakeOpencodePath, shellContent);
-    await chmod(fakeOpencodePath, 0o755);
-  }
-
-  return opencodeDir;
+  return createFakeAgentBinary({
+    dir: opencodeDir,
+    binaryName: "opencode",
+    scriptBody: fakeNodeContent,
+    windowsMode: "batch",
+  });
 }
 
 describe("ch-opencode.cjs boundary tests", () => {
@@ -97,13 +76,7 @@ describe("ch-opencode.cjs boundary tests", () => {
 
   // Check if the compiled script exists before running tests
   beforeAll(async () => {
-    try {
-      await access(COMPILED_SCRIPT_PATH, constants.R_OK);
-    } catch {
-      throw new Error(
-        `Compiled script not found at ${COMPILED_SCRIPT_PATH}. Run 'pnpm build:wrappers' first.`
-      );
-    }
+    await assertCompiledScript(COMPILED_SCRIPT_PATH);
   });
 
   beforeEach(async () => {

--- a/src/modules/agent-module/wrapper-boundary-test-utils.ts
+++ b/src/modules/agent-module/wrapper-boundary-test-utils.ts
@@ -1,4 +1,72 @@
 import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { writeFile, mkdir, chmod, access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { exec as pkgExec } from "@yao-pkg/pkg";
+
+/**
+ * Assert that a compiled wrapper exists (throws with a build hint otherwise).
+ * Call from beforeAll.
+ */
+export async function assertCompiledScript(compiledScriptPath: string): Promise<void> {
+  try {
+    await access(compiledScriptPath, constants.R_OK);
+  } catch {
+    throw new Error(
+      `Compiled script not found at ${compiledScriptPath}. Run 'pnpm build:wrappers' first.`
+    );
+  }
+}
+
+export interface FakeAgentBinaryOptions {
+  /** Directory to create the fake binary in (created recursively). */
+  readonly dir: string;
+  /** Binary name the wrapper discovers on PATH (e.g. "claude", "opencode"). */
+  readonly binaryName: string;
+  /** Node source of the fake binary (a JSON-echo script in practice). */
+  readonly scriptBody: string;
+  /**
+   * Platform wrapper used on Windows:
+   * - "exe": compile to a real .exe via pkg (works with shell:false spawns)
+   * - "batch": .cmd forwarding to node via %~dp0
+   * - "cmd-shim": .cmd embedding the absolute script path (mimics npm shims,
+   *   where %~dp0 can resolve to the caller's CWD)
+   * On Unix, all modes produce a sh shebang wrapper (chmod 755).
+   */
+  readonly windowsMode: "exe" | "batch" | "cmd-shim";
+}
+
+/**
+ * Create a fake agent binary: a Node script plus a platform wrapper that the
+ * compiled CodeHydra wrapper can discover and spawn.
+ *
+ * @returns The directory containing the fake binary (for PATH construction)
+ */
+export async function createFakeAgentBinary(options: FakeAgentBinaryOptions): Promise<string> {
+  const { dir, binaryName, scriptBody, windowsMode } = options;
+  await mkdir(dir, { recursive: true });
+
+  const fakeScriptPath = join(dir, `fake-${binaryName}.cjs`);
+  await writeFile(fakeScriptPath, scriptBody);
+
+  if (process.platform === "win32") {
+    if (windowsMode === "exe") {
+      await pkgExec([fakeScriptPath, "--target", "host", "--output", join(dir, binaryName)]);
+    } else if (windowsMode === "batch") {
+      const batchContent = `@echo off\n"${process.execPath}" "%~dp0fake-${binaryName}.cjs" %*\nexit /b %ERRORLEVEL%\n`;
+      await writeFile(join(dir, `${binaryName}.cmd`), batchContent);
+    } else {
+      const cmdContent = `@echo off\r\nnode "${fakeScriptPath}" %*\r\n`;
+      await writeFile(join(dir, `${binaryName}.cmd`), cmdContent);
+    }
+  } else {
+    const shellContent = `#!/bin/sh\nexec node "${fakeScriptPath}" "$@"\n`;
+    await writeFile(join(dir, binaryName), shellContent);
+    await chmod(join(dir, binaryName), 0o755);
+  }
+
+  return dir;
+}
 
 /**
  * Execute a compiled wrapper script and capture output.

--- a/src/modules/badge-module.integration.test.ts
+++ b/src/modules/badge-module.integration.test.ts
@@ -18,29 +18,15 @@ import {
   UpdateAgentStatusOperation,
   INTENT_UPDATE_AGENT_STATUS,
 } from "../intents/update-agent-status";
-import type { UpdateAgentStatusIntent } from "../intents/update-agent-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../intents/resolve-workspace";
-import type {
-  ResolveHookResult as ResolveWorkspaceHookResult,
-  ResolveHookInput as ResolveWorkspaceHookInput,
-} from "../intents/resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../intents/resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "../intents/resolve-project";
-import { EVENT_WORKSPACE_DELETED, INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
-import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../intents/delete-workspace";
+import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
-import type { Operation, OperationContext, HookContext } from "../intents/lib/operation";
-import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import type { IntentModule } from "../intents/lib/module";
+import {
+  createDeleteEventOperation,
+  createMinimalOperation,
+} from "../intents/lib/operation.test-utils";
+import { registerTestInfrastructure, updateStatusIntent } from "../intents/operations.test-utils";
 import { BadgeManager, createBadgeModule } from "./badge-module";
 import { createMockPlatformInfo } from "../boundaries/platform/platform-info.test-utils";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
@@ -55,7 +41,6 @@ import {
   type MockWindowManager,
 } from "../boundaries/shell/window-manager.test-utils";
 import type { ImageHandle } from "../boundaries/shell/image-types";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
 // =============================================================================
@@ -465,29 +450,6 @@ function createSimpleMockWindowManager(): {
   };
 }
 
-/**
- * Minimal delete operation that only emits EVENT_WORKSPACE_DELETED.
- * Used to trigger workspace:deleted events through the public dispatcher API
- * without needing the full DeleteWorkspaceOperation pipeline.
- */
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { started: true }> {
-  readonly id = "delete-workspace";
-
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
-    const event: WorkspaceDeletedEvent = {
-      type: EVENT_WORKSPACE_DELETED,
-      payload: {
-        projectId: "test-12345678" as ProjectId,
-        workspaceName: "ws" as WorkspaceName,
-        workspacePath: ctx.intent.payload.workspacePath ?? "",
-        projectPath: "/projects/test",
-      },
-    };
-    ctx.emit(event);
-    return { started: true };
-  }
-}
-
 // =============================================================================
 // Test Setup
 // =============================================================================
@@ -495,37 +457,6 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { start
 interface ModuleTestSetup {
   dispatcher: Dispatcher;
   appLayer: MockAppBoundary;
-}
-
-/**
- * Mock resolve module that provides workspace resolution for the
- * update-agent-status operation (replaces the old payload fields).
- * Uses workspacePath as-is to derive projectPath and workspaceName.
- */
-function createMockResolveModule(): IntentModule {
-  return {
-    name: "test-resolve",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ResolveWorkspaceHookInput;
-            return {
-              projectPath: "/projects/test",
-              workspaceName: workspacePath.split("/").pop() as WorkspaceName,
-            };
-          },
-        },
-      },
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveProjectHookResult> => {
-            return { projectId: "test-project" as ProjectId };
-          },
-        },
-      },
-    },
-  };
 }
 
 function createModuleTestSetup(): ModuleTestSetup {
@@ -537,9 +468,16 @@ function createModuleTestSetup(): ModuleTestSetup {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new MinimalDeleteOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, createDeleteEventOperation());
+
+  // Every workspace path resolves; workspaceName derives from the path basename.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: (workspacePath) => ({
+      projectPath: "/projects/test",
+      workspaceName: workspacePath.split("/").pop() as WorkspaceName,
+    }),
+    projects: () => ({ projectId: "test-project" as ProjectId }),
+  });
 
   const badgeModule = createBadgeModule({
     platformInfo,
@@ -548,25 +486,10 @@ function createModuleTestSetup(): ModuleTestSetup {
     windowManager: windowManager as unknown as WindowManager,
     logger: SILENT_LOGGER,
   });
-  const resolveModule = createMockResolveModule();
 
   dispatcher.registerModule(badgeModule);
-  dispatcher.registerModule(resolveModule);
 
   return { dispatcher, appLayer };
-}
-
-function updateStatusIntent(
-  workspacePath: string,
-  status: AggregatedAgentStatus
-): UpdateAgentStatusIntent {
-  return {
-    type: INTENT_UPDATE_AGENT_STATUS,
-    payload: {
-      workspacePath: workspacePath as WorkspacePath,
-      status,
-    },
-  };
 }
 
 // =============================================================================

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -174,22 +174,22 @@ class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, string 
   }
 }
 
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteHookResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<DeleteHookResult> {
-    const { payload } = ctx.intent;
-    const hookCtx: DeletePipelineHookInput = {
-      intent: ctx.intent,
-      projectPath: "/projects/test",
-      workspacePath: payload.workspacePath ?? "",
-      workspaceName: "test-workspace" as WorkspaceName,
-      active: false,
-    };
-    const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
-  }
+/** Runs the "delete" hook point with a canned delete-pipeline context. */
+function createMinimalDeleteOperation(): Operation<DeleteWorkspaceIntent, DeleteHookResult> {
+  return createMinimalOperation<DeleteWorkspaceIntent, DeleteHookResult>(
+    DELETE_WORKSPACE_OPERATION_ID,
+    "delete",
+    {
+      hookContext: (ctx): DeletePipelineHookInput => ({
+        intent: ctx.intent,
+        projectPath: "/projects/test",
+        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        workspaceName: "test-workspace" as WorkspaceName,
+        active: false,
+      }),
+      defaultResult: {},
+    }
+  );
 }
 
 // =============================================================================
@@ -859,7 +859,7 @@ describe("CodeServerModule", () => {
     it("deletes workspace file", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       await dispatcher.dispatch({
         type: "workspace:delete",
@@ -895,7 +895,7 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       // Should not throw
       const result = (await dispatcher.dispatch({
@@ -929,7 +929,7 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       await expect(
         dispatcher.dispatch({

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -15,15 +15,10 @@ import { createMockAccessor } from "../boundaries/platform/config.test-utils";
 import { createCreationModule, validateCloneUrl } from "./creation-module";
 import type { CreationModuleDeps } from "./creation-module";
 import type { IntentModule } from "../intents/lib/module";
-import type { DialogManager, DialogHandle } from "./dialog-manager";
+import { createMockDialogManager } from "./dialog-manager.state-mock";
+import type { MockDialogHandle } from "./dialog-manager.state-mock";
 import type { Dispatcher } from "../intents/lib/dispatcher";
-import type {
-  DialogConfig,
-  DialogSection,
-  DialogActionEvent,
-  DialogFieldChangeEvent,
-  DialogDismissEvent,
-} from "../shared/dialog-types";
+import type { DialogConfig, DialogSection } from "../shared/dialog-types";
 import type { ConfigAgentType } from "../boundaries/platform/config";
 import type { Project, ProjectId, WorkspaceName, BaseInfo } from "../shared/api/types";
 import type { AgentInfo } from "../shared/ipc";
@@ -73,91 +68,6 @@ const BASES_A: readonly BaseInfo[] = [
 
 const CLAUDE_AGENT: AgentInfo = { agent: "claude", label: "Claude Code", icon: "claude" };
 const OPENCODE_AGENT: AgentInfo = { agent: "opencode", label: "OpenCode", icon: "opencode" };
-
-// =============================================================================
-// Mock DialogManager (captures handles with emit helpers)
-// =============================================================================
-
-interface MockHandle {
-  id: string;
-  config: DialogConfig;
-  /** Every config this handle has seen (open + updates), in order. */
-  configs: DialogConfig[];
-  surface: string;
-  closed: boolean;
-  emitAction(actionId: string, data?: Record<string, string>): void;
-  emitChange(fieldId: string, data: Record<string, string>): void;
-  emitDismiss(): void;
-}
-
-function createMockDialogManager(): {
-  manager: DialogManager;
-  handles: MockHandle[];
-  panelHandles(): MockHandle[];
-  modalHandles(): MockHandle[];
-} {
-  const handles: MockHandle[] = [];
-  let nextId = 1;
-
-  const open = vi.fn((config: DialogConfig, options?: { surface?: string }) => {
-    const id = `dlg-test-${nextId++}`;
-    const actionListeners = new Set<(event: DialogActionEvent) => void>();
-    const changeListeners = new Set<(event: DialogFieldChangeEvent) => void>();
-    const dismissListeners = new Set<(event: DialogDismissEvent) => void>();
-    const mock: MockHandle = {
-      id,
-      config,
-      configs: [config],
-      surface: options?.surface ?? "modal",
-      closed: false,
-      emitAction(actionId, data = {}) {
-        for (const l of [...actionListeners]) l({ kind: "action", dialogId: id, actionId, data });
-      },
-      emitChange(fieldId, data) {
-        for (const l of [...changeListeners]) l({ kind: "change", dialogId: id, fieldId, data });
-      },
-      emitDismiss() {
-        for (const l of [...dismissListeners]) l({ kind: "dismiss", dialogId: id });
-      },
-    };
-    handles.push(mock);
-    const handle: DialogHandle = {
-      id,
-      update: (newConfig: DialogConfig) => {
-        mock.config = newConfig;
-        mock.configs.push(newConfig);
-      },
-      close: () => {
-        mock.closed = true;
-        actionListeners.clear();
-        changeListeners.clear();
-        dismissListeners.clear();
-      },
-      onEvent: (handler) => {
-        actionListeners.add(handler);
-        return () => actionListeners.delete(handler);
-      },
-      onChange: (handler) => {
-        changeListeners.add(handler);
-        return () => changeListeners.delete(handler);
-      },
-      onDismiss: (handler) => {
-        dismissListeners.add(handler);
-        return () => dismissListeners.delete(handler);
-      },
-      nextEvent: () => new Promise<DialogActionEvent>(() => {}),
-      closed: new Promise<void>(() => {}),
-    };
-    return handle;
-  });
-
-  return {
-    manager: { open } as unknown as DialogManager,
-    handles,
-    panelHandles: () => handles.filter((h) => h.surface === "panel"),
-    modalHandles: () => handles.filter((h) => h.surface === "modal"),
-  };
-}
 
 // =============================================================================
 // Mock Dispatcher (programmable per-intent results)
@@ -227,7 +137,7 @@ interface Setup {
   dispatcher: MockDispatcher;
   openUrl: ReturnType<typeof vi.fn>;
   emit(eventType: string, payload?: unknown): Promise<void>;
-  start(): Promise<MockHandle>;
+  start(): Promise<MockDialogHandle>;
 }
 
 function setup(options?: {
@@ -278,7 +188,7 @@ function setup(options?: {
     await flush();
   };
 
-  const start = async (): Promise<MockHandle> => {
+  const start = async (): Promise<MockDialogHandle> => {
     await emit(EVENT_APP_STARTED);
     const panel = dialogs.panelHandles().find((h) => !h.closed);
     expect(panel, "open panel session").toBeDefined();
@@ -289,7 +199,7 @@ function setup(options?: {
 }
 
 /** The currently open (non-closed) panel session. */
-function currentPanel(s: Setup): MockHandle {
+function currentPanel(s: Setup): MockDialogHandle {
   const panel = s.dialogs.panelHandles().find((h) => !h.closed);
   expect(panel, "open panel session").toBeDefined();
   return panel!;
@@ -459,7 +369,7 @@ describe("CreationModule", () => {
   });
 
   describe("validation and Create gating", () => {
-    async function startValid(s: Setup): Promise<MockHandle> {
+    async function startValid(s: Setup): Promise<MockDialogHandle> {
       const panel = await s.start();
       await s.emit(EVENT_BASES_UPDATED, {
         projectId: PROJECT_A.id,
@@ -515,7 +425,7 @@ describe("CreationModule", () => {
   });
 
   describe("submit", () => {
-    async function readyPanel(s: Setup): Promise<MockHandle> {
+    async function readyPanel(s: Setup): Promise<MockDialogHandle> {
       const panel = await s.start();
       await s.emit(EVENT_BASES_UPDATED, {
         projectId: PROJECT_A.id,

--- a/src/modules/deletion-dialog-module.integration.test.ts
+++ b/src/modules/deletion-dialog-module.integration.test.ts
@@ -19,10 +19,9 @@ import {
 } from "../intents/delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { createDeletionDialogModule } from "./deletion-dialog-module";
+import { createMockDialogManager } from "./dialog-manager.state-mock";
 import type { IntentModule } from "../intents/lib/module";
-import type { DialogManager, DialogHandle } from "./dialog-manager";
 import type { Dispatcher } from "../intents/lib/dispatcher";
-import type { DialogConfig, DialogUserEvent } from "../shared/dialog-types";
 import type { DeletionProgress } from "../shared/api/types";
 import type { WorkspacePath } from "../shared/ipc";
 import type { WorkspaceName, ProjectId } from "../shared/api/types";
@@ -36,74 +35,6 @@ const WS_PATH_B = "/projects/workspace-b" as WorkspacePath;
 const WS_NAME_A = "workspace-a" as WorkspaceName;
 const WS_NAME_B = "workspace-b" as WorkspaceName;
 const PROJECT_ID = "test-project-12345678" as ProjectId;
-
-// =============================================================================
-// Mock DialogManager
-// =============================================================================
-
-interface MockHandle {
-  id: string;
-  config: DialogConfig;
-  closed: boolean;
-  eventListeners: Set<(event: DialogUserEvent) => void>;
-  emitEvent(event: DialogUserEvent): void;
-  emitDismiss(): void;
-}
-
-interface MockDialogManager {
-  handles: MockHandle[];
-  lastHandle: MockHandle | null;
-  open: ReturnType<typeof vi.fn>;
-  routeEvent: () => void;
-}
-
-function createMockDialogManager(): MockDialogManager {
-  const handles: MockHandle[] = [];
-  return {
-    handles,
-    get lastHandle() {
-      return handles[handles.length - 1] ?? null;
-    },
-    open: vi.fn((config: DialogConfig) => {
-      const listeners = new Set<(event: DialogUserEvent) => void>();
-      const dismissListeners = new Set<() => void>();
-      const handle: MockHandle = {
-        id: `dlg-test-${handles.length + 1}`,
-        config,
-        closed: false,
-        eventListeners: listeners,
-        emitEvent(event) {
-          for (const l of listeners) l(event);
-        },
-        emitDismiss() {
-          for (const l of dismissListeners) l();
-        },
-      };
-      handles.push(handle);
-      return {
-        id: handle.id,
-        update: vi.fn((newConfig: DialogConfig) => {
-          handle.config = newConfig;
-        }),
-        close: vi.fn(() => {
-          handle.closed = true;
-        }),
-        onEvent: vi.fn((handler: (event: DialogUserEvent) => void) => {
-          listeners.add(handler);
-          return () => listeners.delete(handler);
-        }),
-        onChange: vi.fn(() => () => {}),
-        onDismiss: vi.fn((handler: () => void) => {
-          dismissListeners.add(handler);
-          return () => dismissListeners.delete(handler);
-        }),
-        nextEvent: vi.fn(),
-        closed: new Promise<void>(() => {}),
-      } as DialogHandle;
-    }),
-    routeEvent() {},
-  } as unknown as MockDialogManager;
-}
 
 // =============================================================================
 // Mock Dispatcher
@@ -156,7 +87,7 @@ function createTestSetup(): TestSetup {
   const dispatcher = createMockDispatcher();
 
   const module = createDeletionDialogModule({
-    dialogManager: dialogManager as unknown as DialogManager,
+    dialogManager: dialogManager.manager,
     dispatcher: dispatcher as unknown as Dispatcher,
     logger: SILENT_LOGGER,
   });
@@ -205,7 +136,7 @@ describe("DeletionDialogModule", () => {
     // Fire deletion progress for workspace A
     await fireProgress(makeProgress());
 
-    expect(dialogManager.open).toHaveBeenCalledTimes(1);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(1);
     expect(dialogManager.lastHandle).not.toBeNull();
     expect(dialogManager.lastHandle!.closed).toBe(false);
   });
@@ -219,7 +150,7 @@ describe("DeletionDialogModule", () => {
     // Fire deletion progress for workspace B (not active)
     await fireProgress(makeProgress({ workspacePath: WS_PATH_B, workspaceName: WS_NAME_B }));
 
-    expect(dialogManager.open).not.toHaveBeenCalled();
+    expect(dialogManager.manager.open).not.toHaveBeenCalled();
   });
 
   it("should update existing dialog on progress update", async () => {
@@ -229,7 +160,7 @@ describe("DeletionDialogModule", () => {
     await fireSwitched(WS_PATH_A);
     await fireProgress(makeProgress());
 
-    expect(dialogManager.open).toHaveBeenCalledTimes(1);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(1);
     const handle = dialogManager.lastHandle!;
 
     // Fire another progress event
@@ -244,7 +175,7 @@ describe("DeletionDialogModule", () => {
     await fireProgress(updatedProgress);
 
     // Should not open a new dialog, just update
-    expect(dialogManager.open).toHaveBeenCalledTimes(1);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(1);
     // The config should have been updated (verify via the mock handle's config)
     expect(handle.config).toBeDefined();
   });
@@ -339,7 +270,7 @@ describe("DeletionDialogModule", () => {
     expect(handleA.closed).toBe(true);
 
     // New dialog should be opened for workspace B
-    expect(dialogManager.open).toHaveBeenCalledTimes(2);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(2);
     const handleB = dialogManager.lastHandle!;
     expect(handleB.closed).toBe(false);
   });
@@ -361,7 +292,7 @@ describe("DeletionDialogModule", () => {
     expect(handle.closed).toBe(true);
 
     // No new dialog should be opened
-    expect(dialogManager.open).toHaveBeenCalledTimes(1);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(1);
   });
 
   it("should dispatch delete intent on retry", async () => {
@@ -506,6 +437,6 @@ describe("DeletionDialogModule", () => {
 
     // Switching back to workspace A should not re-open dialog (progress was cleaned up)
     await fireSwitched(WS_PATH_A);
-    expect(dialogManager.open).toHaveBeenCalledTimes(1);
+    expect(dialogManager.manager.open).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/dialog-manager.state-mock.ts
+++ b/src/modules/dialog-manager.state-mock.ts
@@ -1,0 +1,191 @@
+/**
+ * Behavioral mock for DialogManager/DialogHandle.
+ *
+ * Simulates the contract in `dialog-manager.ts`: `manager.open()` returns a
+ * DialogHandle whose listeners tests fire via the captured MockDialogHandle's
+ * emit helpers. `update`/`close` are tracked (config history, closed flag),
+ * `closed` resolves on close(), and `nextEvent()` settles on the next action
+ * or dismiss — mirroring the real handle.
+ */
+
+import { vi } from "vitest";
+import type { DialogManager, DialogHandle } from "./dialog-manager";
+import type {
+  DialogConfig,
+  DialogSurface,
+  DialogUserEvent,
+  DialogActionEvent,
+  DialogFieldChangeEvent,
+  DialogDismissEvent,
+} from "../shared/dialog-types";
+
+/**
+ * Test-side view of an open dialog: latest/full config history, surface,
+ * closed flag, the handle given to the module under test, and emit helpers
+ * that fire the handle's listeners.
+ */
+export interface MockDialogHandle {
+  readonly id: string;
+  /** Latest config (from open or the last update). */
+  config: DialogConfig;
+  /** Every config this handle has seen (open + updates), in order. */
+  readonly configs: DialogConfig[];
+  readonly surface: DialogSurface;
+  closed: boolean;
+  /** The DialogHandle handed to the module under test (methods are spies). */
+  readonly handle: DialogHandle;
+  /** Fire an action event (button click) with an optional field-values snapshot. */
+  emitAction(actionId: string, data?: Record<string, string>): void;
+  /** Fire a field-change event. */
+  emitChange(fieldId: string, data: Record<string, string>): void;
+  /** Fire a dismiss event. */
+  emitDismiss(): void;
+  /** Route a raw user event by kind, like the real handle's emit(). */
+  emitEvent(event: DialogUserEvent): void;
+}
+
+export interface MockDialogManager {
+  /** Manager to inject into the module under test. `open` is a vi.fn spy. */
+  readonly manager: DialogManager;
+  /** Every opened dialog, in order. */
+  readonly handles: MockDialogHandle[];
+  /** The most recently opened dialog, or null. */
+  readonly lastHandle: MockDialogHandle | null;
+  /** Opened dialogs hosted in the panel surface. */
+  panelHandles(): MockDialogHandle[];
+  /** Opened dialogs hosted in the modal surface. */
+  modalHandles(): MockDialogHandle[];
+}
+
+/**
+ * Create a behavioral DialogManager mock. Each `open()` captures a
+ * MockDialogHandle in `handles` for inspection and event emission.
+ */
+export function createMockDialogManager(): MockDialogManager {
+  const handles: MockDialogHandle[] = [];
+  let nextId = 1;
+
+  const open = vi.fn((config: DialogConfig, options?: { surface?: DialogSurface }) => {
+    const mock = createMockDialogHandle(`dlg-test-${nextId++}`, config, options?.surface);
+    handles.push(mock);
+    return mock.handle;
+  });
+
+  const manager = { open, routeEvent: vi.fn() } as unknown as DialogManager;
+
+  return {
+    manager,
+    handles,
+    get lastHandle() {
+      return handles[handles.length - 1] ?? null;
+    },
+    panelHandles: () => handles.filter((h) => h.surface === "panel"),
+    modalHandles: () => handles.filter((h) => h.surface === "modal"),
+  };
+}
+
+/**
+ * Create a standalone mock handle (for tests that stub the manager themselves,
+ * e.g. a manager that always returns one handle).
+ */
+export function createMockDialogHandle(
+  id: string,
+  config: DialogConfig = { sections: [] },
+  surface: DialogSurface = "modal"
+): MockDialogHandle {
+  const actionListeners = new Set<(event: DialogActionEvent) => void>();
+  const changeListeners = new Set<(event: DialogFieldChangeEvent) => void>();
+  const dismissListeners = new Set<(event: DialogDismissEvent) => void>();
+
+  let resolveClosed!: () => void;
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const handle: DialogHandle = {
+    id,
+    closed: closedPromise,
+    update: vi.fn((newConfig: DialogConfig) => {
+      if (mock.closed) return;
+      mock.config = newConfig;
+      mock.configs.push(newConfig);
+    }),
+    close: vi.fn(() => {
+      if (mock.closed) return;
+      mock.closed = true;
+      resolveClosed();
+      actionListeners.clear();
+      changeListeners.clear();
+      dismissListeners.clear();
+    }),
+    onEvent: vi.fn((handler: (event: DialogActionEvent) => void) => {
+      actionListeners.add(handler);
+      return () => {
+        actionListeners.delete(handler);
+      };
+    }),
+    onChange: vi.fn((handler: (event: DialogFieldChangeEvent) => void) => {
+      changeListeners.add(handler);
+      return () => {
+        changeListeners.delete(handler);
+      };
+    }),
+    onDismiss: vi.fn((handler: (event: DialogDismissEvent) => void) => {
+      dismissListeners.add(handler);
+      return () => {
+        dismissListeners.delete(handler);
+      };
+    }),
+    nextEvent: vi.fn((timeoutMs?: number) => {
+      const eventPromise = new Promise<DialogActionEvent | DialogDismissEvent>((resolve) => {
+        const settle = (event: DialogActionEvent | DialogDismissEvent): void => {
+          unsubAction();
+          unsubDismiss();
+          resolve(event);
+        };
+        const unsubAction = handle.onEvent(settle);
+        const unsubDismiss = handle.onDismiss(settle);
+      });
+      if (timeoutMs === undefined) return eventPromise;
+      return Promise.race([
+        eventPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`Dialog ${id}: no response within ${timeoutMs}ms`)),
+            timeoutMs
+          )
+        ),
+      ]);
+    }),
+  };
+
+  const mock: MockDialogHandle = {
+    id,
+    config,
+    configs: [config],
+    surface,
+    closed: false,
+    handle,
+    emitAction(actionId, data = {}) {
+      mock.emitEvent({ kind: "action", dialogId: id, actionId, data });
+    },
+    emitChange(fieldId, data) {
+      mock.emitEvent({ kind: "change", dialogId: id, fieldId, data });
+    },
+    emitDismiss() {
+      mock.emitEvent({ kind: "dismiss", dialogId: id });
+    },
+    emitEvent(event) {
+      // Mirror the real handle's kind routing (absent kind = action).
+      if (event.kind === "change") {
+        for (const listener of [...changeListeners]) listener(event);
+      } else if (event.kind === "dismiss") {
+        for (const listener of [...dismissListeners]) listener(event);
+      } else if (event.kind === "action" || event.kind === undefined) {
+        for (const listener of [...actionListeners]) listener(event);
+      }
+    },
+  };
+
+  return mock;
+}

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -33,47 +33,12 @@ import { createMockViewManager } from "../boundaries/shell/view-manager.test-uti
 import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { DialogMessageBoxOptions } from "../boundaries/shell/dialog";
 import type { HookContext } from "../intents/lib/operation";
-import type { DialogHandle } from "./dialog-manager";
-import type { DialogUserEvent, DialogConfig } from "../shared/dialog-types";
+import { createMockDialogHandle } from "./dialog-manager.state-mock";
+import type { DialogConfig } from "../shared/dialog-types";
 
 // =============================================================================
 // Helpers
 // =============================================================================
-
-function createMockHandle(): DialogHandle & {
-  _emitEvent(event: DialogUserEvent): void;
-  _emitDismiss(): void;
-} {
-  const listeners = new Set<(event: DialogUserEvent) => void>();
-  const dismissListeners = new Set<() => void>();
-  let closedResolve!: () => void;
-  const closedPromise = new Promise<void>((resolve) => {
-    closedResolve = resolve;
-  });
-
-  return {
-    id: "dlg-test",
-    closed: closedPromise,
-    update: vi.fn(),
-    close: vi.fn(() => closedResolve()),
-    onEvent: vi.fn((handler) => {
-      listeners.add(handler);
-      return () => listeners.delete(handler);
-    }),
-    onChange: vi.fn(() => () => {}),
-    onDismiss: vi.fn((handler: () => void) => {
-      dismissListeners.add(handler);
-      return () => dismissListeners.delete(handler);
-    }),
-    nextEvent: vi.fn(),
-    _emitEvent(event: DialogUserEvent) {
-      for (const listener of listeners) listener(event);
-    },
-    _emitDismiss() {
-      for (const listener of dismissListeners) listener();
-    },
-  };
-}
 
 function defaultReadFile(path: string): Promise<string> {
   if (path === "/logs/test-session.log") return Promise.resolve("test log content\nline 2");
@@ -89,7 +54,7 @@ interface SetupOverrides {
 }
 
 function setup(overrides?: SetupOverrides) {
-  const handle = createMockHandle();
+  const handle = createMockDialogHandle("dlg-test");
   const boundary = createMockPostHogBoundary();
   const logger = createMockLogger();
   const exits: number[] = [];
@@ -99,7 +64,7 @@ function setup(overrides?: SetupOverrides) {
 
   const deps: ErrorReportModuleDeps = {
     dialogManager: {
-      open: vi.fn().mockReturnValue(handle),
+      open: vi.fn().mockReturnValue(handle.handle),
       routeEvent: vi.fn(),
     } as unknown as ErrorReportModuleDeps["dialogManager"],
     fileSystem: { readFile: vi.fn().mockImplementation(defaultReadFile) },
@@ -206,7 +171,7 @@ describe("ErrorReportModule — bug report dialog", () => {
   it("reads logs and dispatches bug-report:submit on 'send'", async () => {
     const { module, deps, handle } = setup();
     await emitKey(module, "b");
-    handle._emitEvent({
+    handle.emitEvent({
       dialogId: "dlg-test",
       actionId: "send",
       data: { description: "It broke" },
@@ -223,22 +188,22 @@ describe("ErrorReportModule — bug report dialog", () => {
         })
       );
     });
-    expect(handle.close).toHaveBeenCalled();
+    expect(handle.handle.close).toHaveBeenCalled();
   });
 
   it("closes without dispatching on 'cancel'", async () => {
     const { module, deps, handle } = setup();
     await emitKey(module, "b");
-    handle._emitEvent({ dialogId: "dlg-test", actionId: "cancel" });
-    expect(handle.close).toHaveBeenCalled();
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "cancel" });
+    expect(handle.handle.close).toHaveBeenCalled();
     expect(deps.dispatcher.dispatch).not.toHaveBeenCalled();
   });
 
   it("Escape (dismiss) discards the draft like Cancel and allows reopening", async () => {
     const { module, deps, handle } = setup();
     await emitKey(module, "b");
-    handle._emitDismiss();
-    expect(handle.close).toHaveBeenCalled();
+    handle.emitDismiss();
+    expect(handle.handle.close).toHaveBeenCalled();
     expect(deps.dispatcher.dispatch).not.toHaveBeenCalled();
 
     // The active-handle guard is cleared — 'b' opens a fresh dialog.
@@ -254,7 +219,7 @@ describe("ErrorReportModule — bug report dialog", () => {
       return Promise.reject(new Error("ENOENT"));
     });
     await emitKey(module, "b");
-    handle._emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
 
     await vi.waitFor(() => {
       expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -267,7 +232,7 @@ describe("ErrorReportModule — bug report dialog", () => {
     const { module, deps, handle } = setup();
     (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("ENOENT"));
     await emitKey(module, "b");
-    handle._emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
 
     await vi.waitFor(() => {
       expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(

--- a/src/modules/local-project-module.integration.test.ts
+++ b/src/modules/local-project-module.integration.test.ts
@@ -52,6 +52,7 @@ import type { ProjectId } from "../shared/api/types";
 import type { HookContext, ResolvedHooks, HookResult } from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 import { createFileSystemMock, directory } from "../boundaries/platform/filesystem.state-mock";
+import { createMockDialogManager } from "./dialog-manager.state-mock";
 import { projectDirName } from "../boundaries/platform/paths";
 import nodePath from "path";
 
@@ -66,97 +67,6 @@ const PROJECTS_DIR = "/test/app-data/projects";
 // =============================================================================
 // Mock Factories
 // =============================================================================
-
-interface MockDialogHandle {
-  id: string;
-  config: unknown;
-  closed: boolean;
-  eventListeners: Array<(event: { dialogId: string; actionId: string }) => void>;
-  close(): void;
-  nextEvent(): Promise<{ dialogId: string; actionId?: string; kind?: string }>;
-  onEvent(handler: (event: { dialogId: string; actionId: string }) => void): () => void;
-  onDismiss(handler: () => void): () => void;
-  emitEvent(event: { dialogId: string; actionId: string }): void;
-  emitDismiss(): void;
-  readonly closed_promise: Promise<void>;
-}
-
-function createMockDialogManager(): {
-  dialogManager: LocalProjectModuleDeps["dialogManager"];
-  handles: MockDialogHandle[];
-  lastHandle: MockDialogHandle | null;
-} {
-  const handles: MockDialogHandle[] = [];
-  const state = { lastHandle: null as MockDialogHandle | null };
-
-  const dialogManager = {
-    open: vi.fn().mockImplementation((config: unknown) => {
-      const listeners: Array<(event: { dialogId: string; actionId: string }) => void> = [];
-      const dismissListeners: Array<() => void> = [];
-      let resolveClosed: () => void;
-      const closedPromise = new Promise<void>((resolve) => {
-        resolveClosed = resolve;
-      });
-
-      const handle: MockDialogHandle = {
-        id: `dlg-${handles.length + 1}`,
-        config,
-        closed: false,
-        eventListeners: listeners,
-        close() {
-          this.closed = true;
-          resolveClosed();
-        },
-        nextEvent() {
-          // Mirrors DialogHandle.nextEvent: settles on an action OR a dismiss.
-          return new Promise((resolve) => {
-            listeners.push((event) => resolve(event));
-            dismissListeners.push(() => resolve({ dialogId: handle.id, kind: "dismiss" }));
-          });
-        },
-        onEvent(handler: (event: { dialogId: string; actionId: string }) => void) {
-          listeners.push(handler);
-          return () => {
-            const idx = listeners.indexOf(handler);
-            if (idx >= 0) listeners.splice(idx, 1);
-          };
-        },
-        onDismiss(handler: () => void) {
-          dismissListeners.push(handler);
-          return () => {
-            const idx = dismissListeners.indexOf(handler);
-            if (idx >= 0) dismissListeners.splice(idx, 1);
-          };
-        },
-        emitEvent(event: { dialogId: string; actionId: string }) {
-          for (const listener of [...listeners]) {
-            listener(event);
-          }
-        },
-        emitDismiss() {
-          for (const listener of [...dismissListeners]) {
-            listener();
-          }
-        },
-        get closed_promise() {
-          return closedPromise;
-        },
-      };
-      handles.push(handle);
-      state.lastHandle = handle;
-      return handle;
-    }),
-    routeEvent() {},
-  } as unknown as LocalProjectModuleDeps["dialogManager"];
-
-  return {
-    dialogManager,
-    handles,
-    get lastHandle() {
-      return state.lastHandle;
-    },
-  };
-}
 
 function createMockDeps(fsOverrides?: Parameters<typeof createFileSystemMock>[0]): {
   deps: LocalProjectModuleDeps;
@@ -188,7 +98,7 @@ function createMockDeps(fsOverrides?: Parameters<typeof createFileSystemMock>[0]
       projectsDir: PROJECTS_DIR,
       fs,
       gitWorktreeProvider,
-      dialogManager: dialog.dialogManager,
+      dialogManager: dialog.manager,
       gitClient,
     },
     fs,
@@ -795,7 +705,7 @@ describe("LocalProjectModule Integration", () => {
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({});
-      expect(dialogManager.dialogManager.open).not.toHaveBeenCalled();
+      expect(dialogManager.manager.open).not.toHaveBeenCalled();
     });
 
     it("skips when project is already open", async () => {
@@ -903,7 +813,7 @@ describe("LocalProjectModule Integration", () => {
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({});
-      expect(dialogManager.dialogManager.open).not.toHaveBeenCalled();
+      expect(dialogManager.manager.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/mcp-server.boundary.test.ts
+++ b/src/modules/mcp-server.boundary.test.ts
@@ -4,7 +4,6 @@
  * These tests verify actual HTTP transport behavior using real SDK and HTTP.
  */
 
-import { createServer } from "node:net";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { McpServer, createDefaultMcpServer } from "./mcp-module";
 import { createMockLogger } from "../boundaries/platform/logging";
@@ -12,74 +11,11 @@ import { delay } from "@shared/test-fixtures";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockDispatcher as createBaseMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import type { Intent } from "../intents/lib/types";
-import type { OperationContext, Operation } from "../intents/lib/operation";
-import {
-  INTENT_GET_WORKSPACE_STATUS,
-  GET_WORKSPACE_STATUS_OPERATION_ID,
-} from "../intents/get-workspace-status";
-import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "../intents/get-metadata";
-import { INTENT_SET_METADATA, SET_METADATA_OPERATION_ID } from "../intents/set-metadata";
-import {
-  INTENT_GET_AGENT_SESSION,
-  GET_AGENT_SESSION_OPERATION_ID,
-} from "../intents/get-agent-session";
-import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../intents/restart-agent";
-import {
-  INTENT_RESOLVE_WORKSPACE,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-} from "../intents/resolve-workspace";
-import {
-  INTENT_HIBERNATE_WORKSPACE,
-  HIBERNATE_WORKSPACE_OPERATION_ID,
-} from "../intents/hibernate-workspace";
-import { INTENT_WAKE_WORKSPACE, WAKE_WORKSPACE_OPERATION_ID } from "../intents/wake-workspace";
-import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../intents/list-projects";
-import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
-import {
-  INTENT_DELETE_WORKSPACE,
-  DELETE_WORKSPACE_OPERATION_ID,
-} from "../intents/delete-workspace";
-import { INTENT_VSCODE_COMMAND, VSCODE_COMMAND_OPERATION_ID } from "../intents/vscode-command";
-import {
-  INTENT_VSCODE_SHOW_MESSAGE,
-  VSCODE_SHOW_MESSAGE_OPERATION_ID,
-} from "../intents/vscode-show-message";
-
-/**
- * Find a free port for testing.
- */
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address();
-      if (addr && typeof addr === "object") {
-        const port = addr.port;
-        server.close(() => resolve(port));
-      } else {
-        reject(new Error("Could not get port"));
-      }
-    });
-    server.on("error", reject);
-  });
-}
-
-/**
- * Create a capturing operation that records intents and returns a mock result.
- */
-function createCapturingOperation<TIntent extends Intent = Intent, TResult = void>(
-  operationId: string,
-  capturedIntents: Intent[],
-  result: TResult
-): Operation<TIntent, TResult> {
-  return {
-    id: operationId,
-    async execute(ctx: OperationContext<TIntent>): Promise<TResult> {
-      capturedIntents.push(ctx.intent);
-      return result;
-    },
-  };
-}
+import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
+import { INTENT_HIBERNATE_WORKSPACE } from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE } from "../intents/wake-workspace";
+import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
+import { createMockToolOperations, findFreePort } from "./mcp-server.test-utils";
 
 /**
  * Create a Dispatcher with mock operations registered for all MCP tool intents.
@@ -87,77 +23,11 @@ function createCapturingOperation<TIntent extends Intent = Intent, TResult = voi
  */
 function createMockDispatcher(): { dispatcher: Dispatcher; capturedIntents: Intent[] } {
   const dispatcher = createBaseMockDispatcher();
-  const capturedIntents: Intent[] = [];
-
-  dispatcher.registerOperation(
-    INTENT_GET_WORKSPACE_STATUS,
-    createCapturingOperation(GET_WORKSPACE_STATUS_OPERATION_ID, capturedIntents, {
-      isDirty: false,
-      unmergedCommits: 0,
-      agent: { type: "none" as const },
-    })
-  );
-  dispatcher.registerOperation(
-    INTENT_GET_METADATA,
-    createCapturingOperation(GET_METADATA_OPERATION_ID, capturedIntents, { base: "main" })
-  );
-  dispatcher.registerOperation(
-    INTENT_SET_METADATA,
-    createCapturingOperation(SET_METADATA_OPERATION_ID, capturedIntents, undefined as void)
-  );
-  dispatcher.registerOperation(
-    INTENT_GET_AGENT_SESSION,
-    createCapturingOperation(GET_AGENT_SESSION_OPERATION_ID, capturedIntents, null)
-  );
-  dispatcher.registerOperation(
-    INTENT_RESTART_AGENT,
-    createCapturingOperation(RESTART_AGENT_OPERATION_ID, capturedIntents, 14001)
-  );
-  dispatcher.registerOperation(
-    INTENT_LIST_PROJECTS,
-    createCapturingOperation(LIST_PROJECTS_OPERATION_ID, capturedIntents, [])
-  );
-  dispatcher.registerOperation(
-    INTENT_OPEN_WORKSPACE,
-    createCapturingOperation(OPEN_WORKSPACE_OPERATION_ID, capturedIntents, {
-      name: "test",
-      path: "/path",
-    })
-  );
-  dispatcher.registerOperation(
-    INTENT_DELETE_WORKSPACE,
-    createCapturingOperation(DELETE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
-  );
-  dispatcher.registerOperation(
-    INTENT_RESOLVE_WORKSPACE,
-    createCapturingOperation(RESOLVE_WORKSPACE_OPERATION_ID, capturedIntents, {
-      projectPath: "/home/user/projects/my-app",
-      workspaceName: "feature-branch",
-      active: false,
-    })
-  );
-  dispatcher.registerOperation(
-    INTENT_HIBERNATE_WORKSPACE,
-    createCapturingOperation(HIBERNATE_WORKSPACE_OPERATION_ID, capturedIntents, { started: true })
-  );
-  dispatcher.registerOperation(
-    INTENT_WAKE_WORKSPACE,
-    createCapturingOperation(WAKE_WORKSPACE_OPERATION_ID, capturedIntents, {
-      name: "test",
-      path: "/path",
-      branch: "main",
-      metadata: {},
-    })
-  );
-  dispatcher.registerOperation(
-    INTENT_VSCODE_COMMAND,
-    createCapturingOperation(VSCODE_COMMAND_OPERATION_ID, capturedIntents, undefined)
-  );
-  dispatcher.registerOperation(
-    INTENT_VSCODE_SHOW_MESSAGE,
-    createCapturingOperation(VSCODE_SHOW_MESSAGE_OPERATION_ID, capturedIntents, null)
-  );
-
+  const { capturedIntents } = createMockToolOperations(dispatcher, {
+    getAgentSession: null,
+    openWorkspace: { name: "test", path: "/path" },
+    wake: { name: "test", path: "/path", branch: "main", metadata: {} },
+  });
   return { dispatcher, capturedIntents };
 }
 

--- a/src/modules/mcp-server.test-utils.ts
+++ b/src/modules/mcp-server.test-utils.ts
@@ -1,0 +1,242 @@
+/**
+ * Shared test utilities for the MCP server unit and boundary tests.
+ *
+ * Registers canned mock operations for every MCP tool intent on a dispatcher,
+ * capturing dispatched intents for assertions. The delete-workspace operation
+ * is the event-emitting variant: workspace_delete waits for a terminal
+ * deletion-progress event to learn the real outcome, and `deleteControl` lets
+ * tests pick success / blocked / preflight-reject behavior.
+ */
+
+import { createServer } from "node:net";
+import { vi } from "vitest";
+import type { Dispatcher } from "../intents/lib/dispatcher";
+import type { Intent } from "../intents/lib/types";
+import type { Operation, OperationContext } from "../intents/lib/operation";
+import { type ProjectId, type DeletionProgress } from "../shared/api/types";
+import {
+  INTENT_GET_WORKSPACE_STATUS,
+  GET_WORKSPACE_STATUS_OPERATION_ID,
+} from "../intents/get-workspace-status";
+import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "../intents/get-metadata";
+import { INTENT_SET_METADATA, SET_METADATA_OPERATION_ID } from "../intents/set-metadata";
+import {
+  INTENT_GET_AGENT_SESSION,
+  GET_AGENT_SESSION_OPERATION_ID,
+} from "../intents/get-agent-session";
+import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../intents/restart-agent";
+import {
+  INTENT_RESOLVE_WORKSPACE,
+  RESOLVE_WORKSPACE_OPERATION_ID,
+} from "../intents/resolve-workspace";
+import {
+  INTENT_HIBERNATE_WORKSPACE,
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+} from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE, WAKE_WORKSPACE_OPERATION_ID } from "../intents/wake-workspace";
+import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../intents/list-projects";
+import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
+import {
+  INTENT_DELETE_WORKSPACE,
+  DELETE_WORKSPACE_OPERATION_ID,
+  EVENT_WORKSPACE_DELETION_PROGRESS,
+  type DeleteWorkspaceIntent,
+} from "../intents/delete-workspace";
+import { INTENT_VSCODE_COMMAND, VSCODE_COMMAND_OPERATION_ID } from "../intents/vscode-command";
+import {
+  INTENT_VSCODE_SHOW_MESSAGE,
+  VSCODE_SHOW_MESSAGE_OPERATION_ID,
+} from "../intents/vscode-show-message";
+
+/**
+ * Find a free port for testing.
+ */
+export async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        const port = addr.port;
+        server.close(() => resolve(port));
+      } else {
+        reject(new Error("Could not get port"));
+      }
+    });
+    server.on("error", reject);
+  });
+}
+
+/** Controls the mock delete-workspace operation's behavior. */
+export interface DeleteControl {
+  mode: "success" | "blocked" | "reject";
+  blockingProcesses?: ReadonlyArray<{ pid: number; name: string }>;
+}
+
+const TOOL_OPERATIONS = {
+  getStatus: {
+    intent: INTENT_GET_WORKSPACE_STATUS,
+    operationId: GET_WORKSPACE_STATUS_OPERATION_ID,
+    result: { isDirty: false, unmergedCommits: 0, agent: { type: "none" as const } } as unknown,
+  },
+  getMetadata: {
+    intent: INTENT_GET_METADATA,
+    operationId: GET_METADATA_OPERATION_ID,
+    result: { base: "main" } as unknown,
+  },
+  setMetadata: {
+    intent: INTENT_SET_METADATA,
+    operationId: SET_METADATA_OPERATION_ID,
+    result: undefined as unknown,
+  },
+  getAgentSession: {
+    intent: INTENT_GET_AGENT_SESSION,
+    operationId: GET_AGENT_SESSION_OPERATION_ID,
+    result: { port: 14001, sessionId: "test-session" } as unknown,
+  },
+  restartAgent: {
+    intent: INTENT_RESTART_AGENT,
+    operationId: RESTART_AGENT_OPERATION_ID,
+    result: 14001 as unknown,
+  },
+  listProjects: {
+    intent: INTENT_LIST_PROJECTS,
+    operationId: LIST_PROJECTS_OPERATION_ID,
+    result: [] as unknown,
+  },
+  openWorkspace: {
+    intent: INTENT_OPEN_WORKSPACE,
+    operationId: OPEN_WORKSPACE_OPERATION_ID,
+    result: {
+      name: "test",
+      path: "/path",
+      branch: "main",
+      metadata: { base: "main" },
+      projectId: "test-12345678" as ProjectId,
+    } as unknown,
+  },
+  executeCommand: {
+    intent: INTENT_VSCODE_COMMAND,
+    operationId: VSCODE_COMMAND_OPERATION_ID,
+    result: undefined as unknown,
+  },
+  showMessage: {
+    intent: INTENT_VSCODE_SHOW_MESSAGE,
+    operationId: VSCODE_SHOW_MESSAGE_OPERATION_ID,
+    result: null as unknown,
+  },
+  resolveWorkspace: {
+    intent: INTENT_RESOLVE_WORKSPACE,
+    operationId: RESOLVE_WORKSPACE_OPERATION_ID,
+    result: {
+      projectPath: "/home/user/projects/my-app",
+      workspaceName: "feature-branch",
+      active: false,
+    } as unknown,
+  },
+  hibernate: {
+    intent: INTENT_HIBERNATE_WORKSPACE,
+    operationId: HIBERNATE_WORKSPACE_OPERATION_ID,
+    result: { started: true } as unknown,
+  },
+  wake: {
+    intent: INTENT_WAKE_WORKSPACE,
+    operationId: WAKE_WORKSPACE_OPERATION_ID,
+    result: {
+      name: "test",
+      path: "/path",
+      branch: "main",
+      metadata: { base: "main" },
+      projectId: "test-12345678" as ProjectId,
+    } as unknown,
+  },
+} as const;
+
+type ToolOperationKey = keyof typeof TOOL_OPERATIONS | "deleteWorkspace";
+
+export interface MockToolOperations {
+  /** Per-tool execute spies (vi.fn), keyed as in the unit tests. */
+  operations: Record<ToolOperationKey, ReturnType<typeof vi.fn>>;
+  /** Every intent received by any mock operation, in dispatch order. */
+  capturedIntents: Intent[];
+  /** Controls the delete-workspace operation's outcome. */
+  deleteControl: DeleteControl;
+}
+
+/**
+ * Register canned mock operations for all MCP tool intents on the dispatcher.
+ *
+ * @param dispatcher - The dispatcher to register on
+ * @param overrides - Per-tool canned result overrides (e.g. `{ getAgentSession: null }`)
+ */
+export function createMockToolOperations(
+  dispatcher: Dispatcher,
+  overrides: Partial<Record<keyof typeof TOOL_OPERATIONS, unknown>> = {}
+): MockToolOperations {
+  const capturedIntents: Intent[] = [];
+  const operations = {} as Record<ToolOperationKey, ReturnType<typeof vi.fn>>;
+
+  for (const [key, def] of Object.entries(TOOL_OPERATIONS) as Array<
+    [keyof typeof TOOL_OPERATIONS, (typeof TOOL_OPERATIONS)[keyof typeof TOOL_OPERATIONS]]
+  >) {
+    const result = key in overrides ? overrides[key] : def.result;
+    const execute = vi.fn(async (ctx: OperationContext<Intent>): Promise<unknown> => {
+      capturedIntents.push(ctx.intent);
+      return result;
+    });
+    const operation: Operation<Intent, unknown> = { id: def.operationId, execute };
+    dispatcher.registerOperation(def.intent, operation);
+    operations[key] = execute;
+  }
+
+  // workspace_delete waits for a terminal deletion-progress event to learn the
+  // real outcome, so the mock delete op emits one.
+  const deleteControl: DeleteControl = { mode: "success" };
+  const deleteExecute = vi.fn(
+    async (ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> => {
+      capturedIntents.push(ctx.intent);
+      if (deleteControl.mode === "reject") {
+        throw new Error("Preflight check failed: Workspace has uncommitted changes");
+      }
+      const { workspacePath, keepBranch } = ctx.intent.payload;
+      const hasErrors = deleteControl.mode === "blocked";
+      const progress: DeletionProgress = {
+        workspacePath: workspacePath as DeletionProgress["workspacePath"],
+        workspaceName: "feature-branch" as DeletionProgress["workspaceName"],
+        projectId: "test-12345678" as ProjectId,
+        keepBranch,
+        operations: [
+          {
+            id: "cleanup-workspace",
+            label: "Removing workspace",
+            status: hasErrors ? "error" : "done",
+            ...(hasErrors ? { error: "EBUSY: resource busy or locked" } : {}),
+          },
+        ],
+        completed: true,
+        hasErrors,
+        ...(deleteControl.blockingProcesses
+          ? {
+              blockingProcesses: deleteControl.blockingProcesses.map((p) => ({
+                pid: p.pid,
+                name: p.name,
+                commandLine: p.name,
+                files: [],
+                cwd: null,
+              })),
+            }
+          : {}),
+      };
+      await ctx.emit({ type: EVENT_WORKSPACE_DELETION_PROGRESS, payload: progress });
+      return { started: true };
+    }
+  );
+  const deleteOperation: Operation<DeleteWorkspaceIntent, { started: true }> = {
+    id: DELETE_WORKSPACE_OPERATION_ID,
+    execute: deleteExecute,
+  };
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOperation);
+  operations.deleteWorkspace = deleteExecute;
+
+  return { operations, capturedIntents, deleteControl };
+}

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -2,7 +2,6 @@
  * Unit tests for MCP Server.
  */
 
-import { createServer } from "node:net";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   McpServer,
@@ -10,207 +9,32 @@ import {
   SERVER_INSTRUCTIONS,
   type McpServerFactory,
 } from "./mcp-module";
-import { type ProjectId, type DeletionProgress, initialPromptSchema } from "../shared/api/types";
+import { initialPromptSchema } from "../shared/api/types";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockDispatcher as createBaseMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import type { Intent } from "../intents/lib/types";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import { INTENT_HIBERNATE_WORKSPACE } from "../intents/hibernate-workspace";
+import { INTENT_WAKE_WORKSPACE } from "../intents/wake-workspace";
+import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
 import {
-  INTENT_GET_WORKSPACE_STATUS,
-  GET_WORKSPACE_STATUS_OPERATION_ID,
-} from "../intents/get-workspace-status";
-import { INTENT_GET_METADATA, GET_METADATA_OPERATION_ID } from "../intents/get-metadata";
-import { INTENT_SET_METADATA, SET_METADATA_OPERATION_ID } from "../intents/set-metadata";
-import {
-  INTENT_GET_AGENT_SESSION,
-  GET_AGENT_SESSION_OPERATION_ID,
-} from "../intents/get-agent-session";
-import { INTENT_RESTART_AGENT, RESTART_AGENT_OPERATION_ID } from "../intents/restart-agent";
-import {
-  INTENT_RESOLVE_WORKSPACE,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-} from "../intents/resolve-workspace";
-import {
-  INTENT_HIBERNATE_WORKSPACE,
-  HIBERNATE_WORKSPACE_OPERATION_ID,
-} from "../intents/hibernate-workspace";
-import { INTENT_WAKE_WORKSPACE, WAKE_WORKSPACE_OPERATION_ID } from "../intents/wake-workspace";
-import { INTENT_LIST_PROJECTS, LIST_PROJECTS_OPERATION_ID } from "../intents/list-projects";
-import { INTENT_OPEN_WORKSPACE, OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
-import {
-  INTENT_DELETE_WORKSPACE,
-  DELETE_WORKSPACE_OPERATION_ID,
-  EVENT_WORKSPACE_DELETION_PROGRESS,
-  type DeleteWorkspaceIntent,
-} from "../intents/delete-workspace";
-import { INTENT_VSCODE_COMMAND, VSCODE_COMMAND_OPERATION_ID } from "../intents/vscode-command";
-import {
-  INTENT_VSCODE_SHOW_MESSAGE,
-  VSCODE_SHOW_MESSAGE_OPERATION_ID,
-} from "../intents/vscode-show-message";
-
-/**
- * Find a free port for testing.
- */
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address();
-      if (addr && typeof addr === "object") {
-        const port = addr.port;
-        server.close(() => resolve(port));
-      } else {
-        reject(new Error("Could not get port"));
-      }
-    });
-    server.on("error", reject);
-  });
-}
-
-/**
- * Create a mock operation that returns a fixed result.
- */
-function createMockOperation<TIntent extends Intent = Intent, TResult = void>(
-  operationId: string,
-  result: TResult
-): Operation<TIntent, TResult> {
-  return {
-    id: operationId,
-    execute: vi.fn(async (): Promise<TResult> => result),
-  };
-}
+  createMockToolOperations,
+  findFreePort,
+  type DeleteControl,
+  type MockToolOperations,
+} from "./mcp-server.test-utils";
 
 /**
  * Create a Dispatcher with mock operations registered for all MCP tool intents.
  */
-interface DeleteControl {
-  mode: "success" | "blocked" | "reject";
-  blockingProcesses?: ReadonlyArray<{ pid: number; name: string }>;
-}
-
 function createMockDispatcher(): {
   dispatcher: Dispatcher;
-  operations: Record<string, ReturnType<typeof vi.fn>>;
+  operations: MockToolOperations["operations"];
   deleteControl: DeleteControl;
 } {
   const dispatcher = createBaseMockDispatcher();
-
-  const getStatusOp = createMockOperation(GET_WORKSPACE_STATUS_OPERATION_ID, {
-    isDirty: false,
-    unmergedCommits: 0,
-    agent: { type: "none" as const },
-  });
-  const getMetadataOp = createMockOperation(GET_METADATA_OPERATION_ID, { base: "main" });
-  const setMetadataOp = createMockOperation(SET_METADATA_OPERATION_ID, undefined);
-  const getAgentSessionOp = createMockOperation(GET_AGENT_SESSION_OPERATION_ID, {
-    port: 14001,
-    sessionId: "test-session",
-  });
-  const restartAgentOp = createMockOperation(RESTART_AGENT_OPERATION_ID, 14001);
-  const listProjectsOp = createMockOperation(LIST_PROJECTS_OPERATION_ID, []);
-  const openWorkspaceOp = createMockOperation(OPEN_WORKSPACE_OPERATION_ID, {
-    name: "test",
-    path: "/path",
-    branch: "main",
-    metadata: { base: "main" },
-    projectId: "test-12345678" as ProjectId,
-  });
-  // workspace_delete waits for a terminal deletion-progress event to learn the
-  // real outcome, so the mock delete op emits one. deleteControl lets tests pick
-  // success / blocked / preflight-reject behavior.
-  const deleteControl: DeleteControl = { mode: "success" };
-  const deleteWorkspaceOp: Operation<DeleteWorkspaceIntent, { started: true }> = {
-    id: DELETE_WORKSPACE_OPERATION_ID,
-    execute: vi.fn(
-      async (ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> => {
-        if (deleteControl.mode === "reject") {
-          throw new Error("Preflight check failed: Workspace has uncommitted changes");
-        }
-        const { workspacePath, keepBranch } = ctx.intent.payload;
-        const hasErrors = deleteControl.mode === "blocked";
-        const progress: DeletionProgress = {
-          workspacePath: workspacePath as DeletionProgress["workspacePath"],
-          workspaceName: "feature-branch" as DeletionProgress["workspaceName"],
-          projectId: "test-12345678" as ProjectId,
-          keepBranch,
-          operations: [
-            {
-              id: "cleanup-workspace",
-              label: "Removing workspace",
-              status: hasErrors ? "error" : "done",
-              ...(hasErrors ? { error: "EBUSY: resource busy or locked" } : {}),
-            },
-          ],
-          completed: true,
-          hasErrors,
-          ...(deleteControl.blockingProcesses
-            ? {
-                blockingProcesses: deleteControl.blockingProcesses.map((p) => ({
-                  pid: p.pid,
-                  name: p.name,
-                  commandLine: p.name,
-                  files: [],
-                  cwd: null,
-                })),
-              }
-            : {}),
-        };
-        await ctx.emit({ type: EVENT_WORKSPACE_DELETION_PROGRESS, payload: progress });
-        return { started: true };
-      }
-    ),
-  };
-  const executeCommandOp = createMockOperation(VSCODE_COMMAND_OPERATION_ID, undefined);
-  const showMessageOp = createMockOperation(VSCODE_SHOW_MESSAGE_OPERATION_ID, null);
-  const resolveWorkspaceOp = createMockOperation(RESOLVE_WORKSPACE_OPERATION_ID, {
-    projectPath: "/home/user/projects/my-app",
-    workspaceName: "feature-branch",
-    active: false,
-  });
-  const hibernateOp = createMockOperation(HIBERNATE_WORKSPACE_OPERATION_ID, { started: true });
-  const wakeOp = createMockOperation(WAKE_WORKSPACE_OPERATION_ID, {
-    name: "test",
-    path: "/path",
-    branch: "main",
-    metadata: { base: "main" },
-    projectId: "test-12345678" as ProjectId,
-  });
-
-  dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, getStatusOp);
-  dispatcher.registerOperation(INTENT_GET_METADATA, getMetadataOp);
-  dispatcher.registerOperation(INTENT_SET_METADATA, setMetadataOp);
-  dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, getAgentSessionOp);
-  dispatcher.registerOperation(INTENT_RESTART_AGENT, restartAgentOp);
-  dispatcher.registerOperation(INTENT_LIST_PROJECTS, listProjectsOp);
-  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, openWorkspaceOp);
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteWorkspaceOp);
-  dispatcher.registerOperation(INTENT_VSCODE_COMMAND, executeCommandOp);
-  dispatcher.registerOperation(INTENT_VSCODE_SHOW_MESSAGE, showMessageOp);
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, resolveWorkspaceOp);
-  dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, hibernateOp);
-  dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, wakeOp);
-
-  return {
-    dispatcher,
-    operations: {
-      getStatus: getStatusOp.execute as ReturnType<typeof vi.fn>,
-      getMetadata: getMetadataOp.execute as ReturnType<typeof vi.fn>,
-      setMetadata: setMetadataOp.execute as ReturnType<typeof vi.fn>,
-      getAgentSession: getAgentSessionOp.execute as ReturnType<typeof vi.fn>,
-      restartAgent: restartAgentOp.execute as ReturnType<typeof vi.fn>,
-      listProjects: listProjectsOp.execute as ReturnType<typeof vi.fn>,
-      openWorkspace: openWorkspaceOp.execute as ReturnType<typeof vi.fn>,
-      deleteWorkspace: deleteWorkspaceOp.execute as ReturnType<typeof vi.fn>,
-      executeCommand: executeCommandOp.execute as ReturnType<typeof vi.fn>,
-      showMessage: showMessageOp.execute as ReturnType<typeof vi.fn>,
-      resolveWorkspace: resolveWorkspaceOp.execute as ReturnType<typeof vi.fn>,
-      hibernate: hibernateOp.execute as ReturnType<typeof vi.fn>,
-      wake: wakeOp.execute as ReturnType<typeof vi.fn>,
-    },
-    deleteControl,
-  };
+  const { operations, deleteControl } = createMockToolOperations(dispatcher);
+  return { dispatcher, operations, deleteControl };
 }
 
 /**

--- a/src/modules/metadata-module.integration.test.ts
+++ b/src/modules/metadata-module.integration.test.ts
@@ -17,21 +17,7 @@ import { SetMetadataOperation, INTENT_SET_METADATA } from "../intents/set-metada
 import type { SetMetadataIntent } from "../intents/set-metadata";
 import { GetMetadataOperation, INTENT_GET_METADATA } from "../intents/get-metadata";
 import type { GetMetadataIntent } from "../intents/get-metadata";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../intents/resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "../intents/resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../intents/resolve-project";
-import type {
-  ResolveHookResult as ResolveProjectHookResult,
-  ResolveHookInput as ResolveProjectHookInput,
-} from "../intents/resolve-project";
+import { registerTestInfrastructure } from "../intents/operations.test-utils";
 import { createMetadataModule } from "./metadata-module";
 import { createMockGitClient } from "../boundaries/platform/git-client.state-mock";
 import { createFileSystemMock, directory } from "../boundaries/platform/filesystem.state-mock";
@@ -39,8 +25,6 @@ import { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provide
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
-import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
 
 // =============================================================================
 // Test Constants
@@ -97,50 +81,16 @@ function createTestSetup(): TestSetup {
 
   dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
   dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
 
-  // resolve stub: validates workspacePath → returns projectPath + workspaceName
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-            if (wsPath === workspacePath.toString()) {
-              return { projectPath: PROJECT_ROOT.toString(), workspaceName };
-            }
-            return {};
-          },
-        },
-      },
+  registerTestInfrastructure(dispatcher, {
+    workspaces: {
+      [workspacePath.toString()]: { projectPath: PROJECT_ROOT.toString(), workspaceName },
     },
-  };
-
-  // resolve-project stub: resolves projectPath → projectId (for set-metadata commands)
-  const resolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const { projectPath } = ctx as ResolveProjectHookInput;
-            if (projectPath === PROJECT_ROOT.toString()) {
-              return { projectId };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
+    projects: { [PROJECT_ROOT.toString()]: { projectId } },
+  });
 
   // Module under test
   const metadataModule = createMetadataModule({ gitWorktreeProvider });
-
-  dispatcher.registerModule(resolveModule);
-  dispatcher.registerModule(resolveProjectModule);
   dispatcher.registerModule(metadataModule);
 
   return {

--- a/src/modules/plugin-server-module.integration.test.ts
+++ b/src/modules/plugin-server-module.integration.test.ts
@@ -66,22 +66,22 @@ class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, void> {
   }
 }
 
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, DeleteHookResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<DeleteHookResult> {
-    const { payload } = ctx.intent;
-    const hookCtx: DeletePipelineHookInput = {
-      intent: ctx.intent,
-      projectPath: "/projects/test",
-      workspacePath: payload.workspacePath ?? "",
-      workspaceName: "test-workspace" as WorkspaceName,
-      active: false,
-    };
-    const { results, errors } = await ctx.hooks.collect<DeleteHookResult>("delete", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-    return results[0] ?? {};
-  }
+/** Runs the "delete" hook point with a canned delete-pipeline context. */
+function createMinimalDeleteOperation(): Operation<DeleteWorkspaceIntent, DeleteHookResult> {
+  return createMinimalOperation<DeleteWorkspaceIntent, DeleteHookResult>(
+    DELETE_WORKSPACE_OPERATION_ID,
+    "delete",
+    {
+      hookContext: (ctx): DeletePipelineHookInput => ({
+        intent: ctx.intent,
+        projectPath: "/projects/test",
+        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        workspaceName: "test-workspace" as WorkspaceName,
+        active: false,
+      }),
+      defaultResult: {},
+    }
+  );
 }
 
 // =============================================================================
@@ -274,7 +274,7 @@ describe("PluginServerModule", () => {
       dispatcher.registerOperation("app:start", new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -295,7 +295,7 @@ describe("PluginServerModule", () => {
     it("is a no-op when server has not been started (io is null)", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -317,7 +317,7 @@ describe("PluginServerModule", () => {
       // Force mode delete should not throw even if internal state is inconsistent
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", new MinimalDeleteOperation());
+      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",

--- a/src/modules/power-module.integration.test.ts
+++ b/src/modules/power-module.integration.test.ts
@@ -18,91 +18,24 @@ import {
   UpdateAgentStatusOperation,
   INTENT_UPDATE_AGENT_STATUS,
 } from "../intents/update-agent-status";
-import type { UpdateAgentStatusIntent } from "../intents/update-agent-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../intents/resolve-workspace";
-import type {
-  ResolveHookResult as ResolveWorkspaceHookResult,
-  ResolveHookInput as ResolveWorkspaceHookInput,
-} from "../intents/resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../intents/resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "../intents/resolve-project";
-import { EVENT_WORKSPACE_DELETED, INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
-import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../intents/delete-workspace";
+import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
-import type { Operation, OperationContext, HookContext } from "../intents/lib/operation";
-import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import type { IntentModule } from "../intents/lib/module";
+import {
+  createDeleteEventOperation,
+  createMinimalOperation,
+} from "../intents/lib/operation.test-utils";
+import { registerTestInfrastructure, updateStatusIntent } from "../intents/operations.test-utils";
 import { createPowerModule } from "./power-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createAppBoundaryMock, type MockAppBoundary } from "../boundaries/shell/app.state-mock";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
 // =============================================================================
 // Helpers
 // =============================================================================
-
-/**
- * Minimal delete operation that only emits EVENT_WORKSPACE_DELETED, so tests can
- * trigger workspace:deleted through the public dispatcher API without the full
- * DeleteWorkspaceOperation pipeline.
- */
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { started: true }> {
-  readonly id = "delete-workspace";
-
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
-    const event: WorkspaceDeletedEvent = {
-      type: EVENT_WORKSPACE_DELETED,
-      payload: {
-        projectId: "test-12345678" as ProjectId,
-        workspaceName: "ws" as WorkspaceName,
-        workspacePath: ctx.intent.payload.workspacePath ?? "",
-        projectPath: "/projects/test",
-      },
-    };
-    ctx.emit(event);
-    return { started: true };
-  }
-}
-
-/**
- * Mock resolve module providing workspace/project resolution for the
- * update-agent-status operation.
- */
-function createMockResolveModule(): IntentModule {
-  return {
-    name: "test-resolve",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath } = ctx as ResolveWorkspaceHookInput;
-            return {
-              projectPath: "/projects/test",
-              workspaceName: workspacePath.split("/").pop() as WorkspaceName,
-            };
-          },
-        },
-      },
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveProjectHookResult> => {
-            return { projectId: "test-project" as ProjectId };
-          },
-        },
-      },
-    },
-  };
-}
 
 interface ModuleTestSetup {
   dispatcher: Dispatcher;
@@ -114,25 +47,21 @@ function createModuleTestSetup(): ModuleTestSetup {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new MinimalDeleteOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, createDeleteEventOperation());
+
+  // Every workspace path resolves; workspaceName derives from the path basename.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: (workspacePath) => ({
+      projectPath: "/projects/test",
+      workspaceName: workspacePath.split("/").pop() as WorkspaceName,
+    }),
+    projects: () => ({ projectId: "test-project" as ProjectId }),
+  });
 
   const powerModule = createPowerModule({ appLayer, logger: SILENT_LOGGER });
   dispatcher.registerModule(powerModule);
-  dispatcher.registerModule(createMockResolveModule());
 
   return { dispatcher, appLayer };
-}
-
-function updateStatusIntent(
-  workspacePath: string,
-  status: AggregatedAgentStatus
-): UpdateAgentStatusIntent {
-  return {
-    type: INTENT_UPDATE_AGENT_STATUS,
-    payload: { workspacePath: workspacePath as WorkspacePath, status },
-  };
 }
 
 const busy = (n = 1): AggregatedAgentStatus => ({ status: "busy", counts: { idle: 0, busy: n } });

--- a/src/modules/ui-ipc-module.integration.test.ts
+++ b/src/modules/ui-ipc-module.integration.test.ts
@@ -23,41 +23,21 @@ import {
   UpdateAgentStatusOperation,
   INTENT_UPDATE_AGENT_STATUS,
 } from "../intents/update-agent-status";
-import type { UpdateAgentStatusIntent } from "../intents/update-agent-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../intents/resolve-workspace";
-import type {
-  ResolveHookResult as ResolveWorkspaceHookResult,
-  ResolveHookInput as ResolveWorkspaceHookInput,
-} from "../intents/resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../intents/resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "../intents/resolve-project";
-import {
-  INTENT_DELETE_WORKSPACE,
-  EVENT_WORKSPACE_DELETED,
-  DELETE_WORKSPACE_OPERATION_ID,
-} from "../intents/delete-workspace";
-import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../intents/delete-workspace";
+import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import {
   AppShutdownOperation,
   INTENT_APP_SHUTDOWN,
   APP_SHUTDOWN_OPERATION_ID,
 } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import { createDeleteEventOperation } from "../intents/lib/operation.test-utils";
+import { registerTestInfrastructure, updateStatusIntent } from "../intents/operations.test-utils";
 import { createUiIpcModule, type UiIpcModuleDeps } from "./ui-ipc-module";
 import type { NotificationManager } from "./notification-manager";
 import { createMockLogging } from "../boundaries/platform/logging";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
-import { ApiIpcChannels, type WorkspacePath, type AggregatedAgentStatus } from "../shared/ipc";
+import { ApiIpcChannels, type AggregatedAgentStatus } from "../shared/ipc";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 import { EVENT_WORKSPACE_CREATE_FAILED, EVENT_WORKSPACE_LOADING } from "../intents/open-workspace";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
@@ -68,35 +48,6 @@ import {
 } from "../boundaries/shell/ipc.test-utils";
 
 // =============================================================================
-// Minimal operations that emit events for testing
-// =============================================================================
-
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, { started: true }> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-
-  constructor(
-    private readonly projectId: ProjectId,
-    private readonly workspaceName: WorkspaceName,
-    private readonly projectPath: string
-  ) {}
-
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
-    const { payload } = ctx.intent;
-    const event: WorkspaceDeletedEvent = {
-      type: EVENT_WORKSPACE_DELETED,
-      payload: {
-        projectId: this.projectId,
-        workspaceName: this.workspaceName,
-        workspacePath: payload.workspacePath,
-        projectPath: this.projectPath,
-      },
-    };
-    ctx.emit(event);
-    return { started: true };
-  }
-}
-
-// =============================================================================
 // Test Setup helpers
 // =============================================================================
 
@@ -104,32 +55,6 @@ const TEST_PROJECT_ID = "test-project-12345678" as ProjectId;
 const TEST_PROJECT_PATH = "/projects/test";
 const TEST_WORKSPACE_NAME = "feature-branch" as WorkspaceName;
 const TEST_WORKSPACE_PATH = "/projects/test/workspaces/feature-branch";
-
-function createMockResolveModule(): IntentModule {
-  return {
-    name: "test-resolve",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            void (ctx as ResolveWorkspaceHookInput);
-            return {
-              projectPath: TEST_PROJECT_PATH,
-              workspaceName: TEST_WORKSPACE_NAME,
-            };
-          },
-        },
-      },
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (): Promise<ResolveProjectHookResult> => {
-            return { projectId: TEST_PROJECT_ID };
-          },
-        },
-      },
-    },
-  };
-}
 
 type SendToUIMock = ReturnType<typeof vi.fn<(channel: string, ...args: unknown[]) => void>>;
 
@@ -165,32 +90,21 @@ function createStatusTestSetup(): StatusTestSetup {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+
+  // Every workspace path resolves to the test workspace.
+  registerTestInfrastructure(dispatcher, {
+    workspaces: () => ({ projectPath: TEST_PROJECT_PATH, workspaceName: TEST_WORKSPACE_NAME }),
+    projects: () => ({ projectId: TEST_PROJECT_ID }),
+  });
 
   const deps = createBridgeDeps({
     dispatcher: dispatcher as unknown as UiIpcModuleDeps["dispatcher"],
   });
   const uiIpcModule = createUiIpcModule(deps);
-  const resolveModule = createMockResolveModule();
 
   dispatcher.registerModule(uiIpcModule);
-  dispatcher.registerModule(resolveModule);
 
   return { dispatcher, sendToUI: deps.sendToUI };
-}
-
-function updateStatusIntent(
-  workspacePath: string,
-  status: AggregatedAgentStatus
-): UpdateAgentStatusIntent {
-  return {
-    type: INTENT_UPDATE_AGENT_STATUS,
-    payload: {
-      workspacePath: workspacePath as WorkspacePath,
-      status,
-    },
-  };
 }
 
 // =============================================================================
@@ -289,7 +203,11 @@ describe("UiIpcModule - workspace:deleted", () => {
 
     dispatcher.registerOperation(
       INTENT_DELETE_WORKSPACE,
-      new MinimalDeleteOperation(TEST_PROJECT_ID, TEST_WORKSPACE_NAME, TEST_PROJECT_PATH)
+      createDeleteEventOperation({
+        projectId: TEST_PROJECT_ID,
+        workspaceName: TEST_WORKSPACE_NAME,
+        projectPath: TEST_PROJECT_PATH,
+      })
     );
     dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 

--- a/src/modules/workspace-selection-module.integration.test.ts
+++ b/src/modules/workspace-selection-module.integration.test.ts
@@ -14,33 +14,19 @@
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
-import {
-  SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
-  EVENT_WORKSPACE_SWITCHED,
-} from "../intents/switch-workspace";
+import { INTENT_SWITCH_WORKSPACE, EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import type {
   SwitchWorkspaceIntent,
-  SwitchWorkspaceHookResult,
   FindCandidatesHookResult,
   WorkspaceCandidate,
   WorkspaceSwitchedEvent,
 } from "../intents/switch-workspace";
 import { SWITCH_WORKSPACE_OPERATION_ID } from "../intents/switch-workspace";
 import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../intents/resolve-workspace";
-import type { ResolveHookResult as ResolveWorkspaceHookResult } from "../intents/resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../intents/resolve-project";
-import type { ResolveHookResult as ResolveProjectHookResult } from "../intents/resolve-project";
+  createTestViewManager,
+  registerTestInfrastructure,
+} from "../intents/operations.test-utils";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
 import type { DomainEvent } from "../intents/lib/types";
 import { createWorkspaceSelectionModule } from "./workspace-selection-module";
 import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
@@ -91,69 +77,25 @@ interface TestSetup {
 
 function createTestSetup(opts: { candidates: WorkspaceCandidate[] }): TestSetup {
   const dispatcher = createMockDispatcher();
+  const { viewManager, activeWorkspace } = createTestViewManager();
 
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-
-  let activeWorkspacePath: string | null = null;
-
-  // Resolve module: workspace path → project path + workspace name
-  const resolveModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_WORKSPACE_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
-            const found = opts.candidates.find((c) => c.workspacePath === wsPath);
-            if (!found) return {};
-            return {
-              projectPath: found.projectPath,
-              workspaceName: wsPath.slice(wsPath.lastIndexOf("/") + 1) as WorkspaceName,
-            };
-          },
-        },
+  registerTestInfrastructure(dispatcher, {
+    workspaces: (wsPath) => {
+      const found = opts.candidates.find((c) => c.workspacePath === wsPath);
+      if (!found) return undefined;
+      return {
+        projectPath: found.projectPath,
+        workspaceName: wsPath.slice(wsPath.lastIndexOf("/") + 1) as WorkspaceName,
+      };
+    },
+    projects: {
+      [PROJECT_PATH]: {
+        projectId: Buffer.from(PROJECT_PATH).toString("base64url") as ProjectId,
+        projectName: PROJECT_NAME,
       },
     },
-  };
-
-  // Resolve project module
-  const resolveProjectModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [RESOLVE_PROJECT_OPERATION_ID]: {
-        resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
-            const { projectPath } = ctx as { projectPath: string } & HookContext;
-            if (projectPath === PROJECT_PATH) {
-              return {
-                projectId: Buffer.from(PROJECT_PATH).toString("base64url") as ProjectId,
-                projectName: PROJECT_NAME,
-              };
-            }
-            return {};
-          },
-        },
-      },
-    },
-  };
-
-  // Activate module
-  const activateModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [SWITCH_WORKSPACE_OPERATION_ID]: {
-        activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
-            const { workspacePath } = ctx as { workspacePath: string } & HookContext;
-            activeWorkspacePath = workspacePath;
-            return { resolvedPath: workspacePath };
-          },
-        },
-      },
-    },
-  };
+    viewManager,
+  });
 
   // Find-candidates module (returns fixed candidates)
   const findCandidatesModule: IntentModule = {
@@ -171,20 +113,13 @@ function createTestSetup(opts: { candidates: WorkspaceCandidate[] }): TestSetup 
 
   const selectionModule = createWorkspaceSelectionModule();
 
-  for (const m of [
-    resolveModule,
-    resolveProjectModule,
-    activateModule,
-    findCandidatesModule,
-    selectionModule,
-  ])
-    dispatcher.registerModule(m);
+  for (const m of [findCandidatesModule, selectionModule]) dispatcher.registerModule(m);
 
   return {
     dispatcher,
     selectionModule,
     get activeWorkspacePath() {
-      return activeWorkspacePath;
+      return activeWorkspace.path;
     },
   };
 }

--- a/src/renderer/lib/components/CloseProjectDialog.test.ts
+++ b/src/renderer/lib/components/CloseProjectDialog.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
-import type { Project, ProjectId, WorkspaceName, Workspace } from "@shared/api/types";
+import type { Project, ProjectId, Workspace } from "@shared/api/types";
+import { createMockProject, createMockWorkspace } from "@shared/test-fixtures";
 
 // Create mock functions with vi.hoisted
 const { mockCloseProject, mockRemoveWorkspace, mockCloseDialog, mockProjects } = vi.hoisted(() => ({
@@ -45,13 +46,7 @@ import CloseProjectDialog from "./CloseProjectDialog.svelte";
 const testProjectId = "test-project-12345678" as ProjectId;
 
 function createWorkspace(name: string, projectId: ProjectId): Workspace {
-  return {
-    projectId,
-    name: name as WorkspaceName,
-    branch: name,
-    path: `/test/project/.worktrees/${name}`,
-    metadata: { base: "main" },
-  };
+  return createMockWorkspace({ name, projectId, metadata: { base: "main" } });
 }
 
 function createProject(
@@ -60,13 +55,13 @@ function createProject(
   workspaces: Workspace[] = [],
   remoteUrl?: string
 ): Project {
-  return {
+  return createMockProject({
     id,
     name,
     path: `/test/projects/${name}`,
     workspaces,
     ...(remoteUrl !== undefined && { remoteUrl }),
-  };
+  });
 }
 
 /**
@@ -495,13 +490,12 @@ describe("CloseProjectDialog component", () => {
   });
 
   describe("remote project (cloned from URL)", () => {
-    const remoteProject: Project = {
-      id: testProjectId,
-      name: "test-project",
-      path: "/test/projects/test-project",
-      workspaces: [createWorkspace("ws1", testProjectId)],
-      remoteUrl: "https://github.com/org/test-repo.git",
-    };
+    const remoteProject: Project = createProject(
+      testProjectId,
+      "test-project",
+      [createWorkspace("ws1", testProjectId)],
+      "https://github.com/org/test-repo.git"
+    );
 
     beforeEach(() => {
       // Override the global beforeEach mock setup (global beforeEach runs first, then this)

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -24,7 +24,8 @@ import {
   reset as resetProjects,
 } from "$lib/stores/projects.svelte";
 import { reset as resetUiMode } from "$lib/stores/ui-mode.svelte";
-import type { Project, ProjectId, WorkspaceName } from "@shared/api/types";
+import type { Project } from "@shared/api/types";
+import { asProjectId, createMockProject } from "@shared/test-fixtures";
 
 interface FrameHooks {
   __chFocusActiveFrame?: () => void;
@@ -32,45 +33,38 @@ interface FrameHooks {
 }
 
 function makeProject(): Project {
-  return {
-    id: "test-12345678" as ProjectId,
+  return createMockProject({
+    id: asProjectId("test-12345678"),
     name: "test",
     path: "/projects/test",
     workspaces: [
       {
-        projectId: "test-12345678" as ProjectId,
-        name: "ws1" as WorkspaceName,
+        name: "ws1",
         branch: "main",
-        metadata: {},
         path: "/workspaces/ws1",
         url: "http://127.0.0.1:9000/?folder=/workspaces/ws1",
       },
       {
-        projectId: "test-12345678" as ProjectId,
-        name: "ws2" as WorkspaceName,
+        name: "ws2",
         branch: "feature",
-        metadata: {},
         path: "/workspaces/ws2",
         url: "http://127.0.0.1:9000/?folder=/workspaces/ws2",
       },
       {
-        projectId: "test-12345678" as ProjectId,
-        name: "sleeping" as WorkspaceName,
+        name: "sleeping",
         branch: "old",
         metadata: { hibernated: "true" },
         path: "/workspaces/sleeping",
         url: "http://127.0.0.1:9000/?folder=/workspaces/sleeping",
       },
       {
-        projectId: "test-12345678" as ProjectId,
-        name: "pending" as WorkspaceName,
+        name: "pending",
         branch: null,
-        metadata: {},
         path: "/workspaces/__pending__",
         // no url — placeholder from workspace:loading
       },
     ],
-  };
+  });
 }
 
 function frames(container: HTMLElement): HTMLIFrameElement[] {

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -5,7 +5,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/svelte";
-import type { Project, Workspace, ProjectId, WorkspaceName } from "@shared/api/types";
+import type { Project, Workspace, ProjectId } from "@shared/api/types";
+import { createMockProject, createMockWorkspace } from "@shared/test-fixtures";
 
 // API event callbacks - MainView uses api.on() which stores callbacks here
 type EventCallback = (...args: unknown[]) => void;
@@ -209,13 +210,12 @@ function openCreationPanelSession(dialogId = "dlg-creation-1"): void {
 
 // Helper to create mock workspace (v2 API format)
 function createWorkspace(name: string, projectPath: string, projectId?: string): Workspace {
-  return {
+  return createMockWorkspace({
     projectId: (projectId ?? "test-12345678") as ProjectId,
-    name: name as WorkspaceName,
+    name,
     path: `${projectPath}/.worktrees/${name}`,
-    branch: name,
     metadata: { base: "main" },
-  };
+  });
 }
 
 // Helper to generate consistent project ID from name
@@ -227,13 +227,13 @@ function projectIdFromName(name: string): ProjectId {
 // Helper to create mock project (v2 API format with ID)
 function createProject(name: string, workspaces: Workspace[] = []): Project {
   const id = projectIdFromName(name);
-  return {
+  return createMockProject({
     id,
     path: `/test/${name}`,
     name,
     // Add projectId to each workspace for v2 format
     workspaces: workspaces.map((ws) => ({ ...ws, projectId: id })),
-  };
+  });
 }
 
 describe("Integration tests", () => {

--- a/src/renderer/lib/utils/initialize-app.test.ts
+++ b/src/renderer/lib/utils/initialize-app.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Project, Workspace, ProjectId, WorkspaceName } from "@shared/api/types";
+import { createMockProject, createMockWorkspace } from "@shared/test-fixtures";
 
 vi.mock("$lib/api", () => ({
   lifecycle: { ready: vi.fn() },
@@ -20,20 +21,19 @@ const TEST_PROJECT_PATH = "/test/project";
 const TEST_WORKSPACE_NAME = "feature-branch" as WorkspaceName;
 const TEST_WORKSPACE_PATH = "/test/project/.worktrees/feature";
 
-const TEST_WORKSPACE: Workspace = {
+const TEST_WORKSPACE: Workspace = createMockWorkspace({
   projectId: TEST_PROJECT_ID,
   name: TEST_WORKSPACE_NAME,
-  branch: "feature-branch",
   metadata: { base: "main" },
   path: TEST_WORKSPACE_PATH,
-};
+});
 
-const TEST_PROJECT: Project = {
+const TEST_PROJECT: Project = createMockProject({
   id: TEST_PROJECT_ID,
   name: "my-project",
   path: TEST_PROJECT_PATH,
   workspaces: [TEST_WORKSPACE],
-};
+});
 
 function createMockApi(config?: {
   projects?: Project[];

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceName,
   WorkspaceStatus,
 } from "@shared/api/types";
+import { asWorkspaceRef, createMockProject, createMockWorkspace } from "@shared/test-fixtures";
 
 // Mock the API module before importing the setup function
 vi.mock("$lib/api", () => ({
@@ -37,26 +38,25 @@ const TEST_PROJECT_PATH = "/test/project";
 const TEST_WORKSPACE_NAME = "feature-branch" as WorkspaceName;
 const TEST_WORKSPACE_PATH = "/test/project/.worktrees/feature";
 
-const TEST_PROJECT: Project = {
+const TEST_PROJECT: Project = createMockProject({
   id: TEST_PROJECT_ID,
   name: "my-project",
   path: TEST_PROJECT_PATH,
   workspaces: [],
-};
+});
 
-const TEST_WORKSPACE: Workspace = {
+const TEST_WORKSPACE: Workspace = createMockWorkspace({
   projectId: TEST_PROJECT_ID,
   name: TEST_WORKSPACE_NAME,
-  branch: "feature-branch",
   metadata: { base: "main" },
   path: TEST_WORKSPACE_PATH,
-};
+});
 
-const TEST_WORKSPACE_REF: WorkspaceRef = {
-  projectId: TEST_PROJECT_ID,
-  workspaceName: TEST_WORKSPACE_NAME,
-  path: TEST_WORKSPACE_PATH,
-};
+const TEST_WORKSPACE_REF: WorkspaceRef = asWorkspaceRef(
+  TEST_PROJECT_ID,
+  TEST_WORKSPACE_NAME,
+  TEST_WORKSPACE_PATH
+);
 
 // =============================================================================
 // Mock API Factory

--- a/src/shared/test-fixtures.ts
+++ b/src/shared/test-fixtures.ts
@@ -100,6 +100,7 @@ export function createMockWorkspace(overrides: WorkspaceOverrides = {}): Workspa
     branch,
     metadata: { base: branch ?? "main", ...overrides.metadata },
     path: overrides.path ?? `/test/project/.worktrees/${name}`,
+    ...(overrides.url !== undefined ? { url: overrides.url } : {}),
   };
 }
 
@@ -168,6 +169,7 @@ export function createMockProject(
     ...(overrides.defaultBaseBranch !== undefined
       ? { defaultBaseBranch: overrides.defaultBaseBranch }
       : {}),
+    ...(overrides.remoteUrl !== undefined ? { remoteUrl: overrides.remoteUrl } : {}),
   };
 }
 

--- a/src/test/state-mock.ts
+++ b/src/test/state-mock.ts
@@ -29,6 +29,14 @@ export interface MockState {
 }
 
 /**
+ * Create a branded Snapshot from the current state's string representation.
+ * State mocks implement `snapshot()` as `return createSnapshot(this);`.
+ */
+export function createSnapshot(stringable: { toString(): string }): Snapshot {
+  return { __brand: "Snapshot", value: stringable.toString() };
+}
+
+/**
  * A mock with inspectable state via the `$` property.
  * This formalizes the existing `_getState()` pattern.
  */
@@ -63,6 +71,115 @@ export type MatcherImplementationsFor<TMock, TMatchers> = {
     ? (received: TMock, ...args: Args) => MatcherResult
     : never;
 };
+
+// =============================================================================
+// Callback Registries
+// =============================================================================
+
+/**
+ * Per-key callback registry for event simulation in behavioral mocks.
+ *
+ * Replaces the hand-rolled `Map<string, Set<callback>>` scaffolding: keys are
+ * created on resource creation (`init`), subscribed via `add` (which returns
+ * an unsubscribe), fired via `trigger`, and torn down via `delete`/`clear`.
+ *
+ * Triggers with custom semantics (short-circuiting, result aggregation,
+ * selective cleanup) compose via `get()` instead of using `trigger()`.
+ */
+export class CallbackRegistry<Args extends readonly unknown[] = []> {
+  private readonly _callbacks = new Map<string, Set<(...args: Args) => void>>();
+
+  /** Create an empty callback set for a key (called on resource creation). */
+  init(id: string): void {
+    this._callbacks.set(id, new Set());
+  }
+
+  /**
+   * Subscribe a callback for a key. Returns an unsubscribe function.
+   * No-op if the key was never initialized (mirrors `callbacks?.add()`).
+   */
+  add(id: string, callback: (...args: Args) => void): () => void {
+    const callbacks = this._callbacks.get(id);
+    callbacks?.add(callback);
+    return () => {
+      callbacks?.delete(callback);
+    };
+  }
+
+  /** Invoke all callbacks registered for a key. */
+  trigger(id: string, ...args: Args): void {
+    const callbacks = this._callbacks.get(id);
+    if (callbacks) {
+      for (const callback of callbacks) {
+        callback(...args);
+      }
+    }
+  }
+
+  /** Access the raw callback set for custom trigger semantics. */
+  get(id: string): ReadonlySet<(...args: Args) => void> | undefined {
+    return this._callbacks.get(id);
+  }
+
+  /** Remove all callbacks for a key (called on resource destruction). */
+  delete(id: string): void {
+    this._callbacks.delete(id);
+  }
+
+  /** Remove all callbacks for all keys (called on destroyAll/dispose). */
+  clear(): void {
+    this._callbacks.clear();
+  }
+}
+
+/**
+ * Non-keyed variant of {@link CallbackRegistry} for global (per-mock) events.
+ */
+export class CallbackSet<Args extends readonly unknown[] = []> {
+  private readonly _callbacks = new Set<(...args: Args) => void>();
+
+  /** Subscribe a callback. Returns an unsubscribe function. */
+  add(callback: (...args: Args) => void): () => void {
+    this._callbacks.add(callback);
+    return () => {
+      this._callbacks.delete(callback);
+    };
+  }
+
+  /** Invoke all registered callbacks. */
+  trigger(...args: Args): void {
+    for (const callback of this._callbacks) {
+      callback(...args);
+    }
+  }
+}
+
+// =============================================================================
+// Matcher Factories
+// =============================================================================
+
+/**
+ * Create a count-assertion matcher implementation (`toHave*Count` family).
+ *
+ * @param noun - What is being counted, singular (used in failure messages)
+ * @param getActual - Extracts the actual count from the received mock
+ */
+export function countMatcher<TMock>(
+  noun: string,
+  getActual: (received: TMock) => number
+): (received: TMock, count: number) => MatcherResult {
+  return (received, count) => {
+    const actual = getActual(received);
+    const pass = actual === count;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected ${noun} count NOT to be ${count}`
+          : `Expected ${noun} count to be ${count}, but got ${actual}`,
+    };
+  };
+}
 
 // =============================================================================
 // Base Matchers for MockWithState


### PR DESCRIPTION
- Add shared state-mock helpers (`createSnapshot`, `countMatcher`, `CallbackRegistry`/`CallbackSet`) and migrate 14 state mocks plus the window/view/app callback scaffolding onto them
- Extend `operations.test-utils` with function-lookup configs, a `workspacesFromProjects()` reverse-lookup adapter, `updateStatusIntent()`, and a shared `createTestViewManager()` harness; migrate 14 intents/module integration tests off hand-rolled resolve modules and ViewManager mocks
- Add `createDeleteEventOperation()` and a `defaultResult` option to `operation.test-utils`, collapsing 5 of 6 MinimalDeleteOperation copies
- New `dialog-manager.state-mock.ts` unifying the four drifted DialogManager/DialogHandle mocks
- New `agent-module/module-provider.test-utils.ts` (download deps, binary/version config, server-manager factory) and shared wrapper-boundary scaffolding (`assertCompiledScript`, `createFakeAgentBinary`)
- New `mcp-server.test-utils.ts` sharing the canned tool-operation suite (event-emitting delete variant) and `findFreePort` between unit and boundary tests
- Shared test fixtures now pass through `Workspace.url` and `Project.remoteUrl`; renderer tests build fixtures via the shared factories

Net: −2,372 / +1,409 lines across 53 files. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)