### PR TITLE
fix: sidebar did not auto-scroll to active workspace

### DIFF
--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -64,6 +64,29 @@
     projects.reduce((sum, project) => sum + project.workspaces.length, 0)
   );
 
+  // The snapshot key of the currently-active workspace row (or null when the
+  // creation panel is the current tab). Drives the scroll-into-view effect.
+  const activeWorkspaceKey = $derived(
+    projects.flatMap((project) => project.workspaces).find((workspace) => workspace.active)?.key ??
+      null
+  );
+
+  // The scrollable list container. Bound so the effect below can find the
+  // active row within it and scroll it into view.
+  let contentEl = $state<HTMLElement | null>(null);
+
+  // Keep the active row visible: when the active workspace changes (e.g. Alt+X
+  // arrow / jump-key navigation switches to a row scrolled out of view), or the
+  // sidebar expands into shortcut mode, scroll the active row into view. Uses
+  // `block: "nearest"`, so it is a no-op when the row is already visible (mouse
+  // clicks, in-view switches). Only runs while expanded — the collapsed gutter
+  // hides its scrollbar, and expanding re-runs this via the `isExpanded` read.
+  $effect(() => {
+    void activeWorkspaceKey;
+    if (!isExpanded) return;
+    contentEl?.querySelector(".workspace-item.active")?.scrollIntoView({ block: "nearest" });
+  });
+
   // ============ Expansion State ============
 
   /** Debounce for both arming expansion (deliberate-hover filter) and collapsing. */
@@ -301,7 +324,7 @@
     {/if}
   </header>
 
-  <div class="sidebar-content">
+  <div class="sidebar-content" bind:this={contentEl}>
     <!-- Global "New workspace" entry, pinned above the projects. -->
     <button
       type="button"

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -123,6 +123,74 @@ describe("Sidebar component", () => {
     });
   });
 
+  describe("active row scroll-into-view", () => {
+    // Regression: Alt+X arrow/jump navigation switches the active workspace to
+    // a row that may be scrolled out of the sidebar's viewport. The sidebar
+    // must scroll the newly-active row back into view.
+
+    it("scrolls the newly-active row into view when the active workspace changes (expanded)", async () => {
+      const project = makeUiProjectRow([
+        makeUiWorkspaceRow("ws1", { active: true }),
+        makeUiWorkspaceRow("ws2", { active: false }),
+      ]);
+
+      const { rerender } = render(Sidebar, {
+        // shortcut mode keeps the sidebar expanded (as during Alt+X nav).
+        props: { ...defaultProps, projects: [project], mode: "shortcut" as const },
+      });
+
+      // Spy on the second row (jsdom's default scrollIntoView is a no-op). The
+      // keyed {#each} reuses this <li> across the rerender, so the spy survives.
+      const scrollSpy = vi.fn();
+      const ws2Item = screen.getByText("ws2").closest("li")!;
+      ws2Item.scrollIntoView = scrollSpy;
+
+      // Navigate: ws2 becomes active.
+      await rerender({
+        ...defaultProps,
+        projects: [
+          makeUiProjectRow([
+            makeUiWorkspaceRow("ws1", { active: false }),
+            makeUiWorkspaceRow("ws2", { active: true }),
+          ]),
+        ],
+        mode: "shortcut" as const,
+      });
+      flushSync();
+
+      expect(scrollSpy).toHaveBeenCalledWith({ block: "nearest" });
+    });
+
+    it("does not scroll while collapsed (workspace mode)", async () => {
+      const project = makeUiProjectRow([
+        makeUiWorkspaceRow("ws1", { active: true }),
+        makeUiWorkspaceRow("ws2", { active: false }),
+      ]);
+
+      const { rerender } = render(Sidebar, {
+        props: { ...defaultProps, projects: [project], mode: "workspace" as const },
+      });
+
+      const scrollSpy = vi.fn();
+      const ws2Item = screen.getByText("ws2").closest("li")!;
+      ws2Item.scrollIntoView = scrollSpy;
+
+      await rerender({
+        ...defaultProps,
+        projects: [
+          makeUiProjectRow([
+            makeUiWorkspaceRow("ws1", { active: false }),
+            makeUiWorkspaceRow("ws2", { active: true }),
+          ]),
+        ],
+        mode: "workspace" as const,
+      });
+      flushSync();
+
+      expect(scrollSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("state rendering", () => {
     it("shows the New workspace entry and no 'no projects' text when there are no projects", () => {
       render(Sidebar, { props: defaultProps });


### PR DESCRIPTION
- Fix the sidebar not scrolling the active workspace row into view when Alt+X arrow/jump navigation switched to a row that was scrolled out of the viewport (the row became active but stayed off-screen).
- Add a `$effect` in `Sidebar.svelte` that scrolls the active row into view (`block: "nearest"`, a no-op when already visible) when the active workspace changes or the sidebar expands into shortcut mode; gated on the expanded state.
- Add regression tests covering the expanded scroll-into-view and the collapsed no-scroll cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)