### PR TITLE
fix: removed false git errors from console

### DIFF
--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -2657,3 +2657,56 @@ describe("GitWorktreeProvider bare repository support", () => {
     });
   });
 });
+
+describe("GitWorktreeProvider isDirty", () => {
+  const PROJECT_ROOT = new Path("/project");
+  const WORKSPACES_DIR = new Path("/workspaces");
+  const WORKSPACE_PATH = new Path("/workspaces/feature-x");
+
+  it("returns false when the workspace directory no longer exists (deletion race)", async () => {
+    // getStatus throws because the worktree isn't a known repo, and the
+    // directory is absent from the filesystem — the deleted-workspace race.
+    const mockClient = createMockGitClient({
+      repositories: {
+        [PROJECT_ROOT.toString()]: { branches: ["main"], currentBranch: "main" },
+      },
+    });
+    const mockFs = createFileSystemMock({
+      entries: { [WORKSPACES_DIR.toString()]: directory() },
+    });
+    const provider = await createProvider(
+      PROJECT_ROOT,
+      mockClient,
+      WORKSPACES_DIR,
+      mockFs,
+      SILENT_LOGGER
+    );
+
+    expect(await provider.isDirty(WORKSPACE_PATH)).toBe(false);
+  });
+
+  it("rethrows the git error when the workspace directory still exists", async () => {
+    // getStatus fails for a genuine reason but the directory is present — the
+    // error must surface (the delete-preflight dirty check depends on this).
+    const mockClient = createMockGitClient({
+      repositories: {
+        [PROJECT_ROOT.toString()]: { branches: ["main"], currentBranch: "main" },
+      },
+    });
+    const mockFs = createFileSystemMock({
+      entries: {
+        [WORKSPACES_DIR.toString()]: directory(),
+        [WORKSPACE_PATH.toString()]: directory(),
+      },
+    });
+    const provider = await createProvider(
+      PROJECT_ROOT,
+      mockClient,
+      WORKSPACES_DIR,
+      mockFs,
+      SILENT_LOGGER
+    );
+
+    await expect(provider.isDirty(WORKSPACE_PATH)).rejects.toThrow();
+  });
+});

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -16,7 +16,11 @@ import type {
   UpdateBasesResult,
   Workspace,
 } from "./git-types";
-import { WorkspaceError, getErrorMessage } from "../../shared/errors/service-errors";
+import {
+  WorkspaceError,
+  FileSystemError,
+  getErrorMessage,
+} from "../../shared/errors/service-errors";
 import { sanitizeWorkspaceName, unsanitizeWorkspaceName } from "./paths";
 import { isValidMetadataKey } from "../../shared/api/types";
 import type { FileSystemBoundary } from "./filesystem";
@@ -628,8 +632,40 @@ export class GitWorktreeProvider {
   }
 
   async isDirty(workspacePath: Path): Promise<boolean> {
-    const status = await this.gitClient.getStatus(workspacePath);
-    return status.isDirty;
+    try {
+      const status = await this.gitClient.getStatus(workspacePath);
+      return status.isDirty;
+    } catch (error) {
+      // A status query can race with workspace deletion: the directory is
+      // removed on disk while the workspace is still in the in-memory list, so
+      // a get-status request resolves and reaches here. A workspace that no
+      // longer exists has no uncommitted changes to report. Only swallow that
+      // specific case — genuine git failures must still surface (e.g. the
+      // delete-preflight dirty check relies on this to avoid discarding work).
+      if (!(await this.directoryExists(workspacePath))) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Best-effort check for whether a directory still exists. Used only to
+   * classify an already-failed git operation, so it is not subject to the
+   * TOCTOU concerns that motivate omitting a general exists() helper.
+   */
+  private async directoryExists(path: Path): Promise<boolean> {
+    try {
+      await this.fileSystemLayer.readdir(path);
+      return true;
+    } catch (error) {
+      if (error instanceof FileSystemError && error.fsCode === "ENOENT") {
+        return false;
+      }
+      // Some other filesystem problem (permissions, etc.) — assume the
+      // directory exists so the original error is surfaced rather than masked.
+      return true;
+    }
   }
 
   async countUnmergedCommits(workspacePath: Path): Promise<number> {


### PR DESCRIPTION
- Fix a benign race where a `workspace:get-status` request arriving just after a workspace is deleted logged `GitError: Cannot use simple-git on a directory that does not exist` at error level.
- `GitWorktreeProvider.isDirty` now returns `false` when `getStatus` fails and the workspace directory no longer exists (a deleted workspace has no uncommitted changes).
- Genuine git failures on an existing directory are still rethrown, preserving the delete-preflight dirty check that guards against discarding uncommitted work.
- Added integration tests covering both the deletion race and the rethrow-on-real-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)