### PR TITLE
fix: workspaces reloaded each time a workspace was created

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -7,7 +7,11 @@
   agent-selection / loading surfaces before MainView would ever mount).
 
   Renders by the snapshot's main.kind:
-  - startup kinds (starting / setup / agent-selection / loading) → StartupView
+  - startup kinds (starting / setup / agent-selection / loading) → StartupView,
+    but only until the first normal snapshot. Thereafter MainView stays mounted
+    (see showMain) so a mid-session "loading" surface — the still-creating
+    active workspace — never tears down the workspace iframes; it renders as an
+    overlay inside MainView instead (mirroring the hibernated overlay).
   - workspace / hibernated / creation → MainView
   - before the first snapshot arrives → a minimal blank initializing state
 
@@ -49,14 +53,28 @@
   // cannot drift from main's truth). Null until the genesis push arrives.
   let ui = $state.raw<UiState | null>(null);
   const main = $derived(ui?.main ?? null);
-  /** True once a normal (non-startup) snapshot has rendered: MainView shows. */
-  const showMain = $derived(
-    main !== null &&
+  /**
+   * Latches true once the first normal (non-startup) snapshot renders, and
+   * stays true for the rest of the session. Deliberately one-way: a mid-session
+   * "loading" surface (the still-creating active workspace) must NOT swap
+   * MainView back out for StartupView — unmounting MainView destroys every
+   * mounted workspace iframe, so all open workspaces would reload each time a
+   * new one is created. The startup kinds (starting/setup/agent-selection/
+   * loading) only occur before app:started, so the latch never traps a real
+   * startup surface; mid-session loading shows as an overlay inside MainView.
+   */
+  let showMain = $state(false);
+  $effect(() => {
+    if (
+      main !== null &&
       main.kind !== "starting" &&
       main.kind !== "setup" &&
       main.kind !== "agent-selection" &&
       main.kind !== "loading"
-  );
+    ) {
+      showMain = true;
+    }
+  });
 
   // Subscribe to ui:state, then emit the ui-connected handshake (on mount,
   // during the initializing phase). The subscription MUST be in place before
@@ -128,7 +146,7 @@
   {#if main === null}
     <!-- Minimal blank state until the first snapshot arrives. -->
     <div class="initializing-container" aria-busy="true"></div>
-  {:else if main.kind === "starting" || main.kind === "setup" || main.kind === "agent-selection" || main.kind === "loading"}
+  {:else if !showMain && (main.kind === "starting" || main.kind === "setup" || main.kind === "agent-selection" || main.kind === "loading")}
     <StartupView {main} workspaceArea={false} />
   {:else if ui !== null}
     <div class="main-view-container">

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment-options {"settings": {"disableIframePageLoading": true}}
 /**
  * Tests for the App component.
  *
@@ -231,6 +232,66 @@ describe("App component", () => {
       await waitFor(() => {
         expect(screen.getByRole("heading", { name: "New workspace" })).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("mid-session loading keeps workspace iframes mounted", () => {
+    it("overlays the loading surface instead of tearing MainView (and its iframes) down", async () => {
+      const { container } = render(App);
+      await waitFor(() => expect(mockApi.onState).toHaveBeenCalled());
+
+      const wsA = ws("alpha");
+      const frames = { [wsA.key]: "http://127.0.0.1:25448/?workspace=alpha" };
+
+      // First normal snapshot: one workspace active, its iframe mounted.
+      pushState(
+        makeUiState([makeUiProjectRow([{ ...wsA, active: true }])], {
+          frames,
+          main: { kind: "workspace", frameKey: wsA.key },
+        })
+      );
+
+      let iframe: Element | null = null;
+      await waitFor(() => {
+        iframe = container.querySelector(`iframe[data-key="${wsA.key}"]`);
+        expect(iframe).toBeInTheDocument();
+      });
+      expect(container.querySelector(".main-view")).toBeInTheDocument();
+
+      // A new workspace is being created and becomes active: the presenter
+      // pushes main.kind="loading" (no frame for it yet) while keeping the
+      // existing workspace's frame in the snapshot. MainView must survive so
+      // the existing iframe is not destroyed and reloaded.
+      pushState(
+        makeUiState([makeUiProjectRow([{ ...wsA, active: false }])], {
+          frames,
+          main: { kind: "loading", label: "Loading workspace..." },
+          mode: "dialog",
+        })
+      );
+
+      // Loading shows as an overlay (StartupView) rendered INSIDE MainView,
+      // not by swapping MainView out for a top-level StartupView.
+      await waitFor(() => {
+        expect(container.querySelector(".startup-view")).toBeInTheDocument();
+      });
+      expect(container.querySelector(".main-view")).toBeInTheDocument();
+
+      // The kept-alive frame is the same DOM node — no remount, no reload.
+      const sameIframe = container.querySelector(`iframe[data-key="${wsA.key}"]`);
+      expect(sameIframe).toBe(iframe);
+
+      // Creation completes: back to the workspace surface, frame still the same.
+      pushState(
+        makeUiState([makeUiProjectRow([{ ...wsA, active: true }])], {
+          frames,
+          main: { kind: "workspace", frameKey: wsA.key },
+        })
+      );
+      await waitFor(() => {
+        expect(container.querySelector(".startup-view")).not.toBeInTheDocument();
+      });
+      expect(container.querySelector(`iframe[data-key="${wsA.key}"]`)).toBe(iframe);
     });
   });
 

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -37,6 +37,7 @@
   import WorkspaceFrames from "./WorkspaceFrames.svelte";
   import ShortcutOverlay from "./ShortcutOverlay.svelte";
   import HibernatedOverlay from "./HibernatedOverlay.svelte";
+  import StartupView from "./StartupView.svelte";
 
   import PanelView from "./PanelView.svelte";
 
@@ -87,6 +88,13 @@
     }));
   });
   const activeFrameKey = $derived(main?.kind === "workspace" ? main.frameKey : null);
+
+  // The mid-session "Loading workspace…" surface: the active workspace is still
+  // being created, so it has no frame yet. App keeps MainView mounted through
+  // this state (rather than swapping in StartupView) so the OTHER workspaces'
+  // iframes are not torn down and reloaded; we show the loading screen as an
+  // overlay over the kept-alive frames, reusing StartupView's loading visual.
+  const loadingMain = $derived(main?.kind === "loading" ? main : null);
 
   // Mode (including dialog/hover z-order) is now computed in main and shipped
   // in the snapshot; the renderer no longer mirrors dialog/hover state back.
@@ -199,6 +207,13 @@
 
   {#if main?.kind === "hibernated"}
     <HibernatedOverlay screenshot={main.screenshot} onWake={handleWakeActiveWorkspace} />
+  {/if}
+
+  <!-- Mid-session loading (still-creating active workspace): overlay the
+       workspace area, leaving the kept-alive frames mounted underneath so
+       creating a workspace never reloads the others. -->
+  {#if loadingMain}
+    <StartupView main={loadingMain} workspaceArea={true} />
   {/if}
 </div>
 


### PR DESCRIPTION
Creating a workspace makes the still-creating workspace active, flipping `main.kind` to `"loading"`. `App.svelte` treated `"loading"` as a startup surface and swapped `MainView` out for `StartupView`; since `MainView` owns `WorkspaceFrames`, **every workspace iframe was destroyed and reloaded** when creation finished — so all open workspaces reloaded on each create.

**Changes (renderer-only — no IPC/shared-type changes):**

- `App.svelte`: latch `showMain` one-way so `MainView` stays mounted for the rest of the session; a mid-session `"loading"` surface no longer tears it down.
- `MainView.svelte`: render the mid-session "Loading workspace…" surface as an overlay (reusing `StartupView` with `workspaceArea`), like the hibernated overlay, over the kept-alive frames.
- `App.test.ts`: regression test asserting the existing iframe is the same DOM node across a `workspace → loading → workspace` transition (no remount/reload) and `MainView` is never torn down.

The genuine startup loading screen (before `app:started`, no frames yet) is unchanged. Now only the new workspace's iframe loads on create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSbftU98Fw8t863hnXB9Lh