### PR TITLE
fix: auto-reload workspaces on resume

### DIFF
--- a/scripts/appctrl.ts
+++ b/scripts/appctrl.ts
@@ -579,6 +579,33 @@ server.registerTool(
   }
 );
 
+// ── appctrl_resume ──────────────────────────────────────────────────────
+
+server.registerTool(
+  "appctrl_resume",
+  {
+    description:
+      "Simulate a system wake by emitting Electron's powerMonitor 'resume' event " +
+      "in the main process. This drives the same code path as waking the machine " +
+      "from sleep (dispatches the app:resume intent). Use to test resume handling " +
+      "without actually suspending the host.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      if (!electronApp) {
+        throw new Error("App not started. Call appctrl_start first.");
+      }
+      await electronApp.evaluate(({ powerMonitor }) => {
+        powerMonitor.emit("resume");
+      });
+      return textResult({ resumed: true });
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err));
+    }
+  }
+);
+
 // ── appctrl_console ─────────────────────────────────────────────────────
 
 server.registerTool(

--- a/src/boundaries/shell/ui-view-manager.integration.test.ts
+++ b/src/boundaries/shell/ui-view-manager.integration.test.ts
@@ -162,6 +162,29 @@ describe("UiViewManager", () => {
     });
   });
 
+  describe("reloadFrames", () => {
+    it("asks the renderer to reload its workspace frames", () => {
+      const { manager, viewLayer } = createManager();
+      const exec = vi.spyOn(viewLayer, "executeJavaScript");
+
+      manager.reloadFrames();
+
+      expect(exec).toHaveBeenCalledWith(
+        manager.getUIViewHandle(),
+        expect.stringContaining("__chReloadFrames")
+      );
+    });
+
+    it("swallows a rejected executeJavaScript (UI mid-load)", async () => {
+      const { manager, viewLayer } = createManager();
+      vi.spyOn(viewLayer, "executeJavaScript").mockRejectedValue(new Error("page gone"));
+
+      expect(() => manager.reloadFrames()).not.toThrow();
+      // Let the rejected promise settle without an unhandled rejection
+      await Promise.resolve();
+    });
+  });
+
   describe("captureActiveWorkspaceView", () => {
     it("clips the capture to the active frame rect reported by the renderer", async () => {
       const { manager, viewLayer } = createManager();

--- a/src/boundaries/shell/ui-view-manager.ts
+++ b/src/boundaries/shell/ui-view-manager.ts
@@ -60,6 +60,7 @@ const CHILD_FRAME_FOCUS_TRACKER = `
  */
 const FOCUS_ACTIVE_FRAME = `window.__chFocusActiveFrame && window.__chFocusActiveFrame()`;
 const ACTIVE_FRAME_RECT = `window.__chActiveFrameRect ? window.__chActiveFrameRect() : null`;
+const RELOAD_FRAMES = `window.__chReloadFrames && window.__chReloadFrames()`;
 
 const ALLOWED_PERMISSIONS = new Set([
   "clipboard-read",
@@ -280,6 +281,15 @@ export class UiViewManager implements IViewManager {
         });
         break;
     }
+  }
+
+  reloadFrames(): void {
+    if (!this.uiViewHandle || !this.isUIAvailable()) return;
+    // Best-effort fire-and-forget: before WorkspaceFrames mounts the hook is
+    // undefined, and a mid-load UI rejects executeJavaScript.
+    this.viewLayer.executeJavaScript(this.uiViewHandle, RELOAD_FRAMES).catch(() => {
+      // UI may be mid-load
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -101,6 +101,16 @@ export interface IViewManager {
   getMode(): UIMode;
 
   /**
+   * Asks the renderer to reload every mounted workspace iframe (re-assigning
+   * each frame's src) and re-focus the active one. Called after code-server
+   * restarts, when the iframes' connections to the replaced server are stale.
+   *
+   * Best-effort: before the WorkspaceFrames component mounts the hook is
+   * undefined, and a mid-load UI rejects the call silently.
+   */
+  reloadFrames(): void;
+
+  /**
    * Capture a PNG screenshot of the active workspace iframe, by clipping a
    * full-view capture to the iframe's bounding rect (no API exists to
    * capture an out-of-process iframe directly).

--- a/src/boundaries/shell/view-manager.test-utils.ts
+++ b/src/boundaries/shell/view-manager.test-utils.ts
@@ -39,6 +39,7 @@ export function createMockViewManager(options?: CreateMockViewManagerOptions): I
       currentMode = mode;
     }),
     getMode: vi.fn(() => currentMode),
+    reloadFrames: vi.fn(),
     captureActiveWorkspaceView: vi.fn().mockResolvedValue(null),
     destroy: vi.fn(),
   } as IViewManager;

--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -2,12 +2,12 @@
  * AppResumeOperation - Orchestrates recovery after system wake from sleep/hibernate.
  *
  * Single hook point:
- * - "resume" - Probe code-server health and reload workspace views.
- *              code-server-module provides `codeServerReady`; view-module's
- *              reload handler requires it so the reload only runs after the
- *              server is confirmed healthy (or has been restarted).
- *              Hook context includes `emit` so handlers can fire their own
- *              domain events (e.g. code-server:restart-failed).
+ * - "resume" - Probe code-server health and restart it if the probe fails.
+ *              The hook context includes `emit` so handlers can fire their own
+ *              domain events: code-server-module emits `code-server:restarted`
+ *              on a successful restart (view-module reacts by reloading the
+ *              workspace iframes, whose connections to the replaced server are
+ *              stale) and `app:resume-failed` if the restart fails.
  *
  * After hooks complete, emits `app:resumed` for telemetry subscribers
  * (telemetry-module) that don't depend on server state.
@@ -64,6 +64,20 @@ export interface AppResumeFailedEvent extends DomainEvent {
 }
 
 export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
+
+/**
+ * Emitted by code-server-module after it kills and restarts code-server on
+ * resume (the /healthz probe failed and a fresh process is now listening).
+ * view-module reacts by reloading all workspace iframes, whose connections to
+ * the replaced server are stale — otherwise code-server shows its own "Reload"
+ * dialog in each workspace.
+ */
+export interface CodeServerRestartedEvent extends DomainEvent {
+  readonly type: typeof EVENT_CODE_SERVER_RESTARTED;
+  readonly payload: Record<string, never>;
+}
+
+export const EVENT_CODE_SERVER_RESTARTED = "code-server:restarted" as const;
 
 // =============================================================================
 // Operation

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -23,6 +23,7 @@ import {
   INTENT_APP_RESUME,
   EVENT_APP_RESUMED,
   EVENT_APP_RESUME_FAILED,
+  EVENT_CODE_SERVER_RESTARTED,
 } from "../intents/app-resume";
 import type { DomainEvent } from "../intents/lib/types";
 import { SETUP_OPERATION_ID } from "../intents/setup";
@@ -1196,6 +1197,9 @@ describe("CodeServerModule", () => {
         fetch.mockResolvedValueOnce({ status: 503 });
         fetch.mockResolvedValue({ status: 200 });
 
+        const restartedEvents: DomainEvent[] = [];
+        dispatcher.subscribe(EVENT_CODE_SERVER_RESTARTED, (e) => restartedEvents.push(e));
+
         const resumePromise = dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
 
         // Drive the 5s probe timeout + any intervals
@@ -1205,12 +1209,14 @@ describe("CodeServerModule", () => {
         // Old process killed, new process spawned
         expect(initialProcess).toHaveBeenKilled();
         expect(asMockRunner(deps).$.spawnedCount).toBe(2);
+        // A successful restart signals the renderer to reload its frames
+        expect(restartedEvents).toHaveLength(1);
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it("emits app:resume-failed and blocks codeServerReady when restart fails", async () => {
+    it("does not emit code-server:restarted when the restart fails", async () => {
       vi.useFakeTimers();
 
       try {
@@ -1223,7 +1229,9 @@ describe("CodeServerModule", () => {
         (deps.portManager.isPortAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(false);
 
         const failureEvents: DomainEvent[] = [];
+        const restartedEvents: DomainEvent[] = [];
         dispatcher.subscribe(EVENT_APP_RESUME_FAILED, (e) => failureEvents.push(e));
+        dispatcher.subscribe(EVENT_CODE_SERVER_RESTARTED, (e) => restartedEvents.push(e));
 
         const resumePromise = dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
         await vi.advanceTimersByTimeAsync(6000);
@@ -1232,21 +1240,27 @@ describe("CodeServerModule", () => {
         expect(failureEvents).toHaveLength(1);
         const payload = failureEvents[0]!.payload as { error: string };
         expect(payload.error).toContain("already in use");
+        // No restart succeeded, so frames must not be told to reload
+        expect(restartedEvents).toHaveLength(0);
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it("provides codeServerReady capability and emits app:resumed when healthy", async () => {
+    it("emits app:resumed without restarting when healthy", async () => {
       const deps = createMockDeps();
       const { dispatcher } = await startCodeServer(deps);
 
       const resumedEvents: DomainEvent[] = [];
+      const restartedEvents: DomainEvent[] = [];
       dispatcher.subscribe(EVENT_APP_RESUMED, (e) => resumedEvents.push(e));
+      dispatcher.subscribe(EVENT_CODE_SERVER_RESTARTED, (e) => restartedEvents.push(e));
 
       await dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
 
       expect(resumedEvents).toHaveLength(1);
+      // Healthy probe → no restart → no frame reload
+      expect(restartedEvents).toHaveLength(0);
     });
 
     it("skips probe when code-server was never started", async () => {

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -44,6 +44,7 @@ import {
   APP_RESUME_OPERATION_ID,
   APP_RESUME_HOOK_RESUME,
   EVENT_APP_RESUME_FAILED,
+  EVENT_CODE_SERVER_RESTARTED,
   type ResumeHookContext,
 } from "../intents/app-resume";
 import { SETUP_OPERATION_ID } from "../intents/setup";
@@ -741,12 +742,10 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [APP_RESUME_OPERATION_ID]: {
         [APP_RESUME_HOOK_RESUME]: {
-          provides: () => ({ codeServerReady: true }),
           handler: async (ctx: HookContext): Promise<void> => {
             const port = currentPort;
             if (port === null) {
-              // Never started — nothing to probe. Still provide capability so
-              // view-module's reload runs (it will be a no-op with no workspaces).
+              // Never started — nothing to probe or restart.
               return;
             }
 
@@ -763,6 +762,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             }
 
             logger.warn("Code-server unhealthy after resume, restarting");
+            const resumeCtx = ctx as ResumeHookContext;
             try {
               await stop();
               await ensureRunning();
@@ -770,13 +770,20 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             } catch (error) {
               const message = getErrorMessage(error);
               logger.error("Code-server restart failed after resume", { error: message });
-              const resumeCtx = ctx as ResumeHookContext;
               await resumeCtx.emit({
                 type: EVENT_APP_RESUME_FAILED,
                 payload: { error: message },
               });
               throw error;
             }
+
+            // The fresh process invalidates every workspace iframe's connection
+            // to the old server. Tell view-module to reload them before
+            // code-server's client surfaces its own "Reload" dialog.
+            await resumeCtx.emit({
+              type: EVENT_CODE_SERVER_RESTARTED,
+              payload: {},
+            });
           },
         },
       },

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -62,6 +62,8 @@ import {
 } from "../intents/resolve-workspace";
 import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
 import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
+import { EVENT_CODE_SERVER_RESTARTED } from "../intents/app-resume";
+import type { CodeServerRestartedEvent } from "../intents/app-resume";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createMockViewManager } from "../boundaries/shell/view-manager.test-utils";
 import { createViewModule, type ViewModuleDeps } from "./view-module";
@@ -688,6 +690,23 @@ describe("ViewModule Integration", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // code-server:restarted → reload workspace iframes
+  // -------------------------------------------------------------------------
+  describe("code-server:restarted", () => {
+    it("asks the view manager to reload frames", async () => {
+      const { viewManager, module } = createTestSetup();
+
+      const event: CodeServerRestartedEvent = {
+        type: EVENT_CODE_SERVER_RESTARTED,
+        payload: {},
+      };
+      await module.events![EVENT_CODE_SERVER_RESTARTED]!.handler(event);
+
+      expect(viewManager.reloadFrames).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -49,6 +49,7 @@ import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
 import { SET_MODE_OPERATION_ID } from "../intents/set-mode";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
 import { EVENT_APP_STARTED } from "../intents/app-ready";
+import { EVENT_CODE_SERVER_RESTARTED } from "../intents/app-resume";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
 import { WORKSPACE_LOADING_TIMEOUT_MS } from "../boundaries/shell/view-manager.interface";
 import { INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
@@ -861,6 +862,18 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
           const payload = (event as AgentStatusUpdatedEvent).payload;
           finishWorkspaceLoading(payload.workspace.path);
           closeStartupSplash();
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // code-server:restarted → reload every workspace iframe. A resume
+      // restart replaced the code-server process, so each frame's connection
+      // to the old server is dead; reloading reconnects them to the fresh
+      // server instead of leaving code-server's "Reload" dialog in each one.
+      // -------------------------------------------------------------------
+      [EVENT_CODE_SERVER_RESTARTED]: {
+        handler: async (): Promise<void> => {
+          viewManager.reloadFrames();
         },
       },
 

--- a/src/renderer/lib/components/WorkspaceFrames.svelte
+++ b/src/renderer/lib/components/WorkspaceFrames.svelte
@@ -38,6 +38,7 @@
   interface FrameHooks {
     __chFocusActiveFrame?: () => void;
     __chActiveFrameRect?: () => { x: number; y: number; width: number; height: number } | null;
+    __chReloadFrames?: () => void;
   }
 
   const frameEls = new SvelteMap<string, HTMLIFrameElement>();
@@ -94,6 +95,22 @@
     if (el) focusFrame(el);
   }
 
+  // Reload every mounted frame by re-assigning its src (forces a navigation
+  // even though the URL is unchanged — the prod code-server port is stable
+  // across a restart). Invoked by the main process via __chReloadFrames after
+  // code-server restarts on resume, so the frames reconnect to the fresh
+  // server instead of showing code-server's own "Reload" dialog. frameEls
+  // holds exactly the mounted (non-hibernated) frames.
+  function reloadFrames(): void {
+    for (const el of frameEls.values()) {
+      // Re-assigning src (via a local, to dodge no-self-assign) forces a fresh
+      // navigation even though the resolved URL is identical.
+      const url = el.src;
+      el.src = url;
+    }
+    if (uiMode.value === "workspace") focusActiveFrame();
+  }
+
   // Show flow: when the active workspace changes, force a paint-tree refresh
   // of the now-visible frame to work around Windows DirectComposition
   // surfaces that can come back blank after a display:none → display:block
@@ -147,9 +164,11 @@
       if (rect.width <= 0 || rect.height <= 0) return null;
       return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
     };
+    hooks.__chReloadFrames = reloadFrames;
     return () => {
       delete hooks.__chFocusActiveFrame;
       delete hooks.__chActiveFrameRect;
+      delete hooks.__chReloadFrames;
     };
   });
 </script>

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -30,6 +30,7 @@ import { asProjectId, createMockProject } from "@shared/test-fixtures";
 interface FrameHooks {
   __chFocusActiveFrame?: () => void;
   __chActiveFrameRect?: () => { x: number; y: number; width: number; height: number } | null;
+  __chReloadFrames?: () => void;
 }
 
 function makeProject(): Project {
@@ -132,10 +133,40 @@ describe("WorkspaceFrames", () => {
 
     expect(typeof hooks.__chFocusActiveFrame).toBe("function");
     expect(typeof hooks.__chActiveFrameRect).toBe("function");
+    expect(typeof hooks.__chReloadFrames).toBe("function");
 
     unmount();
     expect(hooks.__chFocusActiveFrame).toBeUndefined();
     expect(hooks.__chActiveFrameRect).toBeUndefined();
+    expect(hooks.__chReloadFrames).toBeUndefined();
+  });
+
+  it("__chReloadFrames re-assigns the src of every mounted frame", () => {
+    setProjects([makeProject()]);
+    setActiveWorkspace("/workspaces/ws1");
+    const { container } = render(WorkspaceFrames);
+
+    // Re-assigning src forces a reload; spy on the setter of each frame while
+    // keeping the original URL readable. Only the two mounted (non-hibernated,
+    // url-bearing) frames should be touched.
+    const tracked = frames(container).map((el) => {
+      const original = el.src;
+      const setter = vi.fn();
+      Object.defineProperty(el, "src", {
+        configurable: true,
+        get: () => original,
+        set: setter,
+      });
+      return { setter, original };
+    });
+    expect(tracked).toHaveLength(2);
+
+    const hooks = window as FrameHooks;
+    hooks.__chReloadFrames!();
+
+    for (const { setter, original } of tracked) {
+      expect(setter).toHaveBeenCalledWith(original);
+    }
   });
 
   it("__chActiveFrameRect returns null when no workspace is active", () => {


### PR DESCRIPTION
- After a system wake, the resume handler restarts code-server when its `/healthz` probe fails. The workspace iframes still pointed at the replaced server, so code-server surfaced its own "Reload" dialog in every workspace (PostHog BugReport 019ef885). The load-on-resume reload that used to refresh them was removed in the single-view refactor (051e18fc) and never replaced.
- code-server now emits a `code-server:restarted` domain event after a successful resume-restart (after `ensureRunning`, so the new server is already listening). `view-module` handles it by calling `viewManager.reloadFrames()` → `window.__chReloadFrames()`, which re-assigns each mounted iframe's `src` and re-focuses the active one.
- Reload fires **only** on an actual restart, not on every resume.
- Drops the now-dead `codeServerReady` capability (nothing required it after the old view-module resume hook was removed).
- Verified end-to-end in the running app: kill code-server → simulated resume → restart → `code-server:restarted` handled by view-module → iframes reload (beacon gone, hook invoked once); a healthy resume reloads nothing (4ms vs 5390ms, no restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)