### PR TITLE
fix: fixed crash on workspace creation dialog

### DIFF
--- a/src/renderer/lib/components/FilterableDropdown.svelte
+++ b/src/renderer/lib/components/FilterableDropdown.svelte
@@ -209,18 +209,16 @@
       return;
     }
 
-    // When allowFreeText is false, resolve typed text: select the exact label
-    // match (canonicalizing case), otherwise revert to the prop value.
-    if (!allowFreeText && localFilterOverride !== null) {
-      const exactMatch = selectableOptions.find(
-        (opt) => opt.label.toLowerCase() === localFilterOverride!.toLowerCase()
-      );
-      if (exactMatch === undefined) {
-        // No valid match - revert to original prop value
-        localFilterOverride = null;
-      } else {
-        selectOption(exactMatch.value);
-      }
+    // Strict select (allowFreeText false): leaving the field discards any
+    // transient filter text so the box snaps back to the committed value.
+    // Blur deliberately never commits — selecting a value requires an explicit
+    // gesture (click an option, Enter, or Tab). Keeping blur side-effect-free
+    // means a teardown blur (the focused input being removed from the DOM when
+    // the dialog closes) can't fire onSelect into an already-destroyed parent,
+    // which was the "Cannot read properties of undefined (reading 'config')"
+    // crash. In free-text mode the typed text is itself the value, so it stays.
+    if (!allowFreeText) {
+      localFilterOverride = null;
     }
 
     isOpen = false;

--- a/src/renderer/lib/components/FilterableDropdown.test.ts
+++ b/src/renderer/lib/components/FilterableDropdown.test.ts
@@ -713,7 +713,7 @@ describe("FilterableDropdown component", () => {
       expect(input.value).toBe("Banana");
     });
 
-    it("selects and canonicalizes an exact match on blur when allowFreeText is false", async () => {
+    it("does not commit on blur even for an exact match (allowFreeText false)", async () => {
       const onSelect = vi.fn();
       render(FilterableDropdown, {
         props: { ...defaultProps, onSelect, value: "Banana", allowFreeText: false },
@@ -723,15 +723,18 @@ describe("FilterableDropdown component", () => {
 
       await fireEvent.focus(input);
 
-      // Type valid option label (case-insensitive match)
+      // Type a valid option label (case-insensitive exact match).
       await fireEvent.input(input, { target: { value: "apple" } });
       expect(input.value).toBe("apple");
 
-      // Blur selects the matching option, canonicalizing the displayed label.
+      // Blur never selects: committing requires an explicit gesture (click,
+      // Enter, or Tab). The transient filter text is discarded and the box
+      // reverts to the committed value. This keeps blur side-effect-free so a
+      // teardown blur cannot fire onSelect into a destroyed parent.
       await fireEvent.blur(input);
 
-      expect(onSelect).toHaveBeenCalledWith("Apple");
-      expect(input.value).toBe("Apple");
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(input.value).toBe("Banana");
     });
 
     it("does not revert on blur when allowFreeText is true", async () => {


### PR DESCRIPTION
- Closing the new-workspace dialog while a `FilterableDropdown` input still held focus fired a teardown `blur` that committed a selection into the already-destroyed `Form`, throwing `TypeError: Cannot read properties of undefined (reading 'config')` (PostHog UIRendererError `019f13a8`).
- Drop implicit commit-on-blur in strict-select mode: `blur` now only discards the transient filter text and reverts to the committed value, and never calls `onSelect`.
- Committing a value now requires an explicit gesture (click an option, Enter, or Tab). This removes the cross-component reactive read from the blur edge, so a teardown blur can no longer reach a destroyed parent.
- Updated `FilterableDropdown.test.ts` to lock in the new contract (blur never commits, even on an exact match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EYtzCEa3HZp7x2jyYSneh