### PR TITLE
fix: hibernation view does not show sidebar

### DIFF
--- a/src/boundaries/shell/ui-view-manager.ts
+++ b/src/boundaries/shell/ui-view-manager.ts
@@ -61,6 +61,16 @@ const FOCUS_ACTIVE_FRAME = `window.__chFocusActiveFrame && window.__chFocusActiv
 const ACTIVE_FRAME_RECT = `window.__chActiveFrameRect ? window.__chActiveFrameRect() : null`;
 const RELOAD_FRAMES = `window.__chReloadFrames && window.__chReloadFrames()`;
 
+// Resolves after two animation frames — one committed paint of the current UI
+// state. executeJavaScript awaits the returned promise, giving main a paint
+// barrier to sequence a screenshot after a state-driven layout change (e.g.
+// the sidebar collapsing out of a hibernation capture) has actually rendered.
+const UI_PAINT_BARRIER = `new Promise(function (resolve) {
+  requestAnimationFrame(function () {
+    requestAnimationFrame(function () { resolve(true); });
+  });
+})`;
+
 const ALLOWED_PERMISSIONS = new Set([
   "clipboard-read",
   "clipboard-sanitized-write",
@@ -334,6 +344,16 @@ export class UiViewManager implements IViewManager {
   // ---------------------------------------------------------------------------
   // Capture
   // ---------------------------------------------------------------------------
+
+  async waitForUIPaint(): Promise<void> {
+    if (!this.uiViewHandle || !this.isUIAvailable()) return;
+    try {
+      await this.viewLayer.executeJavaScript(this.uiViewHandle, UI_PAINT_BARRIER);
+    } catch {
+      // UI may be mid-load; best-effort — a missed paint barrier at worst
+      // captures the pre-collapse frame, never fails the hibernation.
+    }
+  }
 
   async captureActiveWorkspaceView(): Promise<Buffer | null> {
     if (!this.uiViewHandle || !this.isUIAvailable()) return null;

--- a/src/boundaries/shell/view-manager.interface.ts
+++ b/src/boundaries/shell/view-manager.interface.ts
@@ -112,6 +112,15 @@ export interface IViewManager {
   reloadFrames(): void;
 
   /**
+   * Resolve after the UI renderer has committed a paint for the current
+   * UiState (waits two animation frames). Used to sequence a screenshot after
+   * a state-driven layout change — collapsing the sidebar before a hibernation
+   * capture — has actually rendered. Best-effort: resolves immediately if the
+   * UI view is unavailable or mid-load.
+   */
+  waitForUIPaint(): Promise<void>;
+
+  /**
    * Capture a PNG screenshot of the active workspace iframe, by clipping a
    * full-view capture to the iframe's bounding rect (no API exists to
    * capture an out-of-process iframe directly).

--- a/src/boundaries/shell/view-manager.test-utils.ts
+++ b/src/boundaries/shell/view-manager.test-utils.ts
@@ -50,6 +50,7 @@ export function createMockViewManager(options?: CreateMockViewManagerOptions): M
     },
     focus: vi.fn(),
     reloadFrames: vi.fn(),
+    waitForUIPaint: vi.fn().mockResolvedValue(undefined),
     captureActiveWorkspaceView: vi.fn().mockResolvedValue(null),
     destroy: vi.fn(),
   } as IViewManager;

--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -22,7 +22,9 @@ import {
   EVENT_WORKSPACE_HIBERNATE_FAILED,
   HIBERNATED_METADATA_KEY,
   type HibernateWorkspaceIntent,
+  type PrepareCaptureHookResult,
   type CaptureHookResult,
+  type CleanupCaptureHookResult,
   type HibernateShutdownHookResult,
   type HibernateReleaseHookResult,
   type HibernatePipelineHookInput,
@@ -169,6 +171,44 @@ function createHibernateHookModule(
             if (opts.releaseThrows) {
               throw new Error("release boom");
             }
+            return { result: {} };
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Registers the prepare-capture → capture → cleanup-capture bracket, recording
+ * call order. `captureThrows` exercises the operation's finally: `collect`
+ * swallows the throw into its errors[] (never rejects), so hibernation still
+ * completes AND cleanup-capture still runs.
+ */
+function createCaptureBracketModule(
+  recorder: Recorder,
+  opts: { captureThrows?: boolean } = {}
+): IntentModule {
+  return {
+    name: "test-capture-bracket",
+    hooks: {
+      [HIBERNATE_WORKSPACE_OPERATION_ID]: {
+        "prepare-capture": {
+          handler: async (): Promise<HookOutput<PrepareCaptureHookResult>> => {
+            recorder.callOrder.push("prepare-capture");
+            return { result: {} };
+          },
+        },
+        capture: {
+          handler: async (): Promise<HookOutput<CaptureHookResult>> => {
+            recorder.callOrder.push("capture");
+            if (opts.captureThrows) throw new Error("capture boom");
+            return { result: {} };
+          },
+        },
+        "cleanup-capture": {
+          handler: async (): Promise<HookOutput<CleanupCaptureHookResult>> => {
+            recorder.callOrder.push("cleanup-capture");
             return { result: {} };
           },
         },
@@ -381,6 +421,50 @@ describe("workspace:hibernate", () => {
       recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATE_FAILED)
     ).toBeUndefined();
     expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
+  });
+
+  it("brackets the capture hook: prepare-capture → capture → cleanup-capture", async () => {
+    const { dispatcher, recorder, waitForBackground } = buildHarness((r) => [
+      createCaptureBracketModule(r),
+    ]);
+
+    await dispatcher.dispatch({
+      type: INTENT_HIBERNATE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    } as HibernateWorkspaceIntent);
+    await waitForBackground();
+
+    // Foreground: the sidebar is collapsed (prepare), the screenshot is taken
+    // (capture), the sidebar is restored (cleanup) — all before metadata flips.
+    expect(recorder.callOrder).toEqual([
+      "prepare-capture",
+      "capture",
+      "cleanup-capture",
+      "set-metadata:true",
+    ]);
+  });
+
+  it("runs cleanup-capture even when the capture hook throws (finally)", async () => {
+    const { dispatcher, recorder, waitForBackground } = buildHarness((r) => [
+      createCaptureBracketModule(r, { captureThrows: true }),
+    ]);
+
+    await dispatcher.dispatch({
+      type: INTENT_HIBERNATE_WORKSPACE,
+      payload: { workspacePath: WORKSPACE_PATH },
+    } as HibernateWorkspaceIntent);
+    await waitForBackground();
+
+    // capture threw, but cleanup-capture still ran and hibernation completed —
+    // the sidebar can never be left stuck collapsed.
+    expect(recorder.callOrder).toEqual([
+      "prepare-capture",
+      "capture",
+      "cleanup-capture",
+      "set-metadata:true",
+    ]);
+    expect(recorder.metadataWrites).toEqual([{ key: HIBERNATED_METADATA_KEY, value: "true" }]);
+    expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
   });
 
   it("hibernate completes when release throws (best-effort)", async () => {

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -8,7 +8,9 @@
  * Foreground (awaited by callers, ~500 ms):
  * 1. Dispatch workspace:resolve — yields projectPath, workspaceName, active
  * 2. Dispatch project:resolve — projectPath → projectId
- * 3. "capture" hook — best-effort screenshot capture
+ * 3. "prepare-capture" → "capture" (in a try) → "cleanup-capture" (finally)
+ *    hooks — collapse the sidebar out of the shot, take the best-effort
+ *    screenshot, then always restore the sidebar
  * 4. Dispatch workspace:set-metadata to persist `hibernated="true"` (this is
  *    what makes the renderer show HibernatedOverlay; switch-workspace's
  *    `c.hibernated` filter also begins excluding the workspace immediately)
@@ -98,7 +100,7 @@ export const EVENT_WORKSPACE_HIBERNATE_FAILED = "workspace:hibernate-failed" as 
 // Hook Types
 // =============================================================================
 
-/** Input for capture/shutdown/release hook handlers. */
+/** Input for prepare-capture/capture/cleanup-capture/shutdown/release hook handlers. */
 export interface HibernatePipelineHookInput extends HookContext {
   readonly projectPath: string;
   readonly workspacePath: string;
@@ -107,8 +109,21 @@ export interface HibernatePipelineHookInput extends HookContext {
   readonly active: boolean;
 }
 
+/**
+ * Per-handler result for the "prepare-capture" hook point. Runs before the
+ * screenshot so the presenter can collapse the sidebar out of the capture.
+ */
+export type PrepareCaptureHookResult = Record<string, never>;
+
 /** Per-handler result for the "capture" hook point. */
 export type CaptureHookResult = Record<string, never>;
+
+/**
+ * Per-handler result for the "cleanup-capture" hook point. Runs in the
+ * operation's `finally` (even if capture throws) so the presenter always
+ * restores the sidebar and can never leave it stuck collapsed.
+ */
+export type CleanupCaptureHookResult = Record<string, never>;
 
 /** Per-handler result for the "shutdown" hook point. */
 export type HibernateShutdownHookResult = Record<string, never>;
@@ -164,7 +179,17 @@ export class HibernateWorkspaceOperation implements Operation<
       // Capture screenshot (best-effort, errors logged but not propagated).
       // Must complete in the foreground so the overlay has a file:// URL to
       // load when the metadata flip below triggers the renderer.
-      await ctx.hooks.collect<CaptureHookResult>("capture", hookCtx);
+      //
+      // "prepare-capture" collapses the sidebar out of the shot (the presenter
+      // owns the sidebar UI state); "cleanup-capture" restores it. Cleanup runs
+      // in `finally` so a stuck capturing flag can never leave the sidebar
+      // permanently collapsed, even if the capture hook throws.
+      await ctx.hooks.collect<PrepareCaptureHookResult>("prepare-capture", hookCtx);
+      try {
+        await ctx.hooks.collect<CaptureHookResult>("capture", hookCtx);
+      } finally {
+        await ctx.hooks.collect<CleanupCaptureHookResult>("cleanup-capture", hookCtx);
+      }
 
       // Persist hibernated flag via existing set-metadata pipeline. This is
       // what makes the renderer swap in HibernatedOverlay via the

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -51,6 +51,10 @@ import {
   EVENT_WORKSPACE_DELETION_PROGRESS,
 } from "../../intents/delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../../intents/switch-workspace";
+import {
+  HIBERNATE_WORKSPACE_OPERATION_ID,
+  type HibernatePipelineHookInput,
+} from "../../intents/hibernate-workspace";
 import { EVENT_AGENT_STATUS_UPDATED } from "../../intents/update-agent-status";
 import { EVENT_METADATA_CHANGED } from "../../intents/set-metadata";
 import { EVENT_SHORTCUT_ACTIVE_CHANGED } from "../../intents/set-shortcut-active";
@@ -318,6 +322,7 @@ describe("PresentationModule - ui:state snapshots", () => {
         main: { kind: "starting" },
         theme: "dark",
         mode: "dialog",
+        capturing: false,
         dialogs: [],
         notifications: [],
       },
@@ -338,6 +343,7 @@ describe("PresentationModule - ui:state snapshots", () => {
       main: { kind: "creation" },
       theme: "dark",
       mode: "hover",
+      capturing: false,
       dialogs: [],
       notifications: [],
     });
@@ -380,6 +386,7 @@ describe("PresentationModule - ui:state snapshots", () => {
       main: { kind: "workspace", frameKey: `${PROJECT_ID}/main` },
       theme: "dark",
       mode: "workspace",
+      capturing: false,
       dialogs: [],
       notifications: [],
     });
@@ -1567,6 +1574,88 @@ describe("PresentationModule - UI mode", () => {
     module.dialog({ sections: [] }, { surface: "panel" });
     await flush();
     expect(mode(deps)).toBe("workspace");
+  });
+});
+
+// =============================================================================
+// Hibernation capture hooks (collapse the sidebar out of the screenshot)
+// =============================================================================
+
+describe("PresentationModule - hibernation capture hooks", () => {
+  function captureInput(active: boolean): HibernatePipelineHookInput {
+    return {
+      intent: { type: "workspace:hibernate", payload: {} },
+      projectPath: PROJECT_PATH,
+      workspacePath: `${PROJECT_PATH}/.worktrees/main`,
+      projectId: PROJECT_ID,
+      workspaceName: "main" as WorkspaceName,
+      active,
+    } as HibernatePipelineHookInput;
+  }
+
+  function prepare(module: UiPresenter, active: boolean): Promise<unknown> {
+    return module.hooks![HIBERNATE_WORKSPACE_OPERATION_ID]!["prepare-capture"]!.handler(
+      captureInput(active)
+    );
+  }
+
+  function cleanup(module: UiPresenter, active: boolean): Promise<unknown> {
+    return module.hooks![HIBERNATE_WORKSPACE_OPERATION_ID]!["cleanup-capture"]!.handler(
+      captureInput(active)
+    );
+  }
+
+  /** Active workspace + shortcut mode: the exact state hibernate fires from. */
+  async function activeInShortcutMode(deps: Deps): Promise<UiPresenter> {
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("main", { url: "http://127.0.0.1:1/main" });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
+    await emit(module, EVENT_SHORTCUT_ACTIVE_CHANGED, { active: true });
+    await flush();
+    return module;
+  }
+
+  it("prepare-capture flips capturing on and waits for the collapsed paint", async () => {
+    const deps = createDeps();
+    const module = await activeInShortcutMode(deps);
+    expect(lastSnapshot(deps).capturing).toBe(false);
+    expect(lastSnapshot(deps).mode).toBe("shortcut");
+
+    await prepare(module, true);
+
+    // The snapshot carries capturing=true (the renderer folds this into an
+    // always-collapsed sidebar) while mode stays "shortcut", and main awaited
+    // the paint barrier so the following capture sees the collapsed sidebar.
+    expect(lastSnapshot(deps).capturing).toBe(true);
+    expect(lastSnapshot(deps).mode).toBe("shortcut");
+    expect(deps.viewManager.waitForUIPaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleanup-capture restores capturing to false", async () => {
+    const deps = createDeps();
+    const module = await activeInShortcutMode(deps);
+    await prepare(module, true);
+    expect(lastSnapshot(deps).capturing).toBe(true);
+
+    await cleanup(module, true);
+    await flush();
+
+    expect(lastSnapshot(deps).capturing).toBe(false);
+  });
+
+  it("is a no-op for a background (inactive) hibernation", async () => {
+    const deps = createDeps();
+    const module = await activeInShortcutMode(deps);
+    const pushesBefore = snapshots(deps).length;
+
+    await prepare(module, false);
+    await cleanup(module, false);
+    await flush();
+
+    expect(deps.viewManager.waitForUIPaint).not.toHaveBeenCalled();
+    expect(snapshots(deps).length).toBe(pushesBefore);
+    expect(lastSnapshot(deps).capturing).toBe(false);
   });
 });
 

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -103,7 +103,11 @@ import {
 } from "../../intents/shortcut-key";
 import {
   INTENT_HIBERNATE_WORKSPACE,
+  HIBERNATE_WORKSPACE_OPERATION_ID,
   type HibernateWorkspaceIntent,
+  type HibernatePipelineHookInput,
+  type PrepareCaptureHookResult,
+  type CleanupCaptureHookResult,
 } from "../../intents/hibernate-workspace";
 import { INTENT_WAKE_WORKSPACE, type WakeWorkspaceIntent } from "../../intents/wake-workspace";
 import { isShortcutKey, jumpKeyToIndex, type JumpKey } from "../../shared/shortcuts";
@@ -132,7 +136,7 @@ import { getErrorMessage } from "../../shared/error-utils";
 
 export interface PresentationModuleDeps {
   readonly loggingService: Pick<Logging, "createLogger">;
-  readonly viewManager: Pick<IViewManager, "sendToUI" | "onFromUI">;
+  readonly viewManager: Pick<IViewManager, "sendToUI" | "onFromUI" | "waitForUIPaint">;
   readonly windowManager: {
     getTheme(): Theme;
     onThemeChange(callback: (theme: Theme) => void): Unsubscribe;
@@ -420,6 +424,12 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   let shortcutActive = false;
   /** Last settled hover region from the renderer's `hover` ui:event. */
   let hoverRegion: "sidebar" | null = null;
+  /**
+   * True only between the hibernate `prepare-capture` and `cleanup-capture`
+   * hooks, while the active workspace's screenshot is being taken. Forces the
+   * sidebar collapsed in the snapshot so it is not baked into the shot.
+   */
+  let capturing = false;
 
   /** Presenter-assigned opaque workspace identity. Never leaves main except inside UiState. */
   function workspaceKey(projectId: string, workspaceName: string): string {
@@ -644,6 +654,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       main,
       theme,
       mode: buildMode(main),
+      capturing,
       dialogs: dialogs.getSnapshot(),
       notifications: notifications.getSnapshot(),
     };
@@ -1264,6 +1275,38 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   };
 
   /**
+   * The "prepare-capture" hook on workspace:hibernate: collapse the sidebar out
+   * of the hibernation screenshot. Only the visible (active) workspace's iframe
+   * is captured, so this is a no-op for background hibernations. The snapshot is
+   * pushed immediately (not coalesced) and we wait for the renderer to paint the
+   * collapsed sidebar before the "capture" hook runs.
+   */
+  async function prepareCapture(ctx: HookContext): Promise<HookOutput<PrepareCaptureHookResult>> {
+    const { active } = ctx as HibernatePipelineHookInput;
+    if (!active) return {};
+    capturing = true;
+    // Flush synchronously so the capturing snapshot reaches the renderer before
+    // the paint barrier (scheduleUpdate would coalesce it onto a later tick).
+    push();
+    await deps.viewManager.waitForUIPaint();
+    return {};
+  }
+
+  /**
+   * The "cleanup-capture" hook on workspace:hibernate: restore the sidebar after
+   * the screenshot. Runs in the operation's `finally`, so it clears the flag
+   * even if the "capture" hook threw — the sidebar can never stay stuck
+   * collapsed.
+   */
+  async function cleanupCapture(ctx: HookContext): Promise<HookOutput<CleanupCaptureHookResult>> {
+    const { active } = ctx as HibernatePipelineHookInput;
+    if (!active) return {};
+    capturing = false;
+    scheduleUpdate();
+    return {};
+  }
+
+  /**
    * The "confirm" hook on project:close (interactive dispatches only): parks
    * the dispatch on the close confirmation dialog. Checkbox changes round-trip
    * through the backend model (interlock: keeping the cloned repository
@@ -1427,6 +1470,12 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       },
       [CLOSE_PROJECT_OPERATION_ID]: {
         confirm: { handler: confirmClose },
+      },
+      [HIBERNATE_WORKSPACE_OPERATION_ID]: {
+        // Collapse the sidebar out of the hibernation screenshot and restore it
+        // after (cleanup runs in the operation's finally).
+        "prepare-capture": { handler: prepareCapture },
+        "cleanup-capture": { handler: cleanupCapture },
       },
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -180,6 +180,7 @@
     notifications={ui.notifications}
     {mode}
     shortcutModeActive={mode === "shortcut"}
+    capturing={ui.capturing}
     newWorkspaceViewOpen={creationShown}
     onCloseProject={handleCloseProject}
     onSwitchWorkspace={handleSwitchWorkspace}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -25,6 +25,11 @@
     /** The single UI mode from the snapshot (main-owned). */
     mode?: UIMode;
     shortcutModeActive?: boolean;
+    /**
+     * True while main is capturing the hibernation screenshot: force the
+     * sidebar collapsed (overriding mode) so it is not baked into the shot.
+     */
+    capturing?: boolean;
     /** When true, the New workspace view is the current tab (highlight it instead of any workspace). */
     newWorkspaceViewOpen?: boolean;
     onCloseProject: (projectId: string) => void;
@@ -40,6 +45,7 @@
     notifications,
     mode = "workspace",
     shortcutModeActive = false,
+    capturing = false,
     newWorkspaceViewOpen = false,
     onCloseProject,
     onSwitchWorkspace,
@@ -70,7 +76,9 @@
   // - the snapshot mode is anything but "workspace" (hover, shortcut, dialog —
   //   the creation panel maps to hover), OR
   // - there are no workspaces (so user can open a project)
-  const isExpanded = $derived(mode !== "workspace" || totalWorkspaces === 0);
+  // ...unless main is capturing the hibernation screenshot, which forces the
+  // sidebar collapsed so it is not baked into the shot.
+  const isExpanded = $derived(!capturing && (mode !== "workspace" || totalWorkspaces === 0));
 
   // Hover may only initiate expansion when nothing else forces the UI on top
   // (i.e. the snapshot mode is "workspace"); otherwise the sidebar expanding

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -641,6 +641,23 @@ describe("Sidebar component", () => {
       expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
     });
 
+    it("is forced collapsed while capturing, even in an otherwise-expanded mode", () => {
+      // capturing overrides mode: the hibernation screenshot must not bake in
+      // the sidebar. Shortcut mode (the state hibernate fires from) would
+      // normally expand it.
+      const { container } = render(Sidebar, {
+        props: { ...propsWithWorkspaces(), mode: "shortcut", capturing: true },
+      });
+      expect(container.querySelector(".sidebar")).not.toHaveClass("expanded");
+    });
+
+    it("expands again once capturing clears", () => {
+      const { container } = render(Sidebar, {
+        props: { ...propsWithWorkspaces(), mode: "shortcut", capturing: false },
+      });
+      expect(container.querySelector(".sidebar")).toHaveClass("expanded");
+    });
+
     it("emits a sidebar hover event after deliberate hover (trigger depth + open delay)", async () => {
       const { container } = render(Sidebar, { props: propsWithWorkspaces() });
 

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -54,6 +54,7 @@ export function makeUiState(
     main: { kind: "creation" },
     theme: "dark",
     mode: "workspace",
+    capturing: false,
     dialogs: [],
     notifications: [],
     ...overrides,

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -32,6 +32,7 @@ function makeState(workspaces: UiWorkspaceRow[]): UiState {
     main: { kind: "creation" },
     theme: "dark",
     mode: "hover",
+    capturing: false,
     dialogs: [],
     notifications: [],
   };

--- a/src/shared/ui-state.ts
+++ b/src/shared/ui-state.ts
@@ -152,6 +152,15 @@ export interface UiState {
    * eligibility, and z-order all derive from it.
    */
   readonly mode: UIMode;
+  /**
+   * True only while the presenter is capturing the active workspace's
+   * hibernation screenshot. Forces the sidebar to its collapsed resting state
+   * (overriding `mode`) so it is not baked into the screenshot; the existing
+   * `.sidebar:not(.expanded)` rule makes that collapse instant. Main-owned,
+   * set by the hibernate `prepare-capture` hook and always cleared by
+   * `cleanup-capture` (runs in the operation's finally).
+   */
+  readonly capturing: boolean;
   /** Open dialog sessions (modal cards + non-modal panels), in open order. */
   readonly dialogs: readonly UiDialog[];
   /** Open sidebar notifications, in open order. */


### PR DESCRIPTION
Hibernation fires from shortcut mode (Alt+X → h), where the sidebar is expanded over the workspace iframe. The screenshot is a `capturePage` clip of the top-level composite, so the expanded sidebar was baked into the shot (and hid the workspace content behind it).

- Capturing the iframe alone is impossible — Chromium rejects `Page.captureScreenshot` on OOPIF targets (verified by a spike). Instead, collapse the sidebar out of the shot before capturing.
- Add a main-owned `capturing` flag to `UiState`; the Sidebar forces itself collapsed when set (the existing `.sidebar:not(.expanded)` rule makes the collapse instant).
- The hibernate operation brackets the screenshot with `prepare-capture` → `try(capture)` → `finally(cleanup-capture)` hook points. The presenter owns both bracket hooks: prepare flips the flag, flushes the snapshot, and awaits a 2-rAF paint barrier so the collapse has rendered before capture; cleanup clears the flag in the `finally`, so it can never get stuck collapsed.
- Both hooks gate on `active` (no-op for background hibernations).
- Adds a `waitForUIPaint()` view-manager method (rAF barrier via the existing `executeJavaScript` channel).
- Tests: operation-level bracket ordering + cleanup-on-throw, presenter capturing/no-op-when-inactive, Sidebar forced-collapse override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQZXEMrFumzPfFe6YwsVQj