### PR TITLE
test(ipc): assert workspace:deleted domain event directly

### DIFF
--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -251,17 +251,6 @@ function createTestAppState(initial?: Partial<TestAppState>): {
   return { appState, state };
 }
 
-function createTestSendToUI(): {
-  sendToUI: (channel: string, payload: unknown) => void;
-  emittedEvents: Array<{ event: string; payload: unknown }>;
-} {
-  const emittedEvents: Array<{ event: string; payload: unknown }> = [];
-  const sendToUI = vi.fn((channel: string, payload: unknown) => {
-    emittedEvents.push({ event: channel, payload });
-  });
-  return { sendToUI, emittedEvents };
-}
-
 function createTestWorkspaceFileService() {
   return {
     deleteWorkspaceFile: vi.fn().mockResolvedValue(undefined),
@@ -280,7 +269,7 @@ interface TestHarness {
   viewManager: TestViewManager;
   activeWorkspace: { path: string | null };
   destroyedViews: string[];
-  emittedEvents: Array<{ event: string; payload: unknown }>;
+  deletedEvents: WorkspaceDeletedEvent["payload"][];
   inProgressDeletions: Set<string>;
   gitWorktreeProviderState: { removed: boolean };
   gitWorktreeProviderMock: {
@@ -329,7 +318,13 @@ function createTestHarness(options?: {
   const { viewManager, activeWorkspace, destroyedViews } = createTestViewManager(
     options?.activeWorkspacePath ?? WORKSPACE_PATH
   );
-  const { sendToUI, emittedEvents } = createTestSendToUI();
+  // Capture the workspace:deleted domain event directly — this is the contract
+  // the presenter (and other consumers) build on; the renderer never sees a
+  // dedicated delete channel, only the api:ui:state snapshot derived from it.
+  const deletedEvents: WorkspaceDeletedEvent["payload"][] = [];
+  dispatcher.subscribe(EVENT_WORKSPACE_DELETED, (event) => {
+    deletedEvents.push((event as WorkspaceDeletedEvent).payload);
+  });
   const logger = SILENT_LOGGER;
   const workspaceFileService = createTestWorkspaceFileService();
 
@@ -637,22 +632,6 @@ function createTestHarness(options?: {
     },
   };
 
-  const deleteIpcBridge: IntentModule = {
-    name: "test",
-    events: {
-      [EVENT_WORKSPACE_DELETED]: {
-        handler: async (event: DomainEvent): Promise<void> => {
-          const payload = (event as WorkspaceDeletedEvent).payload;
-          sendToUI("api:workspace:removed", {
-            projectId: payload.projectId,
-            workspaceName: payload.workspaceName,
-            path: payload.workspacePath,
-          });
-        },
-      },
-    },
-  };
-
   // Switch modules: activate (resolve is handled by shared resolve operations)
   const switchViewModule: IntentModule = {
     name: "test",
@@ -796,7 +775,6 @@ function createTestHarness(options?: {
     deleteWorktreeModule,
     deleteCodeServerModule,
     deleteStateModule,
-    deleteIpcBridge,
     switchViewModule,
     switchFindCandidatesModule,
     switchSelectNextModule,
@@ -811,7 +789,7 @@ function createTestHarness(options?: {
     viewManager,
     activeWorkspace,
     destroyedViews,
-    emittedEvents,
+    deletedEvents,
     inProgressDeletions,
     gitWorktreeProviderState: gitWorktreeProviderMock,
     gitWorktreeProviderMock:
@@ -848,13 +826,13 @@ describe("DeleteWorkspaceOperation.normalDeletion", () => {
       workspacePath: WORKSPACE_PATH,
     });
 
-    // Event subscriber: IPC event emitted
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeDefined();
-    expect(ipcEvent!.payload).toEqual({
+    // Domain event: workspace:deleted emitted with the resolved identity
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeDefined();
+    expect(deleted).toMatchObject({
       projectId: PROJECT_ID,
       workspaceName: WORKSPACE_NAME,
-      path: WORKSPACE_PATH,
+      workspacePath: WORKSPACE_PATH,
     });
 
     // Progress emitted after each hook (shutdown, release, delete + final)
@@ -885,9 +863,9 @@ describe("DeleteWorkspaceOperation.forceDeletion", () => {
       workspacePath: WORKSPACE_PATH,
     });
 
-    // IPC event still emitted
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeDefined();
+    // workspace:deleted still emitted (via the finally block)
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeDefined();
 
     // Final progress should report errors
     const finalProgress = harness.progressCaptures[harness.progressCaptures.length - 1]!;
@@ -1102,9 +1080,9 @@ describe("DeleteWorkspaceOperation.windowsBlockerDetection", () => {
     // Workspace should NOT be removed from state (no workspace:deleted event)
     expect(harness.testState.removedWorkspaces).toHaveLength(0);
 
-    // No IPC workspace:removed event
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeUndefined();
+    // No workspace:deleted event
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeUndefined();
 
     // Idempotency was reset by delete-failed event (allows retry)
     expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
@@ -1429,19 +1407,19 @@ describe("DeleteWorkspaceOperation.stateCleanup", () => {
   });
 });
 
-describe("DeleteWorkspaceOperation.ipcEvents", () => {
-  it("test 11: IPC workspace:removed event emitted with correct payload", async () => {
+describe("DeleteWorkspaceOperation.deletedEvent", () => {
+  it("test 11: workspace:deleted event emitted with correct payload", async () => {
     const harness = createTestHarness();
     const intent = buildDeleteIntent();
 
     await harness.dispatcher.dispatch(intent);
 
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeDefined();
-    expect(ipcEvent!.payload).toEqual({
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeDefined();
+    expect(deleted).toMatchObject({
       projectId: PROJECT_ID,
       workspaceName: WORKSPACE_NAME,
-      path: WORKSPACE_PATH,
+      workspacePath: WORKSPACE_PATH,
     });
   });
 });
@@ -1487,9 +1465,9 @@ describe("DeleteWorkspaceOperation.removeWorktree", () => {
       workspacePath: WORKSPACE_PATH,
     });
 
-    // IPC event emitted
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeDefined();
+    // workspace:deleted event emitted
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeDefined();
   });
 
   it("test 18: removeWorktree=true runs full pipeline", async () => {
@@ -1537,10 +1515,10 @@ describe("DeleteWorkspaceOperation.resolveHooks", () => {
     const result = await harness.dispatcher.dispatch(intent);
     expect(result).toEqual({ started: true });
 
-    // Workspace deleted event should use the resolved project path
-    const ipcEvent = harness.emittedEvents.find((e) => e.event === "api:workspace:removed");
-    expect(ipcEvent).toBeDefined();
-    expect((ipcEvent!.payload as { projectId: string }).projectId).toBe(PROJECT_ID);
+    // Workspace deleted event should use the resolved project id
+    const deleted = harness.deletedEvents.find((p) => p.workspacePath === WORKSPACE_PATH);
+    expect(deleted).toBeDefined();
+    expect(deleted!.projectId).toBe(PROJECT_ID);
 
     // The deleted event payload should carry the resolved projectPath
     expect(harness.testState.removedWorkspaces).toContainEqual({

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -5,7 +5,7 @@
  *
  * Phase A (ui:event intake):
  * - zod validation, invalid events dropped with a warning
- * - log events routed to the LoggingService (replacement for api:log:*)
+ * - log events routed to the LoggingService
  * - app:shutdown removes the ui:event listener
  *
  * Phase B (ui:state shadow snapshots):

--- a/src/renderer/lib/styles/variables.css
+++ b/src/renderer/lib/styles/variables.css
@@ -170,8 +170,8 @@
  * Light theme overrides.
  * Only fallback values change - VS Code variable references stay the same.
  *
- * Selected via [data-theme="light"] on :root, set by the renderer in response
- * to the api:ui:theme event pushed from main (driven by Electron's nativeTheme).
+ * Selected via [data-theme="light"] on :root, set by the renderer from the
+ * theme in the api:ui:state snapshot pushed from main (driven by Electron's nativeTheme).
  */
 :root[data-theme="light"] {
   /*

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -437,8 +437,8 @@ export interface DialogDismissEvent {
 }
 
 /**
- * Events sent from renderer -> main when the user interacts with a dialog, over
- * the api:dialog:event channel. Discriminated by `kind`: "action" (default when
- * absent), "change", or "dismiss".
+ * Events sent from renderer -> main when the user interacts with a dialog, as
+ * dialog-* kinds on the api:ui:event channel. Discriminated by `kind`: "action"
+ * (default when absent), "change", or "dismiss".
  */
 export type DialogUserEvent = DialogActionEvent | DialogFieldChangeEvent | DialogDismissEvent;

--- a/src/shared/ui-event.ts
+++ b/src/shared/ui-event.ts
@@ -2,8 +2,7 @@
  * UI event contract: renderer → main fire-and-forget events on the
  * api:ui:event channel (planning/UI_STATE_ARCHITECTURE.md).
  *
- * `log` is the renderer's logging channel (replacement for the former
- * api:log:* channels). `ui-connected` is the startup handshake: the renderer
+ * `log` is the renderer's logging channel. `ui-connected` is the startup handshake: the renderer
  * emits it once (on App mount, during the initializing phase) after subscribing
  * to ui:state; the presenter responds by flushing buffered notifications and
  * pushing the current snapshot immediately. app:ready is no longer driven by
@@ -63,7 +62,7 @@ export const uiEventSchema = z.discriminatedUnion("kind", [
   // Setup-error actions: retry resolves app:start's retry loop; quit shuts down.
   z.object({ kind: z.literal("setup-retry") }),
   z.object({ kind: z.literal("setup-quit") }),
-  // Dialog user interactions (replace the former api:dialog:event channel). The
+  // Dialog user interactions. The
   // presenter routes these to the matching open dialog session by `dialogId`
   // (the opaque id echoed from the snapshot's `dialogs`). `data` is the flat
   // field-values snapshot (keyed by field id); values are strings.
@@ -80,8 +79,7 @@ export const uiEventSchema = z.discriminatedUnion("kind", [
     data: z.record(z.string(), z.string()),
   }),
   z.object({ kind: z.literal("dialog-dismiss"), dialogId: z.string() }),
-  // Notification user interactions (replace the former api:notification:event
-  // channel). actionId is "dismiss" for the dismiss button, else a button id.
+  // Notification user interactions. actionId is "dismiss" for the dismiss button, else a button id.
   z.object({
     kind: z.literal("notification-event"),
     notificationId: z.string(),


### PR DESCRIPTION
- Drop the fake `api:workspace:removed` IPC bridge from the delete-workspace integration test; that channel was invented by the test and no longer maps to any production path (delete now flows through the `api:ui:state` snapshot).
- Harness now captures `EVENT_WORKSPACE_DELETED` directly, so assertions verify the real contract (identity payload, finally-path in force mode, no event on failure) instead of re-checking a fixture the test wrote.
- Scrub stale references to consolidated-away channel names (`api:log:*`, `api:dialog:event`, `api:notification:event`, `api:ui:theme`) from comments, correcting them to the current `api:ui:event` / `api:ui:state` transports.