### PR TITLE
fix: New-workspace dialog defaults to wrong project

### DIFF
--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -33,7 +33,6 @@ import { EVENT_BASES_UPDATED, INTENT_GET_PROJECT_BASES } from "../intents/get-pr
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import { INTENT_LIST_PROJECTS } from "../intents/list-projects";
-import { INTENT_GET_ACTIVE_WORKSPACE } from "../intents/get-active-workspace";
 import { INTENT_GET_LAUNCH_OPTIONS } from "../intents/agent-launch-options";
 
 // =============================================================================
@@ -69,6 +68,17 @@ const BASES_A: readonly BaseInfo[] = [
 
 const CLAUDE_AGENT: AgentInfo = { agent: "claude", label: "Claude Code", icon: "claude" };
 const OPENCODE_AGENT: AgentInfo = { agent: "opencode", label: "OpenCode", icon: "opencode" };
+
+/** A non-null workspace:switched payload for a project (active-surface bookkeeping). */
+function switchedPayload(project: Project): Record<string, unknown> {
+  return {
+    projectId: project.id,
+    projectName: project.name,
+    projectPath: project.path,
+    workspaceName: "active" as WorkspaceName,
+    path: `${project.path}/.worktrees/active`,
+  };
+}
 
 // =============================================================================
 // Mock Dispatcher (programmable per-intent results)
@@ -177,11 +187,6 @@ function setup(options?: {
       projectId: PROJECT_A.id,
     };
   });
-  dispatcher.results.set(INTENT_GET_ACTIVE_WORKSPACE, () => {
-    const projectId = options?.activeWorkspaceProjectId;
-    if (projectId === null || projectId === undefined) return null;
-    return { projectId, workspaceName: "existing", path: "/projects/a/.worktrees/existing" };
-  });
   dispatcher.results.set(INTENT_GET_LAUNCH_OPTIONS, (payload) => {
     // Mirror real backends: Claude reports permission modes, OpenCode none.
     const backend = (payload as { backend: string }).backend;
@@ -208,6 +213,15 @@ function setup(options?: {
   };
 
   const start = async (): Promise<MockDialogHandle> => {
+    // Mirror the real restore-switch that lands before app:started: the
+    // creation module records the active workspace's project from this event
+    // (it no longer queries a live active ref, which the panel-open deselect
+    // would null before the seed reads it).
+    const activeId = options?.activeWorkspaceProjectId;
+    if (activeId !== null && activeId !== undefined) {
+      const active = projects.find((p) => p.id === activeId);
+      if (active !== undefined) await emit(EVENT_WORKSPACE_SWITCHED, switchedPayload(active));
+    }
     await emit(EVENT_APP_STARTED);
     const panel = dialogs.panelHandles().find((h) => !h.closed);
     expect(panel, "open panel session").toBeDefined();
@@ -258,6 +272,36 @@ describe("CreationModule", () => {
       const s = setup({ projects: [PROJECT_B, PROJECT_A], activeWorkspaceProjectId: null });
       const panel = await s.start();
       expect(field(panel.config, "project")["value"]).toBe(PROJECT_B.path);
+    });
+
+    it("keeps seeding the last active project across the panel-open deselect", async () => {
+      // PROJECT_A is active but is NOT projects[0] — proves the seed follows the
+      // active workspace, not the list head.
+      const s = setup({ projects: [PROJECT_B, PROJECT_A], activeWorkspaceProjectId: PROJECT_A.id });
+      const panel = await s.start();
+      expect(field(panel.config, "project")["value"]).toBe(PROJECT_A.path);
+
+      // Showing the panel deselects the active workspace (workspace:switched
+      // null). The next open must not collapse to projects[0] (PROJECT_B).
+      await s.emit(EVENT_WORKSPACE_SWITCHED, null);
+      currentPanel(s).emitDismiss();
+      await flush();
+
+      expect(field(currentPanel(s).config, "project")["value"]).toBe(PROJECT_A.path);
+    });
+
+    it("falls back to the first project when the last active project is no longer open", async () => {
+      const s = setup({ projects: [PROJECT_B, PROJECT_A], activeWorkspaceProjectId: PROJECT_A.id });
+      const panel = await s.start();
+      expect(field(panel.config, "project")["value"]).toBe(PROJECT_A.path);
+
+      // PROJECT_A closed: the remembered path is no longer in the list, so the
+      // reset must fall back to projects[0] rather than seeding a dead project.
+      s.dispatcher.results.set(INTENT_LIST_PROJECTS, () => [PROJECT_B]);
+      currentPanel(s).emitDismiss();
+      await flush();
+
+      expect(field(currentPanel(s).config, "project")["value"]).toBe(PROJECT_B.path);
     });
 
     it("renders the no-project placeholder (disabled fields, disabled Create) without projects", async () => {
@@ -1019,7 +1063,7 @@ describe("CreationModule", () => {
 
       projects.push(PROJECT_B);
       await s.emit(EVENT_PROJECT_OPENED, { project: PROJECT_B });
-      await s.emit(EVENT_WORKSPACE_SWITCHED, { path: "/projects/a/.worktrees/existing" });
+      await s.emit(EVENT_WORKSPACE_SWITCHED, switchedPayload(PROJECT_A));
 
       panel.emitDismiss();
       await flush();

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -55,7 +55,7 @@ import {
   type BasesUpdatedEvent,
   type GetProjectBasesIntent,
 } from "../intents/get-project-bases";
-import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
+import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "../intents/switch-workspace";
 import {
   INTENT_OPEN_WORKSPACE,
   EVENT_WORKSPACE_CREATED,
@@ -63,10 +63,7 @@ import {
 } from "../intents/open-workspace";
 import { EVENT_WORKSPACE_DELETED } from "../intents/delete-workspace";
 import { INTENT_LIST_PROJECTS, type ListProjectsIntent } from "../intents/list-projects";
-import {
-  INTENT_GET_ACTIVE_WORKSPACE,
-  type GetActiveWorkspaceIntent,
-} from "../intents/get-active-workspace";
+import { Path } from "../utils/path/path";
 import {
   INTENT_GET_LAUNCH_OPTIONS,
   type GetLaunchOptionsIntent,
@@ -167,6 +164,14 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   let formError: string | null = null;
   /** Project to seed the next reset with (most recently opened project). */
   let pendingSeedProjectPath: string | null = null;
+  /**
+   * Project path of the workspace the app last made active. Recorded from
+   * non-null workspace:switched events so it survives the deselect
+   * (workspace:switch → null) the renderer fires when showing the panel —
+   * that deselect would otherwise null the live active ref before the seed
+   * reads it, collapsing the seed to projects[0].
+   */
+  let lastActiveProjectPath: string | null = null;
   /** Guards against overlapping resets (dismiss bursts). */
   let resetting = false;
   /** Invalidates in-flight branch fetches when the selection changes. */
@@ -554,27 +559,20 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
 
   // ---- Session lifecycle ----
 
-  /** Seed rule: pending opened project > active workspace's project > first. */
-  async function computeSeedProject(): Promise<string | null> {
+  /** Seed rule: pending opened project > last active workspace's project > first. */
+  function computeSeedProject(): string | null {
     if (pendingSeedProjectPath !== null) {
       const seed = pendingSeedProjectPath;
       pendingSeedProjectPath = null;
       if (projects.some((p) => p.path === seed)) return seed;
     }
-    try {
-      const intent: GetActiveWorkspaceIntent = {
-        type: INTENT_GET_ACTIVE_WORKSPACE,
-        payload: {},
-      };
-      const ref = await dispatcher.dispatch(intent);
-      if (ref) {
-        const project = projects.find((p) => p.id === ref.projectId);
-        if (project) return project.path;
-      }
-    } catch (error) {
-      logger.debug("Creation form: active workspace lookup failed", {
-        error: getErrorMessage(error),
-      });
+    // The live active ref is unusable here: showing the panel deselects the
+    // active workspace first, so a query would return null. Use the last
+    // workspace the app made active instead (recorded across switches).
+    if (lastActiveProjectPath !== null) {
+      const remembered = new Path(lastActiveProjectPath);
+      const project = projects.find((p) => remembered.equals(new Path(p.path)));
+      if (project) return project.path;
     }
     return projects[0]?.path ?? null;
   }
@@ -595,7 +593,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     await refreshProjects();
     availableAgents = await deps.getAvailableAgents();
     selectedAgentType = resolveInitialAgentType();
-    const seed = await computeSeedProject();
+    const seed = computeSeedProject();
     if (seed !== null) {
       selectedProjectPath = seed;
       branchesLoading = true;
@@ -1039,7 +1037,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         await refreshProjects();
         if (selectedProjectPath !== null && selectedProject() === undefined) {
           // The selected project was closed: fall back to the seed rule.
-          const seed = await computeSeedProject();
+          const seed = computeSeedProject();
           if (seed !== null) {
             selectProject(seed);
             return;
@@ -1083,10 +1081,17 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       },
     },
     [EVENT_WORKSPACE_SWITCHED]: {
-      handler: async (): Promise<void> => {
+      handler: async (event: DomainEvent): Promise<void> => {
         // The user moved on — a stale "recently opened project" seed should
         // not override the active workspace's project on the next reset.
         pendingSeedProjectPath = null;
+        // Remember the active workspace's project for the seed. Only non-null
+        // payloads update it: the deselect (null) the renderer fires when
+        // showing the panel must not erase the project we want to seed.
+        const payload = (event as WorkspaceSwitchedEvent).payload;
+        if (payload !== null) {
+          lastActiveProjectPath = payload.projectPath;
+        }
       },
     },
     [EVENT_WORKSPACE_CREATED]: {


### PR DESCRIPTION
- The new-workspace create panel deselects the active workspace (`workspace:switch` → null) before the seed runs, so the live `get-active-workspace` query returned null and the dialog fell back to `projects[0]` (the first *open*-order project, independent of the alphabetical sidebar order). The "active workspace's project" seed rule was effectively dead for manual panel opens.
- Record the last non-null active project path from `workspace:switched` events (so it survives the panel-open deselect) and seed from it. Seed order is now: pending opened project → last active workspace's project (matched via `Path.equals`) → `projects[0]`.
- Dropped the `get-active-workspace` dispatch from the creation module; the operation stays for its other consumers. No IPC/contract changes.
- Added integration tests (deselect-survival + stale-project fallback) and verified live via appctrl: two projects open `[alpha, beta]`, active workspace in beta → manual panel open now seeds beta, not `projects[0]`.