### PR TITLE
chore(claude): share appctrl MCP auto-approval, gitignore local settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,6 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "context7@claude-plugins-official": true
-  }
+  },
+  "enabledMcpjsonServers": ["appctrl"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ pnpm-debug.log*
 
 # Claude Code scheduler
 .claude/scheduled_tasks.lock
+
+# Claude Code local settings (personal overrides, not shared)
+.claude/settings.local.json


### PR DESCRIPTION
- Promote the `appctrl` MCP server approval from the personal `.claude/settings.local.json` into the tracked `.claude/settings.json` via `enabledMcpjsonServers: ["appctrl"]` (appctrl-only — no blanket `enableAllProjectMcpServers`).
- Add an explicit `.claude/settings.local.json` entry to `.gitignore` so personal overrides stay local.