### PR TITLE
fix(settings): server-level MCP allow rules to stop appctrl/codehydra prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "mcp__codehydra__*",
-      "mcp__appctrl__*",
+      "mcp__codehydra",
+      "mcp__appctrl",
       "Bash(pnpm test:*)",
       "Bash(pnpm validate:*)",
       "Bash(pnpm build:*)",


### PR DESCRIPTION
- Replace the non-functional `mcp__appctrl__*` / `mcp__codehydra__*` wildcard allow rules with the server-level form (`mcp__appctrl`, `mcp__codehydra`)
- MCP permission rules don't support the `__*` suffix, so the old patterns matched nothing and every appctrl/codehydra tool call still prompted

🤖 Generated with [Claude Code](https://claude.com/claude-code)