### PR TITLE
refactor(agents): unify workspace:open agent params into AgentSpec

### DIFF
--- a/extensions/sidekick/api.d.ts
+++ b/extensions/sidekick/api.d.ts
@@ -114,20 +114,34 @@ export interface PromptModel {
 }
 
 /**
- * Initial prompt for workspace creation.
- * Can be a simple string (uses the default agent) or an object with optional
- * agent and model selection.
+ * Agent specification for workspace creation — a discriminated union by backend.
+ * Carries the prompt plus the backend-specific launch config:
+ * - "default": prompt only; the backend is resolved on the CodeHydra side.
+ * - "claude": prompt, model, permissionMode (e.g. "plan") and a named agent.
+ * - "opencode": prompt, model and a named agent (e.g. "build"). No permission mode.
  */
-export type InitialPrompt =
-  | string
-  | { readonly prompt: string; readonly agent?: string; readonly model?: PromptModel };
+export type AgentSpec =
+  | { readonly type: "default"; readonly prompt?: string }
+  | {
+      readonly type: "claude";
+      readonly prompt?: string;
+      readonly model?: PromptModel;
+      readonly permissionMode?: string;
+      readonly agentName?: string;
+    }
+  | {
+      readonly type: "opencode";
+      readonly prompt?: string;
+      readonly model?: PromptModel;
+      readonly agentName?: string;
+    };
 
 /**
  * Options for workspace creation.
  */
 export interface WorkspaceCreateOptions {
-  /** Optional initial prompt to send after workspace is created */
-  readonly initialPrompt?: InitialPrompt;
+  /** Optional agent spec: prompt + backend-specific launch config. */
+  readonly agent?: AgentSpec;
   /** If true, steal focus from current workspace. If false, don't steal focus but still
    *  switch when no workspace is active. Default: switch (undefined treated as true). */
   readonly stealFocus?: boolean;

--- a/extensions/sidekick/src/api-drift-guard.ts
+++ b/extensions/sidekick/src/api-drift-guard.ts
@@ -40,12 +40,9 @@ export type WorkspaceMatches = Expect<Extends<shared.Workspace, api.Workspace>>;
 export type WorkspaceKeysMatch = Expect<SameKeys<shared.Workspace, api.Workspace>>;
 
 // Client → server payloads.
-export type InitialPromptMatches = Expect<MutuallyExtends<api.InitialPrompt, shared.InitialPrompt>>;
+export type AgentSpecMatches = Expect<MutuallyExtends<api.AgentSpec, shared.AgentSpec>>;
 export type PromptModelMatches = Expect<MutuallyExtends<api.PromptModel, shared.PromptModel>>;
 export type LogContextMatches = Expect<MutuallyExtends<api.LogContext, LogContext>>;
 export type WorkspaceCreateOptionsMatch = Expect<
-  MutuallyExtends<
-    api.WorkspaceCreateOptions,
-    Pick<WorkspaceCreateRequest, "initialPrompt" | "stealFocus">
-  >
+  MutuallyExtends<api.WorkspaceCreateOptions, Pick<WorkspaceCreateRequest, "agent" | "stealFocus">>
 >;

--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -11,7 +11,7 @@ import type {
   CommandRequest,
   LogContext,
   WorkspaceCreateRequest,
-  InitialPrompt,
+  AgentSpec,
   AgentSession,
   AgentType,
   ShowNotificationRequest,
@@ -419,11 +419,7 @@ const codehydraApi = {
       return emitApiCall<unknown>("api:workspace:executeCommand", { command, args });
     },
 
-    create(
-      name: string,
-      base: string,
-      options?: { initialPrompt?: InitialPrompt; stealFocus?: boolean }
-    ) {
+    create(name: string, base: string, options?: { agent?: AgentSpec; stealFocus?: boolean }) {
       // Client-side validation
       if (typeof name !== "string" || name.trim().length === 0) {
         return Promise.reject(new Error("Name must be a non-empty string"));
@@ -431,32 +427,27 @@ const codehydraApi = {
       if (typeof base !== "string" || base.trim().length === 0) {
         return Promise.reject(new Error("Base must be a non-empty string"));
       }
-      // Validate initialPrompt if provided
-      if (options?.initialPrompt !== undefined) {
-        const prompt = options.initialPrompt;
-        if (typeof prompt === "string") {
-          if (prompt.length === 0) {
-            return Promise.reject(new Error("Initial prompt cannot be empty"));
-          }
-        } else if (typeof prompt === "object" && prompt !== null) {
-          if (typeof prompt.prompt !== "string" || prompt.prompt.length === 0) {
-            return Promise.reject(new Error("Initial prompt.prompt must be a non-empty string"));
-          }
-          if (prompt.permissionMode !== undefined && typeof prompt.permissionMode !== "string") {
-            return Promise.reject(new Error("Initial prompt.permissionMode must be a string"));
-          }
-          if (prompt.agentName !== undefined && typeof prompt.agentName !== "string") {
-            return Promise.reject(new Error("Initial prompt.agentName must be a string"));
-          }
-        } else {
-          return Promise.reject(new Error("Initial prompt must be a string or object"));
+      // Validate the agent spec if provided
+      if (options?.agent !== undefined) {
+        const agent = options.agent;
+        if (typeof agent !== "object" || agent === null) {
+          return Promise.reject(new Error("agent must be an object"));
+        }
+        if (agent.type !== "default" && agent.type !== "claude" && agent.type !== "opencode") {
+          return Promise.reject(new Error('agent.type must be "default", "claude" or "opencode"'));
+        }
+        if (
+          agent.prompt !== undefined &&
+          (typeof agent.prompt !== "string" || agent.prompt.length === 0)
+        ) {
+          return Promise.reject(new Error("agent.prompt must be a non-empty string"));
         }
       }
       // Build request
       const request: WorkspaceCreateRequest = {
         name,
         base,
-        initialPrompt: options?.initialPrompt,
+        agent: options?.agent,
         stealFocus: options?.stealFocus,
       };
       return emitApiCall("api:workspace:create", request);

--- a/extensions/sidekick/src/types.ts
+++ b/extensions/sidekick/src/types.ts
@@ -51,7 +51,7 @@ export type {
 export type {
   WorkspaceStatus,
   Workspace,
-  InitialPrompt,
+  AgentSpec,
   AgentSession,
 } from "../../../src/shared/api/types";
 

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -297,11 +297,10 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
             await serverManager.startServer(setupCtx.workspacePath);
 
-            if (intent.payload.initialPrompt && serverManager.setInitialPrompt) {
-              await serverManager.setInitialPrompt(
-                setupCtx.workspacePath,
-                intent.payload.initialPrompt
-              );
+            if (intent.payload.agent?.prompt && serverManager.setInitialPrompt) {
+              await serverManager.setInitialPrompt(setupCtx.workspacePath, {
+                prompt: intent.payload.agent.prompt,
+              });
             }
 
             return { envVars };
@@ -586,8 +585,8 @@ describe("OpenWorkspace Operation", () => {
     });
   });
 
-  describe("initial prompt included in event payload (#7)", () => {
-    it("includes normalizedInitialPrompt in event", async () => {
+  describe("agent spec included in event payload (#7)", () => {
+    it("passes the typed agent spec through to the event", async () => {
       const setup = createTestSetup();
 
       const receivedEvents: DomainEvent[] = [];
@@ -597,19 +596,20 @@ describe("OpenWorkspace Operation", () => {
 
       await setup.dispatcher.dispatch(
         createIntent({
-          initialPrompt: { prompt: "Implement login", agentName: "build" },
+          agent: { type: "opencode", prompt: "Implement login", agentName: "build" },
         })
       );
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as WorkspaceCreatedEvent;
-      expect(event.payload.initialPrompt).toEqual({
+      expect(event.payload.agent).toEqual({
+        type: "opencode",
         prompt: "Implement login",
         agentName: "build",
       });
     });
 
-    it("normalizes string prompt to object", async () => {
+    it("passes the default (prompt-only) arm through to the event", async () => {
       const setup = createTestSetup();
 
       const receivedEvents: DomainEvent[] = [];
@@ -619,13 +619,14 @@ describe("OpenWorkspace Operation", () => {
 
       await setup.dispatcher.dispatch(
         createIntent({
-          initialPrompt: "Fix the bug",
+          agent: { type: "default", prompt: "Fix the bug" },
         })
       );
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as WorkspaceCreatedEvent;
-      expect(event.payload.initialPrompt).toEqual({
+      expect(event.payload.agent).toEqual({
+        type: "default",
         prompt: "Fix the bug",
       });
     });

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -19,15 +19,8 @@
 
 import type { Intent, DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type {
-  ProjectId,
-  WorkspaceName,
-  Workspace,
-  InitialPrompt,
-  NormalizedInitialPrompt,
-} from "../shared/api/types";
+import type { ProjectId, WorkspaceName, Workspace, AgentSpec } from "../shared/api/types";
 import type { AgentType } from "../shared/plugin-protocol";
-import { normalizeInitialPrompt } from "../shared/api/types";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
@@ -60,7 +53,6 @@ export interface OpenWorkspacePayload {
   /** Remote branch to check out (e.g., 'origin/feature-login'). When set, the local branch
    *  is created at this ref with upstream configured, instead of forking from base. */
   readonly tracking?: string;
-  readonly initialPrompt?: InitialPrompt;
   /** If true, switch to the new workspace. If false, don't steal focus but still switch when
    *  no workspace is active. Default behavior (undefined): switch. */
   readonly stealFocus?: boolean;
@@ -70,8 +62,12 @@ export interface OpenWorkspacePayload {
   readonly projectPath: string;
   /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
   readonly source?: WorkspaceOpenSource;
-  /** Optional per-workspace agent override. When omitted, falls back to the global default. */
-  readonly agent?: AgentType;
+  /**
+   * Agent spec: prompt + backend-specific launch config. When the `type` is
+   * "claude"/"opencode" it also selects (and persists) the per-workspace
+   * backend; "default" or omitted falls back to git metadata / global config.
+   */
+  readonly agent?: AgentSpec;
 }
 
 export type OpenWorkspaceResult = Workspace;
@@ -97,7 +93,7 @@ export interface WorkspaceCreatedPayload {
   readonly tracking?: string;
   readonly metadata: Readonly<Record<string, string>>;
   readonly workspaceUrl: string;
-  readonly initialPrompt?: NormalizedInitialPrompt;
+  readonly agent?: AgentSpec;
   readonly stealFocus?: boolean;
   /** True when re-activating a discovered workspace (not a fresh creation). */
   readonly reopened?: boolean;
@@ -319,8 +315,8 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
       ...(ctx.intent.payload.tracking !== undefined && { tracking: ctx.intent.payload.tracking }),
       metadata,
       workspaceUrl,
-      ...(ctx.intent.payload.initialPrompt !== undefined && {
-        initialPrompt: normalizeInitialPrompt(ctx.intent.payload.initialPrompt),
+      ...(ctx.intent.payload.agent !== undefined && {
+        agent: ctx.intent.payload.agent,
       }),
       ...(ctx.intent.payload.stealFocus !== undefined && {
         stealFocus: ctx.intent.payload.stealFocus,

--- a/src/modules/agent-module/agent-module-provider.ts
+++ b/src/modules/agent-module/agent-module-provider.ts
@@ -8,16 +8,21 @@
 
 import type { AgentType, AgentLifecycleEvent } from "../../shared/plugin-protocol";
 import type { AggregatedAgentStatus, WorkspacePath } from "../../shared/ipc";
-import type { AgentSessionInfo, McpConfig, StopServerResult, RestartServerResult } from "./types";
+import type {
+  AgentSessionInfo,
+  McpConfig,
+  StopServerResult,
+  RestartServerResult,
+  AgentPromptConfig,
+} from "./types";
 import type { BinaryType } from "../../utils/binary-resolution/types";
-import type { NormalizedInitialPrompt } from "../../shared/api/types";
 import type { DownloadProgressCallback } from "../../utils/binary-download";
 
 /**
  * Options for starting a workspace.
  */
 export interface WorkspaceStartOptions {
-  readonly initialPrompt?: NormalizedInitialPrompt;
+  readonly initialPrompt?: AgentPromptConfig;
   readonly isNewWorkspace?: boolean;
 }
 

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -859,7 +859,7 @@ describe("createAgentModule", () => {
           projectId: "test-12345678",
           workspaceName: "feature-1",
           base: "main",
-          initialPrompt: "Hello Claude",
+          agent: { type: "default", prompt: "Hello Claude" },
         },
       } as unknown as OpenWorkspaceIntent);
 

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -66,7 +66,8 @@ import { RESTART_AGENT_OPERATION_ID } from "../../intents/restart-agent";
 import { AGENT_LIFECYCLE_OPERATION_ID } from "../../intents/agent-lifecycle";
 import { INTENT_UPDATE_AGENT_STATUS } from "../../intents/update-agent-status";
 import { SetupError, getErrorMessage } from "../../shared/errors/service-errors";
-import { normalizeInitialPrompt } from "../../shared/api/types";
+import type { AgentSpec } from "../../shared/api/types";
+import type { AgentPromptConfig } from "./types";
 import type { AgentModuleProvider } from "./agent-module-provider";
 
 // =============================================================================
@@ -86,6 +87,32 @@ export interface AgentModuleDeps {
 // =============================================================================
 // Factory
 // =============================================================================
+
+/**
+ * Project the payload's AgentSpec onto the launch config for the resolved
+ * provider. The "default" arm yields prompt-only; a matching typed arm yields
+ * its full config. Returns undefined when there's nothing to apply (no spec,
+ * or an empty arm) so providers skip prompt/marker work.
+ */
+function agentPromptConfigFor(
+  spec: AgentSpec | undefined,
+  providerType: AgentType
+): AgentPromptConfig | undefined {
+  if (spec === undefined) return undefined;
+  if (spec.type === "default") {
+    return spec.prompt !== undefined ? { prompt: spec.prompt } : undefined;
+  }
+  // Capability gating routes this hook only to the matching provider; guard anyway.
+  if (spec.type !== providerType) return undefined;
+  const config: AgentPromptConfig = {
+    ...(spec.prompt !== undefined && { prompt: spec.prompt }),
+    ...(spec.model !== undefined && { model: spec.model }),
+    ...("permissionMode" in spec &&
+      spec.permissionMode !== undefined && { permissionMode: spec.permissionMode }),
+    ...(spec.agentName !== undefined && { agentName: spec.agentName }),
+  };
+  return Object.keys(config).length > 0 ? config : undefined;
+}
 
 /**
  * Create a generic agent module that manages agent lifecycle by delegating
@@ -321,9 +348,7 @@ export function createAgentModule(
             const intent = ctx.intent as OpenWorkspaceIntent;
             const workspacePath = setupCtx.workspacePath;
 
-            const initialPrompt = intent.payload.initialPrompt
-              ? normalizeInitialPrompt(intent.payload.initialPrompt)
-              : undefined;
+            const initialPrompt = agentPromptConfigFor(intent.payload.agent, provider.type);
             const isNewWorkspace = intent.payload.existingWorkspace === undefined;
 
             const result = await provider.startWorkspace(workspacePath, {

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -23,6 +23,7 @@ import type {
   RestartServerResult,
   AgentStatus,
   McpConfig,
+  AgentPromptConfig,
 } from "../types";
 import { Path } from "../../../utils/path/path";
 import {
@@ -36,7 +37,6 @@ import {
 } from "./types";
 import hooksConfigTemplate from "./hooks.template.json";
 import mcpConfigTemplate from "./mcp.template.json";
-import type { NormalizedInitialPrompt } from "../../../shared/api/types";
 
 /**
  * Per-workspace state tracked by the server manager.
@@ -351,9 +351,9 @@ export class ClaudeCodeServerManager implements AgentServerManager {
    * The wrapper script will read and delete this file on first invocation.
    *
    * @param workspacePath - Absolute path to the workspace
-   * @param config - Normalized initial prompt configuration
+   * @param config - Resolved agent launch configuration
    */
-  async setInitialPrompt(workspacePath: string, config: NormalizedInitialPrompt): Promise<void> {
+  async setInitialPrompt(workspacePath: string, config: AgentPromptConfig): Promise<void> {
     const normalizedPath = new Path(workspacePath).toString();
     const state = this.workspaces.get(normalizedPath);
 
@@ -375,7 +375,7 @@ export class ClaudeCodeServerManager implements AgentServerManager {
         permissionMode?: string;
         agentName?: string;
       } = {
-        prompt: config.prompt,
+        prompt: config.prompt ?? "",
       };
       if (config.model !== undefined) {
         jsonContent.model = config.model.modelID;
@@ -398,7 +398,7 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       // the agent to process. Permission mode is irrelevant (even plan mode
       // works on the prompt); an empty prompt (e.g. only an agent or permission
       // mode was chosen) has nothing to run, so it starts "idle".
-      state.busyOnWrapperStart = config.prompt.trim() !== "";
+      state.busyOnWrapperStart = (config.prompt ?? "").trim() !== "";
 
       this.logger.info("Initial prompt file created", {
         workspacePath: normalizedPath,

--- a/src/modules/agent-module/claude/wrapper.ts
+++ b/src/modules/agent-module/claude/wrapper.ts
@@ -28,7 +28,7 @@ import { dirname } from "node:path";
  * Model is stored as just the modelID string (not full PromptModel).
  */
 export interface InitialPromptConfig {
-  readonly prompt: string;
+  readonly prompt?: string;
   readonly model?: string;
   /** Claude permission mode (e.g. "plan"). Omitted = let Claude decide. */
   readonly permissionMode?: string;

--- a/src/modules/agent-module/opencode/module-provider.ts
+++ b/src/modules/agent-module/opencode/module-provider.ts
@@ -148,9 +148,16 @@ export function createOpenCodeModuleProvider(
 
       // --- Workspace start ---
       startServer: async (workspacePath, options) => {
-        if (options?.initialPrompt) {
+        // OpenCode applies the named agent/model per message, so a prompt is
+        // required to act on them; without a prompt there's nothing to send.
+        const ip = options?.initialPrompt;
+        if (ip?.prompt) {
           await serverManager.startServer(workspacePath, {
-            initialPrompt: options.initialPrompt,
+            initialPrompt: {
+              prompt: ip.prompt,
+              ...(ip.agentName !== undefined && { agentName: ip.agentName }),
+              ...(ip.model !== undefined && { model: ip.model }),
+            },
           });
         } else {
           await serverManager.startServer(workspacePath);

--- a/src/modules/agent-module/types.ts
+++ b/src/modules/agent-module/types.ts
@@ -3,7 +3,21 @@
  * These interfaces enable pluggable agent implementations (OpenCode, Claude, etc.)
  */
 
-import type { NormalizedInitialPrompt } from "../../shared/api/types";
+import type { PromptModel } from "../../shared/api/types";
+
+/**
+ * Resolved per-workspace agent launch config handed to a provider once the
+ * backend is known. Mirrors the typed AgentSpec arms minus the `type`
+ * discriminant; every field is optional (prompt-less opens are valid).
+ */
+export interface AgentPromptConfig {
+  readonly prompt?: string;
+  readonly model?: PromptModel;
+  /** Claude permission mode (e.g. "plan"). Claude-only. */
+  readonly permissionMode?: string;
+  /** Named agent/persona (Claude --agent, or OpenCode's agent). */
+  readonly agentName?: string;
+}
 
 /**
  * MCP server configuration shared by both agent server managers.
@@ -74,9 +88,9 @@ export interface AgentServerManager {
    * Should be called after startServer() but before the workspace view is created.
    *
    * @param workspacePath - Absolute path to the workspace
-   * @param config - Normalized initial prompt configuration
+   * @param config - Resolved agent launch configuration
    */
-  setInitialPrompt?(workspacePath: string, config: NormalizedInitialPrompt): Promise<void>;
+  setInitialPrompt?(workspacePath: string, config: AgentPromptConfig): Promise<void>;
 
   /**
    * Create a no-session marker for a new workspace.

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -492,9 +492,10 @@ describe("AutoWorkspaceModule Integration", () => {
 
       expect(openWorkspaceOp.dispatched).toHaveLength(1);
       expect(openWorkspaceOp.dispatched[0]!.payload.workspaceName).toBe("item-1");
-      // No `agent` in the default template → falls back to the default (no
-      // agent override, default permission mode).
-      expect(openWorkspaceOp.dispatched[0]!.payload.initialPrompt).toEqual({
+      // No `agent.*` in the default template → prompt-only "default" arm; the
+      // backend is resolved later from metadata/config.
+      expect(openWorkspaceOp.dispatched[0]!.payload.agent).toEqual({
+        type: "default",
         prompt: "Work on item-1",
       });
     });
@@ -629,11 +630,12 @@ describe("AutoWorkspaceModule Integration", () => {
         "---",
         "git: https://github.com/org/repo.git",
         "name: ws/{{ id }}",
-        "agent: build",
+        "agent.type: opencode",
+        "agent.name: build",
         "base: origin/develop",
         "focus: true",
-        "model.provider: anthropic",
-        "model.id: claude-sonnet-4-6",
+        "agent.model.provider: anthropic",
+        "agent.model.id: claude-sonnet-4-6",
         "---",
         "Work on {{ id }}",
       ].join("\n");
@@ -653,7 +655,8 @@ describe("AutoWorkspaceModule Integration", () => {
       expect(payload.workspaceName).toBe("ws/item-1");
       expect(payload.base).toBe("origin/develop");
       expect(payload.stealFocus).toBe(true);
-      expect(payload.initialPrompt).toEqual({
+      expect(payload.agent).toEqual({
+        type: "opencode",
         prompt: "Work on item-1",
         agentName: "build",
         model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -52,7 +52,7 @@ import {
 import type { StateService } from "../../boundaries/platform/state-service";
 import type { FileSystemBoundary } from "../../boundaries/platform/filesystem";
 import type { Logger } from "../../boundaries/platform/logging-types";
-import type { NormalizedInitialPrompt } from "../../shared/api/types";
+import type { AgentSpec } from "../../shared/api/types";
 import { getErrorMessage } from "../../shared/error-utils";
 import { renderTemplate } from "../../utils/liquid/liquid-renderer";
 import { parseTemplateOutput } from "./template";
@@ -360,13 +360,12 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
         return;
       }
 
-      // The frontmatter `agent` field selects the named agent (e.g. "plan",
-      // "build", or a custom agent). When unset, fall back to the default — no
-      // agent override. Permission mode is left at the default.
-      const initialPrompt: NormalizedInitialPrompt = {
-        prompt: config.prompt,
-        ...(config.agent !== undefined && { agentName: config.agent }),
-        ...(config.model !== undefined && { model: config.model }),
+      // The template's `agent.*` front-matter (parsed into config.agent) carries
+      // the backend + launch config. With none set, fall back to a prompt-only
+      // "default" arm so the resolved-default backend runs the body.
+      const agent: AgentSpec = config.agent ?? {
+        type: "default",
+        ...(config.prompt !== "" && { prompt: config.prompt }),
       };
 
       // Create the workspace
@@ -378,7 +377,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
           ...(config.tracking !== undefined && { tracking: config.tracking }),
           stealFocus: config.focus ?? false,
           projectPath: project.path,
-          initialPrompt,
+          agent,
           source: "auto-workspace",
         },
       } as OpenWorkspaceIntent);

--- a/src/modules/auto-workspace/template.test.ts
+++ b/src/modules/auto-workspace/template.test.ts
@@ -14,12 +14,14 @@ describe("parseTemplateOutput", () => {
     const input = [
       "---",
       "name: review/42",
-      "agent: plan",
+      "agent.type: claude",
+      "agent.name: plan",
+      "agent.permission-mode: plan",
       "base: origin/main",
       "tracking: origin/feature-login",
       "focus: true",
-      "model.provider: anthropic",
-      "model.id: claude-sonnet-4-6",
+      "agent.model.provider: anthropic",
+      "agent.model.id: claude-sonnet-4-6",
       "project: /home/user/repo",
       "git: https://github.com/org/repo.git",
       "---",
@@ -30,29 +32,70 @@ describe("parseTemplateOutput", () => {
     expect(result.config).toEqual({
       prompt: "Review this PR",
       name: "review/42",
-      agent: "plan",
       base: "origin/main",
       tracking: "origin/feature-login",
       focus: true,
-      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
       project: "/home/user/repo",
       git: "https://github.com/org/repo.git",
+      agent: {
+        type: "claude",
+        prompt: "Review this PR",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+        permissionMode: "plan",
+        agentName: "plan",
+      },
     });
     expect(result.warnings).toEqual([]);
   });
 
   it("returns only specified fields (rest remain undefined)", () => {
-    const input = "---\nagent: build\n---\nDo the thing";
+    const input = "---\nagent.type: opencode\nagent.name: build\n---\nDo the thing";
     const result = parseTemplateOutput(input);
-    expect(result.config.agent).toBe("build");
+    expect(result.config.agent).toEqual({
+      type: "opencode",
+      prompt: "Do the thing",
+      agentName: "build",
+    });
     expect(result.config.name).toBeUndefined();
     expect(result.config.base).toBeUndefined();
     expect(result.config.tracking).toBeUndefined();
     expect(result.config.focus).toBeUndefined();
-    expect(result.config.model).toBeUndefined();
     expect(result.config.project).toBeUndefined();
     expect(result.config.git).toBeUndefined();
     expect(result.config.prompt).toBe("Do the thing");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("shims legacy agent/model keys onto a claude arm with a deprecation warning", () => {
+    const input =
+      "---\nagent: build\nmodel.provider: anthropic\nmodel.id: claude-sonnet-4-6\n---\nDo it";
+    const result = parseTemplateOutput(input);
+    expect(result.config.agent).toEqual({
+      type: "claude",
+      prompt: "Do it",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      agentName: "build",
+    });
+    expect(result.warnings).toContain(
+      "Front-matter keys 'agent', 'model.provider', 'model.id' are deprecated; " +
+        "use 'agent.name' and 'agent.model.*' (with 'agent.type'). Legacy keys assume agent.type: claude."
+    );
+  });
+
+  it("assumes claude and warns when agent options lack an agent.type", () => {
+    const input = "---\nagent.name: plan\n---\nDo it";
+    const result = parseTemplateOutput(input);
+    expect(result.config.agent).toEqual({ type: "claude", prompt: "Do it", agentName: "plan" });
+    expect(result.warnings).toContain(
+      "agent.type is required to set a model, permission mode or named agent; assuming claude"
+    );
+  });
+
+  it("warns and ignores permission-mode for opencode", () => {
+    const input = "---\nagent.type: opencode\nagent.permission-mode: plan\n---\nDo it";
+    const result = parseTemplateOutput(input);
+    expect(result.config.agent).toEqual({ type: "opencode", prompt: "Do it" });
+    expect(result.warnings).toContain("agent.permission-mode is ignored for opencode");
   });
 
   it("handles empty front matter (prompt only)", () => {
@@ -83,22 +126,18 @@ describe("parseTemplateOutput", () => {
     expect(result.warnings).toEqual([]);
   });
 
-  it("warns when only model.provider is specified", () => {
-    const input = "---\nmodel.provider: anthropic\n---\nprompt";
+  it("warns when only the model provider is specified", () => {
+    const input = "---\nagent.type: claude\nagent.model.provider: anthropic\n---\nprompt";
     const result = parseTemplateOutput(input);
-    expect(result.config.model).toBeUndefined();
-    expect(result.warnings).toEqual([
-      "Both model.provider and model.id must be specified together",
-    ]);
+    expect(result.config.agent).toEqual({ type: "claude", prompt: "prompt" });
+    expect(result.warnings).toEqual(["Both the model provider and id must be specified together"]);
   });
 
-  it("warns when only model.id is specified", () => {
-    const input = "---\nmodel.id: claude-sonnet-4-6\n---\nprompt";
+  it("warns when only the model id is specified", () => {
+    const input = "---\nagent.type: claude\nagent.model.id: claude-sonnet-4-6\n---\nprompt";
     const result = parseTemplateOutput(input);
-    expect(result.config.model).toBeUndefined();
-    expect(result.warnings).toEqual([
-      "Both model.provider and model.id must be specified together",
-    ]);
+    expect(result.config.agent).toEqual({ type: "claude", prompt: "prompt" });
+    expect(result.warnings).toEqual(["Both the model provider and id must be specified together"]);
   });
 
   it("ignores comments and blank lines in front matter", () => {
@@ -158,10 +197,10 @@ describe("parseTemplateOutput", () => {
 
   it("metadata works alongside other front-matter fields", () => {
     const input =
-      "---\nname: review/42\nmetadata.pr-url: https://example.com\nagent: plan\n---\nprompt";
+      "---\nname: review/42\nmetadata.pr-url: https://example.com\nagent.type: claude\nagent.name: plan\n---\nprompt";
     const result = parseTemplateOutput(input);
     expect(result.config.name).toBe("review/42");
-    expect(result.config.agent).toBe("plan");
+    expect(result.config.agent).toEqual({ type: "claude", prompt: "prompt", agentName: "plan" });
     expect(result.config.metadata).toEqual({ "pr-url": "https://example.com" });
     expect(result.warnings).toEqual([]);
   });

--- a/src/modules/auto-workspace/template.ts
+++ b/src/modules/auto-workspace/template.ts
@@ -1,16 +1,20 @@
-import { isValidMetadataKey } from "../../shared/api/types";
+import { isValidMetadataKey, type AgentSpec, type PromptModel } from "../../shared/api/types";
 
 export interface TemplateConfig {
   readonly name?: string;
-  readonly agent?: string;
   readonly base?: string;
   readonly tracking?: string;
   readonly focus?: boolean;
-  readonly model?: { readonly providerID: string; readonly modelID: string };
   readonly metadata?: Readonly<Record<string, string>>;
   readonly project?: string;
   readonly git?: string;
   readonly prompt: string;
+  /**
+   * Agent spec built from the `agent.*` front-matter (with a legacy-key shim).
+   * Absent when the template sets no agent config — the caller falls back to a
+   * prompt-only "default" arm.
+   */
+  readonly agent?: AgentSpec;
 }
 
 export interface ParseResult {
@@ -21,15 +25,27 @@ export interface ParseResult {
 const FRONT_MATTER_OPEN = "---\n";
 const KNOWN_KEYS = new Set([
   "name",
-  "agent",
   "base",
   "tracking",
   "focus",
-  "model.provider",
-  "model.id",
   "project",
   "git",
+  // Agent spec (mirrors the AgentSpec union under an `agent.` namespace)
+  "agent.type",
+  "agent.name",
+  "agent.permission-mode",
+  "agent.model.provider",
+  "agent.model.id",
+  // Legacy (deprecated) — mapped onto a Claude agent arm with a warning.
+  "agent",
+  "model.provider",
+  "model.id",
 ]);
+
+/** Treat empty front-matter values ("key:" with no value) as unset. */
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value !== "" ? value : undefined;
+}
 
 export function parseTemplateOutput(rendered: string): ParseResult {
   const warnings: string[] = [];
@@ -95,27 +111,103 @@ export function parseTemplateOutput(rendered: string): ParseResult {
     }
   }
 
-  let model: { readonly providerID: string; readonly modelID: string } | undefined;
-  if (fields["model.provider"] !== undefined || fields["model.id"] !== undefined) {
-    if (fields["model.provider"] && fields["model.id"]) {
-      model = { providerID: fields["model.provider"], modelID: fields["model.id"] };
-    } else {
-      warnings.push("Both model.provider and model.id must be specified together");
-    }
-  }
+  const agent = buildAgentSpec(fields, prompt, warnings);
 
   const config: TemplateConfig = {
     prompt,
     ...(fields["name"] !== undefined && { name: fields["name"] }),
-    ...(fields["agent"] !== undefined && { agent: fields["agent"] }),
     ...(fields["base"] !== undefined && { base: fields["base"] }),
     ...(fields["tracking"] !== undefined && { tracking: fields["tracking"] }),
     ...(focus !== undefined && { focus }),
-    ...(model !== undefined && { model }),
     ...(Object.keys(metadataFields).length > 0 && { metadata: metadataFields }),
     ...(fields["project"] !== undefined && { project: fields["project"] }),
     ...(fields["git"] !== undefined && { git: fields["git"] }),
+    ...(agent !== undefined && { agent }),
   };
 
   return { config, warnings };
+}
+
+/**
+ * Build the AgentSpec from `agent.*` front-matter, applying the legacy-key shim.
+ * Legacy keys (`agent`, `model.*`) and any agent config lacking a valid
+ * `agent.type` assume `claude` (parser stays pure — no config lookup), so an
+ * opencode-default user must migrate to keep portability.
+ */
+function buildAgentSpec(
+  fields: Record<string, string>,
+  prompt: string,
+  warnings: string[]
+): AgentSpec | undefined {
+  const legacyAgentName = nonEmpty(fields["agent"]);
+  const legacyModelProvider = nonEmpty(fields["model.provider"]);
+  const legacyModelId = nonEmpty(fields["model.id"]);
+  if (
+    legacyAgentName !== undefined ||
+    legacyModelProvider !== undefined ||
+    legacyModelId !== undefined
+  ) {
+    warnings.push(
+      "Front-matter keys 'agent', 'model.provider', 'model.id' are deprecated; " +
+        "use 'agent.name' and 'agent.model.*' (with 'agent.type'). Legacy keys assume agent.type: claude."
+    );
+  }
+
+  const agentType = nonEmpty(fields["agent.type"]);
+  const agentName = nonEmpty(fields["agent.name"]) ?? legacyAgentName;
+  const permissionMode = nonEmpty(fields["agent.permission-mode"]);
+  const modelProvider = nonEmpty(fields["agent.model.provider"]) ?? legacyModelProvider;
+  const modelId = nonEmpty(fields["agent.model.id"]) ?? legacyModelId;
+
+  let model: PromptModel | undefined;
+  if (modelProvider !== undefined || modelId !== undefined) {
+    if (modelProvider !== undefined && modelId !== undefined) {
+      model = { providerID: modelProvider, modelID: modelId };
+    } else {
+      warnings.push("Both the model provider and id must be specified together");
+    }
+  }
+
+  const hasAgentConfig =
+    agentType !== undefined ||
+    agentName !== undefined ||
+    permissionMode !== undefined ||
+    model !== undefined;
+  if (!hasAgentConfig) return undefined;
+
+  let resolvedType: "claude" | "opencode";
+  if (agentType === "claude" || agentType === "opencode") {
+    resolvedType = agentType;
+  } else {
+    if (agentType !== undefined) {
+      warnings.push(
+        `Invalid agent.type "${agentType}", expected "claude" or "opencode"; assuming claude`
+      );
+    } else {
+      warnings.push(
+        "agent.type is required to set a model, permission mode or named agent; assuming claude"
+      );
+    }
+    resolvedType = "claude";
+  }
+
+  if (resolvedType === "opencode") {
+    if (permissionMode !== undefined) {
+      warnings.push("agent.permission-mode is ignored for opencode");
+    }
+    return {
+      type: "opencode",
+      ...(prompt !== "" && { prompt }),
+      ...(model !== undefined && { model }),
+      ...(agentName !== undefined && { agentName }),
+    };
+  }
+
+  return {
+    type: "claude",
+    ...(prompt !== "" && { prompt }),
+    ...(model !== undefined && { model }),
+    ...(permissionMode !== undefined && { permissionMode }),
+    ...(agentName !== undefined && { agentName }),
+  };
 }

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -499,10 +499,13 @@ describe("CreationModule", () => {
 
       const opens = s.dispatcher.byType(INTENT_OPEN_WORKSPACE);
       expect(opens).toHaveLength(1);
+      // The form always emits a typed arm for the selected backend; the
+      // resolver only persists it as the workspace agent when != default.
       expect(opens[0]!.payload).toEqual({
         projectPath: PROJECT_A.path,
         workspaceName: "new-feature",
         base: "main",
+        agent: { type: "claude" },
         source: "creation",
       });
 
@@ -531,7 +534,7 @@ describe("CreationModule", () => {
       });
     });
 
-    it("builds the InitialPrompt with permissionMode + agentName and the agent override when != default", async () => {
+    it("builds a claude arm with trimmed prompt, permissionMode and agentName", async () => {
       const s = setup({
         defaultBaseBranch: "main",
         agents: [CLAUDE_AGENT, OPENCODE_AGENT],
@@ -546,18 +549,46 @@ describe("CreationModule", () => {
         prompt: "  do things  ",
         "permission-mode": "plan",
         "agent-name": "reviewer",
+        agent: "claude",
+      });
+      await flush();
+
+      const opens = s.dispatcher.byType(INTENT_OPEN_WORKSPACE);
+      expect(opens[0]!.payload).toMatchObject({
+        agent: {
+          type: "claude",
+          prompt: "do things",
+          permissionMode: "plan",
+          agentName: "reviewer",
+        },
+      });
+    });
+
+    it("builds an opencode arm (agent override != default) and drops permission mode", async () => {
+      const s = setup({
+        defaultBaseBranch: "main",
+        agents: [CLAUDE_AGENT, OPENCODE_AGENT],
+        defaultAgent: "claude",
+      });
+      const panel = await readyPanel(s);
+
+      panel.emitAction("create", {
+        project: PROJECT_A.path,
+        name: "with-prompt",
+        base: "main",
+        prompt: "do things",
+        "agent-name": "build",
         agent: "opencode",
       });
       await flush();
 
       const opens = s.dispatcher.byType(INTENT_OPEN_WORKSPACE);
       expect(opens[0]!.payload).toMatchObject({
-        initialPrompt: { prompt: "do things", permissionMode: "plan", agentName: "reviewer" },
-        agent: "opencode",
+        agent: { type: "opencode", prompt: "do things", agentName: "build" },
       });
     });
 
-    it("omits initialPrompt and agent when prompt empty, mode default, agent = default", async () => {
+    it("emits a bare typed arm when prompt empty, mode default, agent = default", async () => {
       const s = setup({ defaultBaseBranch: "main", defaultAgent: "claude" });
       const panel = await readyPanel(s);
 
@@ -576,8 +607,9 @@ describe("CreationModule", () => {
         string,
         unknown
       >;
-      expect(payload["initialPrompt"]).toBeUndefined();
-      expect(payload["agent"]).toBeUndefined();
+      // Selected backend is emitted as a bare arm (no prompt/options); the
+      // resolver won't persist it since it equals the default.
+      expect(payload["agent"]).toEqual({ type: "claude" });
     });
 
     it("re-validates the snapshot: an invalid submit pushes errors instead of dispatching", async () => {

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -31,7 +31,7 @@ import type { DialogManager, DialogHandle } from "./dialog-manager";
 import type { DialogConfig, DialogSection, DropdownSuggestionGroup } from "../shared/dialog-types";
 import type { Logger } from "../boundaries/platform/logging";
 import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
-import type { Project, BaseInfo, InitialPrompt } from "../shared/api/types";
+import type { Project, BaseInfo, AgentSpec } from "../shared/api/types";
 import { validateWorkspaceName } from "../shared/api/types";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
 import type { ConfigAgentType } from "../boundaries/platform/config";
@@ -707,22 +707,29 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     const agentName = (data[FIELD_AGENT_NAME] ?? "").trim();
     const agentSelection = data[FIELD_AGENT] ?? "";
 
-    let initialPrompt: InitialPrompt | undefined;
-    const hasAgentOptions = permissionMode !== "" || agentName !== "";
-    if (prompt !== "" || hasAgentOptions) {
-      initialPrompt = hasAgentOptions
-        ? {
-            prompt,
-            ...(permissionMode !== "" && { permissionMode }),
-            ...(agentName !== "" && { agentName }),
-          }
-        : prompt;
+    // The form knows the selected backend, so it always emits a typed arm
+    // (carrying prompt + options); the resolver only persists it as the
+    // workspace's agent when it differs from the global default. With no
+    // backend selected, fall back to the prompt-only "default" arm.
+    let agent: AgentSpec | undefined;
+    if (isAvailableAgent(agentSelection)) {
+      if (agentSelection === "claude") {
+        agent = {
+          type: "claude",
+          ...(prompt !== "" && { prompt }),
+          ...(permissionMode !== "" && { permissionMode }),
+          ...(agentName !== "" && { agentName }),
+        };
+      } else {
+        agent = {
+          type: "opencode",
+          ...(prompt !== "" && { prompt }),
+          ...(agentName !== "" && { agentName }),
+        };
+      }
+    } else if (prompt !== "") {
+      agent = { type: "default", prompt };
     }
-
-    const agent =
-      isAvailableAgent(agentSelection) && agentSelection !== defaultAgent()
-        ? agentSelection
-        : undefined;
 
     const intent: OpenWorkspaceIntent = {
       type: INTENT_OPEN_WORKSPACE,
@@ -730,7 +737,6 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         projectPath: project.path,
         workspaceName,
         base,
-        ...(initialPrompt !== undefined && { initialPrompt }),
         ...(agent !== undefined && { agent }),
         source: "creation",
       },

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -22,7 +22,6 @@ import { randomUUID } from "node:crypto";
 import { McpServer as McpServerSdk } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
-import { createOpencodeClient } from "@opencode-ai/sdk";
 
 import type { IntentModule } from "../intents/lib/module";
 import type { Dispatcher } from "../intents/lib/dispatcher";
@@ -35,13 +34,7 @@ import { SILENT_LOGGER, logAtLevel } from "../boundaries/platform/logging";
 import type { LogLevel } from "../boundaries/platform/logging-types";
 import type { IDisposable } from "../shared/types";
 import { getErrorMessage } from "../shared/errors/service-errors";
-import {
-  initialPromptSchema,
-  normalizeInitialPrompt,
-  type PromptModel,
-  type Workspace,
-  type DeletionProgress,
-} from "../shared/api/types";
+import { type Workspace, type DeletionProgress } from "../shared/api/types";
 
 // Intent types for direct dispatch
 import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
@@ -153,13 +146,8 @@ export type McpServerFactory = () => McpServerSdk;
 export const SERVER_INSTRUCTIONS = [
   "CodeHydra manages workspaces as git worktrees, each with its own AI agent session.",
   "",
-  "When creating a workspace with workspace_create, the initialPrompt parameter controls what the new workspace's agent will do.",
-  "Use the object form { prompt, permissionMode, agentName } to control how the agent starts:",
-  '- permissionMode: "plan" — the agent starts in read-only/plan mode (Claude). Use this when the task requires planning, research, or exploration before making changes.',
-  "- No permissionMode field — the agent starts in its default mode. Use this when the task should proceed directly to implementation.",
-  '- agentName — run a named agent/persona (e.g. "build" on OpenCode, or a Claude custom agent). Omit to use the default agent.',
-  "",
-  "The model is automatically propagated from your current session — you do not need to specify it.",
+  "When creating a workspace with workspace_create, pass an optional prompt to tell the new workspace's agent what to do.",
+  "The prompt runs under the workspace agent's default mode and model; backend selection, permission mode and model are configured on the CodeHydra side, not via this tool.",
   "",
   "When working with tool results, write down any important information you might need later in your response,",
   "as the original tool result may be cleared later.",
@@ -709,15 +697,13 @@ export class McpServer {
                 "When set, the local branch is created at this ref with upstream configured. " +
                 "Must be a valid remote-tracking branch."
             ),
-          initialPrompt: initialPromptSchema
+          prompt: z
+            .string()
+            .min(1)
             .optional()
             .describe(
-              "Optional initial prompt to send after workspace is created. " +
-                "Can be a string or { prompt, permissionMode?, agentName? }. " +
-                'Set permissionMode to "plan" for read-only/planning mode (Claude), ' +
-                "or omit it for the default mode. " +
-                'Set agentName to run a named agent (e.g. "build" on OpenCode, ' +
-                "or a Claude custom agent)."
+              "Optional initial prompt to send after the workspace is created. " +
+                "The workspace's agent runs it under that agent's default mode."
             ),
           stealFocus: z
             .boolean()
@@ -727,46 +713,15 @@ export class McpServer {
             ),
         }),
       },
-      async (args, extra) => {
-        const workspacePath = this.getWorkspacePathFromExtra(extra);
-
+      async (args) => {
         try {
           const projectPath = args.projectPath as string;
           const name = args.name as string;
           const base = args.base as string;
           const tracking = args.tracking as string | undefined;
-          const rawInitialPrompt = args.initialPrompt as
-            | string
-            | { prompt: string; permissionMode?: string; agentName?: string; model?: PromptModel }
-            | undefined;
+          const prompt = args.prompt as string | undefined;
           // Default to false for API calls (stay in background)
           const stealFocus = (args.stealFocus as boolean | undefined) ?? false;
-
-          // If initialPrompt provided, resolve model from caller's session if not specified
-          let finalPrompt:
-            | { prompt: string; permissionMode?: string; agentName?: string; model?: PromptModel }
-            | undefined;
-          if (rawInitialPrompt !== undefined) {
-            const normalized = normalizeInitialPrompt(rawInitialPrompt);
-
-            // If no model specified, try to get caller's current model
-            let model = normalized.model;
-            if (!model && workspacePath) {
-              model = await this.getCallerModel(workspacePath);
-            }
-
-            // Build final prompt with model if available
-            finalPrompt = { prompt: normalized.prompt };
-            if (normalized.permissionMode !== undefined) {
-              finalPrompt = { ...finalPrompt, permissionMode: normalized.permissionMode };
-            }
-            if (normalized.agentName !== undefined) {
-              finalPrompt = { ...finalPrompt, agentName: normalized.agentName };
-            }
-            if (model !== undefined) {
-              finalPrompt = { ...finalPrompt, model };
-            }
-          }
 
           const intent: OpenWorkspaceIntent = {
             type: INTENT_OPEN_WORKSPACE,
@@ -775,7 +730,8 @@ export class McpServer {
               workspaceName: name,
               base,
               ...(tracking !== undefined && { tracking }),
-              ...(finalPrompt !== undefined && { initialPrompt: finalPrompt }),
+              // Prompt-only under the resolved-default backend.
+              ...(prompt !== undefined && { agent: { type: "default", prompt } }),
               stealFocus,
               source: "mcp",
             },
@@ -1071,79 +1027,6 @@ export class McpServer {
       current.delete(resolve);
       if (current.size === 0) this.deletionWaiters.delete(workspacePath);
     };
-  }
-
-  /**
-   * Get the model from the caller's current OpenCode session.
-   * Used to propagate the model when creating a new workspace with an initial prompt.
-   *
-   * @param workspacePath - The workspace path of the caller
-   * @returns The model from the most recent user message, or undefined if not available
-   */
-  private async getCallerModel(workspacePath: string): Promise<PromptModel | undefined> {
-    try {
-      // Get caller's OpenCode session
-      const session = await this.dispatcher.dispatch({
-        type: INTENT_GET_AGENT_SESSION,
-        payload: { workspacePath },
-      } as GetAgentSessionIntent);
-
-      if (!session) {
-        this.logger.debug("Cannot determine model: no OpenCode session running", {
-          workspace: workspacePath,
-        });
-        return undefined;
-      }
-
-      // Query caller's OpenCode for current session's model
-      const sdk = createOpencodeClient({ baseUrl: `http://127.0.0.1:${session.port}` });
-      const sessions = await sdk.session.list();
-      const activeSession = sessions.data?.[0];
-
-      if (!activeSession) {
-        this.logger.debug("Cannot determine model: no active session in caller workspace", {
-          workspace: workspacePath,
-        });
-        return undefined;
-      }
-
-      const messages = await sdk.session.messages({ path: { id: activeSession.id } });
-      const lastUserMessage = messages.data?.findLast((m) => m.info.role === "user");
-
-      // SDK types don't include model field, but OpenCode returns it
-      type UserMessageInfo = {
-        role: string;
-        model?: { providerID: string; modelID: string };
-      };
-      const userInfo = lastUserMessage?.info as UserMessageInfo | undefined;
-
-      if (!userInfo?.model) {
-        this.logger.debug("Cannot determine model: no user messages with model in caller session", {
-          workspace: workspacePath,
-          sessionId: activeSession.id,
-        });
-        return undefined;
-      }
-
-      // Extract model from the message info
-      const model: PromptModel = {
-        providerID: userInfo.model.providerID,
-        modelID: userInfo.model.modelID,
-      };
-
-      this.logger.debug("Retrieved caller model", {
-        workspace: workspacePath,
-        model: `${model.providerID}/${model.modelID}`,
-      });
-
-      return model;
-    } catch (error) {
-      this.logger.warn("Failed to get caller model", {
-        workspace: workspacePath,
-        error: getErrorMessage(error),
-      });
-      return undefined;
-    }
   }
 
   /**

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -9,7 +9,7 @@ import {
   SERVER_INSTRUCTIONS,
   type McpServerFactory,
 } from "./mcp-module";
-import { initialPromptSchema } from "../shared/api/types";
+import { agentSpecSchema } from "../shared/api/types";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockDispatcher as createBaseMockDispatcher } from "../intents/lib/dispatcher.test-utils";
@@ -389,55 +389,55 @@ describe("createDefaultMcpServer", () => {
 describe("SERVER_INSTRUCTIONS", () => {
   it("includes workspace creation guidance", () => {
     expect(SERVER_INSTRUCTIONS).toContain("workspace_create");
-    expect(SERVER_INSTRUCTIONS).toContain('"plan"');
-    expect(SERVER_INSTRUCTIONS).toContain("read-only");
+    expect(SERVER_INSTRUCTIONS).toContain("prompt");
     expect(SERVER_INSTRUCTIONS).toContain("default mode");
-    expect(SERVER_INSTRUCTIONS).toContain("agentName");
   });
 });
 
-describe("initialPromptSchema validation", () => {
-  // Uses the schema imported from types - this tests the exact schema used by workspace_create
+describe("agentSpecSchema validation", () => {
+  // Uses the schema imported from types - the exact schema used by the create paths
 
-  it("rejects empty string prompt", () => {
-    const result = initialPromptSchema.safeParse("");
+  it("rejects a bare string (must be a typed object)", () => {
+    const result = agentSpecSchema.safeParse("Implement the feature");
     expect(result.success).toBe(false);
   });
 
-  it("rejects object with empty prompt string", () => {
-    const result = initialPromptSchema.safeParse({ prompt: "" });
+  it("rejects an unknown backend type", () => {
+    const result = agentSpecSchema.safeParse({ type: "gemini", prompt: "x" });
     expect(result.success).toBe(false);
   });
 
-  it("accepts non-empty string prompt", () => {
-    const result = initialPromptSchema.safeParse("Implement the feature");
+  it("accepts the default arm with a prompt", () => {
+    const result = agentSpecSchema.safeParse({ type: "default", prompt: "Implement the feature" });
     expect(result.success).toBe(true);
   });
 
-  it("accepts object with non-empty prompt", () => {
-    const result = initialPromptSchema.safeParse({ prompt: "Implement the feature" });
+  it("accepts the default arm with no prompt", () => {
+    const result = agentSpecSchema.safeParse({ type: "default" });
     expect(result.success).toBe(true);
   });
 
-  it("accepts object with prompt and agentName", () => {
-    const result = initialPromptSchema.safeParse({
-      prompt: "Implement the feature",
-      agentName: "build",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toEqual({ prompt: "Implement the feature", agentName: "build" });
-    }
+  it("rejects the default arm with an empty prompt", () => {
+    const result = agentSpecSchema.safeParse({ type: "default", prompt: "" });
+    expect(result.success).toBe(false);
   });
 
-  it("accepts object with prompt and permissionMode", () => {
-    const result = initialPromptSchema.safeParse({
+  it("accepts a claude arm with permissionMode", () => {
+    const result = agentSpecSchema.safeParse({
+      type: "claude",
       prompt: "Investigate the bug",
       permissionMode: "plan",
     });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toEqual({ prompt: "Investigate the bug", permissionMode: "plan" });
-    }
+  });
+
+  it("accepts an opencode arm with agentName and model", () => {
+    const result = agentSpecSchema.safeParse({
+      type: "opencode",
+      prompt: "Implement the feature",
+      agentName: "build",
+      model: { providerID: "anthropic", modelID: "claude-sonnet" },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/src/modules/mcp-tools.test.ts
+++ b/src/modules/mcp-tools.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import type { WorkspaceStatus, InitialPrompt } from "../shared/api/types";
+import type { WorkspaceStatus } from "../shared/api/types";
 import type { McpError } from "./mcp-module";
 import type { Logger, LogContext } from "../boundaries/platform/logging";
 import type { LogLevel } from "../boundaries/platform/logging-types";
@@ -28,7 +28,7 @@ interface ToolHandlerFns {
     name: string;
     base: string;
     tracking?: string;
-    initialPrompt?: InitialPrompt;
+    prompt?: string;
     stealFocus?: boolean;
   }): Promise<unknown>;
   deleteWorkspace(

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -738,8 +738,8 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
                 projectPath: resolved.projectPath,
                 workspaceName: req.name,
                 base: req.base,
-                ...(req.initialPrompt !== undefined && {
-                  initialPrompt: req.initialPrompt,
+                ...(req.agent !== undefined && {
+                  agent: req.agent,
                 }),
                 ...(req.stealFocus !== undefined && {
                   stealFocus: req.stealFocus,

--- a/src/modules/plugin-server.boundary.test.ts
+++ b/src/modules/plugin-server.boundary.test.ts
@@ -796,7 +796,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
           {
             name: "my-ws",
             base: "main",
-            initialPrompt: "Do something",
+            agent: { type: "default", prompt: "Do something" },
             stealFocus: false,
           },
           (res) => resolve(res)
@@ -814,7 +814,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
             projectPath: "/project/path",
             workspaceName: "my-ws",
             base: "main",
-            initialPrompt: "Do something",
+            agent: { type: "default", prompt: "Do something" },
             stealFocus: false,
           }),
         })

--- a/src/modules/ui-ipc-module.ts
+++ b/src/modules/ui-ipc-module.ts
@@ -19,6 +19,7 @@ import type {
   UiSetModePayload,
 } from "../shared/ipc";
 import { ApiIpcChannels } from "../shared/ipc";
+import { agentSpecHasPrompt } from "../shared/api/types";
 import type { DialogUserEvent } from "../shared/dialog-types";
 import type { NotificationUserEvent } from "../shared/notification-types";
 import type { DialogManager } from "./dialog-manager";
@@ -184,7 +185,7 @@ export function createUiIpcModule(deps: UiIpcModuleDeps): IntentModule {
             path: p.workspacePath,
             url: p.workspaceUrl,
           },
-          ...(p.initialPrompt && { hasInitialPrompt: true }),
+          ...(agentSpecHasPrompt(p.agent) && { hasInitialPrompt: true }),
           ...(p.stealFocus !== undefined && { stealFocus: p.stealFocus }),
         });
       },

--- a/src/modules/workspace-agent-resolver-module.ts
+++ b/src/modules/workspace-agent-resolver-module.ts
@@ -114,7 +114,11 @@ export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverD
       if (!workspacePath) return;
 
       const defaultAgent = deps.agentConfig.get();
-      const requested = intent.payload.agent;
+      // Only the typed arms ("claude"/"opencode") pin a backend; "default" and
+      // absent defer to metadata/config.
+      const requestedType = intent.payload.agent?.type;
+      const requested =
+        requestedType === "claude" || requestedType === "opencode" ? requestedType : undefined;
 
       if (requested !== undefined && requested !== defaultAgent) {
         // Persist a non-default agent choice so future operations resolve to it.

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -372,11 +372,11 @@ export interface DeletionProgress {
 }
 
 // =============================================================================
-// Initial Prompt Types
+// Agent Spec Types
 // =============================================================================
 
 /**
- * Model identifier for OpenCode prompts.
+ * Model identifier (provider + model id) carried by an agent spec.
  */
 export interface PromptModel {
   readonly providerID: string;
@@ -384,67 +384,50 @@ export interface PromptModel {
 }
 
 /**
- * Initial prompt for workspace creation.
- * Can be a simple string (uses defaults) or an object with optional
- * permissionMode / agentName / model.
+ * Agent specification for workspace creation — a discriminated union by backend.
  *
- * Axes (independent):
- * - permissionMode: Claude permission mode (e.g. "plan", "acceptEdits",
- *   "bypassPermissions"). Claude-only; ignored by OpenCode. Omit for the
- *   default (Claude decides; no --permission-mode flag).
- * - agentName: named agent/persona. Claude -> --agent; OpenCode -> the agent
- *   to run (e.g. "build", "plan", or a custom agent). Omit for the default.
+ * Carries both the prompt and the backend-specific launch config in one object,
+ * so each backend only exposes the options it actually understands:
+ * - "default": no backend chosen → resolved late from git metadata / config.
+ *   Accepts a prompt only. To set a model, permission mode or named agent you
+ *   must name the backend (a typed arm).
+ * - "claude": Claude. Supports prompt, model, permissionMode (e.g. "plan"),
+ *   and a named agent (--agent).
+ * - "opencode": OpenCode. Supports prompt, model and a named agent (e.g.
+ *   "build"). No permission mode (Claude-only concept).
  *
  * @example
- * // Simple string - uses defaults
- * initialPrompt: "Implement the login feature"
+ * // Just a prompt under whatever the resolved-default backend is
+ * agent: { type: "default", prompt: "Implement the login feature" }
  *
  * // Read-only/plan mode on Claude
- * initialPrompt: { prompt: "Investigate the bug", permissionMode: "plan" }
+ * agent: { type: "claude", prompt: "Investigate the bug", permissionMode: "plan" }
  *
- * // Named agent (OpenCode 'build', or a Claude custom agent)
- * initialPrompt: { prompt: "Implement the login feature", agentName: "build" }
- *
- * // Object with model
- * initialPrompt: { prompt: "Implement the login feature", model: { providerID: "anthropic", modelID: "claude-sonnet" } }
+ * // OpenCode 'build' agent with an explicit model
+ * agent: { type: "opencode", prompt: "Ship it", agentName: "build", model: { providerID: "anthropic", modelID: "claude-sonnet" } }
  */
-export type InitialPrompt =
-  | string
+export type AgentSpec =
+  | { readonly type: "default"; readonly prompt?: string }
   | {
-      readonly prompt: string;
+      readonly type: "claude";
+      readonly prompt?: string;
+      readonly model?: PromptModel;
       readonly permissionMode?: string;
       readonly agentName?: string;
+    }
+  | {
+      readonly type: "opencode";
+      readonly prompt?: string;
       readonly model?: PromptModel;
+      readonly agentName?: string;
     };
 
 /**
- * Normalized initial prompt structure.
- * Always has prompt text; permissionMode, agentName and model are optional.
+ * Whether an agent spec carries a non-empty prompt the agent will run on start.
+ * Used to signal optimistic "busy" state to the renderer.
  */
-export interface NormalizedInitialPrompt {
-  readonly prompt: string;
-  readonly permissionMode?: string;
-  readonly agentName?: string;
-  readonly model?: PromptModel;
-}
-
-/**
- * Normalize an initial prompt to a consistent structure.
- *
- * @param input - The initial prompt (string or object)
- * @returns Normalized object with prompt and optional permissionMode/agentName/model
- */
-export function normalizeInitialPrompt(input: InitialPrompt): NormalizedInitialPrompt {
-  if (typeof input === "string") {
-    return { prompt: input };
-  }
-  // Conditional spread keeps undefined keys out (exactOptionalPropertyTypes).
-  return {
-    prompt: input.prompt,
-    ...(input.permissionMode !== undefined && { permissionMode: input.permissionMode }),
-    ...(input.agentName !== undefined && { agentName: input.agentName }),
-    ...(input.model !== undefined && { model: input.model }),
-  };
+export function agentSpecHasPrompt(spec: AgentSpec | undefined): boolean {
+  return spec?.prompt !== undefined && spec.prompt.trim() !== "";
 }
 
 /**
@@ -456,17 +439,26 @@ const promptModelSchema = z.object({
 });
 
 /**
- * Zod schema for validating InitialPrompt.
- * Accepts either a non-empty string or an object with prompt and optional
- * permissionMode / agentName / model.
+ * Zod schema for validating AgentSpec. Discriminated on `type` so each backend
+ * only accepts the options it understands (e.g. permissionMode is Claude-only).
  */
-export const initialPromptSchema = z.union([
-  z.string().min(1),
+export const agentSpecSchema = z.discriminatedUnion("type", [
   z.object({
-    prompt: z.string().min(1),
-    permissionMode: z.string().optional(),
-    agentName: z.string().optional(),
+    type: z.literal("default"),
+    prompt: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("claude"),
+    prompt: z.string().min(1).optional(),
     model: promptModelSchema.optional(),
+    permissionMode: z.string().min(1).optional(),
+    agentName: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("opencode"),
+    prompt: z.string().min(1).optional(),
+    model: promptModelSchema.optional(),
+    agentName: z.string().min(1).optional(),
   }),
 ]);
 

--- a/src/shared/plugin-protocol.test.ts
+++ b/src/shared/plugin-protocol.test.ts
@@ -356,29 +356,30 @@ describe("validateWorkspaceCreateRequest", () => {
       expect(result).toEqual({ valid: true });
     });
 
-    it("accepts string initialPrompt", () => {
+    it("accepts the default agent arm with a prompt", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: "Implement the feature",
+        agent: { type: "default", prompt: "Implement the feature" },
       });
       expect(result).toEqual({ valid: true });
     });
 
-    it("accepts whitespace-only initialPrompt string (no trim, by design)", () => {
+    it("accepts whitespace-only prompt (no trim, by design)", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: "   ",
+        agent: { type: "default", prompt: "   " },
       });
       expect(result).toEqual({ valid: true });
     });
 
-    it("accepts initialPrompt object with agent and model", () => {
+    it("accepts a typed arm with agentName and model", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: {
+        agent: {
+          type: "opencode",
           prompt: "Implement the feature",
           agentName: "build",
           model: { providerID: "anthropic", modelID: "claude-sonnet" },
@@ -407,39 +408,39 @@ describe("validateWorkspaceCreateRequest", () => {
       expect(result).toEqual({ valid: false, error: "Field 'base' cannot be empty" });
     });
 
-    it("rejects empty initialPrompt string", () => {
+    it("rejects an empty prompt in the default arm", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: "",
+        agent: { type: "default", prompt: "" },
       });
       expect(result).toEqual({
         valid: false,
-        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+        error: "Field 'agent' must be a valid agent spec ({ type, prompt?, ... })",
       });
     });
 
-    it("rejects initialPrompt object without prompt", () => {
+    it("rejects an unknown backend type", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: { agentName: "build" },
+        agent: { type: "gemini", prompt: "Implement" },
       });
       expect(result).toEqual({
         valid: false,
-        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+        error: "Field 'agent' must be a valid agent spec ({ type, prompt?, ... })",
       });
     });
 
-    it("rejects malformed initialPrompt model", () => {
+    it("rejects a malformed model", () => {
       const result = validateWorkspaceCreateRequest({
         name: "feature-x",
         base: "main",
-        initialPrompt: { prompt: "Implement", model: { providerID: "anthropic" } },
+        agent: { type: "claude", prompt: "Implement", model: { providerID: "anthropic" } },
       });
       expect(result).toEqual({
         valid: false,
-        error: "Field 'initialPrompt' must be a non-empty string or a prompt object",
+        error: "Field 'agent' must be a valid agent spec ({ type, prompt?, ... })",
       });
     });
 

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from "zod/v4";
-import type { WorkspaceStatus, Workspace, InitialPrompt, AgentSession } from "./api/types";
-import { METADATA_KEY_REGEX, isValidMetadataKey, initialPromptSchema } from "./api/types";
+import type { WorkspaceStatus, Workspace, AgentSpec, AgentSession } from "./api/types";
+import { METADATA_KEY_REGEX, isValidMetadataKey, agentSpecSchema } from "./api/types";
 
 // ============================================================================
 // Result Types
@@ -296,8 +296,8 @@ export interface WorkspaceCreateRequest {
   readonly name: string;
   /** Base branch to create the workspace from */
   readonly base: string;
-  /** Optional initial prompt to send after workspace is created */
-  readonly initialPrompt?: InitialPrompt;
+  /** Optional agent spec: prompt + backend-specific launch config. */
+  readonly agent?: AgentSpec;
   /** If true, steal focus from current workspace. If false, don't steal focus but still
    *  switch when no workspace is active. Default: switch (undefined treated as true). */
   readonly stealFocus?: boolean;
@@ -306,11 +306,11 @@ export interface WorkspaceCreateRequest {
 const workspaceCreateRequestSchema = z.object({
   name: nonEmptyString("name"),
   base: nonEmptyString("base"),
-  initialPrompt: z
+  agent: z
     .unknown()
     .refine(
-      (value) => initialPromptSchema.safeParse(value).success,
-      "Field 'initialPrompt' must be a non-empty string or a prompt object"
+      (value) => agentSpecSchema.safeParse(value).success,
+      "Field 'agent' must be a valid agent spec ({ type, prompt?, ... })"
     )
     .optional(),
   stealFocus: z.boolean().optional(),
@@ -318,9 +318,8 @@ const workspaceCreateRequestSchema = z.object({
 
 /**
  * Runtime validation for WorkspaceCreateRequest.
- * Validates structure and required fields. The optional initialPrompt is
- * checked against initialPromptSchema (including the model field), keeping
- * this path in sync with the MCP server's validation.
+ * Validates structure and required fields. The optional agent spec is checked
+ * against agentSpecSchema, keeping this path in sync with the intent contract.
  */
 export const validateWorkspaceCreateRequest = validateWith(workspaceCreateRequestSchema);
 


### PR DESCRIPTION
Replaces the flat `agent: AgentType` + `initialPrompt: InitialPrompt` pair on `workspace:open` with a single discriminated `AgentSpec` (`default` | `claude` | `opencode`) carrying the prompt plus each backend's own launch config. `permissionMode` is now structurally Claude-only; `prompt` is optional on every arm.

- shared: drop `InitialPrompt`/`NormalizedInitialPrompt`/`normalizeInitialPrompt`/`initialPromptSchema`; add `AgentSpec` + `agentSpecSchema` (zod discriminated union) + `agentSpecHasPrompt`
- MCP `workspace_create`: reduce to a prompt-only input (emits the `default` arm); remove `getCallerModel` / model auto-propagation; update server instructions
- creation form: always emit a typed arm for the selected backend (resolver persists it only when != default)
- auto-workspace templates: `agent.*` namespaced front-matter; legacy `agent:`/`model.*` keys shim onto a claude arm with a deprecation warning (parser stays pure)
- resolver reads `payload.agent?.type` to pin/persist the backend
- plugin protocol + sidekick `api.d.ts`/drift-guard switch to `agent: AgentSpec`

Behavior changes: MCP-created workspaces use the agent's default model (no caller propagation); an opencode-default user's legacy template runs under claude until migrated (with a warning).