### PR TITLE
refactor(intents): return hook capabilities as data, not a provides closure

### DIFF
--- a/RESEARCH-provides-closures.md
+++ b/RESEARCH-provides-closures.md
@@ -1,0 +1,302 @@
+# Research: Reshaping `provides` from a closure to returned data
+
+**Goal:** Federate the intent dispatcher across a host/remote boundary — one dispatcher on
+the host, some hook handlers executing remotely over a wire. The blocker is the hook
+**capability** mechanism: a handler advertises capabilities via `provides`, a _closure_ that
+the dispatcher invokes **host-side** after the handler runs. A remote handler cannot ship a
+closure across a wire; it must **return** its provided capabilities as data alongside its
+result so the host merges from data instead of calling a local closure.
+
+Research only — no implementation.
+
+---
+
+## 1. The current contract
+
+`HookHandler` (`src/intents/lib/operation.ts:47-57`):
+
+```ts
+export interface HookHandler<T = unknown> {
+  readonly name?: string;
+  readonly handler: (ctx: HookContext) => Promise<T>;
+  readonly requires?: Readonly<Record<string, unknown>>; // already plain data
+  readonly provides?: () => Readonly<Record<string, unknown>>; // <-- CLOSURE
+}
+```
+
+Merge happens in `src/intents/lib/dispatcher.ts:284-291`:
+
+```ts
+const result = await entry.handler(frozenCtx);
+if (result !== undefined && result !== null) {
+  results.push(result as T); // handler RESULT -> results[]
+}
+if (entry.provides) {
+  Object.assign(capabilities, entry.provides()); // CAPABILITIES -> running bag
+}
+```
+
+Two separate output channels per handler:
+
+- **result** (`T`) → pushed to `results[]`, consumed by the operation.
+- **capabilities** (`provides()` return) → merged into the running `capabilities` bag, used to
+  gate later handlers (`requires`) and read by downstream handlers via `ctx.capabilities?.X`.
+
+`requires` is already plain data and is evaluated host-side (`requirementsSatisfied`), so it is
+**not** part of the problem. Only `provides` is a closure.
+
+### The universal closure idiom
+
+Every `provides` closure captures a handler-local `let` and follows the same lifecycle:
+
+1. Declared in the module factory: `let capX = <default>`.
+2. Reset at the **start** of the handler: `capX = undefined` (guards against a stale value
+   leaking if the handler throws).
+3. Assigned during handler execution: `capX = <computed>`.
+4. Read by the closure **after** the handler returns: `provides: () => ({ x: capX })`.
+
+This reset-then-set dance exists _only_ because the closure is invoked separately, after the
+handler. Returning the data inline makes the captured mutable variable unnecessary.
+
+---
+
+## 2. Every `provides` use (10 sites)
+
+| #   | File:line                                              | Provided key(s)  | Captured state                                        | Value type      | Handler also returns a result?                   |
+| --- | ------------------------------------------------------ | ---------------- | ----------------------------------------------------- | --------------- | ------------------------------------------------ |
+| 1   | `src/modules/plugin-server-module.ts:874`              | `pluginPort`     | `capPluginPort` (decl `:163` `number \| null`)        | number/null     | no (void)                                        |
+| 2   | `src/modules/code-server-module.ts:715`                | `codeServerPort` | `codeServerPort` (decl `:392` `number`, init `0`)     | number          | no (void)                                        |
+| 3   | `src/modules/code-server-module.ts:911`                | `workspaceUrl`   | `capWorkspaceUrl` (decl `:650` `string \| undefined`) | string          | no (void)                                        |
+| 4   | `src/modules/electron-lifecycle-module.ts:207`         | `"app-ready"`    | none — constant `true`                                | boolean literal | no (void)                                        |
+| 5   | `src/modules/mcp-module.ts:1206`                       | `mcpPort`        | `capMcpPort` (decl `:1199` `number \| undefined`)     | number          | no (void)                                        |
+| 6   | `src/modules/workspace-agent-resolver-module.ts:93`    | `agent`          | `resolved` (`AgentType \| null`)                      | string union    | no (void)                                        |
+| 7   | `src/modules/workspace-agent-resolver-module.ts:108`   | `agent`          | `openResolved` (`AgentType \| null`)                  | string union    | no (void)                                        |
+| 8   | `src/modules/view-module.ts:122`                       | `"ui-ready"`     | none — constant `true`                                | boolean literal | no (void)                                        |
+| 9   | `src/modules/agent-module/agent-module.ts:340`         | `agentType`      | `capAgentType` (decl `:132` `AgentType \| undefined`) | string union    | **YES** — returns `SetupHookResult \| undefined` |
+| 10  | `src/modules/presentation/presentation-module.ts:1422` | `agentType`      | `chosenAgent` (`LifecycleAgentType \| undefined`)     | string union    | no (void)                                        |
+
+Notes:
+
+- Sites 3, 5, 9, 10 use the conditional-spread idiom
+  `...(capX !== undefined && { key: capX })`, so the closure can legitimately return `{}`
+  (provide nothing). Site 6/7 similarly return `{}` when unresolved. The replacement shape must
+  preserve "provide nothing" as a valid outcome.
+- Sites 4 and 8 (`app-ready`, `ui-ready`) are **constant** boolean capabilities — these never
+  needed a closure at all and could be static data today.
+- **Only site 9** (`agent-module` setup) emits _both_ a meaningful result and a capability in
+  the same handler. Its result `SetupHookResult` is consumed by the operation
+  (`src/intents/open-workspace.ts`), while its `agentType` capability is read from the final
+  bag at `src/intents/open-workspace.ts:267-268`. This is the case that proves the new shape
+  must carry result **and** provides simultaneously — they can't be collapsed into one.
+
+### Capability consumers (who reads the bag)
+
+- Downstream-handler reads: `code-server-module.ts:718` (`pluginPort`),
+  `agent-module.ts:212` (`mcpPort`).
+- `requires` gates (already plain-data comparisons, host-side): `app-ready`, `ui-ready`,
+  `codeServerPort`, `pluginPort`, `mcpPort`, `agent` — see `agent-module.ts:210/339/...`,
+  `code-server-module.ts:714`, `presentation-module.ts:1401/1415`, `view-module.ts:121`, etc.
+- Operation reads the finalized bag: `open-workspace.ts:268`
+  (`setupResult.capabilities.agentType`).
+
+---
+
+## 3. Are provided values wire-safe? — Yes, all of them
+
+Every provided value is a JSON primitive:
+
+- **numbers**: `pluginPort`, `codeServerPort`, `mcpPort` (plus `null` for plugin/mcp).
+- **booleans**: `app-ready`, `ui-ready` (literal `true`).
+- **strings**: `workspaceUrl`, `agent`/`agentType` (string-union literals like `"claude"` /
+  `"opencode"`).
+
+No functions, class instances, `Path` objects, handles, or symbols are ever provided. The
+capability **keys** are plain strings. The whole capability bag is already `JSON.stringify`-able,
+so shipping provided capabilities as data across the wire needs no value-encoding work — only
+the _delivery mechanism_ (closure → returned data) changes.
+
+(Caveat for the wire layer: `requires` sentinels use `ANY_VALUE = Symbol(...)`
+(`operation.ts:28`). Those live in `requires`, are compared host-side, and are never _provided_,
+so they don't cross the boundary. No issue for this change.)
+
+---
+
+## 4. Proposed reshape of the `HookHandler` contract
+
+The handler must be able to return **both** a result and its provided capabilities. Recommended
+shape: have the handler return a structured envelope; the dispatcher reads `provides` off the
+returned value instead of calling a closure.
+
+### Recommended: tagged envelope, opt-in (minimal churn)
+
+Add a small wrapper that handlers use only when they provide capabilities. Non-providing
+handlers stay exactly as they are.
+
+```ts
+// operation.ts
+export interface HookOutput<T> {
+  readonly result?: T; // -> results[]
+  readonly provides?: Readonly<Record<string, unknown>>; // -> capability bag (plain data)
+}
+
+export interface HookHandler<T = unknown> {
+  readonly name?: string;
+  readonly handler: (ctx: HookContext) => Promise<T | HookOutput<T>>;
+  readonly requires?: Readonly<Record<string, unknown>>;
+  // `provides` field removed
+}
+```
+
+Dispatcher (`dispatcher.ts:285-291`) splits the two channels by recognizing the envelope. To
+avoid mistaking a plain object result (e.g. code-server's `{ missingBinaries, ... }`) for an
+envelope, tag it with an explicit, **serializable** discriminant rather than `instanceof` (a
+class won't survive the wire):
+
+```ts
+const raw = await entry.handler(frozenCtx);
+const out = isHookOutput(raw) ? raw : { result: raw }; // isHookOutput checks a "__hookOutput": true marker
+if (out.result !== undefined && out.result !== null) results.push(out.result as T);
+if (out.provides) Object.assign(capabilities, out.provides);
+```
+
+A `provide(caps)` / `provide(result, caps)` helper keeps call sites terse, e.g. site 2 becomes
+`return provide({ codeServerPort: port })` and site 9 becomes
+`return provide(setupResult, { agentType: provider.type })`.
+
+**Why this beats the alternatives:**
+
+- It carries result + provides together — required by site 9.
+- It's pure data, so a remote handler's return serializes verbatim; the transport unwraps the
+  same `{ result, provides }` on the host with no closure involved.
+- It eliminates the reset-then-set captured-`let` idiom (sites 1-3, 5, 9, 10): the handler just
+  computes a value and returns it; nothing to reset, no stale-value risk.
+- Constant providers (sites 4, 8) become `return provide({ "app-ready": true })`.
+
+### Alternative A — uniform envelope (every handler returns `HookOutput<T>`)
+
+Cleaner type (no `T | HookOutput<T>` union, no discriminant guesswork) but touches **all ~192
+handlers** in `src/modules` + `src/intents`. Large, mechanical, high-diff. Not recommended for a
+first step.
+
+### Alternative B — keep `provides` field but make it `Record`, not a closure
+
+Doesn't work: provided values are **computed at runtime** by the handler (ports, resolved agent,
+workspace URL). A static field can't capture them. The data must originate from handler
+execution, so it must ride the return value. (Constant sites 4/8 _could_ use a static field, but
+that's only 2 of 10.)
+
+---
+
+## 5. Call sites that change & migration
+
+- **`HookHandler` definition** — 1 site (`operation.ts:47-57`): drop `provides`, widen handler
+  return to `T | HookOutput<T>`, add `HookOutput`/helper/guard.
+- **Dispatcher merge** — 1 site (`dispatcher.ts:285-291`): unwrap envelope instead of calling
+  `entry.provides()`.
+- **Provider handlers** — **10 sites** (table in §2), across 7 modules:
+  `plugin-server-module`, `code-server-module` (×2), `electron-lifecycle-module`, `mcp-module`,
+  `workspace-agent-resolver-module` (×2), `view-module`, `agent-module`, `presentation-module`.
+  Each: delete the captured `let` + its reset/assignment, and `return provide(...)` instead.
+- **Consumers unchanged**: `ctx.capabilities?.X` reads (`code-server:718`, `agent-module:212`),
+  `requires` gates, and `open-workspace.ts:268` all read the same merged bag — its shape and
+  contents are identical, only how it gets populated changes.
+
+### Backwards-compatibility / migration considerations
+
+- **Type safety of the union.** `handler: Promise<T | HookOutput<T>>` makes the dispatcher
+  discriminate. The discriminant must be an explicit serializable marker (e.g. a
+  `"__hookOutput": true` field), **not** `instanceof`/symbol — a class or symbol tag is lost on
+  the wire, which is the whole point. Risk: a handler whose genuine result legitimately looks
+  like a `HookOutput`. Real results today are `SetupHookResult`,
+  `{ missingBinaries, extensionInstallPlan }`, etc. — none carry a `__hookOutput` marker, so a
+  reserved-key marker is safe. The uniform-envelope alternative sidesteps this entirely.
+- **Two transition styles.** Either flip all 10 + dispatcher atomically (small enough to do in
+  one change), or support both shapes transiently — dispatcher accepts a returned envelope _and_
+  still calls a legacy `provides` closure if present — then remove the closure path once all 10
+  migrate. Atomic is cleaner given only 10 sites.
+- **Reset semantics preserved for free.** The closures reset their captured `let` at handler
+  entry precisely to avoid leaking a previous run's value when a handler throws. With inline
+  return, a throwing handler returns nothing → no result, no provides merged — same observable
+  outcome, no shared mutable state, and inherently re-entrant/concurrency-safe (relevant once
+  remote handlers run out-of-process).
+- **No IPC/shared-type contract impact (per CLAUDE.md).** `HookHandler`/`HookOutput` are
+  internal dispatcher types (`src/intents/lib`), not `api:*` IPC channels or `src/shared` types,
+  so this is not an API/IPC interface change. It _is_ a change to a core dispatcher contract,
+  so it should still be done deliberately and with the existing dispatcher/operation tests
+  updated.
+- **Wire layer is a separate, later step.** This reshape only makes provided capabilities
+  _expressible as returned data_. Actually shipping a handler's `{ result, provides }` across a
+  transport (and merging it host-side) is the federation work that this change unblocks; it is
+  out of scope here.
+
+---
+
+## 6. Resolved design decisions (interview)
+
+Decisions taken for the implementation:
+
+1. **Scope:** In-process refactor only. Closure→data is a standalone, behavior-preserving
+   change; the remote/wire transport is follow-on work this unblocks.
+2. **Contract:** Uniform envelope. The handler return type becomes
+   `Promise<HookOutput<T> | void>` where `HookOutput<T> = { result?: T; provides?: Readonly<Record<string, unknown>> }`.
+   The `provides` _field_ is removed from `HookHandler`. `requires` stays declarative
+   (evaluated before the handler runs — must remain static data).
+3. **Generic typing:** `T` stays the **unwrapped result type**. `collect<T>()` still returns
+   `HookResult<T>` with `results: T[]`; the dispatcher unwraps `out.result`. Every existing
+   `collect<SomeResult>()` call and every `.results` consumer (`open-workspace.ts:261`,
+   `app-ready.ts:108/117`, `list-projects.ts`, …) is **untouched**.
+4. **Return shape at call sites:** Raw object literal — `return { result: X }`,
+   `return { provides: {...} }`, `return { result: X, provides: {...} }`. No helper functions,
+   no imports.
+5. **Void handlers:** Allowed. Dispatcher coerces a `void`/`undefined` return to `{}`, so the
+   ~130+ pure-void handlers (logging, shutdown `stop`, most `init`/`start` hooks) **don't
+   change**. Only the data-returning subset (handlers behind `collect<SomeResult>`) and the
+   10 providers adopt the envelope. No ambiguity: the only non-envelope return permitted is
+   `void`, never a bare result object.
+6. **Merge rule — skip `undefined` keys:** Because `requirementsSatisfied` checks key
+   _presence_ (`key in capabilities`) for `ANY_VALUE` (`dispatcher.ts:478`), the merge must
+   skip `undefined`-valued provides keys: `for (const [k,v] of Object.entries(out.provides ?? {})) if (v !== undefined) capabilities[k] = v;`.
+   This lets the 4 conditional-spread sites (`...(capX !== undefined && { key: capX })`) drop
+   the boilerplate and just `return { provides: { key: value } }`. Trade-off accepted: an
+   explicit `undefined` capability value can never be provided — no site does.
+7. **Migration:** Atomic cutover, compiler-driven. Flip `HookHandler`'s return type first; TS
+   flags every non-conforming handler. A handler that forgets to wrap (`return { missingBinaries }`
+   instead of `return { result: { missingBinaries } }`) fails the excess-property check against
+   `HookOutput<T>`, so the silent-result-loss footgun is caught at compile time.
+
+### Resulting dispatcher merge (`dispatcher.ts:284-291`)
+
+```ts
+const raw = await entry.handler(frozenCtx);
+const out = raw ?? {}; // void -> {}
+if (out.result !== undefined && out.result !== null) {
+  // preserve null/undefined skip
+  results.push(out.result as T);
+}
+for (const [k, v] of Object.entries(out.provides ?? {})) {
+  if (v !== undefined) capabilities[k] = v; // skip undefined (key-presence safety)
+}
+```
+
+### Edit inventory
+
+- **Contract** (`operation.ts`): add `HookOutput<T>`, widen `handler` return, remove `provides`. (1)
+- **Dispatcher** (`dispatcher.ts:284-291`): unwrap + skip-undefined merge. (1)
+- **10 provider handlers** (§2 table): delete captured `let` + reset + assignment; `return { provides: {...} }` (or `{ result, provides }` for `agent-module` setup). Removes the reset-then-set idiom entirely; concurrency-safe.
+- **Data-returning handlers**: wrap `return X` → `return { result: X }` (the `collect<SomeResult>` producers). Compiler enumerates them.
+- **Tests**: `dispatcher.integration.test.ts` inline `provides: () => (...)` handlers (lines ~517/561/607/951/1437/1461/1467) and module integration tests for the 7 provider modules.
+- **Docs**: `docs/INTENTS.md` (HookHandler type ~109-111, capability table ~264, example ~268).
+
+---
+
+## 7. Bottom line
+
+- **10 `provides` closures**, in 7 modules; all capture a handler-local `let` (or a constant)
+  and the merge is a single host-side `Object.assign` at `dispatcher.ts:290`.
+- **Every provided value is a JSON primitive** (number/boolean/string) — the wire needs no
+  value encoding; only the delivery mechanism (closure vs returned data) blocks federation.
+- **Recommended change:** handlers return a tagged `HookOutput<T> = { result?, provides? }`
+  envelope; the dispatcher reads `out.provides` (data) instead of invoking `entry.provides()`
+  (closure). **~12 edited sites total** (contract + dispatcher + 10 handlers); consumers,
+  `requires` gates, and the capability bag's shape are untouched. Site 9 (`agent-module` setup)
+  is the one case proving result and provides must coexist in the return.

--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -98,17 +98,25 @@ export interface HookContext {
 /**
  * A handler registered for a hook point.
  *
- * Generic parameter T is the return type for collect() -- defaults to unknown
- * so that HookDeclarations (which uses HookHandler) accepts handlers with any return type.
+ * A handler returns a HookOutput: an optional `result` (lifted into collect()'s
+ * results[]) and/or `provides` (capabilities merged into the running bag as plain
+ * data). Returning void is shorthand for an empty output. Generic parameter T is the
+ * unwrapped result type -- defaults to unknown so HookDeclarations accepts any result.
  */
+export interface HookOutput<T = unknown> {
+  /** Value contributed to collect()'s results[]. Omit / undefined / null for none. */
+  readonly result?: T | null;
+  /** Capabilities merged into the running bag after the handler completes. Plain data
+   *  (no closure), so a remotely-executed handler can ship them across a wire.
+   *  undefined-valued keys are skipped during the merge. */
+  readonly provides?: Readonly<Record<string, unknown>>;
+}
+
 export interface HookHandler<T = unknown> {
-  readonly handler: (ctx: HookContext) => Promise<T>;
+  readonly handler: (ctx: HookContext) => Promise<HookOutput<T> | void>;
   /** Capabilities this handler requires before it can execute.
    *  Key = capability name. Value = required value, or ANY_VALUE for "must exist, any value". */
   readonly requires?: Readonly<Record<string, unknown>>;
-  /** Capabilities this handler provides after successful execution.
-   *  Called after the handler completes; return value is merged into capabilities. */
-  readonly provides?: () => Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -132,7 +140,7 @@ export interface ResolvedHooks {
 }
 ```
 
-`DispatchFn` is the type signature for nested dispatch, available in `OperationContext`. `ANY_VALUE` is a sentinel symbol used in `requires` to mean "this capability must exist, but any value is accepted." `HookContext` is the base context passed to hook handlers -- operations extend it with additional readonly fields. `HookHandler<T>` declares a handler function plus optional capability requirements (`requires`) and provisions (`provides`). `HookResult<T>` collects all handler results, errors, and accumulated capabilities from a single `collect()` call. `ResolvedHooks` is the interface operations use to run hook points.
+`DispatchFn` is the type signature for nested dispatch, available in `OperationContext`. `ANY_VALUE` is a sentinel symbol used in `requires` to mean "this capability must exist, but any value is accepted." `HookContext` is the base context passed to hook handlers -- operations extend it with additional readonly fields. `HookHandler<T>` declares a handler function plus optional capability requirements (`requires`); the handler returns a `HookOutput<T>` carrying its `result` and/or the capabilities it `provides` as plain data (the dispatcher merges them after the handler completes -- no closure). `HookResult<T>` collects all handler results, errors, and accumulated capabilities from a single `collect()` call. `ResolvedHooks` is the interface operations use to run hook points.
 
 ### OperationContext and Operation
 
@@ -253,19 +261,20 @@ export interface IDispatcher {
 
 ## Capability-Based Hook Ordering
 
-Hooks are unordered by default. When execution order matters, handlers declare `requires` and `provides` capabilities. The `collect()` function topologically sorts handlers based on these declarations, running providers before consumers.
+Hooks are unordered by default. When execution order matters, a handler declares the capabilities it `requires` (a static field) and returns the capabilities it `provides` (in its `HookOutput`). The `collect()` function topologically sorts handlers based on these declarations, running providers before consumers.
 
-Each `HookHandler` has three fields:
+Each `HookHandler` has two fields; capabilities are returned, not declared via a closure:
 
-| Field      | Type                               | Purpose                                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------------------ |
-| `handler`  | `(ctx: HookContext) => Promise<T>` | The hook logic                                               |
-| `requires` | `Record<string, unknown>`          | Capabilities this handler needs before it can run            |
-| `provides` | `() => Record<string, unknown>`    | Capabilities this handler makes available after it completes |
+| Field      | Type                                                   | Purpose                                            |
+| ---------- | ------------------------------------------------------ | -------------------------------------------------- |
+| `handler`  | `(ctx: HookContext) => Promise<HookOutput<T> \| void>` | The hook logic; returns `result` and/or `provides` |
+| `requires` | `Record<string, unknown>`                              | Capabilities this handler needs before it can run  |
+
+A handler advertises capabilities by returning `{ provides: { … } }` (optionally alongside `result`). The dispatcher merges that returned data into the running bag after the handler completes -- there is no host-side `provides` closure, so a handler that runs remotely can ship its capabilities across a wire as plain data. Keys whose value is `undefined` are skipped during the merge, so a capability is only "present" when it carries a defined value.
 
 The `ANY_VALUE` sentinel (exported from `operation.ts`) matches any value for a required capability -- it means "this capability must exist, but I do not care about its value."
 
-**Example**: In the `app:start` operation's `start` hook point, the code-server module provides `{ codeServerPort: number }` after starting code-server. The plugin-server module requires `{ codeServerPort: ANY_VALUE }` so it runs after the port is known.
+**Example**: In the `app:start` operation's `start` hook point, the code-server module's start handler returns `{ provides: { codeServerPort } }` after starting code-server. The presentation module requires `{ codeServerPort: ANY_VALUE }` so it runs after the port is known.
 
 Capabilities accumulate across handlers within a single `collect()` call and are available on `HookResult.capabilities` for the operation to inspect.
 

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -21,7 +21,7 @@ import type { AppReadyIntent, LoadProjectsResult } from "./app-ready";
 import { INTENT_OPEN_PROJECT } from "./open-project";
 import type { OpenProjectIntent } from "./open-project";
 import type { IntentModule } from "./lib/module";
-import type { Operation, OperationContext } from "./lib/operation";
+import type { HookOutput, Operation, OperationContext } from "./lib/operation";
 import type { Project } from "../shared/api/types";
 import { createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { ConfigAgentType } from "../boundaries/platform/config";
@@ -48,8 +48,8 @@ function createProjectModule(projectPaths: readonly string[]): IntentModule {
     hooks: {
       [APP_READY_OPERATION_ID]: {
         "load-projects": {
-          handler: async (): Promise<LoadProjectsResult> => {
-            return { projectPaths };
+          handler: async (): Promise<HookOutput<LoadProjectsResult>> => {
+            return { result: { projectPaths } };
           },
         },
       },
@@ -249,7 +249,7 @@ describe("AppReady Operation", () => {
         hooks: {
           [APP_READY_OPERATION_ID]: {
             "load-projects": {
-              handler: async (): Promise<LoadProjectsResult> => {
+              handler: async (): Promise<HookOutput<LoadProjectsResult>> => {
                 throw new Error("Failed to load project configs");
               },
             },

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -46,6 +46,7 @@ import type { IntentModule } from "./lib/module";
 import {
   ANY_VALUE,
   type HookContext,
+  type HookOutput,
   type Operation,
   type OperationContext,
 } from "./lib/operation";
@@ -90,13 +91,13 @@ function createCodeServerModule(state: TestState, options?: { fail?: boolean }):
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({ codeServerPort: 8080 }),
-          handler: async (): Promise<void> => {
+          handler: async (): Promise<HookOutput> => {
             if (options?.fail) {
               throw new Error("CodeServer failed to start");
             }
             state.codeServerStarted = true;
             state.executionOrder.push("codeserver-start");
+            return { provides: { codeServerPort: 8080 } };
           },
         },
       },
@@ -110,13 +111,13 @@ function createMcpModule(state: TestState, options?: { fail?: boolean }): Intent
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({ mcpPort: 9090 }),
-          handler: async (): Promise<void> => {
+          handler: async (): Promise<HookOutput> => {
             if (options?.fail) {
               throw new Error("MCP server failed to start");
             }
             state.mcpStarted = true;
             state.executionOrder.push("mcp-start");
+            return { provides: { mcpPort: 9090 } };
           },
         },
       },
@@ -173,8 +174,7 @@ function createCodeServerModuleWithGracefulPluginDegradation(
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({ codeServerPort: 8080 }),
-          handler: async (): Promise<void> => {
+          handler: async (): Promise<HookOutput> => {
             // Simulate PluginServer start attempt (internal try/catch)
             let pluginPort: number | undefined;
             try {
@@ -191,6 +191,7 @@ function createCodeServerModuleWithGracefulPluginDegradation(
             state.codeServerStarted = true;
             state.executionOrder.push("codeserver-start");
             void pluginPort; // Used for code-server config in real impl
+            return { provides: { codeServerPort: 8080 } };
           },
         },
       },
@@ -210,7 +211,7 @@ function defaultCheckModules(): IntentModule[] {
       hooks: {
         [APP_START_OPERATION_ID]: {
           init: {
-            handler: async (): Promise<InitResult> => ({}),
+            handler: async (): Promise<HookOutput<InitResult>> => ({ result: {} }),
           },
         },
       },
@@ -378,7 +379,7 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
-              handler: async (): Promise<InitResult> => ({}),
+              handler: async (): Promise<HookOutput<InitResult>> => ({ result: {} }),
             },
           },
         },
@@ -391,8 +392,8 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
-              handler: async (): Promise<CheckDepsResult> => {
-                return { missingBinaries };
+              handler: async (): Promise<HookOutput<CheckDepsResult>> => {
+                return { result: { missingBinaries } };
               },
             },
           },
@@ -408,11 +409,13 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
-              handler: async (): Promise<CheckDepsResult> => {
+              handler: async (): Promise<HookOutput<CheckDepsResult>> => {
                 return {
-                  ...(opts.installPlan !== undefined && {
-                    extensionInstallPlan: opts.installPlan,
-                  }),
+                  result: {
+                    ...(opts.installPlan !== undefined && {
+                      extensionInstallPlan: opts.installPlan,
+                    }),
+                  },
                 };
               },
             },
@@ -553,7 +556,7 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
-              handler: async (): Promise<InitResult> => {
+              handler: async (): Promise<HookOutput<InitResult>> => {
                 throw new Error("Config load failed");
               },
             },
@@ -578,7 +581,7 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
-              handler: async (): Promise<CheckDepsResult> => {
+              handler: async (): Promise<HookOutput<CheckDepsResult>> => {
                 throw new Error("Binary preflight failed");
               },
             },
@@ -609,9 +612,9 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "check-deps": {
-              handler: async (ctx: HookContext): Promise<CheckDepsResult> => {
+              handler: async (ctx: HookContext): Promise<HookOutput<CheckDepsResult>> => {
                 receivedAgent = (ctx as CheckDepsHookContext).configuredAgent;
-                return {};
+                return { result: {} };
               },
             },
           },
@@ -707,8 +710,8 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
-              handler: async (): Promise<ConfigureResult> => {
-                return { scripts };
+              handler: async (): Promise<HookOutput<ConfigureResult>> => {
+                return { result: { scripts } };
               },
             },
           },
@@ -722,7 +725,7 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
-              handler: async (): Promise<ConfigureResult> => {
+              handler: async (): Promise<HookOutput<ConfigureResult>> => {
                 throw new Error(message);
               },
             },
@@ -740,7 +743,7 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             init: {
-              handler: async (ctx: HookContext): Promise<InitResult> => {
+              handler: async (ctx: HookContext): Promise<HookOutput<InitResult>> => {
                 if (options?.fail) {
                   throw new Error("Init failed");
                 }
@@ -748,7 +751,7 @@ describe("AppStart Operation", () => {
                 if (options?.captureScripts) {
                   options.captureScripts((ctx as InitHookContext).requiredScripts);
                 }
-                return {};
+                return { result: {} };
               },
             },
           },
@@ -840,9 +843,9 @@ describe("AppStart Operation", () => {
         hooks: {
           [APP_START_OPERATION_ID]: {
             "before-ready": {
-              handler: async (): Promise<ConfigureResult> => {
+              handler: async (): Promise<HookOutput<ConfigureResult>> => {
                 state.executionOrder.push("before-ready");
-                return { scripts: ["test-script"] };
+                return { result: { scripts: ["test-script"] } };
               },
             },
           },

--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -21,7 +21,7 @@ import { describe, it, expect, vi } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent } from "./lib/types";
 import {
   CloseProjectOperation,
@@ -210,7 +210,7 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             // Track that skipSwitch is set
@@ -219,7 +219,7 @@ function createTestHarness(options?: {
               viewManager.setActiveWorkspace(null);
             }
             await viewManager.destroyWorkspaceView(workspacePath);
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -231,13 +231,13 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const serverManager = appState.getServerManager();
             if (serverManager) {
               await serverManager.stopServer(workspacePath);
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -262,7 +262,7 @@ function createTestHarness(options?: {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<CloseResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseResolveHookResult>> => {
             const intent = ctx.intent as CloseProjectIntent;
             const { projectPath: payloadPath } = intent.payload;
 
@@ -277,8 +277,10 @@ function createTestHarness(options?: {
             const config = await store.getProjectConfig(found.path);
 
             return {
-              workspaces: found.workspaces ?? [],
-              ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
+              result: {
+                workspaces: found.workspaces ?? [],
+                ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
+              },
             };
           },
         },
@@ -293,14 +295,14 @@ function createTestHarness(options?: {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath } = ctx as CloseHookInput;
             const allProjects: Project[] = await appState.getAllProjects();
             const otherProjectsExist = allProjects.some((p) => p.path !== projectPath);
             if (!otherProjectsExist) {
               viewManager.setActiveWorkspace(null);
             }
-            return { otherProjectsExist };
+            return { result: { otherProjectsExist } };
           },
         },
       },
@@ -313,12 +315,12 @@ function createTestHarness(options?: {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath, remoteUrl } = ctx as CloseHookInput;
 
             // Self-select: only handle local projects (no remoteUrl)
             if (remoteUrl !== undefined) {
-              return {};
+              return { result: {} };
             }
 
             appState.deregisterProject(projectPath);
@@ -330,7 +332,7 @@ function createTestHarness(options?: {
               // Fail silently
             }
 
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -343,12 +345,12 @@ function createTestHarness(options?: {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath, remoteUrl, removeLocalRepo } = ctx as CloseHookInput;
 
             // Self-select: only handle remote projects (has remoteUrl)
             if (!remoteUrl) {
-              return {};
+              return { result: {} };
             }
 
             appState.deregisterProject(projectPath);
@@ -366,7 +368,7 @@ function createTestHarness(options?: {
               });
             }
 
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -379,10 +381,10 @@ function createTestHarness(options?: {
     hooks: {
       [CLOSE_PROJECT_OPERATION_ID]: {
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath } = ctx as CloseHookInput;
             gitWorktreeProvider.unregisterProject(new Path(projectPath));
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -541,8 +543,9 @@ describe("CloseProjectOperation.interactiveConfirm", () => {
       hooks: {
         [CLOSE_PROJECT_OPERATION_ID]: {
           confirm: {
-            handler: async (ctx: HookContext): Promise<CloseConfirmHookResult> =>
-              spy(ctx as CloseConfirmHookInput),
+            handler: async (ctx: HookContext): Promise<HookOutput<CloseConfirmHookResult>> => ({
+              result: await spy(ctx as CloseConfirmHookInput),
+            }),
           },
         },
       },
@@ -562,7 +565,7 @@ describe("CloseProjectOperation.interactiveConfirm", () => {
           delete: {
             handler: async (ctx: HookContext) => {
               payloads.push((ctx.intent as DeleteWorkspaceIntent).payload);
-              return {};
+              return { result: {} };
             },
           },
         },

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -44,7 +44,7 @@ import type {
   FlushHookInput,
   DeletePipelineHookInput,
 } from "./delete-workspace";
-import type { HookContext, OperationContext } from "./lib/operation";
+import type { HookContext, HookOutput, OperationContext } from "./lib/operation";
 import type {
   BlockingProcess,
   DeletionProgress,
@@ -388,16 +388,18 @@ function createTestHarness(options?: {
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
             const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
             // Reverse lookup: find which project owns this workspace path
             const project = appState.findProjectForWorkspace(wsPath);
-            if (!project) return {};
+            if (!project) return { result: {} };
             const workspaceName = wsPath.slice(wsPath.lastIndexOf("/") + 1);
             return {
-              projectPath: project.path,
-              workspaceName: workspaceName as WorkspaceName,
-              active: viewManager.getActiveWorkspacePath() === wsPath,
+              result: {
+                projectPath: project.path,
+                workspaceName: workspaceName as WorkspaceName,
+                active: viewManager.getActiveWorkspacePath() === wsPath,
+              },
             };
           },
         },
@@ -410,13 +412,15 @@ function createTestHarness(options?: {
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
             const { projectPath } = ctx as { projectPath: string } & HookContext;
             const allProjects = await appState.getAllProjects();
             const project = allProjects.find((p) => p.path === projectPath);
-            return project
-              ? { projectId: testProjectId(project.path), projectName: project.name }
-              : {};
+            return {
+              result: project
+                ? { projectId: testProjectId(project.path), projectName: project.name }
+                : {},
+            };
           },
         },
       },
@@ -428,21 +432,23 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath, active: isActive } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
             try {
               await viewManager.destroyWorkspaceView(workspacePath);
-              return { ...(isActive && { wasActive: true }) };
+              return { result: { ...(isActive && { wasActive: true }) } };
             } catch (error) {
               if (payload.force) {
                 logger.warn("ViewModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
                 return {
-                  ...(isActive && { wasActive: true }),
-                  error: getErrorMessage(error),
+                  result: {
+                    ...(isActive && { wasActive: true }),
+                    error: getErrorMessage(error),
+                  },
                 };
               }
               throw error;
@@ -458,7 +464,7 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -486,13 +492,13 @@ function createTestHarness(options?: {
                 }
               }
 
-              return serverError ? { error: serverError } : {};
+              return { result: serverError ? { error: serverError } : {} };
             } catch (error) {
               if (payload.force) {
                 logger.warn("AgentModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return { error: getErrorMessage(error) };
+                return { result: { error: getErrorMessage(error) } };
               }
               throw error;
             }
@@ -507,12 +513,12 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         release: {
-          handler: async (ctx: HookContext): Promise<ReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ReleaseHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
             if (payload.force || !workspaceLockHandler) {
-              return {};
+              return { result: {} };
             }
 
             // CWD-only scan: find and kill processes whose CWD is under workspace
@@ -524,34 +530,34 @@ function createTestHarness(options?: {
             } catch {
               // Non-fatal
             }
-            return {};
+            return { result: {} };
           },
         },
         detect: {
-          handler: async (ctx: HookContext): Promise<DetectHookResult> => {
-            if (!workspaceLockHandler) return {};
+          handler: async (ctx: HookContext): Promise<HookOutput<DetectHookResult>> => {
+            if (!workspaceLockHandler) return { result: {} };
             const { workspacePath } = ctx as DeletePipelineHookInput;
 
             try {
               const detected = await workspaceLockHandler.detect(new Path(workspacePath));
-              return { blockingProcesses: detected };
+              return { result: { blockingProcesses: detected } };
             } catch {
-              return { blockingProcesses: [] };
+              return { result: { blockingProcesses: [] } };
             }
           },
         },
         flush: {
-          handler: async (ctx: HookContext): Promise<FlushHookResult> => {
-            if (!workspaceLockHandler) return {};
+          handler: async (ctx: HookContext): Promise<HookOutput<FlushHookResult>> => {
+            if (!workspaceLockHandler) return { result: {} };
             const { blockingPids } = ctx as FlushHookInput;
             if (blockingPids.length > 0) {
               try {
                 await workspaceLockHandler.killProcesses([...blockingPids]);
               } catch (error) {
-                return { error: getErrorMessage(error) };
+                return { result: { error: getErrorMessage(error) } };
               }
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -563,7 +569,7 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { projectPath, workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -574,13 +580,13 @@ function createTestHarness(options?: {
                 !payload.keepBranch
               );
               testState.worktreeRemoved = true;
-              return {};
+              return { result: {} };
             } catch (error) {
               if (payload.force) {
                 logger.warn("WorktreeModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return { error: getErrorMessage(error) };
+                return { result: { error: getErrorMessage(error) } };
               }
               throw error;
             }
@@ -595,7 +601,7 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -604,13 +610,13 @@ function createTestHarness(options?: {
               const workspaceName = workspacePath.basename;
               const projectWorkspacesDir = workspacePath.dirname;
               await workspaceFileService.deleteWorkspaceFile(workspaceName, projectWorkspacesDir);
-              return {};
+              return { result: {} };
             } catch (error) {
               if (payload.force) {
                 logger.warn("CodeServerModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return {};
+                return { result: {} };
               }
               throw error;
             }
@@ -638,16 +644,16 @@ function createTestHarness(options?: {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SwitchWorkspaceHookResult>> => {
             const { workspacePath, active } = ctx as ActivateHookInput;
             const intent = ctx.intent as SwitchWorkspaceIntent;
 
             if (workspacePath === null || active) {
-              return {};
+              return { result: {} };
             }
             const focus = intent.payload.focus ?? true;
             viewManager.setActiveWorkspace(workspacePath, focus);
-            return { resolvedPath: workspacePath };
+            return { result: { resolvedPath: workspacePath } };
           },
         },
       },
@@ -670,7 +676,7 @@ function createTestHarness(options?: {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "find-candidates": {
-          handler: async (): Promise<FindCandidatesHookResult> => {
+          handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
             const allProjects = await appState.getAllProjects();
             const candidates: Array<{
               projectPath: string;
@@ -688,7 +694,7 @@ function createTestHarness(options?: {
                 });
               }
             }
-            return { candidates };
+            return { result: { candidates } };
           },
         },
       },
@@ -700,14 +706,16 @@ function createTestHarness(options?: {
     hooks: {
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
+          handler: async (): Promise<HookOutput<GetActiveWorkspaceHookResult>> => {
             const path = activeWorkspace.path;
-            if (!path) return { workspaceRef: null };
+            if (!path) return { result: { workspaceRef: null } };
             return {
-              workspaceRef: {
-                projectId: PROJECT_ID,
-                workspaceName: path.slice(path.lastIndexOf("/") + 1) as WorkspaceName,
-                path,
+              result: {
+                workspaceRef: {
+                  projectId: PROJECT_ID,
+                  workspaceName: path.slice(path.lastIndexOf("/") + 1) as WorkspaceName,
+                  path,
+                },
               },
             };
           },
@@ -733,13 +741,13 @@ function createTestHarness(options?: {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "select-next": {
-          handler: async (ctx: HookContext): Promise<SelectNextHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SelectNextHookResult>> => {
             const { currentPath, candidates } = ctx as unknown as SelectNextHookInput;
             // In production, scoring uses an internal status cache.
             // For these tests, all workspaces are treated as idle (score 0).
             const scorer = (): number => 0;
             const result = selectNextWorkspace(currentPath, candidates, scorer);
-            return result ? { selected: result } : {};
+            return { result: result ? { selected: result } : {} };
           },
         },
       },
@@ -751,10 +759,12 @@ function createTestHarness(options?: {
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         preflight: {
-          handler: async (): Promise<PreflightHookResult> => {
+          handler: async (): Promise<HookOutput<PreflightHookResult>> => {
             return {
-              isDirty: options?.isDirty ?? false,
-              unmergedCommits: options?.unmergedCommits ?? 0,
+              result: {
+                isDirty: options?.isDirty ?? false,
+                unmergedCommits: options?.unmergedCommits ?? 0,
+              },
             };
           },
         },
@@ -1881,8 +1891,9 @@ describe("DeleteWorkspaceOperation.interactiveConfirm", () => {
       hooks: {
         [DELETE_WORKSPACE_OPERATION_ID]: {
           confirm: {
-            handler: async (ctx: HookContext): Promise<ConfirmHookResult> =>
-              spy(ctx as DeletePipelineHookInput),
+            handler: async (ctx: HookContext): Promise<HookOutput<ConfirmHookResult>> => ({
+              result: await spy(ctx as DeletePipelineHookInput),
+            }),
           },
         },
       },

--- a/src/intents/get-active-workspace.integration.test.ts
+++ b/src/intents/get-active-workspace.integration.test.ts
@@ -26,6 +26,7 @@ import type {
   GetActiveWorkspaceHookResult,
 } from "./get-active-workspace";
 import type { IntentModule } from "./lib/module";
+import type { HookOutput } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceRef } from "../shared/api/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
@@ -57,8 +58,8 @@ function createTestSetup(cachedRef: WorkspaceRef | null): TestSetup {
     hooks: {
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-            return { workspaceRef: cachedRef };
+          handler: async (): Promise<HookOutput<GetActiveWorkspaceHookResult>> => {
+            return { result: { workspaceRef: cachedRef } };
           },
         },
       },

--- a/src/intents/get-agent-session.integration.test.ts
+++ b/src/intents/get-agent-session.integration.test.ts
@@ -22,6 +22,7 @@ import {
 import type { GetAgentSessionIntent, GetAgentSessionHookResult } from "./get-agent-session";
 import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
+import type { HookOutput } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceName, AgentSession } from "../shared/api/types";
 
@@ -67,8 +68,8 @@ function createTestSetup(opts: { session?: AgentSessionInfo | null }): TestSetup
     hooks: {
       [GET_AGENT_SESSION_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetAgentSessionHookResult> => {
-            return { session: opts.session ?? null };
+          handler: async (): Promise<HookOutput<GetAgentSessionHookResult>> => {
+            return { result: { session: opts.session ?? null } };
           },
         },
       },

--- a/src/intents/get-metadata.integration.test.ts
+++ b/src/intents/get-metadata.integration.test.ts
@@ -32,7 +32,7 @@ import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { isValidMetadataKey } from "../shared/api/types";
 import type { IntentModule } from "./lib/module";
 import type { Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 
 // =============================================================================
 // Test Constants
@@ -106,10 +106,10 @@ function createTestSetup(): TestSetup {
       },
       [GET_METADATA_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext): Promise<GetMetadataHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetMetadataHookResult>> => {
             const { workspacePath: wp } = ctx as GetHookInput;
             const metadata = metadataStore.get(wp) ?? {};
-            return { metadata };
+            return { result: { metadata } };
           },
         },
       },

--- a/src/intents/get-project-bases.integration.test.ts
+++ b/src/intents/get-project-bases.integration.test.ts
@@ -38,7 +38,7 @@ import type {
   ResolveHookInput as ResolveProjectHookInput,
 } from "./resolve-project";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent } from "./lib/types";
 import type { ProjectId } from "../shared/api/types";
 
@@ -87,12 +87,12 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
             const { projectPath } = ctx as ResolveProjectHookInput;
             if (opts?.unknownProject || projectPath !== PROJECT_ROOT) {
-              return {};
+              return { result: {} };
             }
-            return { projectId: PROJECT_ID, projectName: "test" };
+            return { result: { projectId: PROJECT_ID, projectName: "test" } };
           },
         },
       },
@@ -110,11 +110,13 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [GET_PROJECT_BASES_OPERATION_ID]: {
         list: {
-          handler: async (): Promise<ListBasesHookResult> => {
+          handler: async (): Promise<HookOutput<ListBasesHookResult>> => {
             listCallCount++;
             // First call returns cached, subsequent calls return fresh
             const bases = listCallCount === 1 ? [...CACHED_BASES] : [...freshBases];
-            return opts?.noDefaultBaseBranch ? { bases } : { bases, defaultBaseBranch: "main" };
+            return {
+              result: opts?.noDefaultBaseBranch ? { bases } : { bases, defaultBaseBranch: "main" },
+            };
           },
         },
         refresh: {

--- a/src/intents/get-workspace-status.integration.test.ts
+++ b/src/intents/get-workspace-status.integration.test.ts
@@ -27,7 +27,7 @@ import type {
 } from "./get-workspace-status";
 import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceName, WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
@@ -86,11 +86,11 @@ function createTestSetup(opts: {
     hooks: {
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext): Promise<GetStatusHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetStatusHookResult>> => {
             const { workspacePath } = ctx as GetStatusHookInput;
             const provider = opts.workspaceProvider;
             const isDirty = provider ? await provider.isDirty(new Path(workspacePath)) : false;
-            return { isDirty };
+            return { result: { isDirty } };
           },
         },
       },
@@ -103,12 +103,12 @@ function createTestSetup(opts: {
     hooks: {
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetStatusHookResult> => {
+          handler: async (): Promise<HookOutput<GetStatusHookResult>> => {
             const status = opts.agentStatus;
             if (status) {
-              return { agentStatus: status };
+              return { result: { agentStatus: status } };
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -231,9 +231,11 @@ describe("GetWorkspaceStatus Operation", () => {
         hooks: {
           [GET_WORKSPACE_STATUS_OPERATION_ID]: {
             get: {
-              handler: async (): Promise<GetStatusHookResult> => ({
-                isDirty: false,
-                unmergedCommits: 3,
+              handler: async (): Promise<HookOutput<GetStatusHookResult>> => ({
+                result: {
+                  isDirty: false,
+                  unmergedCommits: 3,
+                },
               }),
             },
           },

--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 import type { IntentModule } from "./lib/module";
 import type { DomainEvent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import {
   HibernateWorkspaceOperation,
   HIBERNATE_WORKSPACE_OPERATION_ID,
@@ -118,10 +118,10 @@ function createSwitchModule(recorder: Recorder): IntentModule {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (): Promise<Record<string, never>> => {
+          handler: async (): Promise<HookOutput<Record<string, never>>> => {
             recorder.switchCalled = true;
             recorder.callOrder.push("switch");
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -141,27 +141,27 @@ function createHibernateHookModule(
     hooks: {
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         capture: {
-          handler: async (ctx: HookContext): Promise<CaptureHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CaptureHookResult>> => {
             const c = ctx as HibernatePipelineHookInput;
             expect(c.workspacePath).toBe(WORKSPACE_PATH);
             expect(c.projectId).toBe(PROJECT_ID);
             recorder.captureCalled = true;
             recorder.callOrder.push("capture");
-            return {};
+            return { result: {} };
           },
         },
         shutdown: {
-          handler: async (): Promise<HibernateShutdownHookResult> => {
+          handler: async (): Promise<HookOutput<HibernateShutdownHookResult>> => {
             if (opts.shutdownGate) {
               await opts.shutdownGate;
             }
             recorder.shutdownCalled = true;
             recorder.callOrder.push("shutdown");
-            return {};
+            return { result: {} };
           },
         },
         release: {
-          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<HibernateReleaseHookResult>> => {
             const c = ctx as HibernatePipelineHookInput;
             expect(c.workspacePath).toBe(WORKSPACE_PATH);
             recorder.releaseCalled = true;
@@ -169,7 +169,7 @@ function createHibernateHookModule(
             if (opts.releaseThrows) {
               throw new Error("release boom");
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -183,11 +183,11 @@ function createWakeHookModule(recorder: Recorder): IntentModule {
     hooks: {
       [WAKE_WORKSPACE_OPERATION_ID]: {
         cleanup: {
-          handler: async (ctx: HookContext): Promise<CleanupHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CleanupHookResult>> => {
             const c = ctx as WakePipelineHookInput;
             expect(c.workspacePath).toBe(WORKSPACE_PATH);
             recorder.cleanupCalled = true;
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -358,10 +358,12 @@ describe("workspace:hibernate", () => {
         hooks: {
           [HIBERNATE_WORKSPACE_OPERATION_ID]: {
             capture: {
-              handler: async (): Promise<CaptureHookResult> => ({}),
+              handler: async (): Promise<HookOutput<CaptureHookResult>> => ({ result: {} }),
             },
             shutdown: {
-              handler: async (): Promise<HibernateShutdownHookResult> => ({}),
+              handler: async (): Promise<HookOutput<HibernateShutdownHookResult>> => ({
+                result: {},
+              }),
             },
           },
         },

--- a/src/intents/lib/dispatcher.integration.test.ts
+++ b/src/intents/lib/dispatcher.integration.test.ts
@@ -514,8 +514,7 @@ describe("Dispatcher", () => {
         hooks: {
           "action-op": {
             run: {
-              provides: () => ({ serverPort: 3000 }),
-              handler: async () => undefined,
+              handler: async () => ({ provides: { serverPort: 3000 } }),
             },
           },
         },
@@ -558,8 +557,7 @@ describe("Dispatcher", () => {
         hooks: {
           "action-op": {
             run: {
-              provides: () => ({ portA: 1000, portB: 2000 }),
-              handler: async () => undefined,
+              handler: async () => ({ provides: { portA: 1000, portB: 2000 } }),
             },
           },
         },
@@ -604,8 +602,7 @@ describe("Dispatcher", () => {
         hooks: {
           "action-op": {
             run: {
-              provides: () => ({ setting: 42 }),
-              handler: async () => undefined,
+              handler: async () => ({ provides: { setting: 42 } }),
             },
           },
         },
@@ -897,7 +894,7 @@ describe("Dispatcher", () => {
         name: "test-mod",
         hooks: {
           "action-op": {
-            run: { handler: async () => ({ value: 1 }) },
+            run: { handler: async () => ({ result: { value: 1 } }) },
           },
         },
       };
@@ -948,8 +945,7 @@ describe("Dispatcher", () => {
         hooks: {
           "action-op": {
             run: {
-              provides: () => ({ port: 3000 }),
-              handler: async () => undefined,
+              handler: async () => ({ provides: { port: 3000 } }),
             },
           },
         },
@@ -1308,9 +1304,9 @@ describe("Dispatcher", () => {
     it("returns typed results from handlers", async () => {
       const result = await collectWithModules(
         [
-          { handler: async () => ({ value: 1 }) },
-          { handler: async () => ({ value: 2 }) },
-          { handler: async () => ({ value: 3 }) },
+          { handler: async () => ({ result: { value: 1 } }) },
+          { handler: async () => ({ result: { value: 2 } }) },
+          { handler: async () => ({ result: { value: 3 } }) },
         ],
         { intent: { type: "test:noop", payload: {} } }
       );
@@ -1350,7 +1346,7 @@ describe("Dispatcher", () => {
           {
             handler: async () => {
               ran.push(2);
-              return "ok";
+              return { result: "ok" };
             },
           },
           {
@@ -1391,7 +1387,7 @@ describe("Dispatcher", () => {
       const result = await collectWithModules(
         [
           { handler: async () => undefined },
-          { handler: async () => ({ projectPath: "/selected" }) },
+          { handler: async () => ({ result: { projectPath: "/selected" } }) },
           { handler: async () => undefined },
         ],
         { intent: { type: "test:noop", payload: {} } }
@@ -1403,7 +1399,10 @@ describe("Dispatcher", () => {
 
     it("filters null results from self-selecting handlers", async () => {
       const result = await collectWithModules(
-        [{ handler: async () => null }, { handler: async () => ({ value: "kept" }) }],
+        [
+          { handler: async () => ({ result: null }) },
+          { handler: async () => ({ result: { value: "kept" } }) },
+        ],
         { intent: { type: "test:noop", payload: {} } }
       );
 
@@ -1417,7 +1416,7 @@ describe("Dispatcher", () => {
       };
       const originalIntent = ctx.intent;
 
-      await collectWithModules([{ handler: async () => "result" }], ctx);
+      await collectWithModules([{ handler: async () => ({ result: "result" }) }], ctx);
 
       expect(ctx.intent).toBe(originalIntent);
     });
@@ -1434,9 +1433,9 @@ describe("Dispatcher", () => {
             },
           },
           {
-            provides: () => ({ port: 3000 }),
             handler: async () => {
               order.push("provider");
+              return { provides: { port: 3000 } };
             },
           },
         ],
@@ -1458,15 +1457,15 @@ describe("Dispatcher", () => {
             },
           },
           {
-            provides: () => ({ a: 1 }),
             handler: async () => {
               order.push("provides-a");
+              return { provides: { a: 1 } };
             },
           },
           {
-            provides: () => ({ b: 2 }),
             handler: async () => {
               order.push("provides-b");
+              return { provides: { b: 2 } };
             },
           },
         ],
@@ -1482,8 +1481,7 @@ describe("Dispatcher", () => {
       await collectWithModules(
         [
           {
-            provides: () => ({ port: 8080 }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { port: 8080 } }),
           },
           {
             requires: { port: ANY_VALUE },
@@ -1504,7 +1502,6 @@ describe("Dispatcher", () => {
       const result = await collectWithModules(
         [
           {
-            provides: () => ({ token: "abc" }),
             handler: async () => {
               throw new Error("provider failed");
             },
@@ -1551,22 +1548,22 @@ describe("Dispatcher", () => {
         [
           {
             requires: { y: ANY_VALUE },
-            provides: () => ({ z: 3 }),
             handler: async () => {
               order.push("C");
+              return { provides: { z: 3 } };
             },
           },
           {
             requires: { x: ANY_VALUE },
-            provides: () => ({ y: 2 }),
             handler: async () => {
               order.push("B");
+              return { provides: { y: 2 } };
             },
           },
           {
-            provides: () => ({ x: 1 }),
             handler: async () => {
               order.push("A");
+              return { provides: { x: 1 } };
             },
           },
         ],
@@ -1583,16 +1580,16 @@ describe("Dispatcher", () => {
         [
           {
             requires: { b: ANY_VALUE },
-            provides: () => ({ a: 1 }),
             handler: async () => {
               ran.push("A");
+              return { provides: { a: 1 } };
             },
           },
           {
             requires: { a: ANY_VALUE },
-            provides: () => ({ b: 2 }),
             handler: async () => {
               ran.push("B");
+              return { provides: { b: 2 } };
             },
           },
         ],
@@ -1621,9 +1618,9 @@ describe("Dispatcher", () => {
             },
           },
           {
-            provides: () => ({ setup: true }),
             handler: async () => {
               order.push("provides-setup");
+              return { provides: { setup: true } };
             },
           },
         ],
@@ -1687,8 +1684,7 @@ describe("Dispatcher", () => {
       await collectWithModules(
         [
           {
-            provides: () => ({ key: 42 }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { key: 42 } }),
           },
           {
             requires: { key: ANY_VALUE },
@@ -1709,8 +1705,7 @@ describe("Dispatcher", () => {
       await collectWithModules(
         [
           {
-            provides: () => ({ platform: "darwin" }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { platform: "darwin" } }),
           },
           {
             requires: { platform: "linux" },
@@ -1725,16 +1720,17 @@ describe("Dispatcher", () => {
       expect(ran).toEqual([]);
     });
 
-    it("dynamic provides: closure value read at call time", async () => {
-      let port = 0;
+    it("capabilities returned from the handler are merged into the bag", async () => {
       let receivedCaps: Record<string, unknown> | undefined;
 
       await collectWithModules(
         [
           {
-            provides: () => ({ port }),
             handler: async () => {
-              port = 9090;
+              // Value computed during handler execution and returned as data
+              // (no closure read after the fact).
+              const port = 9090;
+              return { provides: { port } };
             },
           },
           {
@@ -1754,12 +1750,10 @@ describe("Dispatcher", () => {
       const result = await collectWithModules(
         [
           {
-            provides: () => ({ port: 8080 }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { port: 8080 } }),
           },
           {
-            provides: () => ({ host: "127.0.0.1" }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { host: "127.0.0.1" } }),
           },
         ],
         { intent: { type: "test:noop", payload: {} } }
@@ -1779,8 +1773,7 @@ describe("Dispatcher", () => {
           },
           {
             name: "provider",
-            provides: () => ({ port: 3000 }),
-            handler: async () => undefined,
+            handler: async () => ({ provides: { port: 3000 } }),
           },
         ],
         { intent: { type: "test:noop", payload: {} } },

--- a/src/intents/lib/dispatcher.ts
+++ b/src/intents/lib/dispatcher.ts
@@ -23,6 +23,7 @@ import type {
   ResolvedHooks,
   HookContext,
   HookHandler,
+  HookOutput,
   HookResult,
 } from "./operation";
 import { ANY_VALUE } from "./operation";
@@ -282,12 +283,19 @@ export class Dispatcher implements IDispatcher {
             capabilities: Object.freeze({ ...capabilities }),
           });
           try {
-            const result = await entry.handler(frozenCtx);
-            if (result !== undefined && result !== null) {
-              results.push(result as T);
+            // A handler returns a HookOutput (result and/or provided capabilities);
+            // void is shorthand for an empty output.
+            const output: HookOutput = (await entry.handler(frozenCtx)) ?? {};
+            if (output.result !== undefined && output.result !== null) {
+              results.push(output.result as T);
             }
-            if (entry.provides) {
-              Object.assign(capabilities, entry.provides());
+            // Merge provided capabilities from returned data (no host-side closure).
+            // Skip undefined-valued keys: requires/ANY_VALUE test key *presence*, so a
+            // key must only appear when it carries a defined value.
+            if (output.provides) {
+              for (const [key, value] of Object.entries(output.provides)) {
+                if (value !== undefined) capabilities[key] = value;
+              }
             }
           } catch (err) {
             errors.push(err instanceof Error ? err : new Error(String(err)));

--- a/src/intents/lib/operation.test-utils.integration.test.ts
+++ b/src/intents/lib/operation.test-utils.integration.test.ts
@@ -40,7 +40,7 @@ describe("createMinimalOperation", () => {
       name: "test-handler",
       hooks: {
         [TEST_OPERATION_ID]: {
-          [TEST_HOOK_POINT]: { handler: async () => ({ value: 42 }) },
+          [TEST_HOOK_POINT]: { handler: async () => ({ result: { value: 42 } }) },
         },
       },
     });
@@ -122,7 +122,7 @@ describe("createMinimalOperation", () => {
           [TEST_HOOK_POINT]: {
             handler: async (ctx: HookContext) => {
               receivedContext = ctx;
-              return "ok";
+              return { result: "ok" };
             },
           },
         },

--- a/src/intents/lib/operation.ts
+++ b/src/intents/lib/operation.ts
@@ -39,21 +39,41 @@ export interface HookContext {
 }
 
 /**
+ * A handler's return value.
+ *
+ * Both fields are optional so a handler can contribute a result, capabilities,
+ * both, or neither. Replaces the former `HookHandler.provides` closure: capabilities
+ * are returned as plain data, so a handler that executes remotely can ship them
+ * across a wire and the host dispatcher merges from the returned data instead of
+ * invoking a host-side closure.
+ *
+ * Generic parameter `T` is the unwrapped result type — the dispatcher lifts `result`
+ * into `collect()`'s `results[]`, so `collect<T>()` consumers are unchanged.
+ */
+export interface HookOutput<T = unknown> {
+  /** Value contributed to `collect()`'s `results[]`. Omit (or `undefined`/`null`) for none. */
+  readonly result?: T | null;
+  /** Capabilities merged into the running capability bag after the handler completes.
+   *  Plain data (no closure). Keys with `undefined` values are skipped during the merge,
+   *  so a capability is only "present" when it carries a defined value. */
+  readonly provides?: Readonly<Record<string, unknown>>;
+}
+
+/**
  * A handler registered for a hook point.
  *
- * Generic parameter `T` is the return type for `collect()` — defaults to `unknown`
- * so that `HookDeclarations` (which uses `HookHandler`) accepts handlers with any return type.
+ * Generic parameter `T` is the unwrapped result type for `collect()` — defaults to `unknown`
+ * so that `HookDeclarations` (which uses `HookHandler`) accepts handlers with any result type.
+ * A handler returns a `HookOutput<T>` (result and/or provided capabilities); returning `void`
+ * is shorthand for an empty output (no result, no capabilities).
  */
 export interface HookHandler<T = unknown> {
   /** Module name — set by the Dispatcher during registerModule(). */
   readonly name?: string;
-  readonly handler: (ctx: HookContext) => Promise<T>;
+  readonly handler: (ctx: HookContext) => Promise<HookOutput<T> | void>;
   /** Capabilities this handler requires before it can execute.
    *  Key = capability name. Value = required value, or ANY_VALUE for "must exist, any value". */
   readonly requires?: Readonly<Record<string, unknown>>;
-  /** Capabilities this handler provides after successful execution.
-   *  Called after the handler completes; return value is merged into capabilities. */
-  readonly provides?: () => Readonly<Record<string, unknown>>;
 }
 
 /**

--- a/src/intents/lib/workspace-operation.integration.test.ts
+++ b/src/intents/lib/workspace-operation.integration.test.ts
@@ -17,7 +17,7 @@ import { createMockDispatcher } from "./dispatcher.test-utils";
 import { WorkspaceHookOperation } from "./workspace-operation";
 import { lastDefined, requireResult } from "./hook-helpers";
 import type { Intent, DomainEvent } from "./types";
-import type { HookHandler } from "./operation";
+import type { HookHandler, HookOutput } from "./operation";
 import {
   ResolveWorkspaceOperation,
   RESOLVE_WORKSPACE_OPERATION_ID,
@@ -102,21 +102,23 @@ function createSetup(opts: {
     hooks: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx): Promise<ResolveWorkspaceHookResult> => {
+          handler: async (ctx): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
             const intent = ctx.intent as TestIntent;
             if (intent.payload.workspacePath === WORKSPACE_PATH) {
-              return { projectPath: PROJECT_ROOT, workspaceName: WORKSPACE_NAME };
+              return { result: { projectPath: PROJECT_ROOT, workspaceName: WORKSPACE_NAME } };
             }
-            return {};
+            return { result: {} };
           },
         },
       },
       ...(opts.registerProject && {
         [RESOLVE_PROJECT_OPERATION_ID]: {
           resolve: {
-            handler: async (): Promise<ResolveProjectHookResult> => ({
-              projectId: PROJECT_ID,
-              projectName: "project",
+            handler: async (): Promise<HookOutput<ResolveProjectHookResult>> => ({
+              result: {
+                projectId: PROJECT_ID,
+                projectName: "project",
+              },
             }),
           },
         },
@@ -159,7 +161,7 @@ describe("WorkspaceHookOperation", () => {
   it("resolve failure short-circuits before the hook runs", async () => {
     const { dispatcher, hookRuns } = createSetup({
       operation: new TestOperation(),
-      workHandlers: [{ handler: async () => ({ value: "x" }) }],
+      workHandlers: [{ handler: async () => ({ result: { value: "x" } }) }],
     });
 
     await expect(dispatcher.dispatch(testIntent("/unknown"))).rejects.toThrow(
@@ -171,7 +173,7 @@ describe("WorkspaceHookOperation", () => {
   it("returns the extracted result on success", async () => {
     const { dispatcher } = createSetup({
       operation: new TestOperation(),
-      workHandlers: [{ handler: async () => ({ value: "result-1" }) }],
+      workHandlers: [{ handler: async () => ({ result: { value: "result-1" } }) }],
     });
 
     await expect(dispatcher.dispatch(testIntent())).resolves.toBe("result-1");
@@ -217,7 +219,7 @@ describe("WorkspaceHookOperation", () => {
   it("throws the extract guard when no handler provides a result", async () => {
     const { dispatcher } = createSetup({
       operation: new TestOperation(),
-      workHandlers: [{ handler: async () => ({}) }],
+      workHandlers: [{ handler: async () => ({ result: {} }) }],
     });
 
     await expect(dispatcher.dispatch(testIntent())).rejects.toThrow(
@@ -228,7 +230,7 @@ describe("WorkspaceHookOperation", () => {
   it("emits the onSuccess event with resolved identity, project, and result", async () => {
     const { dispatcher } = createSetup({
       operation: new TestOperation({ resolveProject: true, emitEvent: true }),
-      workHandlers: [{ handler: async () => ({ value: "done" }) }],
+      workHandlers: [{ handler: async () => ({ result: { value: "done" } }) }],
       registerProject: true,
     });
 
@@ -251,7 +253,7 @@ describe("WorkspaceHookOperation", () => {
     // "No operation registered" if the skeleton tried to resolve the project.
     const { dispatcher } = createSetup({
       operation: new TestOperation(),
-      workHandlers: [{ handler: async () => ({ value: "ok" }) }],
+      workHandlers: [{ handler: async () => ({ result: { value: "ok" } }) }],
     });
 
     await expect(dispatcher.dispatch(testIntent())).resolves.toBe("ok");

--- a/src/intents/list-projects.integration.test.ts
+++ b/src/intents/list-projects.integration.test.ts
@@ -21,6 +21,7 @@ import type {
   ListWorkspacesHookResult,
 } from "./list-projects";
 import type { IntentModule } from "./lib/module";
+import type { HookOutput } from "./lib/operation";
 import type { Project, ProjectId } from "../shared/api/types";
 import type { InternalWorkspace } from "./list-projects";
 import { Path } from "../utils/path/path";
@@ -52,8 +53,8 @@ interface TestSetup {
 }
 
 function createTestSetup(
-  projectsHandler: () => Promise<ListProjectsHookResult>,
-  workspacesHandler: () => Promise<ListWorkspacesHookResult>
+  projectsHandler: () => Promise<HookOutput<ListProjectsHookResult>>,
+  workspacesHandler: () => Promise<HookOutput<ListWorkspacesHookResult>>
 ): TestSetup {
   const dispatcher = createMockDispatcher();
 
@@ -108,8 +109,8 @@ describe("ListProjects Operation", () => {
 
     beforeEach(() => {
       setup = createTestSetup(
-        async () => ({ projects: [] }),
-        async () => ({ entries: [] })
+        async () => ({ result: { projects: [] } }),
+        async () => ({ result: { entries: [] } })
       );
     });
 
@@ -128,10 +129,12 @@ describe("ListProjects Operation", () => {
     beforeEach(() => {
       setup = createTestSetup(
         async () => ({
-          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          result: {
+            projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          },
         }),
         async () => ({
-          entries: [{ projectPath: PROJECT_A_PATH, workspaces: [ws1, ws2] }],
+          result: { entries: [{ projectPath: PROJECT_A_PATH, workspaces: [ws1, ws2] }] },
         })
       );
     });
@@ -159,16 +162,20 @@ describe("ListProjects Operation", () => {
     beforeEach(() => {
       setup = createTestSetup(
         async () => ({
-          projects: [
-            { projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH },
-            { projectId: PROJECT_B_ID, name: "project-b", path: PROJECT_B_PATH },
-          ],
+          result: {
+            projects: [
+              { projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH },
+              { projectId: PROJECT_B_ID, name: "project-b", path: PROJECT_B_PATH },
+            ],
+          },
         }),
         async () => ({
-          entries: [
-            { projectPath: PROJECT_A_PATH, workspaces: [wsA] },
-            { projectPath: PROJECT_B_PATH, workspaces: [wsB] },
-          ],
+          result: {
+            entries: [
+              { projectPath: PROJECT_A_PATH, workspaces: [wsA] },
+              { projectPath: PROJECT_B_PATH, workspaces: [wsB] },
+            ],
+          },
         })
       );
     });
@@ -196,9 +203,11 @@ describe("ListProjects Operation", () => {
     beforeEach(() => {
       setup = createTestSetup(
         async () => ({
-          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          result: {
+            projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          },
         }),
-        async () => ({ entries: [] })
+        async () => ({ result: { entries: [] } })
       );
     });
 
@@ -217,10 +226,12 @@ describe("ListProjects Operation", () => {
     beforeEach(() => {
       setup = createTestSetup(
         async () => ({
-          projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          result: {
+            projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          },
         }),
         async () => ({
-          entries: [{ projectPath: "/repos/unknown", workspaces: [ws] }],
+          result: { entries: [{ projectPath: "/repos/unknown", workspaces: [ws] }] },
         })
       );
     });
@@ -239,7 +250,7 @@ describe("ListProjects Operation", () => {
         async () => {
           throw new Error("project hook failed");
         },
-        async () => ({ entries: [] })
+        async () => ({ result: { entries: [] } })
       );
 
       await expect(setup.dispatcher.dispatch(listProjectsIntent())).rejects.toThrow(
@@ -249,7 +260,7 @@ describe("ListProjects Operation", () => {
 
     it("propagates list-workspaces hook errors", async () => {
       const setup = createTestSetup(
-        async () => ({ projects: [] }),
+        async () => ({ result: { projects: [] } }),
         async () => {
           throw new Error("workspace hook failed");
         }

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect, vi } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent } from "./lib/types";
 import {
   OpenProjectOperation,
@@ -311,17 +311,17 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { path, git } = intent.payload;
 
             // Self-select: only handle local paths
             if (git || !path) {
-              return {};
+              return { result: {} };
             }
 
             await gitWorktreeProvider.validateRepository(path);
-            return { projectPath: path.toString() };
+            return { result: { projectPath: path.toString() } };
           },
         },
       },
@@ -334,20 +334,20 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { git } = intent.payload;
 
             // Self-select: only handle git URLs
             if (!git) {
-              return {};
+              return { result: {} };
             }
 
             // Test URLs are fully-qualified HTTPS URLs; no expansion needed
             const remoteUrl = git;
             const existing = await projectStore.findByRemoteUrl(remoteUrl);
             if (existing) {
-              return { projectPath: existing, remoteUrl };
+              return { result: { projectPath: existing, remoteUrl } };
             }
 
             const gitPath = new Path("/test/cloned", "repo");
@@ -357,7 +357,7 @@ function createTestHarness(options?: {
             });
             projectStoreState.configs.set(gitPath.toString(), { remoteUrl });
 
-            return { projectPath: gitPath.toString(), remoteUrl };
+            return { result: { projectPath: gitPath.toString(), remoteUrl } };
           },
         },
       },
@@ -376,7 +376,7 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         register: {
-          handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<RegisterHookResult>> => {
             const { projectPath: projectPathStr } = ctx as RegisterHookInput;
 
             const projectPath = new Path(projectPathStr);
@@ -385,7 +385,7 @@ function createTestHarness(options?: {
 
             // Already registered — return alreadyOpen
             if (registeredPaths.has(normalizedKey)) {
-              return { projectId, name: projectPath.basename, alreadyOpen: true };
+              return { result: { projectId, name: projectPath.basename, alreadyOpen: true } };
             }
 
             const config = await projectStore.getProjectConfig(projectPathStr);
@@ -394,7 +394,7 @@ function createTestHarness(options?: {
             }
 
             registeredPaths.add(normalizedKey);
-            return { projectId, name: projectPath.basename };
+            return { result: { projectId, name: projectPath.basename } };
           },
         },
       },
@@ -407,7 +407,7 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         register: {
-          handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<RegisterHookResult>> => {
             const { projectPath: projectPathStr, remoteUrl } = ctx as RegisterHookInput;
             const projectPath = new Path(projectPathStr);
             const projectId = testProjectId(projectPathStr);
@@ -420,7 +420,7 @@ function createTestHarness(options?: {
               ...(remoteUrl !== undefined && { remoteUrl }),
             });
 
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -446,8 +446,8 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_PROJECT_OPERATION_ID]: {
         discover: {
-          handler: async (): Promise<DiscoverHookResult> => {
-            return { workspaces: discoverResult, defaultBaseBranch: "main" };
+          handler: async (): Promise<HookOutput<DiscoverHookResult>> => {
+            return { result: { workspaces: discoverResult, defaultBaseBranch: "main" } };
           },
         },
       },
@@ -464,7 +464,7 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         create: {
-          handler: async (ctx: HookContext): Promise<CreateHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CreateHookResult>> => {
             const intent = ctx.intent as OpenWorkspaceIntent;
 
             if (intent.payload.existingWorkspace) {
@@ -476,9 +476,11 @@ function createTestHarness(options?: {
               }
 
               return {
-                workspacePath: existing.path,
-                branch: existing.branch ?? existing.name,
-                metadata: existing.metadata,
+                result: {
+                  workspacePath: existing.path,
+                  branch: existing.branch ?? existing.name,
+                  metadata: existing.metadata,
+                },
               };
             }
 
@@ -495,9 +497,9 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          provides: () => ({ workspaceUrl: WORKSPACE_URL }),
-          handler: async (ctx: HookContext): Promise<void> => {
+          handler: async (ctx: HookContext): Promise<HookOutput> => {
             void (ctx as FinalizeHookInput).envVars;
+            return { provides: { workspaceUrl: WORKSPACE_URL } };
           },
         },
       },
@@ -563,22 +565,24 @@ function createTestHarness(options?: {
     hooks: {
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
+          handler: async (): Promise<HookOutput<GetActiveWorkspaceHookResult>> => {
             const path = viewManager.getActiveWorkspacePath();
-            if (!path) return { workspaceRef: null };
+            if (!path) return { result: { workspaceRef: null } };
             const name = extractWorkspaceName(path);
             // Find the project that owns this workspace
             const project = projectState.registeredProjects.find((p) =>
               p.workspaces.some((w) => w.path === path)
             );
             return {
-              workspaceRef: project
-                ? {
-                    projectId: testProjectId(project.path),
-                    workspaceName: name as WorkspaceName,
-                    path,
-                  }
-                : null,
+              result: {
+                workspaceRef: project
+                  ? {
+                      projectId: testProjectId(project.path),
+                      workspaceName: name as WorkspaceName,
+                      path,
+                    }
+                  : null,
+              },
             };
           },
         },
@@ -730,11 +734,11 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           resolve: {
-            handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+            handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
               const intent = ctx.intent as OpenProjectIntent;
               const { path } = intent.payload;
-              if (!path) return {};
-              return { projectPath: path.toString(), alreadyOpen: true };
+              if (!path) return { result: {} };
+              return { result: { projectPath: path.toString(), alreadyOpen: true } };
             },
           },
         },
@@ -747,10 +751,10 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           register: {
-            handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+            handler: async (ctx: HookContext): Promise<HookOutput<RegisterHookResult>> => {
               const { projectPath: projectPathStr } = ctx as RegisterHookInput;
               const projectId = testProjectId(projectPathStr);
-              return { projectId, name: new Path(projectPathStr).basename };
+              return { result: { projectId, name: new Path(projectPathStr).basename } };
             },
           },
         },
@@ -763,17 +767,19 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           discover: {
-            handler: async (): Promise<DiscoverHookResult> => {
+            handler: async (): Promise<HookOutput<DiscoverHookResult>> => {
               return {
-                workspaces: [
-                  {
-                    name: "feature-a",
-                    path: new Path(WORKSPACE_A_PATH),
-                    branch: "feature-a",
-                    metadata: { base: "main" },
-                  },
-                ],
-                defaultBaseBranch: "main",
+                result: {
+                  workspaces: [
+                    {
+                      name: "feature-a",
+                      path: new Path(WORKSPACE_A_PATH),
+                      branch: "feature-a",
+                      metadata: { base: "main" },
+                    },
+                  ],
+                  defaultBaseBranch: "main",
+                },
               };
             },
           },
@@ -896,8 +902,8 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {
-            handler: async (): Promise<SelectFolderHookResult> => {
-              return { folderPath: PROJECT_PATH };
+            handler: async (): Promise<HookOutput<SelectFolderHookResult>> => {
+              return { result: { folderPath: PROJECT_PATH } };
             },
           },
         },
@@ -929,8 +935,8 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {
-            handler: async (): Promise<SelectFolderHookResult> => {
-              return { folderPath: null };
+            handler: async (): Promise<HookOutput<SelectFolderHookResult>> => {
+              return { result: { folderPath: null } };
             },
           },
         },
@@ -957,9 +963,9 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           "select-folder": {
-            handler: async (): Promise<SelectFolderHookResult> => {
+            handler: async (): Promise<HookOutput<SelectFolderHookResult>> => {
               selectFolderSpy();
-              return { folderPath: "/should-not-be-used" };
+              return { result: { folderPath: "/should-not-be-used" } };
             },
           },
         },
@@ -1029,22 +1035,22 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           resolve: {
-            handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+            handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
               const intent = ctx.intent as OpenProjectIntent;
               const { path } = intent.payload;
-              if (!path) return {};
-              return { projectPath: path.toString(), alreadyOpen: true };
+              if (!path) return { result: {} };
+              return { result: { projectPath: path.toString(), alreadyOpen: true } };
             },
           },
           register: {
-            handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+            handler: async (ctx: HookContext): Promise<HookOutput<RegisterHookResult>> => {
               const { projectPath: p } = ctx as RegisterHookInput;
-              return { projectId: testProjectId(p), name: new Path(p).basename };
+              return { result: { projectId: testProjectId(p), name: new Path(p).basename } };
             },
           },
           discover: {
-            handler: async (): Promise<DiscoverHookResult> => {
-              return { workspaces: [] };
+            handler: async (): Promise<HookOutput<DiscoverHookResult>> => {
+              return { result: { workspaces: [] } };
             },
           },
         },
@@ -1103,8 +1109,8 @@ describe("OpenProjectOperation", () => {
       hooks: {
         [OPEN_PROJECT_OPERATION_ID]: {
           prepare: {
-            handler: async (): Promise<PrepareHookResult> => {
-              return { canceled: true };
+            handler: async (): Promise<HookOutput<PrepareHookResult>> => {
+              return { result: { canceled: true } };
             },
           },
         },

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -58,7 +58,7 @@ import type {
   ExistingWorkspaceData,
 } from "./open-workspace";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { ProjectId, Workspace, WorkspaceName } from "../shared/api/types";
 
@@ -210,9 +210,9 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SwitchWorkspaceHookResult>> => {
             const { workspacePath } = ctx as ActivateHookInput;
-            return workspacePath === null ? {} : { resolvedPath: workspacePath };
+            return { result: workspacePath === null ? {} : { resolvedPath: workspacePath } };
           },
         },
       },
@@ -225,7 +225,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         create: {
-          handler: async (ctx: HookContext): Promise<CreateHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CreateHookResult>> => {
             const intent = ctx.intent as OpenWorkspaceIntent;
             const { projectPath } = ctx as CreateHookInput;
 
@@ -233,9 +233,11 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
             if (intent.payload.existingWorkspace) {
               const existing = intent.payload.existingWorkspace;
               return {
-                workspacePath: existing.path,
-                branch: existing.branch ?? existing.name,
-                metadata: existing.metadata,
+                result: {
+                  workspacePath: existing.path,
+                  branch: existing.branch ?? existing.name,
+                  metadata: existing.metadata,
+                },
               };
             }
 
@@ -252,9 +254,11 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
             void projectPath;
 
             return {
-              workspacePath: workspace.path.toString(),
-              branch: workspace.branch,
-              metadata: workspace.metadata,
+              result: {
+                workspacePath: workspace.path.toString(),
+                branch: workspace.branch,
+                metadata: workspace.metadata,
+              },
             };
           },
         },
@@ -268,7 +272,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
-          handler: async (ctx: HookContext): Promise<SetupHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SetupHookResult>> => {
             const setupCtx = ctx as SetupHookInput;
             try {
               await keepFilesService.copyToWorkspace(
@@ -278,7 +282,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
             } catch {
               // Best-effort: do not re-throw
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -291,7 +295,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
-          handler: async (ctx: HookContext): Promise<SetupHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SetupHookResult>> => {
             const setupCtx = ctx as SetupHookInput;
             const intent = ctx.intent as OpenWorkspaceIntent;
 
@@ -303,7 +307,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
               });
             }
 
-            return { envVars };
+            return { result: { envVars } };
           },
         },
       },
@@ -335,9 +339,9 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          provides: () => ({ workspaceUrl }),
-          handler: async (ctx: HookContext): Promise<void> => {
+          handler: async (ctx: HookContext): Promise<HookOutput> => {
             void (ctx as FinalizeHookInput).envVars;
+            return { provides: { workspaceUrl } };
           },
         },
       },
@@ -916,8 +920,8 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             setup: {
-              handler: async (): Promise<SetupHookResult> => {
-                return { envVars: { BRIDGE_PORT: "15000" } };
+              handler: async (): Promise<HookOutput<SetupHookResult>> => {
+                return { result: { envVars: { BRIDGE_PORT: "15000" } } };
               },
             },
           },
@@ -943,9 +947,9 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [SWITCH_WORKSPACE_OPERATION_ID]: {
             activate: {
-              handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
+              handler: async (ctx: HookContext): Promise<HookOutput<SwitchWorkspaceHookResult>> => {
                 const { workspacePath } = ctx as ActivateHookInput;
-                return workspacePath === null ? {} : { resolvedPath: workspacePath };
+                return { result: workspacePath === null ? {} : { resolvedPath: workspacePath } };
               },
             },
           },
@@ -956,10 +960,12 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             create: {
-              handler: async (): Promise<CreateHookResult> => ({
-                workspacePath: WORKSPACE_PATH,
-                branch: WORKSPACE_BRANCH,
-                metadata: WORKSPACE_METADATA,
+              handler: async (): Promise<HookOutput<CreateHookResult>> => ({
+                result: {
+                  workspacePath: WORKSPACE_PATH,
+                  branch: WORKSPACE_BRANCH,
+                  metadata: WORKSPACE_METADATA,
+                },
               }),
             },
           },
@@ -971,8 +977,8 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             setup: {
-              handler: async (): Promise<SetupHookResult> => {
-                return { envVars: { AGENT_PORT: "9090" } };
+              handler: async (): Promise<HookOutput<SetupHookResult>> => {
+                return { result: { envVars: { AGENT_PORT: "9090" } } };
               },
             },
           },
@@ -985,9 +991,9 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             finalize: {
-              provides: () => ({ workspaceUrl: WORKSPACE_URL }),
-              handler: async (ctx: HookContext): Promise<void> => {
+              handler: async (ctx: HookContext): Promise<HookOutput> => {
                 capturedEnvVars = (ctx as FinalizeHookInput).envVars;
+                return { provides: { workspaceUrl: WORKSPACE_URL } };
               },
             },
           },

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -17,7 +17,7 @@
 
 import type { Dispatcher } from "./lib/dispatcher";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { ProjectId, WorkspaceName, WorkspaceRef } from "../shared/api/types";
 import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_UPDATE_AGENT_STATUS } from "./update-agent-status";
@@ -215,7 +215,7 @@ export function createTestViewManager(initialActive: string | null = null): Test
 export function createTestMockModule(config: TestMockConfig): IntentModule {
   const hooks: Record<
     string,
-    Record<string, { handler: (ctx: HookContext) => Promise<unknown> }>
+    Record<string, { handler: (ctx: HookContext) => Promise<HookOutput | void> }>
   > = {};
 
   // -- resolve-workspace --
@@ -226,15 +226,17 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
     const vm = config.viewManager;
     hooks[RESOLVE_WORKSPACE_OPERATION_ID] = {
       resolve: {
-        handler: async (ctx: HookContext): Promise<ResolveWorkspaceHookResult> => {
+        handler: async (ctx: HookContext): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
           const intent = ctx.intent as { payload: { workspacePath: string } };
           const entry = lookupWorkspace(intent.payload.workspacePath);
-          if (!entry) return {};
+          if (!entry) return { result: {} };
           return {
-            ...entry,
-            active:
-              entry.active ??
-              (vm ? vm.getActiveWorkspacePath() === intent.payload.workspacePath : false),
+            result: {
+              ...entry,
+              active:
+                entry.active ??
+                (vm ? vm.getActiveWorkspacePath() === intent.payload.workspacePath : false),
+            },
           };
         },
       },
@@ -248,15 +250,15 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
       typeof projects === "function" ? projects : (path: string) => projects[path];
     hooks[RESOLVE_PROJECT_OPERATION_ID] = {
       resolve: {
-        handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+        handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
           const { projectPath } = ctx as ResolveProjectHookInput;
           const entry = lookupProject(projectPath);
-          if (!entry) return {};
+          if (!entry) return { result: {} };
           const result: ResolveProjectHookResult = { projectId: entry.projectId };
           if (entry.projectName !== undefined) {
-            return { ...result, projectName: entry.projectName };
+            return { result: { ...result, projectName: entry.projectName } };
           }
-          return result;
+          return { result };
         },
       },
     };
@@ -269,8 +271,8 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
     const activeRef = config.activeWorkspaceRef;
     hooks[GET_ACTIVE_WORKSPACE_OPERATION_ID] = {
       get: {
-        handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-          return { workspaceRef: activeRef };
+        handler: async (): Promise<HookOutput<GetActiveWorkspaceHookResult>> => {
+          return { result: { workspaceRef: activeRef } };
         },
       },
     };
@@ -281,20 +283,20 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
     const vm = config.viewManager;
     hooks[SWITCH_WORKSPACE_OPERATION_ID] = {
       activate: {
-        handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
+        handler: async (ctx: HookContext): Promise<HookOutput<SwitchWorkspaceHookResult>> => {
           const { workspacePath, active } = ctx as ActivateHookInput;
           const intent = ctx.intent as SwitchWorkspaceIntent;
           // Deselect: mirrors the production view-module null branch.
           if (workspacePath === null) {
             vm.setActiveWorkspace(null);
-            return {};
+            return { result: {} };
           }
           if (active) {
-            return {};
+            return { result: {} };
           }
           const focus = intent.payload.focus ?? true;
           vm.setActiveWorkspace(workspacePath, focus);
-          return { resolvedPath: workspacePath };
+          return { result: { resolvedPath: workspacePath } };
         },
       },
     };

--- a/src/intents/resolve-project.integration.test.ts
+++ b/src/intents/resolve-project.integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from "./resolve-project";
 import type { ResolveProjectIntent, ResolveHookResult } from "./resolve-project";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { ProjectId } from "../shared/api/types";
 
 // =============================================================================
@@ -37,7 +37,9 @@ const PROJECT_NAME = "my-app";
 // Test Setup
 // =============================================================================
 
-function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveHookResult>): {
+function createTestSetup(
+  resolveHandler?: (ctx: HookContext) => Promise<HookOutput<ResolveHookResult>>
+): {
   dispatcher: Dispatcher;
 } {
   const dispatcher = createMockDispatcher();
@@ -74,9 +76,11 @@ describe("ResolveProjectOperation Integration", () => {
   describe("success", () => {
     it("resolves projectPath to projectId + projectName (#1)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectId: PROJECT_ID,
-          projectName: PROJECT_NAME,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectId: PROJECT_ID,
+            projectName: PROJECT_NAME,
+          },
         })
       );
 
@@ -90,8 +94,10 @@ describe("ResolveProjectOperation Integration", () => {
 
     it("defaults projectName to empty string when not provided (#3)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectId: PROJECT_ID,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectId: PROJECT_ID,
+          },
         })
       );
 
@@ -107,8 +113,10 @@ describe("ResolveProjectOperation Integration", () => {
   describe("failure", () => {
     it("throws when no handler returns projectId (#2)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectName: PROJECT_NAME,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectName: PROJECT_NAME,
+          },
         })
       );
 

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from "./resolve-workspace";
 import type { ResolveWorkspaceIntent, ResolveHookResult } from "./resolve-workspace";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { WorkspaceName } from "../shared/api/types";
 
 // =============================================================================
@@ -37,7 +37,9 @@ const WORKSPACE_NAME = "feature-x" as WorkspaceName;
 // Test Setup
 // =============================================================================
 
-function createTestSetup(resolveHandler?: (ctx: HookContext) => Promise<ResolveHookResult>): {
+function createTestSetup(
+  resolveHandler?: (ctx: HookContext) => Promise<HookOutput<ResolveHookResult>>
+): {
   dispatcher: Dispatcher;
 } {
   const dispatcher = createMockDispatcher();
@@ -74,9 +76,11 @@ describe("ResolveWorkspaceOperation Integration", () => {
   describe("success", () => {
     it("resolves workspacePath to projectPath + workspaceName (#1)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectPath: PROJECT_PATH,
-          workspaceName: WORKSPACE_NAME,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectPath: PROJECT_PATH,
+            workspaceName: WORKSPACE_NAME,
+          },
         })
       );
 
@@ -93,10 +97,12 @@ describe("ResolveWorkspaceOperation Integration", () => {
 
     it("returns the branch when a handler provides it", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectPath: PROJECT_PATH,
-          workspaceName: WORKSPACE_NAME,
-          branch: "feature-x",
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectPath: PROJECT_PATH,
+            workspaceName: WORKSPACE_NAME,
+            branch: "feature-x",
+          },
         })
       );
 
@@ -109,8 +115,10 @@ describe("ResolveWorkspaceOperation Integration", () => {
   describe("failure", () => {
     it("throws when no handler returns projectPath (#2)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          workspaceName: WORKSPACE_NAME,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            workspaceName: WORKSPACE_NAME,
+          },
         })
       );
 
@@ -121,8 +129,10 @@ describe("ResolveWorkspaceOperation Integration", () => {
 
     it("throws when no handler returns workspaceName (#3)", async () => {
       const { dispatcher } = createTestSetup(
-        async (): Promise<ResolveHookResult> => ({
-          projectPath: PROJECT_PATH,
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectPath: PROJECT_PATH,
+          },
         })
       );
 

--- a/src/intents/restart-agent.integration.test.ts
+++ b/src/intents/restart-agent.integration.test.ts
@@ -29,7 +29,7 @@ import type {
 } from "./restart-agent";
 import { registerTestInfrastructure } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
@@ -89,11 +89,11 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
     hooks: {
       [RESTART_AGENT_OPERATION_ID]: {
         restart: {
-          handler: async (ctx: HookContext): Promise<RestartAgentHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<RestartAgentHookResult>> => {
             const { workspacePath } = ctx as RestartAgentHookInput;
             const result = await opts.serverManager.restartServer(workspacePath);
             if (result.success) {
-              return { port: result.port };
+              return { result: { port: result.port } };
             } else {
               throw new Error(result.error);
             }

--- a/src/intents/set-metadata.integration.test.ts
+++ b/src/intents/set-metadata.integration.test.ts
@@ -37,7 +37,7 @@ import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { isValidMetadataKey } from "../shared/api/types";
 import type { IntentModule } from "./lib/module";
 import type { DomainEvent, Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 
 // =============================================================================
 // Test Constants
@@ -112,10 +112,10 @@ function createTestSetup(): TestSetup {
       },
       [GET_METADATA_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext): Promise<GetMetadataHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetMetadataHookResult>> => {
             const { workspacePath: wp } = ctx as GetHookInput;
             const metadata = metadataStore.get(wp) ?? {};
-            return { metadata };
+            return { result: { metadata } };
           },
         },
       },

--- a/src/intents/switch-workspace.integration.test.ts
+++ b/src/intents/switch-workspace.integration.test.ts
@@ -40,7 +40,7 @@ import {
   workspacesFromProjects,
 } from "./operations.test-utils";
 import type { IntentModule } from "./lib/module";
-import type { HookContext } from "./lib/operation";
+import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 
@@ -181,7 +181,7 @@ function createTestSetup(opts?: {
       hooks: {
         [SWITCH_WORKSPACE_OPERATION_ID]: {
           "find-candidates": {
-            handler: async (): Promise<FindCandidatesHookResult> => {
+            handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
               const candidates: Array<{
                 projectPath: string;
                 projectName: string;
@@ -198,7 +198,7 @@ function createTestSetup(opts?: {
                   });
                 }
               }
-              return { candidates };
+              return { result: { candidates } };
             },
           },
         },
@@ -211,10 +211,10 @@ function createTestSetup(opts?: {
       hooks: {
         [SWITCH_WORKSPACE_OPERATION_ID]: {
           "select-next": {
-            handler: async (ctx: HookContext): Promise<SelectNextHookResult> => {
+            handler: async (ctx: HookContext): Promise<HookOutput<SelectNextHookResult>> => {
               const { currentPath, candidates } = ctx as unknown as SelectNextHookInput;
               const result = selectNextWorkspace(currentPath, candidates, () => 2);
-              return result ? { selected: result } : {};
+              return { result: result ? { selected: result } : {} };
             },
           },
         },

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -11,7 +11,7 @@
  */
 
 import type { IntentModule } from "../../intents/lib/module";
-import { ANY_VALUE, type HookContext } from "../../intents/lib/operation";
+import { ANY_VALUE, type HookContext, type HookOutput } from "../../intents/lib/operation";
 import type { Logger } from "../../boundaries/platform/logging-types";
 import type { BinaryType } from "../../utils/binary-resolution/types";
 import type { AgentType } from "../../shared/plugin-protocol";
@@ -128,9 +128,6 @@ export function createAgentModule(
   // Internal closure state
   // =========================================================================
 
-  /** Capability: agentType provided by setup handler. */
-  let capAgentType: AgentType | undefined;
-
   /** MCP port captured during app:start; consumed on lazy initialize. */
   let capturedMcpPort: number | null = null;
 
@@ -185,24 +182,26 @@ export function createAgentModule(
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
-          handler: async (): Promise<ConfigureResult> => {
+          handler: async (): Promise<HookOutput<ConfigureResult>> => {
             return {
-              scripts: provider.scripts,
+              result: {
+                scripts: provider.scripts,
+              },
             };
           },
         },
 
         "check-deps": {
-          handler: async (ctx: HookContext): Promise<CheckDepsResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CheckDepsResult>> => {
             const { configuredAgent } = ctx as CheckDepsHookContext;
-            if (configuredAgent !== provider.type) return {};
+            if (configuredAgent !== provider.type) return { result: {} };
 
             const missingBinaries: BinaryType[] = [];
             const result = await provider.preflight();
             if (result.success && result.needsDownload) {
               missingBinaries.push(provider.binaryType);
             }
-            return { missingBinaries };
+            return { result: { missingBinaries } };
           },
         },
 
@@ -219,19 +218,21 @@ export function createAgentModule(
 
       [APP_READY_OPERATION_ID]: {
         "available-agents": {
-          handler: async (): Promise<AvailableAgentsResult> => {
+          handler: async (): Promise<HookOutput<AvailableAgentsResult>> => {
             try {
               const result = await provider.preflight();
-              if (!result.success || result.needsDownload) return {};
+              if (!result.success || result.needsDownload) return { result: {} };
               return {
-                agent: {
-                  agent: provider.type,
-                  label: provider.displayName,
-                  icon: provider.icon,
+                result: {
+                  agent: {
+                    agent: provider.type,
+                    label: provider.displayName,
+                    icon: provider.icon,
+                  },
                 },
               };
             } catch {
-              return {};
+              return { result: {} };
             }
           },
         },
@@ -239,18 +240,18 @@ export function createAgentModule(
 
       [GET_LAUNCH_OPTIONS_OPERATION_ID]: {
         "launch-options": {
-          handler: async (ctx: HookContext): Promise<LaunchOptionsHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<LaunchOptionsHookResult>> => {
             const { backend } = ctx as LaunchOptionsHookInput;
             // Only the module matching the requested backend contributes.
             if (backend !== provider.type || provider.getLaunchOptions === undefined) {
-              return {};
+              return { result: {} };
             }
             try {
               const { permissionModes } = await provider.getLaunchOptions();
-              return { permissionModes };
+              return { result: { permissionModes } };
             } catch {
               // Best-effort: detection failure → form offers only the default.
-              return {};
+              return { result: {} };
             }
           },
         },
@@ -273,11 +274,13 @@ export function createAgentModule(
 
       [SETUP_OPERATION_ID]: {
         "register-agents": {
-          handler: async (): Promise<RegisterAgentResult> => {
+          handler: async (): Promise<HookOutput<RegisterAgentResult>> => {
             return {
-              agent: provider.type,
-              label: provider.displayName,
-              icon: provider.icon,
+              result: {
+                agent: provider.type,
+                label: provider.displayName,
+                icon: provider.icon,
+              },
             };
           },
         },
@@ -337,11 +340,7 @@ export function createAgentModule(
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
           requires: { agent: provider.type },
-          provides: () => ({
-            ...(capAgentType !== undefined && { agentType: capAgentType }),
-          }),
-          handler: async (ctx: HookContext): Promise<SetupHookResult | undefined> => {
-            capAgentType = undefined;
+          handler: async (ctx: HookContext): Promise<HookOutput<SetupHookResult>> => {
             ensureInitialized();
 
             const setupCtx = ctx as SetupHookInput;
@@ -356,8 +355,10 @@ export function createAgentModule(
               isNewWorkspace,
             });
 
-            capAgentType = provider.type;
-            return { envVars: result.envVars };
+            return {
+              result: { envVars: result.envVars },
+              provides: { agentType: provider.type },
+            };
           },
         },
       },
@@ -365,16 +366,18 @@ export function createAgentModule(
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           requires: { agent: provider.type },
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
             const result = await stopAgentForWorkspace(workspacePath, "delete shutdown");
             if (result.error && !payload.force) {
               throw new Error(result.error);
             }
-            return result.error
-              ? { serverName: provider.serverName, error: result.error }
-              : { serverName: provider.serverName };
+            return {
+              result: result.error
+                ? { serverName: provider.serverName, error: result.error }
+                : { serverName: provider.serverName },
+            };
           },
         },
       },
@@ -382,10 +385,10 @@ export function createAgentModule(
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           requires: { agent: provider.type },
-          handler: async (ctx: HookContext): Promise<HibernateShutdownHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<HibernateShutdownHookResult>> => {
             const { workspacePath } = ctx as HibernatePipelineHookInput;
             await stopAgentForWorkspace(workspacePath, "hibernate shutdown");
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -393,10 +396,12 @@ export function createAgentModule(
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
           requires: { agent: provider.type },
-          handler: async (ctx: HookContext): Promise<GetStatusHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetStatusHookResult>> => {
             const { workspacePath } = ctx as GetStatusHookInput;
             return {
-              agentStatus: provider.getStatus(workspacePath as WorkspacePath),
+              result: {
+                agentStatus: provider.getStatus(workspacePath as WorkspacePath),
+              },
             };
           },
         },
@@ -405,10 +410,12 @@ export function createAgentModule(
       [GET_AGENT_SESSION_OPERATION_ID]: {
         get: {
           requires: { agent: provider.type },
-          handler: async (ctx: HookContext): Promise<GetAgentSessionHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetAgentSessionHookResult>> => {
             const { workspacePath } = ctx as GetAgentSessionHookInput;
             return {
-              session: provider.getSession(workspacePath as WorkspacePath),
+              result: {
+                session: provider.getSession(workspacePath as WorkspacePath),
+              },
             };
           },
         },
@@ -417,11 +424,11 @@ export function createAgentModule(
       [RESTART_AGENT_OPERATION_ID]: {
         restart: {
           requires: { agent: provider.type },
-          handler: async (ctx: HookContext): Promise<RestartAgentHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<RestartAgentHookResult>> => {
             const { workspacePath } = ctx as RestartAgentHookInput;
             const result = await provider.restartWorkspace(workspacePath);
             if (result.success) {
-              return { port: result.port };
+              return { result: { port: result.port } };
             } else {
               throw new Error(result.error);
             }

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -270,8 +270,7 @@ function createPluginPortProvider(port: number | null = null): IntentModule {
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({ pluginPort: port }),
-          handler: async () => undefined,
+          handler: async () => ({ provides: { pluginPort: port } }),
         },
       },
     },

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -16,7 +16,7 @@
 import { join, delimiter } from "node:path";
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import { ANY_VALUE } from "../intents/lib/operation";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { ProcessRunner, SpawnedProcess } from "../boundaries/platform/process";
@@ -646,9 +646,6 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
     }
   }
 
-  /** Capability: workspaceUrl provided by finalize handler. */
-  let capWorkspaceUrl: string | undefined;
-
   // -------------------------------------------------------------------------
   // Module definition
   // -------------------------------------------------------------------------
@@ -661,8 +658,8 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
         // app-start -> before-ready: declare required scripts
         // -------------------------------------------------------------------
         "before-ready": {
-          handler: async (): Promise<ConfigureResult> => {
-            return { scripts: ["code", "code.cmd"] };
+          handler: async (): Promise<HookOutput<ConfigureResult>> => {
+            return { result: { scripts: ["code", "code.cmd"] } };
           },
         },
 
@@ -670,7 +667,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
         // app-start -> check-deps: preflight code-server binary + extensions
         // -------------------------------------------------------------------
         "check-deps": {
-          handler: async (ctx: HookContext): Promise<CheckDepsResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CheckDepsResult>> => {
             const { extensionRequirements } = ctx as CheckDepsHookContext;
             const missingBinaries: BinaryType[] = [];
 
@@ -682,7 +679,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
             // Compare requirements against installed extensions
             if (extensionRequirements.length === 0) {
-              return { missingBinaries };
+              return { result: { missingBinaries } };
             }
 
             try {
@@ -699,10 +696,10 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
                 installPlanCount: extensionInstallPlan.length,
               });
 
-              return { missingBinaries, extensionInstallPlan };
+              return { result: { missingBinaries, extensionInstallPlan } };
             } catch (error) {
               logger.warn("Extension check failed", { error: getErrorMessage(error) });
-              return { missingBinaries };
+              return { result: { missingBinaries } };
             }
           },
         },
@@ -712,8 +709,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
         // -------------------------------------------------------------------
         start: {
           requires: { pluginPort: ANY_VALUE },
-          provides: () => ({ codeServerPort }),
-          handler: async (ctx: HookContext): Promise<void> => {
+          handler: async (ctx: HookContext): Promise<HookOutput> => {
             // Read pluginPort from capabilities (provided by plugin-server-module)
             const pluginPort = ctx.capabilities?.pluginPort as number | null;
             if (pluginPort !== null) {
@@ -733,6 +729,8 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
 
             // Update internal port (consumed by finalize hook for workspace URLs)
             codeServerPort = port;
+
+            return { provides: { codeServerPort: port } };
           },
         },
       },
@@ -908,11 +906,8 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          provides: () => ({
-            ...(capWorkspaceUrl !== undefined && { workspaceUrl: capWorkspaceUrl }),
-          }),
-          handler: async (ctx: HookContext): Promise<void> => {
-            capWorkspaceUrl = undefined;
+          handler: async (ctx: HookContext): Promise<HookOutput> => {
+            let workspaceUrl: string;
             const finalizeCtx = ctx as FinalizeHookInput;
 
             try {
@@ -930,14 +925,16 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
                 "extensions.autoCheckUpdates": false,
               };
               const wsFilePath = await writeWorkspaceFile(workspacePathObj, agentSettings);
-              capWorkspaceUrl = urlForWorkspace(codeServerPort, wsFilePath.toString());
+              workspaceUrl = urlForWorkspace(codeServerPort, wsFilePath.toString());
             } catch (error) {
               logger.warn("Failed to ensure workspace file, using folder URL", {
                 workspacePath: finalizeCtx.workspacePath,
                 error: error instanceof Error ? error.message : String(error),
               });
-              capWorkspaceUrl = urlForFolder(codeServerPort, finalizeCtx.workspacePath);
+              workspaceUrl = urlForFolder(codeServerPort, finalizeCtx.workspacePath);
             }
+
+            return { provides: { workspaceUrl } };
           },
         },
       },
@@ -947,7 +944,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -956,13 +953,13 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
               const workspaceName = workspacePath.basename;
               const projectWorkspacesDir = workspacePath.dirname;
               await removeWorkspaceFile(workspaceName, projectWorkspacesDir);
-              return {};
+              return { result: {} };
             } catch (error) {
               if (payload.force) {
                 logger.warn("CodeServerModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return {};
+                return { result: {} };
               }
               throw error;
             }

--- a/src/modules/debug-module.integration.test.ts
+++ b/src/modules/debug-module.integration.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { createDebugModule } from "./debug-module";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookHandler, HookContext } from "../intents/lib/operation";
+import type { HookHandler, HookContext, HookOutput } from "../intents/lib/operation";
 import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { Config } from "../boundaries/platform/config";
 import type { CheckDepsResult } from "../intents/app-start";
@@ -84,14 +84,16 @@ describe("DebugModule Integration", () => {
     it("delete hook returns empty object", async () => {
       const module = createDebugModule({ configService: createMockConfig() });
       const hook = getHook(module, DELETE_WORKSPACE_OPERATION_ID, "delete");
-      const result = (await hook.handler(makeHookContext())) as DeleteHookResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<DeleteHookResult>)
+        .result!;
       expect(result).toEqual({});
     });
 
     it("detect hook returns empty object", async () => {
       const module = createDebugModule({ configService: createMockConfig() });
       const hook = getHook(module, DELETE_WORKSPACE_OPERATION_ID, "detect");
-      const result = (await hook.handler(makeHookContext())) as DetectHookResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<DetectHookResult>)
+        .result!;
       expect(result).toEqual({});
     });
   });
@@ -111,9 +113,11 @@ describe("DebugModule Integration", () => {
         configService: createMockConfig({ defaults: { "debug.blocking-pids": true } }),
       });
       const hook = getHook(module, DELETE_WORKSPACE_OPERATION_ID, "delete");
-      const result = (await hook.handler(
-        makeDeleteCtx("/projects/my-app/workspaces/test-1", "/projects/my-app")
-      )) as DeleteHookResult;
+      const result = (
+        (await hook.handler(
+          makeDeleteCtx("/projects/my-app/workspaces/test-1", "/projects/my-app")
+        )) as HookOutput<DeleteHookResult>
+      ).result!;
       expect(result.error).toBe("Debug: simulated file lock");
     });
 
@@ -122,7 +126,8 @@ describe("DebugModule Integration", () => {
         configService: createMockConfig({ defaults: { "debug.blocking-pids": true } }),
       });
       const hook = getHook(module, DELETE_WORKSPACE_OPERATION_ID, "detect");
-      const result = (await hook.handler(makeHookContext())) as DetectHookResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<DetectHookResult>)
+        .result!;
       expect(result.blockingProcesses).toHaveLength(1);
       expect(result.blockingProcesses![0]).toEqual({
         pid: 99999,
@@ -150,7 +155,8 @@ describe("DebugModule Integration", () => {
         intent: { type: "workspace:resolve", payload: {} },
         workspacePath: "/projects/my-app/workspaces/test-1",
       } as unknown as HookContext;
-      const result = (await resolveHook.handler(resolveCtx)) as ResolveHookResult;
+      const result = ((await resolveHook.handler(resolveCtx)) as HookOutput<ResolveHookResult>)
+        .result!;
       expect(result).toEqual({
         projectPath: "/projects/my-app",
         workspaceName: "test-1",
@@ -166,7 +172,7 @@ describe("DebugModule Integration", () => {
         intent: { type: "workspace:resolve", payload: {} },
         workspacePath: "/unknown/path",
       } as unknown as HookContext;
-      const result = (await resolveHook.handler(ctx)) as ResolveHookResult;
+      const result = ((await resolveHook.handler(ctx)) as HookOutput<ResolveHookResult>).result!;
       expect(result).toEqual({});
     });
   });
@@ -175,7 +181,8 @@ describe("DebugModule Integration", () => {
     it("check-deps returns empty object", async () => {
       const module = createDebugModule({ configService: createMockConfig() });
       const hook = getHook(module, APP_START_OPERATION_ID, "check-deps");
-      const result = (await hook.handler(makeHookContext())) as CheckDepsResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<CheckDepsResult>)
+        .result!;
       expect(result).toEqual({});
     });
 
@@ -195,7 +202,8 @@ describe("DebugModule Integration", () => {
         configService: createMockConfig({ defaults: { "debug.setup": true } }),
       });
       const hook = getHook(module, APP_START_OPERATION_ID, "check-deps");
-      const result = (await hook.handler(makeHookContext())) as CheckDepsResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<CheckDepsResult>)
+        .result!;
       expect(result.missingBinaries).toEqual(["claude"]);
     });
 
@@ -336,7 +344,8 @@ describe("DebugModule Integration", () => {
         }),
       });
       const hook = getHook(module, APP_START_OPERATION_ID, "check-deps");
-      const result = (await hook.handler(makeHookContext())) as CheckDepsResult;
+      const result = ((await hook.handler(makeHookContext())) as HookOutput<CheckDepsResult>)
+        .result!;
       expect(result.missingBinaries).toEqual(["claude"]);
     });
   });

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -12,7 +12,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Config } from "../boundaries/platform/config";
 import { storeBoolean, storeEnum } from "../boundaries/platform/store-definition";
 import { APP_START_OPERATION_ID, type CheckDepsResult } from "../intents/app-start";
@@ -86,26 +86,28 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
       // --- Blocking PIDs scenario ---
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
-            if (!isActive("debug.blocking-pids")) return {};
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
+            if (!isActive("debug.blocking-pids")) return { result: {} };
             const { projectPath, workspacePath, workspaceName } = ctx as DeletePipelineHookInput;
             debugWorkspaces.set(workspacePath, { projectPath, workspaceName });
-            return { error: "Debug: simulated file lock" };
+            return { result: { error: "Debug: simulated file lock" } };
           },
         },
         detect: {
-          handler: async (): Promise<DetectHookResult> => {
-            if (!isActive("debug.blocking-pids")) return {};
+          handler: async (): Promise<HookOutput<DetectHookResult>> => {
+            if (!isActive("debug.blocking-pids")) return { result: {} };
             return {
-              blockingProcesses: [
-                {
-                  pid: 99999,
-                  name: "debug-blocker",
-                  commandLine: "debug --simulated",
-                  files: ["locked-file.txt"],
-                  cwd: null,
-                },
-              ],
+              result: {
+                blockingProcesses: [
+                  {
+                    pid: 99999,
+                    name: "debug-blocker",
+                    commandLine: "debug --simulated",
+                    files: ["locked-file.txt"],
+                    cwd: null,
+                  },
+                ],
+              },
             };
           },
         },
@@ -114,13 +116,15 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
       // --- Blocking PIDs: resolve cached workspace identity ---
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const { workspacePath } = ctx as ResolveHookInput;
             const cached = debugWorkspaces.get(workspacePath);
-            if (!cached) return {};
+            if (!cached) return { result: {} };
             return {
-              projectPath: cached.projectPath,
-              workspaceName: cached.workspaceName,
+              result: {
+                projectPath: cached.projectPath,
+                workspaceName: cached.workspaceName,
+              },
             };
           },
         },
@@ -129,9 +133,9 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
       // --- Setup: check-deps + binary download simulation ---
       [APP_START_OPERATION_ID]: {
         "check-deps": {
-          handler: async (): Promise<CheckDepsResult> => {
-            if (!isActive("debug.setup")) return {};
-            return { missingBinaries: ["claude" as BinaryType] };
+          handler: async (): Promise<HookOutput<CheckDepsResult>> => {
+            if (!isActive("debug.setup")) return { result: {} };
+            return { result: { missingBinaries: ["claude" as BinaryType] } };
           },
         },
         start: {

--- a/src/modules/deletion-dialog-module.integration.test.ts
+++ b/src/modules/deletion-dialog-module.integration.test.ts
@@ -25,7 +25,7 @@ import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { createDeletionDialogModule } from "./deletion-dialog-module";
 import { createMockDialogManager } from "./presentation/dialog-manager.state-mock";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { DeletionProgress } from "../shared/api/types";
 import type { WorkspacePath } from "../shared/ipc";
@@ -508,8 +508,8 @@ describe("DeletionDialogModule - remove confirm", () => {
       logger: SILENT_LOGGER,
     });
 
-    const confirm = (): Promise<ConfirmHookResult> =>
-      module.hooks![DELETE_WORKSPACE_OPERATION_ID]!["confirm"]!.handler({
+    const confirm = async (): Promise<ConfirmHookResult> => {
+      const output = (await module.hooks![DELETE_WORKSPACE_OPERATION_ID]!["confirm"]!.handler({
         intent: {
           type: INTENT_DELETE_WORKSPACE,
           payload: {
@@ -524,7 +524,9 @@ describe("DeletionDialogModule - remove confirm", () => {
         workspacePath: WS_PATH_A,
         workspaceName: WS_NAME_A,
         active: true,
-      } as unknown as HookContext) as Promise<ConfirmHookResult>;
+      } as unknown as HookContext)) as HookOutput<ConfirmHookResult>;
+      return output.result!;
+    };
 
     return {
       dialogManager,

--- a/src/modules/deletion-dialog-module.ts
+++ b/src/modules/deletion-dialog-module.ts
@@ -14,7 +14,7 @@
 
 import type { IntentModule, EventDeclarations, HookDeclarations } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { DialogHandle } from "./presentation/sessions";
 import type { UiPresenter } from "./presentation/presentation-module";
@@ -341,7 +341,7 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
    * warnings in when the background status check lands, and parks the
    * dispatch until the user answers.
    */
-  async function confirmRemove(ctx: HookContext): Promise<ConfirmHookResult> {
+  async function confirmRemove(ctx: HookContext): Promise<HookOutput<ConfirmHookResult>> {
     const input = ctx as DeletePipelineHookInput;
     let state: RemoveConfirmState = {
       workspaceName: input.workspaceName,
@@ -391,10 +391,10 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
     try {
       const event = await handle.nextEvent();
       if (event.kind !== "dismiss" && event.actionId === "remove") {
-        return { keepBranch: event.data?.["keep-branch"] === "true" };
+        return { result: { keepBranch: event.data?.["keep-branch"] === "true" } };
       }
       // Cancel button or Escape.
-      return { canceled: true };
+      return { result: { canceled: true } };
     } finally {
       dialogOpen = false;
       handle.close();

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -12,6 +12,7 @@ import type { PathProvider } from "../boundaries/platform/path-provider";
 import type { AsyncWatcher } from "../boundaries/platform/async-watcher";
 import type { Logger } from "../boundaries/platform/logging";
 import type { IntentModule } from "../intents/lib/module";
+import type { HookOutput } from "../intents/lib/operation";
 import type { ConfigureResult } from "../intents/app-start";
 import type { Config } from "../boundaries/platform/config";
 import type { Dispatcher } from "../intents/lib/dispatcher";
@@ -156,7 +157,7 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
-          handler: async (): Promise<ConfigureResult> => {
+          handler: async (): Promise<HookOutput<ConfigureResult>> => {
             // Disable ASAR when not packaged
             if (!deps.buildInfo.isPackaged) {
               process.noAsar = true;
@@ -200,14 +201,14 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
                 ...(flag.value !== undefined && { value: flag.value }),
               });
             }
-            return {};
+            return { result: {} };
           },
         },
         init: {
-          provides: () => ({ "app-ready": true }),
-          handler: async (): Promise<void> => {
+          handler: async (): Promise<HookOutput> => {
             deps.asyncWatcher.check();
             await deps.app.whenReady();
+            return { provides: { "app-ready": true } };
           },
         },
         start: {

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -49,6 +49,7 @@ import type { DialogBoundary } from "../boundaries/shell/dialog";
 import type { ViewBoundary, UncaughtExceptionDetails } from "../boundaries/shell/view";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
 import { ANY_VALUE } from "../intents/lib/operation";
+import type { HookOutput } from "../intents/lib/operation";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
 import { INTENT_APP_SHUTDOWN, type AppShutdownIntent } from "../intents/app-shutdown";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
@@ -416,9 +417,9 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
-          handler: async (): Promise<Record<string, never>> => {
+          handler: async (): Promise<HookOutput<Record<string, never>>> => {
             registerErrorHandlers();
-            return {};
+            return { result: {} };
           },
         },
         // The UI view exists once the view module's init handler has run
@@ -426,9 +427,9 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
         // before the renderer mounts the Svelte app.
         init: {
           requires: { "ui-ready": ANY_VALUE },
-          handler: async (): Promise<Record<string, never>> => {
+          handler: async (): Promise<HookOutput<Record<string, never>>> => {
             subscribeUiCrashGuard();
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/extension-module.ts
+++ b/src/modules/extension-module.ts
@@ -12,6 +12,7 @@ import type { PathProvider } from "../boundaries/platform/path-provider";
 import type { Logger } from "../boundaries/platform/logging-types";
 import type { InitResult, ExtensionRequirement } from "../intents/app-start";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
+import type { HookOutput } from "../intents/lib/operation";
 import { Path } from "../utils/path/path";
 import { getErrorMessage } from "../shared/errors/service-errors";
 
@@ -98,7 +99,7 @@ export function createExtensionModule(deps: ExtensionModuleDeps): IntentModule {
       [APP_START_OPERATION_ID]: {
         init: {
           requires: { "app-ready": true },
-          handler: async (): Promise<InitResult> => {
+          handler: async (): Promise<HookOutput<InitResult>> => {
             try {
               const manifestPath = pathProvider.runtimePath("extensions/manifest.json");
               const content = await fileSystemLayer.readFile(manifestPath);
@@ -107,7 +108,7 @@ export function createExtensionModule(deps: ExtensionModuleDeps): IntentModule {
 
               if (!validation.isValid) {
                 logger.warn("Invalid extensions manifest", { error: validation.error });
-                return {};
+                return { result: {} };
               }
 
               const extensionRequirements: ExtensionRequirement[] = validation.manifest.map(
@@ -122,12 +123,12 @@ export function createExtensionModule(deps: ExtensionModuleDeps): IntentModule {
                 count: extensionRequirements.length,
               });
 
-              return { extensionRequirements };
+              return { result: { extensionRequirements } };
             } catch (error) {
               logger.warn("Failed to load extensions manifest", {
                 error: getErrorMessage(error),
               });
-              return {};
+              return { result: {} };
             }
           },
         },

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -14,7 +14,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 
-import type { Operation, OperationContext, HookContext } from "../intents/lib/operation";
+import type {
+  Operation,
+  OperationContext,
+  HookContext,
+  HookOutput,
+} from "../intents/lib/operation";
 import type { Intent, DomainEvent } from "../intents/lib/types";
 import type { IntentModule } from "../intents/lib/module";
 import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
@@ -588,9 +593,11 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       // The CloseProjectOperation collects this hook to drive its
       // per-workspace teardown (and the close confirm dialog's count).
-      const result = (await module.hooks![CLOSE_PROJECT_OPERATION_ID]!["resolve"]!.handler({
-        intent: { type: "project:close", payload: { projectPath } },
-      } as HookContext)) as { workspaces: ReadonlyArray<{ path: string }> };
+      const result = (
+        (await module.hooks![CLOSE_PROJECT_OPERATION_ID]!["resolve"]!.handler({
+          intent: { type: "project:close", payload: { projectPath } },
+        } as HookContext)) as HookOutput<{ workspaces: ReadonlyArray<{ path: string }> }>
+      ).result!;
 
       expect(result.workspaces.map((workspace) => workspace.path)).toEqual([
         `${projectPath}/.worktrees/feature-1`,

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -17,7 +17,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
 import type { Workspace } from "../boundaries/platform/git-types";
 import type { PathProvider } from "../boundaries/platform/path-provider";
@@ -189,10 +189,10 @@ export function createGitWorktreeWorkspaceModule(
       // resolve-workspace -> resolve (single registration replaces 8 per-operation hooks)
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const { workspacePath } = ctx as ResolveHookInput;
             const resolved = resolveFromWorkspacePath(workspacePath);
-            return resolved ?? {};
+            return { result: resolved ?? {} };
           },
         },
       },
@@ -200,7 +200,7 @@ export function createGitWorktreeWorkspaceModule(
       // open-project -> discover
       [OPEN_PROJECT_OPERATION_ID]: {
         discover: {
-          handler: async (ctx: HookContext): Promise<DiscoverHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DiscoverHookResult>> => {
             const { projectPath } = ctx as DiscoverHookInput;
             const projectPathObj = new Path(projectPath);
             const workspacesDir = pathProvider.getProjectWorkspacesDir(projectPathObj);
@@ -224,8 +224,10 @@ export function createGitWorktreeWorkspaceModule(
             const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj);
 
             return {
-              workspaces: discovered,
-              ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              result: {
+                workspaces: discovered,
+                ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              },
             };
           },
         },
@@ -237,16 +239,20 @@ export function createGitWorktreeWorkspaceModule(
         // tears each down (runtime teardown), upgrades to full deletion on a
         // confirmed removeAll, and the confirm dialog shows the count.
         resolve: {
-          handler: async (ctx: HookContext): Promise<CloseResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseResolveHookResult>> => {
             const intent = ctx.intent as CloseProjectIntent;
             const key = new Path(intent.payload.projectPath).toString();
             const list = workspaces.get(key) ?? [];
             // IPC-shaped contract: paths cross the hook boundary as strings.
-            return { workspaces: list.map((workspace) => ({ path: workspace.path.toString() })) };
+            return {
+              result: {
+                workspaces: list.map((workspace) => ({ path: workspace.path.toString() })),
+              },
+            };
           },
         },
         close: {
-          handler: async (ctx: HookContext): Promise<Record<string, never>> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<Record<string, never>>> => {
             const { projectPath } = ctx as CloseHookInput;
             const projectPathObj = new Path(projectPath);
 
@@ -261,7 +267,7 @@ export function createGitWorktreeWorkspaceModule(
               }
             }
 
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -269,7 +275,7 @@ export function createGitWorktreeWorkspaceModule(
       // open-workspace -> create
       [OPEN_WORKSPACE_OPERATION_ID]: {
         create: {
-          handler: async (ctx: HookContext): Promise<CreateHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CreateHookResult>> => {
             const intent = ctx.intent as OpenWorkspaceIntent;
             const { payload } = intent;
             const { projectPath } = ctx as CreateHookInput;
@@ -302,10 +308,12 @@ export function createGitWorktreeWorkspaceModule(
               }
 
               return {
-                workspacePath,
-                branch,
-                metadata,
-                ...(payload.base !== undefined && { resolvedBase: payload.base }),
+                result: {
+                  workspacePath,
+                  branch,
+                  metadata,
+                  ...(payload.base !== undefined && { resolvedBase: payload.base }),
+                },
               };
             }
 
@@ -348,10 +356,12 @@ export function createGitWorktreeWorkspaceModule(
             }
 
             return {
-              workspacePath: internalWorkspace.path.toString(),
-              branch: internalWorkspace.branch ?? internalWorkspace.name,
-              metadata: internalWorkspace.metadata,
-              resolvedBase: base,
+              result: {
+                workspacePath: internalWorkspace.path.toString(),
+                branch: internalWorkspace.branch ?? internalWorkspace.name,
+                metadata: internalWorkspace.metadata,
+                resolvedBase: base,
+              },
             };
           },
         },
@@ -360,7 +370,7 @@ export function createGitWorktreeWorkspaceModule(
       // get-project-bases -> list + refresh
       [GET_PROJECT_BASES_OPERATION_ID]: {
         list: {
-          handler: async (ctx: HookContext): Promise<ListBasesHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ListBasesHookResult>> => {
             const { projectPath } = ctx as ListBasesHookInput;
             const projectPathObj = new Path(projectPath);
 
@@ -368,8 +378,10 @@ export function createGitWorktreeWorkspaceModule(
             const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj);
 
             return {
-              bases,
-              ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              result: {
+                bases,
+                ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
+              },
             };
           },
         },
@@ -384,21 +396,21 @@ export function createGitWorktreeWorkspaceModule(
       // delete-workspace -> preflight + delete (resolve hook removed, now uses resolve-workspace dispatch)
       [DELETE_WORKSPACE_OPERATION_ID]: {
         preflight: {
-          handler: async (ctx: HookContext): Promise<PreflightHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<PreflightHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             try {
               const isDirty = await gitWorktreeProvider.isDirty(new Path(wsPath));
               const unmergedCommits = await gitWorktreeProvider.countUnmergedCommits(
                 new Path(wsPath)
               );
-              return { isDirty, unmergedCommits };
+              return { result: { isDirty, unmergedCommits } };
             } catch (error) {
-              return { error: getErrorMessage(error) };
+              return { result: { error: getErrorMessage(error) } };
             }
           },
         },
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { projectPath, workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -422,7 +434,7 @@ export function createGitWorktreeWorkspaceModule(
                   unregisterWorkspaceFromState(projectPath, wsPath);
                 }
                 // Non-force: workspace stays in deletionPending for resolve/list
-                return { error: getErrorMessage(error) };
+                return { result: { error: getErrorMessage(error) } };
               }
 
               // Success: clean up deletionPending
@@ -430,7 +442,7 @@ export function createGitWorktreeWorkspaceModule(
             }
 
             unregisterWorkspaceFromState(projectPath, wsPath);
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -438,7 +450,7 @@ export function createGitWorktreeWorkspaceModule(
       // switch-workspace -> find-candidates (resolve hook removed)
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "find-candidates": {
-          handler: async (): Promise<FindCandidatesHookResult> => {
+          handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
             const candidates: Array<{
               projectPath: string;
               projectName: string;
@@ -459,7 +471,7 @@ export function createGitWorktreeWorkspaceModule(
                 });
               }
             }
-            return { candidates };
+            return { result: { candidates } };
           },
         },
       },
@@ -467,13 +479,13 @@ export function createGitWorktreeWorkspaceModule(
       // get-workspace-status -> get (resolve hook removed)
       [GET_WORKSPACE_STATUS_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext): Promise<GetStatusHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetStatusHookResult>> => {
             const { workspacePath: wsPath } = ctx as GetStatusHookInput;
             const isDirty = await gitWorktreeProvider.isDirty(new Path(wsPath));
             const unmergedCommits = await gitWorktreeProvider.countUnmergedCommits(
               new Path(wsPath)
             );
-            return { isDirty, unmergedCommits };
+            return { result: { isDirty, unmergedCommits } };
           },
         },
       },
@@ -481,7 +493,7 @@ export function createGitWorktreeWorkspaceModule(
       // list-projects -> list-workspaces
       [LIST_PROJECTS_OPERATION_ID]: {
         "list-workspaces": {
-          handler: async (): Promise<ListWorkspacesHookResult> => {
+          handler: async (): Promise<HookOutput<ListWorkspacesHookResult>> => {
             const entries: ListWorkspacesHookEntry[] = [];
             for (const [key, wsList] of getMergedWorkspaces()) {
               entries.push({
@@ -489,7 +501,7 @@ export function createGitWorktreeWorkspaceModule(
                 workspaces: wsList,
               });
             }
-            return { entries };
+            return { result: { entries } };
           },
         },
       },

--- a/src/modules/hibernation-screenshot-module.ts
+++ b/src/modules/hibernation-screenshot-module.ts
@@ -17,7 +17,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Logger } from "../boundaries/platform/logging";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { PathProvider } from "../boundaries/platform/path-provider";
@@ -77,7 +77,7 @@ export function createHibernationScreenshotModule(
     hooks: {
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         capture: {
-          handler: async (ctx: HookContext): Promise<CaptureHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CaptureHookResult>> => {
             const { active, projectId, workspaceName } = ctx as HibernatePipelineHookInput;
             try {
               // Only the visible iframe has pixels to capture; a background
@@ -85,32 +85,32 @@ export function createHibernationScreenshotModule(
               // the shared host view, which showed the active workspace's
               // pixels regardless of which workspace was hibernating.)
               if (!active) {
-                return {};
+                return { result: {} };
               }
               const png = await viewManager.captureActiveWorkspaceView();
               if (!png) {
-                return {};
+                return { result: {} };
               }
               const filePath = buildScreenshotPath(pathProvider, projectId, workspaceName);
               await fileSystem.mkdir(filePath.dirname);
               await fileSystem.writeFileBuffer(filePath, png);
-              return {};
+              return { result: {} };
             } catch (error) {
               logger.debug("hibernation-screenshot: capture failed (ignored)", {
                 error: getErrorMessage(error),
               });
-              return {};
+              return { result: {} };
             }
           },
         },
       },
       [WAKE_WORKSPACE_OPERATION_ID]: {
         cleanup: {
-          handler: async (ctx: HookContext): Promise<CleanupHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CleanupHookResult>> => {
             const { projectId, workspaceName } = ctx as WakePipelineHookInput;
             const filePath = buildScreenshotPath(pathProvider, projectId, workspaceName);
             await deletePath(filePath);
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/keepfiles-module.ts
+++ b/src/modules/keepfiles-module.ts
@@ -15,7 +15,7 @@
 import * as path from "node:path";
 import ignore, { type Ignore } from "ignore";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { Logger } from "../boundaries/platform/logging-types";
 import {
@@ -274,13 +274,13 @@ export function createKeepFilesModule(deps: KeepFilesModuleDeps): IntentModule {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         setup: {
-          handler: async (ctx: HookContext): Promise<SetupHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SetupHookResult>> => {
             const setupCtx = ctx as SetupHookInput;
             const intent = ctx.intent as OpenWorkspaceIntent;
 
             // Skip keepfiles for re-opened workspaces — only copy for newly created ones
             if (intent.payload.existingWorkspace !== undefined) {
-              return {};
+              return { result: {} };
             }
 
             try {
@@ -297,7 +297,7 @@ export function createKeepFilesModule(deps: KeepFilesModuleDeps): IntentModule {
               // Do not re-throw -- keepfiles is best-effort
             }
 
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/local-project-module.integration.test.ts
+++ b/src/modules/local-project-module.integration.test.ts
@@ -49,7 +49,7 @@ import { APP_READY_OPERATION_ID, type LoadProjectsResult } from "../intents/app-
 import type { AppReadyIntent } from "../intents/app-ready";
 import { Path } from "../utils/path/path";
 import type { ProjectId } from "../shared/api/types";
-import type { HookContext, ResolvedHooks, HookResult } from "../intents/lib/operation";
+import type { HookContext, ResolvedHooks, HookResult, HookOutput } from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 import { createFileSystemMock, directory } from "../boundaries/platform/filesystem.state-mock";
 import { createMockDialogManager } from "./presentation/dialog-manager.state-mock";
@@ -125,8 +125,9 @@ function resolveHooksFromModule(module: IntentModule, operationId: string): Reso
         return { results: [], errors: [], capabilities: {} };
       }
       try {
-        const result = await hookHandler.handler(ctx);
-        const results = result !== undefined ? [result as T] : [];
+        const output = await hookHandler.handler(ctx);
+        const result = (output as HookOutput<T> | undefined)?.result;
+        const results: T[] = result !== undefined && result !== null ? [result] : [];
         return { results, errors: [], capabilities: {} };
       } catch (error) {
         return { results: [], errors: [error as Error], capabilities: {} };

--- a/src/modules/local-project-module.ts
+++ b/src/modules/local-project-module.ts
@@ -16,7 +16,7 @@
 import * as crypto from "node:crypto";
 import nodePath from "path";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { ProjectId } from "../shared/api/types";
 import { Path } from "../utils/path/path";
 import { projectDirName } from "../boundaries/platform/paths";
@@ -294,12 +294,12 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       // resolve-project -> resolve (single registration replaces 5 per-operation hooks)
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveProjectHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
             const { projectPath } = ctx as ResolveProjectHookInput;
             const normalizedKey = new Path(projectPath).toString();
             const project = projects.get(normalizedKey);
-            if (!project) return {};
-            return { projectId: project.id, projectName: project.name };
+            if (!project) return { result: {} };
+            return { result: { projectId: project.id, projectName: project.name } };
           },
         },
       },
@@ -307,15 +307,15 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       [OPEN_PROJECT_OPERATION_ID]: {
         // prepare: offer git init for non-git directories
         prepare: {
-          handler: async (ctx: HookContext): Promise<PrepareHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<PrepareHookResult>> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { path, git } = intent.payload;
 
             // Self-select: only handle local paths
-            if (git || !path) return {};
+            if (git || !path) return { result: {} };
 
             // Already open — skip
-            if (projects.has(path.toString())) return {};
+            if (projects.has(path.toString())) return { result: {} };
 
             // Check if it's already a git repo
             let isRepo: boolean;
@@ -323,9 +323,9 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               isRepo = await gitClient.isRepositoryRoot(path);
             } catch {
               // Path doesn't exist or inaccessible — let resolve handle the error
-              return {};
+              return { result: {} };
             }
-            if (isRepo) return {};
+            if (isRepo) return { result: {} };
 
             // Not a git repo — ask user
             const dialog = ui.dialog({
@@ -354,23 +354,23 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             dialog.close();
 
             if (event.kind === "dismiss" || event.actionId !== "init") {
-              return { canceled: true };
+              return { result: { canceled: true } };
             }
 
             await gitClient.init(path, { initialCommit: "Initial commit" });
-            return {};
+            return { result: {} };
           },
         },
 
         // resolve: validate .git exists for local paths
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { path, git } = intent.payload;
 
             // Self-select: only handle local paths (not git URLs)
             if (git || !path) {
-              return {};
+              return { result: {} };
             }
 
             // Check persisted config for remoteUrl (restores icon on startup)
@@ -380,24 +380,28 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             // Already open — skip validation, signal short-circuit
             if (projects.has(path.toString())) {
               return {
-                projectPath: path.toString(),
-                alreadyOpen: true,
-                ...(remoteUrl !== undefined && { remoteUrl }),
+                result: {
+                  projectPath: path.toString(),
+                  alreadyOpen: true,
+                  ...(remoteUrl !== undefined && { remoteUrl }),
+                },
               };
             }
 
             await gitWorktreeProvider.validateRepository(path);
 
             return {
-              projectPath: path.toString(),
-              ...(remoteUrl !== undefined && { remoteUrl }),
+              result: {
+                projectPath: path.toString(),
+                ...(remoteUrl !== undefined && { remoteUrl }),
+              },
             };
           },
         },
 
         // register: generate ID, persist, add to internal state (all projects)
         register: {
-          handler: async (ctx: HookContext): Promise<RegisterHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<RegisterHookResult>> => {
             const { projectPath: projectPathStr, remoteUrl } = ctx as RegisterHookInput;
 
             const projectPath = new Path(projectPathStr);
@@ -406,7 +410,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
 
             // Already in state — return alreadyOpen without re-persisting
             if (projects.has(normalizedKey)) {
-              return { projectId, name: projectPath.basename, alreadyOpen: true };
+              return { result: { projectId, name: projectPath.basename, alreadyOpen: true } };
             }
 
             // Persist to store if new
@@ -422,7 +426,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               path: projectPath,
             });
 
-            return { projectId, name: projectPath.basename };
+            return { result: { projectId, name: projectPath.basename } };
           },
         },
       },
@@ -430,7 +434,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       [CLOSE_PROJECT_OPERATION_ID]: {
         // resolve: look up projectPath in config to get remoteUrl
         resolve: {
-          handler: async (ctx: HookContext): Promise<CloseResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseResolveHookResult>> => {
             const intent = ctx.intent as CloseProjectIntent;
             const { projectPath } = intent.payload;
 
@@ -438,14 +442,16 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             const config = await getProjectConfig(fs, projectsDir, projectPath);
 
             return {
-              ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
+              result: {
+                ...(config?.remoteUrl !== undefined && { remoteUrl: config.remoteUrl }),
+              },
             };
           },
         },
 
         // close: remove from internal state and config (all projects)
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath, removeLocalRepo, remoteUrl } = ctx as CloseHookInput;
 
             // Remove from internal state
@@ -469,7 +475,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               }
             }
 
-            return { otherProjectsExist: projects.size > 0 };
+            return { result: { otherProjectsExist: projects.size > 0 } };
           },
         },
       },
@@ -477,9 +483,9 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       [APP_READY_OPERATION_ID]: {
         // load-projects: load all saved project configs
         "load-projects": {
-          handler: async (): Promise<LoadProjectsResult> => {
+          handler: async (): Promise<HookOutput<LoadProjectsResult>> => {
             const configs = await loadAllProjectConfigs(fs, projectsDir);
-            return { projectPaths: configs.map((c) => c.path) };
+            return { result: { projectPaths: configs.map((c) => c.path) } };
           },
         },
       },
@@ -487,7 +493,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
       // list-projects -> list-projects
       [LIST_PROJECTS_OPERATION_ID]: {
         "list-projects": {
-          handler: async (): Promise<ListProjectsHookResult> => {
+          handler: async (): Promise<HookOutput<ListProjectsHookResult>> => {
             const entries: ListProjectsHookEntry[] = [];
             for (const [key, project] of projects) {
               entries.push({
@@ -496,7 +502,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
                 path: key,
               });
             }
-            return { projects: entries };
+            return { result: { projects: entries } };
           },
         },
       },

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -24,6 +24,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 
 import type { IntentModule } from "../intents/lib/module";
+import type { HookOutput } from "../intents/lib/operation";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { DomainEvent } from "../intents/lib/types";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
@@ -1195,20 +1196,14 @@ export function createMcpModule(deps: McpModuleDeps): IntentModule {
     deps.config
   );
 
-  /** Capability: mcpPort provided by start handler. */
-  let capMcpPort: number | undefined;
-
   return {
     name: "mcp",
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({
-            ...(capMcpPort !== undefined && { mcpPort: capMcpPort }),
-          }),
-          handler: async (): Promise<void> => {
-            capMcpPort = undefined;
-            capMcpPort = await mcpServerManager.start();
+          handler: async (): Promise<HookOutput> => {
+            const mcpPort = await mcpServerManager.start();
+            return { provides: { mcpPort } };
           },
         },
       },

--- a/src/modules/metadata-module.ts
+++ b/src/modules/metadata-module.ts
@@ -7,7 +7,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
 import { Path } from "../utils/path/path";
 import { SET_METADATA_OPERATION_ID } from "../intents/set-metadata";
@@ -38,10 +38,10 @@ export function createMetadataModule(deps: MetadataModuleDeps): IntentModule {
       },
       [GET_METADATA_OPERATION_ID]: {
         get: {
-          handler: async (ctx: HookContext): Promise<GetMetadataHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<GetMetadataHookResult>> => {
             const { workspacePath } = ctx as GetHookInput;
             const metadata = await deps.gitWorktreeProvider.getMetadata(new Path(workspacePath));
-            return { metadata };
+            return { result: { metadata } };
           },
         },
       },

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -18,7 +18,7 @@ import { dirname } from "node:path";
 import { stat } from "node:fs/promises";
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { Logger } from "../boundaries/platform/logging-types";
 import { SILENT_LOGGER, logAtLevel } from "../boundaries/platform/logging";
@@ -158,9 +158,6 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
     string,
     { env: Record<string, string>; agentType: AgentType; resetWorkspace: boolean }
   >();
-
-  /** Capability: pluginPort provided by start handler. */
-  let capPluginPort: number | null = null;
 
   // ---------------------------------------------------------------------------
   // Server lifecycle functions
@@ -871,17 +868,21 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
     hooks: {
       [APP_START_OPERATION_ID]: {
         start: {
-          provides: () => ({ pluginPort: capPluginPort }),
-          handler: async (): Promise<void> => {
-            capPluginPort = null;
+          handler: async (): Promise<HookOutput> => {
+            // pluginPort stays null on failure; the key is still provided (null,
+            // not undefined) so code-server's `requires: { pluginPort: ANY_VALUE }`
+            // gate is satisfied and it runs in degraded mode.
+            let pluginPort: number | null = null;
 
             try {
-              capPluginPort = await start();
-              logger.info("Plugin server started", { port: capPluginPort });
+              pluginPort = await start();
+              logger.info("Plugin server started", { port: pluginPort });
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
               logger.warn("PluginServer start failed", { error: message });
             }
+
+            return { provides: { pluginPort } };
           },
         },
       },
@@ -915,7 +916,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
 
       [DELETE_WORKSPACE_OPERATION_ID]: {
         delete: {
-          handler: async (ctx: HookContext): Promise<DeleteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
@@ -930,14 +931,14 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
               });
             }
 
-            return {};
+            return { result: {} };
           },
         },
       },
 
       [VSCODE_SHOW_MESSAGE_OPERATION_ID]: {
         show: {
-          handler: async (ctx: HookContext): Promise<ShowHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShowHookResult>> => {
             if (!io) {
               throw new Error("Plugin server not available");
             }
@@ -947,14 +948,16 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
             const { type, message, hint, options: msgOptions, timeoutMs } = intent.payload;
 
             return {
-              result: await handleShowMessage(
-                workspacePath,
-                type,
-                message,
-                hint,
-                msgOptions,
-                timeoutMs
-              ),
+              result: {
+                result: await handleShowMessage(
+                  workspacePath,
+                  type,
+                  message,
+                  hint,
+                  msgOptions,
+                  timeoutMs
+                ),
+              },
             };
           },
         },
@@ -962,7 +965,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
 
       [VSCODE_COMMAND_OPERATION_ID]: {
         execute: {
-          handler: async (ctx: HookContext): Promise<ExecuteHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ExecuteHookResult>> => {
             if (!io) {
               throw new Error("Plugin server not available");
             }
@@ -976,7 +979,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
               throw new Error(commandResult.error);
             }
 
-            return { result: commandResult.data };
+            return { result: { result: commandResult.data } };
           },
         },
       },

--- a/src/modules/posix-process-cleanup-module.ts
+++ b/src/modules/posix-process-cleanup-module.ts
@@ -12,7 +12,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Logger } from "../boundaries/platform/logging-types";
 import type { ProcessRunner, ProcessResult } from "../boundaries/platform/process";
 import {
@@ -157,25 +157,25 @@ export function createPosixProcessCleanupModule(deps: PosixProcessCleanupModuleD
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         release: {
-          handler: async (ctx: HookContext): Promise<ReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ReleaseHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
             if (payload.force) {
-              return {};
+              return { result: {} };
             }
 
             await runCwdReleaseKill(deps, workspacePath, "deletion");
-            return {};
+            return { result: {} };
           },
         },
       },
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         release: {
-          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<HibernateReleaseHookResult>> => {
             const { workspacePath } = ctx as HibernatePipelineHookInput;
             await runCwdReleaseKill(deps, workspacePath, "hibernation");
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -37,6 +37,7 @@ import { APP_START_OPERATION_ID } from "../../intents/app-start";
 import type { ShowUIHookResult } from "../../intents/app-start";
 import { SETUP_OPERATION_ID, EVENT_SETUP_PROGRESS, EVENT_SETUP_ERROR } from "../../intents/setup";
 import type { AgentSelectionHookContext } from "../../intents/setup";
+import type { HookOutput } from "../../intents/lib/operation";
 import { EVENT_PROJECT_OPENED } from "../../intents/open-project";
 import { EVENT_PROJECT_CLOSED, CLOSE_PROJECT_OPERATION_ID } from "../../intents/close-project";
 import type { CloseConfirmHookResult } from "../../intents/close-project";
@@ -1100,9 +1101,11 @@ describe("PresentationModule - startup flow", () => {
     const module = createPresentationModule(deps);
     connect(deps);
 
-    const result = (await runHook(module, APP_START_OPERATION_ID, "show-ui", {
-      intent: { type: "app:start", payload: {} },
-    })) as ShowUIHookResult;
+    const result = (
+      (await runHook(module, APP_START_OPERATION_ID, "show-ui", {
+        intent: { type: "app:start", payload: {} },
+      })) as HookOutput<ShowUIHookResult>
+    ).result!;
     await flush();
 
     expect(typeof result.waitForRetry).toBe("function");
@@ -1193,10 +1196,10 @@ describe("PresentationModule - startup flow", () => {
 
     // The user picks opencode; the parked hook resolves.
     emitUiEvent(deps, { kind: "agent-selected", agent: "opencode" });
-    await pending;
+    const output = await pending;
 
-    // provides() exposes the chosen agent as the agentType capability.
-    expect(handlerDecl.provides!()).toEqual({ agentType: "opencode" });
+    // The handler returns the chosen agent as the agentType capability.
+    expect(output).toEqual({ provides: { agentType: "opencode" } });
   });
 
   it("app:setup hide-ui returns to the boot-splash phase", async () => {
@@ -1245,9 +1248,11 @@ describe("PresentationModule - startup flow", () => {
     const deps = createDeps();
     const module = createPresentationModule(deps);
     connect(deps);
-    const result = (await runHook(module, APP_START_OPERATION_ID, "show-ui", {
-      intent: { type: "app:start", payload: {} },
-    })) as ShowUIHookResult;
+    const result = (
+      (await runHook(module, APP_START_OPERATION_ID, "show-ui", {
+        intent: { type: "app:start", payload: {} },
+      })) as HookOutput<ShowUIHookResult>
+    ).result!;
 
     let resolved = false;
     void result.waitForRetry!().then(() => {
@@ -1291,7 +1296,7 @@ describe("PresentationModule - startup flow", () => {
     });
 
     // The parked promise resolves (defaulting to the first option) — no hang.
-    await expect(pending).resolves.toBeUndefined();
+    await expect(pending).resolves.toEqual({ provides: { agentType: "claude" } });
   });
 });
 
@@ -1319,9 +1324,11 @@ describe("PresentationModule - close confirm", () => {
       ...(input.remoteUrl !== undefined && { remoteUrl: input.remoteUrl }),
       workspaces,
     };
-    return module.hooks![CLOSE_PROJECT_OPERATION_ID]!["confirm"]!.handler(
-      hookInput as never
-    ) as Promise<CloseConfirmHookResult>;
+    return (
+      module.hooks![CLOSE_PROJECT_OPERATION_ID]!["confirm"]!.handler(hookInput as never) as Promise<
+        HookOutput<CloseConfirmHookResult>
+      >
+    ).then((output) => output.result!);
   }
 
   function buttonLabel(config: { sections: readonly unknown[] }): string | undefined {

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -29,7 +29,7 @@
 
 import type { IntentModule, EventDeclarations } from "../../intents/lib/module";
 import type { DomainEvent } from "../../intents/lib/types";
-import type { HookContext } from "../../intents/lib/operation";
+import type { HookContext, HookOutput } from "../../intents/lib/operation";
 import { ANY_VALUE } from "../../intents/lib/operation";
 import type { IDispatcher } from "../../intents/lib/dispatcher";
 import type { Logging, LoggerName, LogContext } from "../../boundaries/platform/logging";
@@ -1269,7 +1269,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * through the backend model (interlock: keeping the cloned repository
    * unchecks remove-all; deleting it forces remove-all on).
    */
-  async function confirmClose(ctx: HookContext): Promise<CloseConfirmHookResult> {
+  async function confirmClose(ctx: HookContext): Promise<HookOutput<CloseConfirmHookResult>> {
     const input = ctx as CloseConfirmHookInput;
     const isRemote = input.remoteUrl !== undefined;
     const state: CloseConfirmState = { removeAll: false, keepRepo: false };
@@ -1295,12 +1295,14 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       if (event.kind !== "dismiss" && event.actionId === "close") {
         const shouldDeleteRepo = isRemote && !state.keepRepo;
         return {
-          removeAll: state.removeAll || shouldDeleteRepo,
-          removeLocalRepo: shouldDeleteRepo,
+          result: {
+            removeAll: state.removeAll || shouldDeleteRepo,
+            removeLocalRepo: shouldDeleteRepo,
+          },
         };
       }
       // Cancel button or Escape.
-      return { canceled: true };
+      return { result: { canceled: true } };
     } finally {
       unsubscribe();
       handle.close();
@@ -1317,14 +1319,16 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * waitForRetry hook it needs for the setup retry loop. The promise resolves
    * when the user emits `setup-retry` (preserving app-start.ts's loop exactly).
    */
-  async function appStartShowUi(): Promise<ShowUIHookResult> {
+  async function appStartShowUi(): Promise<HookOutput<ShowUIHookResult>> {
     startupPhase = "starting";
     scheduleUpdate();
     return {
-      waitForRetry: () =>
-        new Promise<void>((resolve) => {
-          retryResolve = resolve;
-        }),
+      result: {
+        waitForRetry: () =>
+          new Promise<void>((resolve) => {
+            retryResolve = resolve;
+          }),
+      },
     };
   }
 
@@ -1357,13 +1361,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
 
   /**
    * app:setup `agent-selection`: show the picker and park until the user emits
-   * `agent-selected`. The chosen agent is exposed as the `agentType` capability
+   * `agent-selected`. The chosen agent is returned as the `agentType` capability
    * (same contract the view-module hook provided). The handler awaits the pick
-   * so `provides` reads the populated value.
+   * before returning so the provided value is populated.
    */
-  let chosenAgent: LifecycleAgentType | undefined;
-  async function setupAgentSelection(ctx: HookContext): Promise<void> {
-    chosenAgent = undefined;
+  async function setupAgentSelection(ctx: HookContext): Promise<HookOutput> {
     const { availableAgents } = ctx as AgentSelectionHookContext;
     agentOptions = availableAgents;
     startupPhase = "agent-selection";
@@ -1372,8 +1374,8 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     const agent = await new Promise<LifecycleAgentType>((resolve) => {
       agentSelectionResolve = resolve;
     });
-    chosenAgent = agent;
     logger.info("Agent selected", { agent });
+    return { provides: { agentType: agent } };
   }
 
   /** app:setup `hide-ui`: return to the boot-splash phase. */
@@ -1419,9 +1421,6 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       [SETUP_OPERATION_ID]: {
         "show-ui": { handler: setupShowUi },
         "agent-selection": {
-          provides: () => ({
-            ...(chosenAgent !== undefined && { agentType: chosenAgent }),
-          }),
           handler: setupAgentSelection,
         },
         "hide-ui": { handler: setupHideUi },

--- a/src/modules/remote-project-module.integration.test.ts
+++ b/src/modules/remote-project-module.integration.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { HookContext, ResolvedHooks, HookResult } from "../intents/lib/operation";
+import type { HookContext, ResolvedHooks, HookResult, HookOutput } from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
@@ -54,9 +54,11 @@ function resolveHooksFromModule(module: IntentModule, operationId: string): Reso
         return { results: [], errors: [], capabilities: {} };
       }
       try {
-        const result = await hookHandler.handler(ctx);
-        // Filter out undefined results to match Dispatcher behavior (undefined = "not handled")
-        const results = result !== undefined ? [result as T] : [];
+        const output = await hookHandler.handler(ctx);
+        // Unwrap HookOutput.result; filter out undefined/null to match Dispatcher
+        // behavior (undefined/null = "not handled")
+        const result = (output as HookOutput<T> | undefined)?.result;
+        const results: T[] = result !== undefined && result !== null ? [result] : [];
         return { results, errors: [], capabilities: {} };
       } catch (error) {
         return { results: [], errors: [error as Error], capabilities: {} };

--- a/src/modules/remote-project-module.ts
+++ b/src/modules/remote-project-module.ts
@@ -13,7 +13,7 @@
 import * as crypto from "node:crypto";
 import nodePath from "path";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { IGitClient } from "../boundaries/platform/git-client";
 import type { PathProvider } from "../boundaries/platform/path-provider";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
@@ -69,13 +69,13 @@ export function createRemoteProjectModule(deps: {
       // -----------------------------------------------------------------------
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult | undefined> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const intent = ctx.intent as OpenProjectIntent;
             const { git } = intent.payload;
             const { report } = ctx as ResolveHookInput;
 
             if (!git) {
-              return undefined;
+              return {};
             }
 
             const expanded = expandGitUrl(git);
@@ -95,8 +95,10 @@ export function createRemoteProjectModule(deps: {
                 existingPath: gitPath.toString(),
               });
               return {
-                projectPath: gitPath.toString(),
-                remoteUrl: expanded,
+                result: {
+                  projectPath: gitPath.toString(),
+                  remoteUrl: expanded,
+                },
               };
             } catch {
               // Not found — clone
@@ -114,7 +116,7 @@ export function createRemoteProjectModule(deps: {
             // No saveProject call — LocalProjectModule.register handles persistence
             // with remoteUrl from context
 
-            return { projectPath: gitPath.toString(), remoteUrl: expanded };
+            return { result: { projectPath: gitPath.toString(), remoteUrl: expanded } };
           },
         },
       },
@@ -126,18 +128,18 @@ export function createRemoteProjectModule(deps: {
         // close: filesystem cleanup only — delete cloned directory if requested
         // Uses remoteUrl from hook context (provided by resolve-project results)
         close: {
-          handler: async (ctx: HookContext): Promise<CloseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<CloseHookResult>> => {
             const { projectPath, removeLocalRepo, remoteUrl } = ctx as CloseHookInput;
 
             if (!removeLocalRepo || !remoteUrl) {
-              return {};
+              return { result: {} };
             }
 
             // Delete the clone directory (parent of gitPath, e.g. remotes/<url-hash>/)
             const cloneDir = nodePath.dirname(new Path(projectPath).toString());
             await fs.rm(cloneDir, { recursive: true, force: true });
 
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -13,7 +13,7 @@
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import type { Operation, OperationContext, HookOutput } from "../intents/lib/operation";
 import type { Intent } from "../intents/lib/types";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import type { IntentModule } from "../intents/lib/module";
@@ -214,9 +214,11 @@ async function resolveActive(module: IntentModule, workspacePath: string): Promi
     intent: { type: "workspace:resolve", payload: { workspacePath } },
     workspacePath,
   } as unknown as ResolveHookInput;
-  const result = (await module.hooks![RESOLVE_WORKSPACE_OPERATION_ID]!.resolve!.handler(
-    hookCtx
-  )) as ResolveHookResult;
+  const result = (
+    (await module.hooks![RESOLVE_WORKSPACE_OPERATION_ID]!.resolve!.handler(
+      hookCtx
+    )) as HookOutput<ResolveHookResult>
+  ).result!;
   return result.active === true;
 }
 

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -17,7 +17,7 @@
 
 import type { DialogBoundary } from "../boundaries/shell/dialog";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { DomainEvent } from "../intents/lib/types";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
 import type { Logger } from "../boundaries/platform/logging";
@@ -119,8 +119,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [APP_START_OPERATION_ID]: {
         init: {
           requires: { "app-ready": true },
-          provides: () => ({ "ui-ready": true }),
-          handler: async (): Promise<void> => {
+          handler: async (): Promise<HookOutput> => {
             // Disable application menu
             if (deps.menuLayer) {
               deps.menuLayer.setApplicationMenu(null);
@@ -145,6 +144,8 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
 
             // Focus UI
             viewManager.focus();
+
+            return { provides: { "ui-ready": true } };
           },
         },
       },
@@ -161,9 +162,9 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<ResolveHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
             const { workspacePath } = ctx as ResolveHookInput;
-            return { active: activeWorkspacePath === workspacePath };
+            return { result: { active: activeWorkspacePath === workspacePath } };
           },
         },
       },
@@ -173,8 +174,8 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [GET_ACTIVE_WORKSPACE_OPERATION_ID]: {
         get: {
-          handler: async (): Promise<GetActiveWorkspaceHookResult> => {
-            return { workspaceRef: cachedActiveRef };
+          handler: async (): Promise<HookOutput<GetActiveWorkspaceHookResult>> => {
+            return { result: { workspaceRef: cachedActiveRef } };
           },
         },
       },
@@ -187,22 +188,22 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         activate: {
-          handler: async (ctx: HookContext): Promise<SwitchWorkspaceHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SwitchWorkspaceHookResult>> => {
             const { workspacePath, active } = ctx as ActivateHookInput;
 
             // Deselect: clear the active-workspace bookkeeping so a later
             // switch back to it isn't short-circuited as already-active.
             if (workspacePath === null) {
               activeWorkspacePath = null;
-              return {};
+              return { result: {} };
             }
 
             if (active) {
-              return {};
+              return { result: {} };
             }
 
             activeWorkspacePath = workspacePath;
-            return { resolvedPath: workspacePath };
+            return { result: { resolvedPath: workspacePath } };
           },
         },
       },
@@ -215,12 +216,12 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<ShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath, active } = ctx as DeletePipelineHookInput;
             if (activeWorkspacePath === workspacePath) {
               activeWorkspacePath = null;
             }
-            return { ...(active && { wasActive: true }) };
+            return { result: { ...(active && { wasActive: true }) } };
           },
         },
       },
@@ -233,12 +234,12 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
-          handler: async (ctx: HookContext): Promise<HibernateShutdownHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<HibernateShutdownHookResult>> => {
             const { workspacePath } = ctx as HibernatePipelineHookInput;
             if (activeWorkspacePath === workspacePath) {
               activeWorkspacePath = null;
             }
-            return {};
+            return { result: {} };
           },
         },
       },
@@ -248,17 +249,17 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [OPEN_PROJECT_OPERATION_ID]: {
         "select-folder": {
-          handler: async (): Promise<SelectFolderHookResult> => {
+          handler: async (): Promise<HookOutput<SelectFolderHookResult>> => {
             if (!deps.dialogLayer) {
-              return { folderPath: null };
+              return { result: { folderPath: null } };
             }
             const result = await deps.dialogLayer.showOpenDialog({
               properties: ["openDirectory"] as const,
             });
             if (result.canceled || result.filePaths.length === 0) {
-              return { folderPath: null };
+              return { result: { folderPath: null } };
             }
-            return { folderPath: result.filePaths[0]!.toString() };
+            return { result: { folderPath: result.filePaths[0]!.toString() } };
           },
         },
       },

--- a/src/modules/windows-file-lock-module.ts
+++ b/src/modules/windows-file-lock-module.ts
@@ -12,7 +12,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Logger } from "../boundaries/platform/logging-types";
 import type { ProcessRunner } from "../boundaries/platform/process";
 import type { BlockingProcess } from "../shared/api/types";
@@ -231,20 +231,20 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
     hooks: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         release: {
-          handler: async (ctx: HookContext): Promise<ReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ReleaseHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
             if (payload.force) {
-              return {};
+              return { result: {} };
             }
 
             await runCwdReleaseKill(deps, workspacePath, "deletion");
-            return {};
+            return { result: {} };
           },
         },
         detect: {
-          handler: async (ctx: HookContext): Promise<DetectHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<DetectHookResult>> => {
             const { workspacePath } = ctx as DeletePipelineHookInput;
 
             try {
@@ -255,36 +255,36 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
                 "Detect",
                 deps.logger
               );
-              return { blockingProcesses: detected };
+              return { result: { blockingProcesses: detected } };
             } catch (error) {
               deps.logger.warn("Detection failed", {
                 workspacePath,
                 error: getErrorMessage(error),
               });
-              return { blockingProcesses: [] };
+              return { result: { blockingProcesses: [] } };
             }
           },
         },
         flush: {
-          handler: async (ctx: HookContext): Promise<FlushHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<FlushHookResult>> => {
             const { blockingPids } = ctx as FlushHookInput;
             if (blockingPids.length > 0) {
               try {
                 await killBlockingProcesses(deps.processRunner, [...blockingPids], deps.logger);
               } catch (error) {
-                return { error: getErrorMessage(error) };
+                return { result: { error: getErrorMessage(error) } };
               }
             }
-            return {};
+            return { result: {} };
           },
         },
       },
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         release: {
-          handler: async (ctx: HookContext): Promise<HibernateReleaseHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<HibernateReleaseHookResult>> => {
             const { workspacePath } = ctx as HibernatePipelineHookInput;
             await runCwdReleaseKill(deps, workspacePath, "hibernation");
-            return {};
+            return { result: {} };
           },
         },
       },

--- a/src/modules/workspace-agent-resolver-module.ts
+++ b/src/modules/workspace-agent-resolver-module.ts
@@ -9,7 +9,7 @@
  *     `requires: { agent: provider.type }`.
  */
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext, HookHandler } from "../intents/lib/operation";
+import type { HookContext, HookHandler, HookOutput } from "../intents/lib/operation";
 import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provider";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
 import type { ConfigAgentType } from "../boundaries/platform/config";
@@ -88,14 +88,14 @@ function makeResolverHandler(
   deps: WorkspaceAgentResolverDeps,
   getWorkspacePath: (ctx: HookContext) => string | undefined
 ): HookHandler {
-  let resolved: AgentType | null = null;
   return {
-    provides: () => (resolved !== null ? { agent: resolved } : {}),
-    handler: async (ctx: HookContext): Promise<void> => {
-      resolved = null;
+    handler: async (ctx: HookContext): Promise<HookOutput> => {
       const workspacePath = getWorkspacePath(ctx);
-      if (workspacePath === undefined) return;
-      resolved = await resolveAgent(workspacePath, deps);
+      if (workspacePath === undefined) return {};
+      const resolved = await resolveAgent(workspacePath, deps);
+      // Omit the capability entirely when unresolved (null) — a present-but-null
+      // `agent` would differ from "absent" for key-presence checks.
+      return resolved !== null ? { provides: { agent: resolved } } : {};
     },
   };
 }
@@ -103,15 +103,12 @@ function makeResolverHandler(
 export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverDeps): IntentModule {
   // workspace:open is special — the intent payload may carry a per-workspace
   // override that must be persisted before downstream hooks read it.
-  let openResolved: AgentType | null = null;
   const openSetupHandler: HookHandler = {
-    provides: () => (openResolved !== null ? { agent: openResolved } : {}),
-    handler: async (ctx: HookContext): Promise<void> => {
-      openResolved = null;
+    handler: async (ctx: HookContext): Promise<HookOutput> => {
       const setupCtx = ctx as SetupHookInput;
       const intent = ctx.intent as OpenWorkspaceIntent;
       const { workspacePath } = setupCtx;
-      if (!workspacePath) return;
+      if (!workspacePath) return {};
 
       const defaultAgent = deps.agentConfig.get();
       // Only the typed arms ("claude"/"opencode") pin a backend; "default" and
@@ -137,7 +134,8 @@ export function createWorkspaceAgentResolverModule(deps: WorkspaceAgentResolverD
         }
       }
 
-      openResolved = await resolveAgent(workspacePath, deps);
+      const openResolved = await resolveAgent(workspacePath, deps);
+      return openResolved !== null ? { provides: { agent: openResolved } } : {};
     },
   };
 

--- a/src/modules/workspace-selection-module.integration.test.ts
+++ b/src/modules/workspace-selection-module.integration.test.ts
@@ -27,6 +27,7 @@ import {
   registerTestInfrastructure,
 } from "../intents/operations.test-utils";
 import type { IntentModule } from "../intents/lib/module";
+import type { HookOutput } from "../intents/lib/operation";
 import type { DomainEvent } from "../intents/lib/types";
 import { createWorkspaceSelectionModule } from "./workspace-selection-module";
 import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
@@ -103,8 +104,8 @@ function createTestSetup(opts: { candidates: WorkspaceCandidate[] }): TestSetup 
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "find-candidates": {
-          handler: async (): Promise<FindCandidatesHookResult> => {
-            return { candidates: opts.candidates };
+          handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
+            return { result: { candidates: opts.candidates } };
           },
         },
       },

--- a/src/modules/workspace-selection-module.ts
+++ b/src/modules/workspace-selection-module.ts
@@ -9,7 +9,7 @@
  */
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { DomainEvent } from "../intents/lib/types";
 import { SWITCH_WORKSPACE_OPERATION_ID, selectNextWorkspace } from "../intents/switch-workspace";
 import type {
@@ -38,10 +38,10 @@ export function createWorkspaceSelectionModule(): IntentModule {
     hooks: {
       [SWITCH_WORKSPACE_OPERATION_ID]: {
         "select-next": {
-          handler: async (ctx: HookContext): Promise<SelectNextHookResult> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<SelectNextHookResult>> => {
             const { currentPath, candidates } = ctx as unknown as SelectNextHookInput;
             const result = selectNextWorkspace(currentPath, candidates, scorer);
-            return result ? { selected: result } : {};
+            return result ? { result: { selected: result } } : { result: {} };
           },
         },
       },


### PR DESCRIPTION
Reshape the `HookHandler` contract so a handler returns a `HookOutput` (`{ result?, provides? }`) instead of declaring a `provides: () => …` closure that the dispatcher invokes host-side. Capabilities are now plain returned data, so a hook handler executing remotely can ship them across a wire and the host dispatcher merges from that data — the prerequisite for federating the dispatcher across a host/remote boundary.

- `operation.ts`: add `HookOutput<T>`; `handler` returns `Promise<HookOutput<T> | void>`; remove the `provides` field.
- `dispatcher.ts`: coerce `void → {}`, lift `output.result` into `results[]` (keeping the null/undefined skip), merge `output.provides` skipping `undefined`-valued keys so a capability is only "present" with a defined value (preserves `pluginPort: null`, which code-server's `ANY_VALUE` gate depends on).
- All 10 capability providers return `{ provides: … }` (`agent-module` setup returns `{ result, provides }`); the captured-`let` + reset-then-set idiom is removed.
- ~65 result-returning handlers wrap their returns in `{ result: … }`.
- Tests, mock handlers, and direct-invocation assertions migrated; `docs/INTENTS.md` updated to the returned-data model.

In-process refactor only; the wire transport is follow-on work this unblocks. All tests (3430), type-check, lint, and format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)