### PR TITLE
feat: exact permission mode and agent name selectable on workspace creation

### DIFF
--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -442,8 +442,11 @@ const codehydraApi = {
           if (typeof prompt.prompt !== "string" || prompt.prompt.length === 0) {
             return Promise.reject(new Error("Initial prompt.prompt must be a non-empty string"));
           }
-          if (prompt.agent !== undefined && typeof prompt.agent !== "string") {
-            return Promise.reject(new Error("Initial prompt.agent must be a string"));
+          if (prompt.permissionMode !== undefined && typeof prompt.permissionMode !== "string") {
+            return Promise.reject(new Error("Initial prompt.permissionMode must be a string"));
+          }
+          if (prompt.agentName !== undefined && typeof prompt.agentName !== "string") {
+            return Promise.reject(new Error("Initial prompt.agentName must be a string"));
           }
         } else {
           return Promise.reject(new Error("Initial prompt must be a string or object"));

--- a/src/intents/agent-launch-options.ts
+++ b/src/intents/agent-launch-options.ts
@@ -1,0 +1,83 @@
+/**
+ * AgentLaunchOptionsOperation - Query the per-backend launch options shown in
+ * the creation form (Claude permission modes; OpenCode currently none).
+ *
+ * Trivial query operation: no workspace, no domain events. The agent modules
+ * fill in the options via the "launch-options" hook point — only the module
+ * whose provider type matches the requested backend contributes. Detection is
+ * best-effort: a provider that fails to report contributes nothing, so the form
+ * falls back to offering only the default.
+ */
+
+import type { Intent } from "./lib/types";
+import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import type { LifecycleAgentType } from "../shared/ipc";
+
+// =============================================================================
+// Intent Types
+// =============================================================================
+
+export interface GetLaunchOptionsPayload {
+  /** Backend the form currently targets. */
+  readonly backend: LifecycleAgentType;
+}
+
+/**
+ * Launch options for a backend.
+ * - permissionModes: selectable Claude permission modes (empty for OpenCode,
+ *   or when detection fails — the form then offers only the default).
+ */
+export interface LaunchOptionsResult {
+  readonly permissionModes: readonly string[];
+}
+
+export interface GetLaunchOptionsIntent extends Intent<LaunchOptionsResult> {
+  readonly type: "agent:get-launch-options";
+  readonly payload: GetLaunchOptionsPayload;
+}
+
+export const INTENT_GET_LAUNCH_OPTIONS = "agent:get-launch-options" as const;
+
+export const GET_LAUNCH_OPTIONS_OPERATION_ID = "get-launch-options";
+
+// =============================================================================
+// Hook Result & Input Types
+// =============================================================================
+
+/** Input context for the "launch-options" hook point. */
+export interface LaunchOptionsHookInput extends HookContext {
+  readonly backend: LifecycleAgentType;
+}
+
+/**
+ * Per-handler result for the "launch-options" hook point. Each agent module
+ * contributes only when the requested backend matches its provider type.
+ */
+export interface LaunchOptionsHookResult {
+  readonly permissionModes?: readonly string[];
+}
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class AgentLaunchOptionsOperation implements Operation<
+  GetLaunchOptionsIntent,
+  LaunchOptionsResult
+> {
+  readonly id = GET_LAUNCH_OPTIONS_OPERATION_ID;
+
+  async execute(ctx: OperationContext<GetLaunchOptionsIntent>): Promise<LaunchOptionsResult> {
+    const hookCtx: LaunchOptionsHookInput = {
+      intent: ctx.intent,
+      backend: ctx.intent.payload.backend,
+    };
+    const { results } = await ctx.hooks.collect<LaunchOptionsHookResult>("launch-options", hookCtx);
+
+    const permissionModes: string[] = [];
+    for (const result of results) {
+      if (result.permissionModes) permissionModes.push(...result.permissionModes);
+    }
+    return { permissionModes };
+  }
+}

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -597,7 +597,7 @@ describe("OpenWorkspace Operation", () => {
 
       await setup.dispatcher.dispatch(
         createIntent({
-          initialPrompt: { prompt: "Implement login", agent: "build" },
+          initialPrompt: { prompt: "Implement login", agentName: "build" },
         })
       );
 
@@ -605,7 +605,7 @@ describe("OpenWorkspace Operation", () => {
       const event = receivedEvents[0] as WorkspaceCreatedEvent;
       expect(event.payload.initialPrompt).toEqual({
         prompt: "Implement login",
-        agent: "build",
+        agentName: "build",
       });
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,10 @@ import { ListProjectsOperation, INTENT_LIST_PROJECTS } from "./intents/list-proj
 import { OpenWorkspaceOperation, INTENT_OPEN_WORKSPACE } from "./intents/open-workspace";
 import { GetProjectBasesOperation, INTENT_GET_PROJECT_BASES } from "./intents/get-project-bases";
 import {
+  AgentLaunchOptionsOperation,
+  INTENT_GET_LAUNCH_OPTIONS,
+} from "./intents/agent-launch-options";
+import {
   DeleteWorkspaceOperation,
   INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETED,
@@ -509,6 +513,7 @@ const claudeProvider = createClaudeModuleProvider({
   platform,
   arch,
   logger: providerLogger,
+  processRunner,
 });
 const claudeAgentModule = createAgentModule(claudeProvider, {
   dispatcher,
@@ -766,6 +771,7 @@ dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspace
 dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
 dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
 dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
+dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
 
 dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
 dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());

--- a/src/modules/agent-module/agent-module-provider.ts
+++ b/src/modules/agent-module/agent-module-provider.ts
@@ -29,6 +29,14 @@ export interface WorkspaceStartResult {
 }
 
 /**
+ * Launch options the agent contributes to the creation form (e.g. Claude
+ * permission modes). Empty arrays mean "nothing to offer beyond the default".
+ */
+export interface AgentLaunchOptions {
+  readonly permissionModes: readonly string[];
+}
+
+/**
  * Unified agent provider interface for the generic module factory.
  *
  * Each agent implementation (Claude, OpenCode) provides one of these.
@@ -100,6 +108,12 @@ export interface AgentModuleProvider {
   applyTerminalLifecycle(workspacePath: string, event: AgentLifecycleEvent): void;
 
   // --- Query ---
+
+  /**
+   * Launch options this agent offers the creation form (e.g. Claude permission
+   * modes). Optional — agents without dynamic options omit it.
+   */
+  getLaunchOptions?(): Promise<AgentLaunchOptions>;
 
   /** Get aggregated status for a workspace */
   getStatus(workspacePath: WorkspacePath): AggregatedAgentStatus;

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -14,6 +14,10 @@ import type { Operation, OperationContext, HookContext } from "../../intents/lib
 import type { Intent } from "../../intents/lib/types";
 import { createMinimalOperation } from "../../intents/lib/operation.test-utils";
 import { APP_START_OPERATION_ID } from "../../intents/app-start";
+import {
+  AgentLaunchOptionsOperation,
+  INTENT_GET_LAUNCH_OPTIONS,
+} from "../../intents/agent-launch-options";
 import type {
   ConfigureResult,
   CheckDepsResult,
@@ -347,6 +351,54 @@ async function activateModule(
 describe("createAgentModule", () => {
   beforeEach(() => {
     capturedStatusCallback = null;
+  });
+
+  // ---------------------------------------------------------------------------
+  // launch options
+  // ---------------------------------------------------------------------------
+
+  describe("agent:get-launch-options", () => {
+    it("fills in the matching backend's permission modes via the hook", async () => {
+      const { dispatcher } = createTestSetup({
+        type: "claude",
+        getLaunchOptions: async () => ({ permissionModes: ["plan", "acceptEdits"] }),
+      });
+      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+
+      const result = await dispatcher.dispatch({
+        type: INTENT_GET_LAUNCH_OPTIONS,
+        payload: { backend: "claude" },
+      });
+
+      expect(result).toEqual({ permissionModes: ["plan", "acceptEdits"] });
+    });
+
+    it("contributes nothing when the requested backend doesn't match the provider", async () => {
+      const { dispatcher } = createTestSetup({
+        type: "claude",
+        getLaunchOptions: async () => ({ permissionModes: ["plan"] }),
+      });
+      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+
+      const result = await dispatcher.dispatch({
+        type: INTENT_GET_LAUNCH_OPTIONS,
+        payload: { backend: "opencode" },
+      });
+
+      expect(result).toEqual({ permissionModes: [] });
+    });
+
+    it("returns empty when the provider exposes no launch options", async () => {
+      const { dispatcher } = createTestSetup({ type: "claude" });
+      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+
+      const result = await dispatcher.dispatch({
+        type: INTENT_GET_LAUNCH_OPTIONS,
+        payload: { backend: "claude" },
+      });
+
+      expect(result).toEqual({ permissionModes: [] });
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -52,6 +52,11 @@ import type { UpdateAgentStatusIntent } from "../../intents/update-agent-status"
 import { APP_START_OPERATION_ID } from "../../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
 import { APP_READY_OPERATION_ID, type AvailableAgentsResult } from "../../intents/app-ready";
+import {
+  GET_LAUNCH_OPTIONS_OPERATION_ID,
+  type LaunchOptionsHookInput,
+  type LaunchOptionsHookResult,
+} from "../../intents/agent-launch-options";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
@@ -199,6 +204,25 @@ export function createAgentModule(
                 },
               };
             } catch {
+              return {};
+            }
+          },
+        },
+      },
+
+      [GET_LAUNCH_OPTIONS_OPERATION_ID]: {
+        "launch-options": {
+          handler: async (ctx: HookContext): Promise<LaunchOptionsHookResult> => {
+            const { backend } = ctx as LaunchOptionsHookInput;
+            // Only the module matching the requested backend contributes.
+            if (backend !== provider.type || provider.getLaunchOptions === undefined) {
+              return {};
+            }
+            try {
+              const { permissionModes } = await provider.getLaunchOptions();
+              return { permissionModes };
+            } catch {
+              // Best-effort: detection failure → form offers only the default.
               return {};
             }
           },

--- a/src/modules/agent-module/claude/module-provider.integration.test.ts
+++ b/src/modules/agent-module/claude/module-provider.integration.test.ts
@@ -25,6 +25,7 @@ import {
   createVersionConfig,
 } from "../module-provider.test-utils";
 import { createMockPathProvider } from "../../../boundaries/platform/path-provider.test-utils";
+import { createMockProcessRunner } from "../../../boundaries/platform/process.state-mock";
 
 // =============================================================================
 // Mock ClaudeCodeProvider via vi.mock
@@ -90,7 +91,9 @@ describe("createClaudeModuleProvider", () => {
     pathProvider = createMockPathProvider();
   });
 
-  function createProvider() {
+  function createProvider(
+    helpStdout = '--permission-mode <mode>  mode (choices: "plan", "acceptEdits")'
+  ) {
     return createClaudeModuleProvider({
       serverManager: mockServerManager,
       downloadDeps,
@@ -100,6 +103,7 @@ describe("createClaudeModuleProvider", () => {
       platform: "linux",
       arch: "x64",
       logger: SILENT_LOGGER,
+      processRunner: createMockProcessRunner({ defaultResult: { stdout: helpStdout } }),
     });
   }
 
@@ -133,6 +137,35 @@ describe("createClaudeModuleProvider", () => {
   // ---------------------------------------------------------------------------
   // Binary delegation
   // ---------------------------------------------------------------------------
+
+  describe("launch options", () => {
+    it("parses permission modes from `claude --help`", async () => {
+      const provider = createProvider();
+
+      expect(await provider.getLaunchOptions?.()).toEqual({
+        permissionModes: ["plan", "acceptEdits"],
+      });
+    });
+
+    it("parses a multi-line choices list", async () => {
+      const help = [
+        "  --permission-mode <mode>  Permission mode to use",
+        '                            (choices: "acceptEdits", "auto",',
+        '                            "bypassPermissions", "default", "plan")',
+      ].join("\n");
+      const provider = createProvider(help);
+
+      expect(await provider.getLaunchOptions?.()).toEqual({
+        permissionModes: ["acceptEdits", "auto", "bypassPermissions", "default", "plan"],
+      });
+    });
+
+    it("reports no modes when the help output has no choices list", async () => {
+      const provider = createProvider("usage: claude [options]");
+
+      expect(await provider.getLaunchOptions?.()).toEqual({ permissionModes: [] });
+    });
+  });
 
   describe("binary management", () => {
     it("binaryType returns the name from binaryConfig", () => {

--- a/src/modules/agent-module/claude/module-provider.ts
+++ b/src/modules/agent-module/claude/module-provider.ts
@@ -15,8 +15,27 @@ import type { ClaudeCodeServerManager } from "./server-manager";
 import { ClaudeCodeProvider } from "./provider";
 import type { PathProvider } from "../../../boundaries/platform/path-provider";
 import type { SupportedPlatform, SupportedArch } from "../../../boundaries/platform/platform-info";
-import { getClaudeUrlForVersion, getClaudeSubPath } from "./setup-info";
+import type { ProcessRunner } from "../../../boundaries/platform/process";
+import { getClaudeUrlForVersion, getClaudeSubPath, getClaudeExecutablePath } from "./setup-info";
 import { createAgentModuleProvider } from "../module-provider";
+import { getErrorMessage } from "../../../shared/error-utils";
+
+/**
+ * Matches the `(choices: ...)` list on the `--permission-mode` line of
+ * `claude --help` — parsed rather than hardcoded so the form tracks whatever
+ * the installed Claude version supports.
+ */
+const PERMISSION_MODE_CHOICES_REGEX = /--permission-mode\b[\s\S]*?\(choices:\s*([^)]*)\)/;
+
+/** Parse the permission-mode choices from `claude --help` output ([] if none). */
+function parsePermissionModes(helpText: string): string[] {
+  const match = PERMISSION_MODE_CHOICES_REGEX.exec(helpText);
+  if (match === null || match[1] === undefined) return [];
+  return match[1]
+    .split(",")
+    .map((entry) => entry.trim().replace(/^["']|["']$/g, ""))
+    .filter((entry) => entry.length > 0);
+}
 
 // =============================================================================
 // Dependency Interface
@@ -38,6 +57,8 @@ export interface ClaudeModuleProviderDeps {
   readonly platform: SupportedPlatform;
   readonly arch: SupportedArch;
   readonly logger: Logger;
+  /** Process runner used to detect permission modes via `claude --help`. */
+  readonly processRunner: Pick<ProcessRunner, "run">;
 }
 
 // =============================================================================
@@ -57,7 +78,26 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
     platform,
     arch,
     logger,
+    processRunner,
   } = deps;
+
+  // Owned by the module: parse `claude --help` once (cached) for the permission
+  // modes the creation form offers. Pinned version.claude relies on the binary
+  // being on PATH; otherwise detection degrades to the default mode only. A
+  // failed run is not cached, so a later call can retry.
+  let permissionModesCache: readonly string[] | undefined;
+  const detectPermissionModes = async (): Promise<readonly string[]> => {
+    if (permissionModesCache !== undefined) return permissionModesCache;
+    try {
+      const proc = processRunner.run(getClaudeExecutablePath(platform), ["--help"]);
+      const { stdout } = await proc.wait();
+      permissionModesCache = parsePermissionModes(stdout);
+      return permissionModesCache;
+    } catch (error) {
+      logger.warn("Failed to detect Claude permission modes", { error: getErrorMessage(error) });
+      return [];
+    }
+  };
 
   return createAgentModuleProvider<ClaudeCodeProvider>(
     {
@@ -120,6 +160,9 @@ export function createClaudeModuleProvider(deps: ClaudeModuleProviderDeps): Agen
           event === "open" ? "WrapperStart" : "WrapperEnd"
         );
       },
+
+      // --- Launch options ---
+      getLaunchOptions: async () => ({ permissionModes: await detectPermissionModes() }),
     },
     { logger, downloadDeps, binaryName: binaryConfig.name }
   );

--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -882,7 +882,8 @@ describe("ClaudeCodeServerManager integration", () => {
 
       await serverManager.setInitialPrompt("/workspace/feature-a", {
         prompt: "Test prompt",
-        agent: "coder",
+        agentName: "coder",
+        permissionMode: "plan",
         model: { providerID: "anthropic", modelID: "claude-sonnet" },
       });
 
@@ -894,7 +895,8 @@ describe("ClaudeCodeServerManager integration", () => {
       const parsed = JSON.parse(content);
 
       expect(parsed.prompt).toBe("Test prompt");
-      expect(parsed.agent).toBe("coder");
+      expect(parsed.agentName).toBe("coder");
+      expect(parsed.permissionMode).toBe("plan");
       expect(parsed.model).toBe("claude-sonnet"); // modelID only, not full object
     });
 
@@ -959,20 +961,40 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChanges).toEqual(["busy"]);
     });
 
-    it("WrapperStart with plan initial prompt sets status to idle", async () => {
+    it("WrapperStart with a plan-mode prompt still sets status to busy (mode is irrelevant)", async () => {
       await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
       serverManager.onStatusChange("/workspace/feature-a", (status) => {
         statusChanges.push(status);
       });
 
-      // Set initial prompt with plan agent
+      const markActiveHandler = vi.fn();
+      serverManager.setMarkActiveHandler(markActiveHandler);
+
+      // A prompt is given — the agent works on it regardless of permission mode.
       await serverManager.setInitialPrompt("/workspace/feature-a", {
         prompt: "Plan a feature",
-        agent: "plan",
+        permissionMode: "plan",
       });
 
-      // WrapperStart should set status to idle (normal behavior)
+      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
+
+      expect(statusChanges).toEqual(["busy"]);
+    });
+
+    it("WrapperStart with an agent/mode-only prompt (empty text) sets status to idle", async () => {
+      await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Only an agent name was chosen — no prompt text to process.
+      await serverManager.setInitialPrompt("/workspace/feature-a", {
+        prompt: "",
+        agentName: "reviewer",
+      });
+
       serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
 
       expect(statusChanges).toEqual(["idle"]);

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -56,7 +56,7 @@ export interface WorkspaceState {
   initialPromptPath?: Path;
   /** Path to the no-session marker file (for getNoSessionMarkerPath) */
   noSessionMarkerPath?: Path;
-  /** Flag: first WrapperStart should set status to busy (non-plan initial prompt) */
+  /** Flag: first WrapperStart should set status to busy (a non-empty initial prompt) */
   busyOnWrapperStart?: boolean;
   /** Set of active sub-agent IDs (tracked via SubagentStart/SubagentStop) */
   activeSubagents: Set<string>;
@@ -369,14 +369,22 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       const tempDir = await this.fileSystem.mkdtemp("codehydra-initial-prompt-");
 
       // Build JSON content - extract modelID from model if present
-      const jsonContent: { prompt: string; model?: string; agent?: string } = {
+      const jsonContent: {
+        prompt: string;
+        model?: string;
+        permissionMode?: string;
+        agentName?: string;
+      } = {
         prompt: config.prompt,
       };
       if (config.model !== undefined) {
         jsonContent.model = config.model.modelID;
       }
-      if (config.agent !== undefined) {
-        jsonContent.agent = config.agent;
+      if (config.permissionMode !== undefined) {
+        jsonContent.permissionMode = config.permissionMode;
+      }
+      if (config.agentName !== undefined) {
+        jsonContent.agentName = config.agentName;
       }
 
       // Write the initial prompt file
@@ -386,9 +394,11 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       // Store the path for later retrieval
       state.initialPromptPath = promptFilePath;
 
-      // Non-plan agents will immediately process the prompt, so the first
-      // WrapperStart should show "busy" instead of "idle".
-      state.busyOnWrapperStart = config.agent !== "plan";
+      // Show "busy" on the first WrapperStart only when there is a prompt for
+      // the agent to process. Permission mode is irrelevant (even plan mode
+      // works on the prompt); an empty prompt (e.g. only an agent or permission
+      // mode was chosen) has nothing to run, so it starts "idle".
+      state.busyOnWrapperStart = config.prompt.trim() !== "";
 
       this.logger.info("Initial prompt file created", {
         workspacePath: normalizedPath,

--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -222,7 +222,7 @@ describe("ch-claude.cjs boundary tests", () => {
       expect(output!.args).toContain("/tmp/settings.json");
       expect(output!.args).toContain("--mcp-config");
       expect(output!.args).toContain("/tmp/mcp.json");
-      expect(output!.args).toContain("--dangerously-skip-permissions");
+      expect(output!.args).toContain("--allow-dangerously-skip-permissions");
     });
 
     it("deletes CLAUDECODE env var before spawning", async () => {
@@ -319,7 +319,10 @@ describe("ch-claude.cjs boundary tests", () => {
       const promptFile = join(promptDir, "initial-prompt.json");
       const multiLinePrompt =
         "Please review these changes:\n\n- Fix the login bug\n- Update the tests\n\nFocus on error handling.";
-      await writeFile(promptFile, JSON.stringify({ prompt: multiLinePrompt, agent: "plan" }));
+      await writeFile(
+        promptFile,
+        JSON.stringify({ prompt: multiLinePrompt, permissionMode: "plan" })
+      );
 
       const result = await executeScript(
         COMPILED_SCRIPT_PATH,
@@ -370,12 +373,12 @@ describe("ch-claude.cjs boundary tests", () => {
       expect(output).not.toBeNull();
       // Without initial prompt, first non-continue arg should be a flag, not a prompt string
       const firstNonContinueArg = output!.args.find((a) => a !== "--continue");
-      expect(firstNonContinueArg).toBe("--dangerously-skip-permissions");
+      expect(firstNonContinueArg).toBe("--allow-dangerously-skip-permissions");
     });
   });
 
   describe("permission modes", () => {
-    it("uses --dangerously-skip-permissions when no agent is set", async () => {
+    it("uses only --allow-dangerously-skip-permissions when no mode is set", async () => {
       const result = await executeScript(
         COMPILED_SCRIPT_PATH,
         {
@@ -392,15 +395,15 @@ describe("ch-claude.cjs boundary tests", () => {
       ).toBe(0);
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
-      expect(output!.args).toContain("--dangerously-skip-permissions");
-      expect(output!.args).not.toContain("--allow-dangerously-skip-permissions");
+      expect(output!.args).toContain("--allow-dangerously-skip-permissions");
+      expect(output!.args).not.toContain("--permission-mode");
     });
 
-    it("uses plan permission mode when agent is 'plan'", async () => {
+    it("uses plan permission mode when permissionMode is 'plan'", async () => {
       const promptDir = join(tempDir.path, "prompt-dir");
       await mkdir(promptDir, { recursive: true });
       const promptFile = join(promptDir, "initial-prompt.json");
-      await writeFile(promptFile, JSON.stringify({ prompt: "test", agent: "plan" }));
+      await writeFile(promptFile, JSON.stringify({ prompt: "test", permissionMode: "plan" }));
 
       const result = await executeScript(
         COMPILED_SCRIPT_PATH,

--- a/src/modules/agent-module/claude/wrapper.integration.test.ts
+++ b/src/modules/agent-module/claude/wrapper.integration.test.ts
@@ -55,7 +55,8 @@ describe("getInitialPromptConfig integration", () => {
     const fileContent = JSON.stringify({
       prompt: "Hello, Claude!",
       model: "claude-sonnet",
-      agent: "coder",
+      agentName: "coder",
+      permissionMode: "plan",
     });
     mockReadFileSync.mockReturnValue(fileContent);
 
@@ -66,7 +67,8 @@ describe("getInitialPromptConfig integration", () => {
     expect(result).toEqual({
       prompt: "Hello, Claude!",
       model: "claude-sonnet",
-      agent: "coder",
+      agentName: "coder",
+      permissionMode: "plan",
     });
 
     // Verify file was read
@@ -149,7 +151,8 @@ describe("getInitialPromptConfig integration", () => {
 
     expect(result).toEqual({ prompt: "Simple prompt" });
     expect(result?.model).toBeUndefined();
-    expect(result?.agent).toBeUndefined();
+    expect(result?.agentName).toBeUndefined();
+    expect(result?.permissionMode).toBeUndefined();
   });
 
   it("continues cleanup even if unlink fails", () => {

--- a/src/modules/agent-module/claude/wrapper.test.ts
+++ b/src/modules/agent-module/claude/wrapper.test.ts
@@ -16,15 +16,15 @@ import {
 } from "./wrapper";
 
 describe("buildPermissionArgs", () => {
-  it("returns --dangerously-skip-permissions when no agent", () => {
-    expect(buildPermissionArgs()).toEqual(["--dangerously-skip-permissions"]);
+  it("returns only --allow-dangerously-skip-permissions for the default (no mode)", () => {
+    expect(buildPermissionArgs()).toEqual(["--allow-dangerously-skip-permissions"]);
   });
 
-  it("returns --dangerously-skip-permissions for implement agent", () => {
-    expect(buildPermissionArgs("implement")).toEqual(["--dangerously-skip-permissions"]);
+  it("treats an empty mode as the default", () => {
+    expect(buildPermissionArgs("")).toEqual(["--allow-dangerously-skip-permissions"]);
   });
 
-  it("returns plan mode flags for plan agent", () => {
+  it("adds --permission-mode for plan", () => {
     expect(buildPermissionArgs("plan")).toEqual([
       "--allow-dangerously-skip-permissions",
       "--permission-mode",
@@ -32,8 +32,12 @@ describe("buildPermissionArgs", () => {
     ]);
   });
 
-  it("returns --dangerously-skip-permissions for unknown agents", () => {
-    expect(buildPermissionArgs("coder")).toEqual(["--dangerously-skip-permissions"]);
+  it("adds --permission-mode for any detected mode", () => {
+    expect(buildPermissionArgs("bypassPermissions")).toEqual([
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
   });
 });
 
@@ -50,8 +54,8 @@ describe("buildInitialPromptArgs", () => {
     expect(args).toEqual(["Hi", "--model", "claude-sonnet"]);
   });
 
-  it("with agent adds --agent flag", () => {
-    const config: InitialPromptConfig = { prompt: "Hi", agent: "coder" };
+  it("with agentName adds --agent flag", () => {
+    const config: InitialPromptConfig = { prompt: "Hi", agentName: "coder" };
     const args = buildInitialPromptArgs(config);
     expect(args).toEqual(["Hi", "--agent", "coder"]);
   });
@@ -60,7 +64,7 @@ describe("buildInitialPromptArgs", () => {
     const config: InitialPromptConfig = {
       prompt: "Implement the feature",
       model: "claude-opus",
-      agent: "architect",
+      agentName: "architect",
     };
     const args = buildInitialPromptArgs(config);
     expect(args).toEqual([
@@ -89,7 +93,7 @@ describe("buildInitialPromptArgs", () => {
   });
 
   it("omits empty prompt but includes agent flag", () => {
-    const config: InitialPromptConfig = { prompt: "", agent: "plan" };
+    const config: InitialPromptConfig = { prompt: "", agentName: "plan" };
     const args = buildInitialPromptArgs(config);
     expect(args).toEqual(["--agent", "plan"]);
   });

--- a/src/modules/agent-module/claude/wrapper.ts
+++ b/src/modules/agent-module/claude/wrapper.ts
@@ -30,7 +30,10 @@ import { dirname } from "node:path";
 export interface InitialPromptConfig {
   readonly prompt: string;
   readonly model?: string;
-  readonly agent?: string;
+  /** Claude permission mode (e.g. "plan"). Omitted = let Claude decide. */
+  readonly permissionMode?: string;
+  /** Named agent/persona passed to --agent. */
+  readonly agentName?: string;
 }
 
 /**
@@ -97,18 +100,23 @@ function getInitialPromptConfig(): InitialPromptConfig | undefined {
 }
 
 /**
- * Build permission flags based on agent type.
- * - "plan" agent: read-only mode with --permissions-mode plan
- * - All others (including "implement" and no agent): full permissions
+ * Build permission flags from the selected permission mode.
  *
- * @param agent - The agent name from initial prompt config
+ * Always passes --allow-dangerously-skip-permissions so bypass stays reachable
+ * via Shift+Tab without forcing it. The starting mode is set with
+ * --permission-mode when a mode is chosen; omitting it lets Claude use its
+ * default (normal prompting). On resume (no initial-prompt config) the mode is
+ * not re-applied — Claude does not restore --permission-mode across --continue.
+ *
+ * @param permissionMode - The permission mode from initial prompt config
  * @returns Array of CLI permission flags
  */
-function buildPermissionArgs(agent?: string): string[] {
-  if (agent === "plan") {
-    return ["--allow-dangerously-skip-permissions", "--permission-mode", "plan"];
+function buildPermissionArgs(permissionMode?: string): string[] {
+  const args = ["--allow-dangerously-skip-permissions"];
+  if (permissionMode !== undefined && permissionMode !== "") {
+    args.push("--permission-mode", permissionMode);
   }
-  return ["--dangerously-skip-permissions"];
+  return args;
 }
 
 /**
@@ -128,8 +136,8 @@ function buildInitialPromptArgs(config: InitialPromptConfig): string[] {
     args.push("--model", config.model);
   }
 
-  if (config.agent !== undefined) {
-    args.push("--agent", config.agent);
+  if (config.agentName !== undefined && config.agentName !== "") {
+    args.push("--agent", config.agentName);
   }
 
   return args;
@@ -391,7 +399,7 @@ async function main(): Promise<never> {
   // User args can override these if they come after
   const args = [
     ...initialPromptArgs,
-    ...buildPermissionArgs(initialPromptConfig?.agent),
+    ...buildPermissionArgs(initialPromptConfig?.permissionMode),
     "--ide",
     "--settings",
     settingsPath,

--- a/src/modules/agent-module/module-provider.ts
+++ b/src/modules/agent-module/module-provider.ts
@@ -13,6 +13,7 @@
 
 import type {
   AgentModuleProvider,
+  AgentLaunchOptions,
   WorkspaceStartOptions,
   WorkspaceStartResult,
 } from "./agent-module-provider";
@@ -148,6 +149,11 @@ export interface AgentModuleSpec<P extends AgentProvider> {
 
   /** Clear agent-specific state on dispose. */
   onDispose?(): void;
+
+  // --- Launch options ---
+
+  /** Launch options this agent offers the creation form (e.g. permission modes). */
+  getLaunchOptions?(): Promise<AgentLaunchOptions>;
 }
 
 /**
@@ -350,6 +356,9 @@ export function createAgentModuleProvider<P extends AgentProvider>(
 
     // --- Binary ---
     binaryType: binaryName as BinaryType,
+
+    // --- Launch options (optional per spec) ---
+    ...(spec.getLaunchOptions && { getLaunchOptions: spec.getLaunchOptions }),
 
     async preflight(): Promise<{ success: boolean; needsDownload: boolean }> {
       try {

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -207,6 +207,10 @@ describe("OpenCode module provider", () => {
       expect(provider.serverName).toBe("OpenCode");
     });
 
+    it("offers no launch options (no permission-mode axis)", () => {
+      expect(provider.getLaunchOptions).toBeUndefined();
+    });
+
     it("has correct scripts", () => {
       expect(provider.scripts).toEqual(["ch-opencode", "ch-opencode.cjs", "ch-opencode.cmd"]);
     });
@@ -519,7 +523,7 @@ describe("OpenCode module provider", () => {
     it("passes initialPrompt to startServer options", async () => {
       provider.initialize(null);
 
-      const initialPrompt = { prompt: "build feature X", agent: "coder" };
+      const initialPrompt = { prompt: "build feature X", agentName: "coder" };
       // startServer will trigger the callback
       vi.mocked(serverManager.startServer).mockImplementation(async () => {
         serverManager._triggerStarted(WS_PATH, 8080, undefined);

--- a/src/modules/agent-module/opencode/server-manager.ts
+++ b/src/modules/agent-module/opencode/server-manager.ts
@@ -84,7 +84,8 @@ export interface StartServerOptions {
   /** Initial prompt to send after server becomes healthy */
   readonly initialPrompt?: {
     readonly prompt: string;
-    readonly agent?: string;
+    /** Named agent to run (OpenCode's agent, e.g. "build"/"plan"/custom). */
+    readonly agentName?: string;
     readonly model?: PromptModel;
   };
 }
@@ -155,7 +156,7 @@ export class OpenCodeServerManager implements AgentServerManager, IDisposable {
       this.setPendingPrompt(
         workspacePath,
         options.initialPrompt.prompt,
-        options.initialPrompt.agent,
+        options.initialPrompt.agentName,
         options.initialPrompt.model
       );
     }

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -492,9 +492,10 @@ describe("AutoWorkspaceModule Integration", () => {
 
       expect(openWorkspaceOp.dispatched).toHaveLength(1);
       expect(openWorkspaceOp.dispatched[0]!.payload.workspaceName).toBe("item-1");
+      // No `agent` in the default template → falls back to the default (no
+      // agent override, default permission mode).
       expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
         prompt: "Work on item-1",
-        agent: "plan",
       });
     });
 
@@ -654,7 +655,7 @@ describe("AutoWorkspaceModule Integration", () => {
       expect(payload.stealFocus).toBe(true);
       expect(payload.initialPrompt).toEqual({
         prompt: "Work on item-1",
-        agent: "build",
+        agentName: "build",
         model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
       });
     });

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -360,9 +360,12 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
         return;
       }
 
+      // The frontmatter `agent` field selects the named agent (e.g. "plan",
+      // "build", or a custom agent). When unset, fall back to the default — no
+      // agent override. Permission mode is left at the default.
       const initialPrompt: NormalizedInitialPrompt = {
         prompt: config.prompt,
-        agent: config.agent ?? "plan",
+        ...(config.agent !== undefined && { agentName: config.agent }),
         ...(config.model !== undefined && { model: config.model }),
       };
 

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -34,6 +34,7 @@ import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import { INTENT_LIST_PROJECTS } from "../intents/list-projects";
 import { INTENT_GET_ACTIVE_WORKSPACE } from "../intents/get-active-workspace";
+import { INTENT_GET_LAUNCH_OPTIONS } from "../intents/agent-launch-options";
 
 // =============================================================================
 // Fixtures
@@ -170,6 +171,13 @@ function setup(options?: {
     if (projectId === null || projectId === undefined) return null;
     return { projectId, workspaceName: "existing", path: "/projects/a/.worktrees/existing" };
   });
+  dispatcher.results.set(INTENT_GET_LAUNCH_OPTIONS, (payload) => {
+    // Mirror real backends: Claude reports permission modes, OpenCode none.
+    const backend = (payload as { backend: string }).backend;
+    return {
+      permissionModes: backend === "claude" ? ["plan", "acceptEdits", "bypassPermissions"] : [],
+    };
+  });
 
   const deps: CreationModuleDeps = {
     dialogManager: dialogs.manager,
@@ -276,6 +284,18 @@ describe("CreationModule", () => {
       expect(fresh.id).not.toBe(panel.id);
     });
 
+    it("re-queries launch options on every form open (no stale cache)", async () => {
+      const s = setup();
+      await s.start();
+      await flush();
+      expect(s.dispatcher.byType(INTENT_GET_LAUNCH_OPTIONS)).toHaveLength(1);
+
+      currentPanel(s).emitDismiss();
+      await flush();
+
+      expect(s.dispatcher.byType(INTENT_GET_LAUNCH_OPTIONS)).toHaveLength(2);
+    });
+
     it("shows the agent dropdown only when more than one agent is available", async () => {
       const single = setup({ agents: [CLAUDE_AGENT] });
       const panelSingle = await single.start();
@@ -285,7 +305,35 @@ describe("CreationModule", () => {
       const panelDual = await dual.start();
       const agent = field(panelDual.config, "agent");
       expect(suggestionValues(agent)).toEqual(["claude", "opencode"]);
-      expect(agent["initialValue"]).toBe("claude");
+      expect(agent["value"]).toBe("claude");
+      expect(agent["changeEvent"]).toBe(true);
+    });
+
+    it("shows the permission-mode dropdown for Claude, populated from launch options", async () => {
+      const s = setup({ agents: [CLAUDE_AGENT, OPENCODE_AGENT], defaultAgent: "claude" });
+      await s.start();
+      await flush();
+
+      // Always-present free-text agent name field.
+      expect(field(currentPanel(s).config, "agent-name")["type"]).toBe("input");
+
+      // Permission mode is Claude-only: default entry plus detected modes.
+      const perm = field(currentPanel(s).config, "permission-mode");
+      expect(suggestionValues(perm)).toEqual(["", "plan", "acceptEdits", "bypassPermissions"]);
+    });
+
+    it("hides the permission-mode dropdown when switching to OpenCode", async () => {
+      const s = setup({ agents: [CLAUDE_AGENT, OPENCODE_AGENT], defaultAgent: "claude" });
+      const panel = await s.start();
+      await flush();
+      expect(sectionById(currentPanel(s).config, "permission-mode")).toBeDefined();
+
+      panel.emitChange("agent", { agent: "opencode" });
+      await flush();
+
+      expect(sectionById(currentPanel(s).config, "permission-mode")).toBeUndefined();
+      // The agent name field stays for both backends.
+      expect(sectionById(currentPanel(s).config, "agent-name")).toBeDefined();
     });
   });
 
@@ -445,7 +493,6 @@ describe("CreationModule", () => {
         name: "new-feature",
         base: "main",
         prompt: "",
-        "agent-mode": "",
         agent: "claude",
       });
       await flush();
@@ -473,7 +520,6 @@ describe("CreationModule", () => {
         name: "origin/feature-x",
         base: "origin/feature-x",
         prompt: "",
-        "agent-mode": "",
         agent: "claude",
       });
       await flush();
@@ -485,7 +531,7 @@ describe("CreationModule", () => {
       });
     });
 
-    it("builds the InitialPrompt: plain prompt, plan mode, and agent only when != default", async () => {
+    it("builds the InitialPrompt with permissionMode + agentName and the agent override when != default", async () => {
       const s = setup({
         defaultBaseBranch: "main",
         agents: [CLAUDE_AGENT, OPENCODE_AGENT],
@@ -498,19 +544,20 @@ describe("CreationModule", () => {
         name: "with-prompt",
         base: "main",
         prompt: "  do things  ",
-        "agent-mode": "plan",
+        "permission-mode": "plan",
+        "agent-name": "reviewer",
         agent: "opencode",
       });
       await flush();
 
       const opens = s.dispatcher.byType(INTENT_OPEN_WORKSPACE);
       expect(opens[0]!.payload).toMatchObject({
-        initialPrompt: { prompt: "do things", agent: "plan" },
+        initialPrompt: { prompt: "do things", permissionMode: "plan", agentName: "reviewer" },
         agent: "opencode",
       });
     });
 
-    it("omits initialPrompt and agent when prompt empty, mode full, agent = default", async () => {
+    it("omits initialPrompt and agent when prompt empty, mode default, agent = default", async () => {
       const s = setup({ defaultBaseBranch: "main", defaultAgent: "claude" });
       const panel = await readyPanel(s);
 
@@ -519,7 +566,8 @@ describe("CreationModule", () => {
         name: "plain",
         base: "main",
         prompt: "   ",
-        "agent-mode": "",
+        "permission-mode": "",
+        "agent-name": "",
         agent: "claude",
       });
       await flush();
@@ -541,7 +589,6 @@ describe("CreationModule", () => {
         name: "existing",
         base: "main",
         prompt: "",
-        "agent-mode": "",
         agent: "claude",
       });
       await flush();

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -66,6 +66,11 @@ import {
   INTENT_GET_ACTIVE_WORKSPACE,
   type GetActiveWorkspaceIntent,
 } from "../intents/get-active-workspace";
+import {
+  INTENT_GET_LAUNCH_OPTIONS,
+  type GetLaunchOptionsIntent,
+  type LaunchOptionsResult,
+} from "../intents/agent-launch-options";
 
 // =============================================================================
 // Dependencies
@@ -91,7 +96,8 @@ const FIELD_NAME = "name";
 const FIELD_BASE = "base";
 const FIELD_PROMPT = "prompt";
 const FIELD_AGENT = "agent";
-const FIELD_AGENT_MODE = "agent-mode";
+const FIELD_AGENT_NAME = "agent-name";
+const FIELD_PERMISSION_MODE = "permission-mode";
 const ACTION_OPEN_FOLDER = "open-folder";
 const ACTION_CLONE = "clone";
 const ACTION_CREATE = "create";
@@ -136,6 +142,17 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   let projects: readonly Project[] = [];
   /** Agents available at the last session (re)open. */
   let availableAgents: readonly AgentInfo[] = [];
+  /** Backend the form currently targets (drives the per-backend fields). */
+  let selectedAgentType: LifecycleAgentType | null = null;
+  /**
+   * Launch options the selected backend reported (via agent:get-launch-options).
+   * The form is agent-agnostic: it renders whatever options come back. Re-fetched
+   * on every form open / backend switch; the heavy work (e.g. parsing
+   * `claude --help`) is cached inside the provider, so re-querying is cheap.
+   */
+  let launchOptions: LaunchOptionsResult | null = null;
+  /** The backend whose launch options are currently being fetched (if any). */
+  let loadingLaunchOptionsFor: LifecycleAgentType | null = null;
   let selectedProjectPath: string | null = null;
   let branches: readonly BaseInfo[] = [];
   let branchesLoading = false;
@@ -165,9 +182,77 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     return projects.find((p) => p.path === selectedProjectPath);
   }
 
+  /** The configured global default agent (already validated by the store). */
   function defaultAgent(): LifecycleAgentType | null {
-    const raw = deps.agentConfig.get();
-    return raw === "claude" || raw === "opencode" ? raw : null;
+    return deps.agentConfig.get();
+  }
+
+  /** Narrow a raw field value to a currently-available agent. */
+  function isAvailableAgent(value: string): value is LifecycleAgentType {
+    return availableAgents.some((a) => a.agent === value);
+  }
+
+  /** Backend to target on a fresh form: configured default, else first available. */
+  function resolveInitialAgentType(): LifecycleAgentType | null {
+    const configured = defaultAgent();
+    if (configured !== null && availableAgents.some((a) => a.agent === configured)) {
+      return configured;
+    }
+    return availableAgents[0]?.agent ?? null;
+  }
+
+  /** Permission modes reported by the currently selected backend. */
+  function currentPermissionModes(): readonly string[] {
+    return launchOptions?.permissionModes ?? [];
+  }
+
+  /** True while the selected backend's launch options are being fetched. */
+  function launchOptionsLoading(): boolean {
+    return loadingLaunchOptionsFor !== null && loadingLaunchOptionsFor === selectedAgentType;
+  }
+
+  /** Permission-mode suggestions: the default entry plus the backend's modes. */
+  function permissionModeSuggestions(): DropdownSuggestionGroup[] {
+    const items = [
+      { value: "", label: "default" },
+      ...currentPermissionModes()
+        .filter((mode) => mode !== "default")
+        .map((mode) => ({ value: mode, label: mode })),
+    ];
+    return [{ items }];
+  }
+
+  /**
+   * Fetch the selected backend's launch options. Agent-agnostic: the form just
+   * asks the backend what it offers. Called on every form open and backend
+   * switch — the provider caches the heavy work, so re-querying is cheap. The
+   * stale options are cleared up front so the form never shows another backend's
+   * values, and a late response is ignored if the backend changed meanwhile.
+   */
+  async function loadLaunchOptions(): Promise<void> {
+    const backend = selectedAgentType;
+    launchOptions = null;
+    if (backend === null) {
+      pushConfig();
+      return;
+    }
+    loadingLaunchOptionsFor = backend;
+    pushConfig();
+    try {
+      const intent: GetLaunchOptionsIntent = {
+        type: INTENT_GET_LAUNCH_OPTIONS,
+        payload: { backend },
+      };
+      const result = await dispatcher.dispatch(intent);
+      if (selectedAgentType === backend) launchOptions = result;
+    } catch (error) {
+      logger.warn("Creation form: launch options fetch failed", {
+        error: getErrorMessage(error),
+      });
+    } finally {
+      if (loadingLaunchOptionsFor === backend) loadingLaunchOptionsFor = null;
+      pushConfig();
+    }
   }
 
   /**
@@ -349,24 +434,34 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         label: "Agent",
         searchable: false,
         suggestions: [{ items: availableAgents.map((a) => ({ value: a.agent, label: a.label })) }],
-        ...(defaultAgent() !== null && { initialValue: defaultAgent()! }),
+        value: selectedAgentType ?? "",
+        changeEvent: true,
       });
     }
 
+    // Named agent/persona — free text for any backend (maps to the backend's
+    // named-agent option). Empty reports "" and omits the flag.
     sections.push({
-      type: "dropdown",
-      id: FIELD_AGENT_MODE,
-      label: "Agent mode",
-      searchable: false,
-      suggestions: [
-        {
-          items: [
-            { value: "", label: "Full permissions" },
-            { value: "plan", label: "Plan mode (read-only)" },
-          ],
-        },
-      ],
+      type: "input",
+      id: FIELD_AGENT_NAME,
+      label: "Agent name",
+      placeholder: "default",
     });
+
+    // Permission mode is driven by the backend's reported launch options: shown
+    // while loading or when the backend offers any modes, hidden otherwise (the
+    // form stays agent-agnostic — it never special-cases a backend). The
+    // "default" entry reports "" and omits the flag.
+    if (launchOptionsLoading() || currentPermissionModes().length > 0) {
+      sections.push({
+        type: "dropdown",
+        id: FIELD_PERMISSION_MODE,
+        label: "Permission mode",
+        searchable: false,
+        suggestions: permissionModeSuggestions(),
+        loading: launchOptionsLoading(),
+      });
+    }
 
     if (formError !== null) {
       sections.push({ type: "text", content: formError, icon: "error" });
@@ -493,9 +588,12 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     baseValue = "";
     pickerBusy = false;
     formError = null;
+    launchOptions = null;
+    loadingLaunchOptionsFor = null;
 
     await refreshProjects();
     availableAgents = await deps.getAvailableAgents();
+    selectedAgentType = resolveInitialAgentType();
     const seed = await computeSeedProject();
     if (seed !== null) {
       selectedProjectPath = seed;
@@ -507,6 +605,9 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     const newHandle = dialogManager.open(config, { surface: "panel" });
     handle = newHandle;
     wireSession(newHandle);
+
+    // Fetch the selected backend's launch options for the opening form.
+    void loadLaunchOptions();
 
     // Kick the branch load for the seeded project (re-selects to fetch).
     if (seed !== null) {
@@ -549,6 +650,15 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       } else if (event.fieldId === FIELD_BASE) {
         baseValue = data[FIELD_BASE] ?? "";
         pushConfig();
+      } else if (event.fieldId === FIELD_AGENT) {
+        const next = data[FIELD_AGENT] ?? "";
+        if (isAvailableAgent(next) && next !== selectedAgentType) {
+          selectedAgentType = next;
+          // Fetch the new backend's launch options; loadLaunchOptions clears the
+          // stale options and re-renders (which drives whether the
+          // permission-mode field appears).
+          void loadLaunchOptions();
+        }
       }
     });
 
@@ -591,18 +701,26 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     }
 
     const prompt = (data[FIELD_PROMPT] ?? "").trim();
-    const agentMode = data[FIELD_AGENT_MODE] ?? "";
+    // Permission mode is absent from the data when the backend doesn't offer it
+    // (the field isn't rendered); "" means the default (omit the flag).
+    const permissionMode = data[FIELD_PERMISSION_MODE] ?? "";
+    const agentName = (data[FIELD_AGENT_NAME] ?? "").trim();
     const agentSelection = data[FIELD_AGENT] ?? "";
 
     let initialPrompt: InitialPrompt | undefined;
-    if (prompt !== "" || agentMode === "plan") {
-      initialPrompt = agentMode === "plan" ? { prompt, agent: "plan" } : prompt;
+    const hasAgentOptions = permissionMode !== "" || agentName !== "";
+    if (prompt !== "" || hasAgentOptions) {
+      initialPrompt = hasAgentOptions
+        ? {
+            prompt,
+            ...(permissionMode !== "" && { permissionMode }),
+            ...(agentName !== "" && { agentName }),
+          }
+        : prompt;
     }
 
     const agent =
-      (agentSelection === "claude" || agentSelection === "opencode") &&
-      agentSelection !== defaultAgent() &&
-      availableAgents.some((a) => a.agent === agentSelection)
+      isAvailableAgent(agentSelection) && agentSelection !== defaultAgent()
         ? agentSelection
         : undefined;
 

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -154,9 +154,10 @@ export const SERVER_INSTRUCTIONS = [
   "CodeHydra manages workspaces as git worktrees, each with its own AI agent session.",
   "",
   "When creating a workspace with workspace_create, the initialPrompt parameter controls what the new workspace's agent will do.",
-  "Use the object form { prompt, agent } to control the agent's permission mode:",
-  '- agent: "plan" — the agent starts in read-only/plan mode. Use this when the task requires planning, research, or exploration before making changes.',
-  "- No agent field — the agent starts with full permissions. Use this when the task should proceed directly to implementation.",
+  "Use the object form { prompt, permissionMode, agentName } to control how the agent starts:",
+  '- permissionMode: "plan" — the agent starts in read-only/plan mode (Claude). Use this when the task requires planning, research, or exploration before making changes.',
+  "- No permissionMode field — the agent starts in its default mode. Use this when the task should proceed directly to implementation.",
+  '- agentName — run a named agent/persona (e.g. "build" on OpenCode, or a Claude custom agent). Omit to use the default agent.',
   "",
   "The model is automatically propagated from your current session — you do not need to specify it.",
   "",
@@ -712,9 +713,11 @@ export class McpServer {
             .optional()
             .describe(
               "Optional initial prompt to send after workspace is created. " +
-                "Can be a string or { prompt, agent? }. " +
-                'Set agent to "plan" for read-only/planning mode, ' +
-                "or omit agent for full-permission implementation mode."
+                "Can be a string or { prompt, permissionMode?, agentName? }. " +
+                'Set permissionMode to "plan" for read-only/planning mode (Claude), ' +
+                "or omit it for the default mode. " +
+                'Set agentName to run a named agent (e.g. "build" on OpenCode, ' +
+                "or a Claude custom agent)."
             ),
           stealFocus: z
             .boolean()
@@ -734,13 +737,15 @@ export class McpServer {
           const tracking = args.tracking as string | undefined;
           const rawInitialPrompt = args.initialPrompt as
             | string
-            | { prompt: string; agent?: string; model?: PromptModel }
+            | { prompt: string; permissionMode?: string; agentName?: string; model?: PromptModel }
             | undefined;
           // Default to false for API calls (stay in background)
           const stealFocus = (args.stealFocus as boolean | undefined) ?? false;
 
           // If initialPrompt provided, resolve model from caller's session if not specified
-          let finalPrompt: { prompt: string; agent?: string; model?: PromptModel } | undefined;
+          let finalPrompt:
+            | { prompt: string; permissionMode?: string; agentName?: string; model?: PromptModel }
+            | undefined;
           if (rawInitialPrompt !== undefined) {
             const normalized = normalizeInitialPrompt(rawInitialPrompt);
 
@@ -752,8 +757,11 @@ export class McpServer {
 
             // Build final prompt with model if available
             finalPrompt = { prompt: normalized.prompt };
-            if (normalized.agent !== undefined) {
-              finalPrompt = { ...finalPrompt, agent: normalized.agent };
+            if (normalized.permissionMode !== undefined) {
+              finalPrompt = { ...finalPrompt, permissionMode: normalized.permissionMode };
+            }
+            if (normalized.agentName !== undefined) {
+              finalPrompt = { ...finalPrompt, agentName: normalized.agentName };
             }
             if (model !== undefined) {
               finalPrompt = { ...finalPrompt, model };

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -391,7 +391,8 @@ describe("SERVER_INSTRUCTIONS", () => {
     expect(SERVER_INSTRUCTIONS).toContain("workspace_create");
     expect(SERVER_INSTRUCTIONS).toContain('"plan"');
     expect(SERVER_INSTRUCTIONS).toContain("read-only");
-    expect(SERVER_INSTRUCTIONS).toContain("full permissions");
+    expect(SERVER_INSTRUCTIONS).toContain("default mode");
+    expect(SERVER_INSTRUCTIONS).toContain("agentName");
   });
 });
 
@@ -418,14 +419,25 @@ describe("initialPromptSchema validation", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts object with prompt and agent", () => {
+  it("accepts object with prompt and agentName", () => {
     const result = initialPromptSchema.safeParse({
       prompt: "Implement the feature",
-      agent: "build",
+      agentName: "build",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({ prompt: "Implement the feature", agent: "build" });
+      expect(result.data).toEqual({ prompt: "Implement the feature", agentName: "build" });
+    }
+  });
+
+  it("accepts object with prompt and permissionMode", () => {
+    const result = initialPromptSchema.safeParse({
+      prompt: "Investigate the bug",
+      permissionMode: "plan",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ prompt: "Investigate the bug", permissionMode: "plan" });
     }
   });
 });

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -385,33 +385,46 @@ export interface PromptModel {
 
 /**
  * Initial prompt for workspace creation.
- * Can be a simple string (uses default agent) or an object with optional agent/model.
+ * Can be a simple string (uses defaults) or an object with optional
+ * permissionMode / agentName / model.
+ *
+ * Axes (independent):
+ * - permissionMode: Claude permission mode (e.g. "plan", "acceptEdits",
+ *   "bypassPermissions"). Claude-only; ignored by OpenCode. Omit for the
+ *   default (Claude decides; no --permission-mode flag).
+ * - agentName: named agent/persona. Claude -> --agent; OpenCode -> the agent
+ *   to run (e.g. "build", "plan", or a custom agent). Omit for the default.
  *
  * @example
- * // Simple string - uses default agent
+ * // Simple string - uses defaults
  * initialPrompt: "Implement the login feature"
  *
- * // Object with agent - uses specified agent
- * initialPrompt: { prompt: "Implement the login feature", agent: "build" }
+ * // Read-only/plan mode on Claude
+ * initialPrompt: { prompt: "Investigate the bug", permissionMode: "plan" }
  *
- * // Object with model - uses specified model
+ * // Named agent (OpenCode 'build', or a Claude custom agent)
+ * initialPrompt: { prompt: "Implement the login feature", agentName: "build" }
+ *
+ * // Object with model
  * initialPrompt: { prompt: "Implement the login feature", model: { providerID: "anthropic", modelID: "claude-sonnet" } }
  */
 export type InitialPrompt =
   | string
   | {
       readonly prompt: string;
-      readonly agent?: string;
+      readonly permissionMode?: string;
+      readonly agentName?: string;
       readonly model?: PromptModel;
     };
 
 /**
  * Normalized initial prompt structure.
- * Always has prompt text, agent and model are optional.
+ * Always has prompt text; permissionMode, agentName and model are optional.
  */
 export interface NormalizedInitialPrompt {
   readonly prompt: string;
-  readonly agent?: string;
+  readonly permissionMode?: string;
+  readonly agentName?: string;
   readonly model?: PromptModel;
 }
 
@@ -419,24 +432,19 @@ export interface NormalizedInitialPrompt {
  * Normalize an initial prompt to a consistent structure.
  *
  * @param input - The initial prompt (string or object)
- * @returns Normalized object with prompt and optional agent/model
+ * @returns Normalized object with prompt and optional permissionMode/agentName/model
  */
 export function normalizeInitialPrompt(input: InitialPrompt): NormalizedInitialPrompt {
   if (typeof input === "string") {
     return { prompt: input };
   }
-  // Build result conditionally to satisfy exactOptionalPropertyTypes
-  const result: NormalizedInitialPrompt = { prompt: input.prompt };
-  if (input.agent !== undefined && input.model !== undefined) {
-    return { prompt: input.prompt, agent: input.agent, model: input.model };
-  }
-  if (input.agent !== undefined) {
-    return { prompt: input.prompt, agent: input.agent };
-  }
-  if (input.model !== undefined) {
-    return { prompt: input.prompt, model: input.model };
-  }
-  return result;
+  // Conditional spread keeps undefined keys out (exactOptionalPropertyTypes).
+  return {
+    prompt: input.prompt,
+    ...(input.permissionMode !== undefined && { permissionMode: input.permissionMode }),
+    ...(input.agentName !== undefined && { agentName: input.agentName }),
+    ...(input.model !== undefined && { model: input.model }),
+  };
 }
 
 /**
@@ -449,13 +457,15 @@ const promptModelSchema = z.object({
 
 /**
  * Zod schema for validating InitialPrompt.
- * Accepts either a non-empty string or an object with prompt and optional agent/model.
+ * Accepts either a non-empty string or an object with prompt and optional
+ * permissionMode / agentName / model.
  */
 export const initialPromptSchema = z.union([
   z.string().min(1),
   z.object({
     prompt: z.string().min(1),
-    agent: z.string().optional(),
+    permissionMode: z.string().optional(),
+    agentName: z.string().optional(),
     model: promptModelSchema.optional(),
   }),
 ]);

--- a/src/shared/plugin-protocol.test.ts
+++ b/src/shared/plugin-protocol.test.ts
@@ -380,7 +380,7 @@ describe("validateWorkspaceCreateRequest", () => {
         base: "main",
         initialPrompt: {
           prompt: "Implement the feature",
-          agent: "build",
+          agentName: "build",
           model: { providerID: "anthropic", modelID: "claude-sonnet" },
         },
         stealFocus: false,
@@ -423,7 +423,7 @@ describe("validateWorkspaceCreateRequest", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: { agent: "build" },
+        initialPrompt: { agentName: "build" },
       });
       expect(result).toEqual({
         valid: false,


### PR DESCRIPTION
- Split the per-workspace "agent mode" into two independent axes — permission mode and named agent — on top of the existing backend selector.
- `InitialPrompt`: `agent` → `permissionMode` + `agentName` (IPC + MCP contract migrated; sidekick, auto-workspace and all callers updated).
- Claude: always passes `--allow-dangerously-skip-permissions`; `--permission-mode` / `--agent` applied only when set. The default now prompts instead of silently bypassing.
- New `agent:get-launch-options` intent (hook-collected) — each agent provider reports its own options. Claude parses `claude --help` (cached, inline); OpenCode reports none.
- Creation form is agent-agnostic: re-queries launch options on each open, renders the permission-mode dropdown only when the backend reports modes.
- Auto-workspace template `agent` → `agentName`, falls back to default (not plan).
- `busyOnWrapperStart` keys on a non-empty prompt only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)