### PR TITLE
feat: Add auto-populated settings menu

### DIFF
--- a/src/boundaries/platform/config.integration.test.ts
+++ b/src/boundaries/platform/config.integration.test.ts
@@ -954,3 +954,66 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--unknown-flag=val"])).toEqual({ "unknown-flag": "val" });
   });
 });
+
+// =============================================================================
+// Settings-support surface: getSource / wasConfigured / getDefinitions
+// =============================================================================
+
+describe("Config — settings support", () => {
+  it("wasConfigured() is false on a genuine first run (no config.json)", () => {
+    const svc = createService();
+    svc.load();
+    expect(svc.wasConfigured()).toBe(false);
+  });
+
+  it("wasConfigured() is true when config.json exists", () => {
+    const svc = createService({
+      fileEntries: { "/app": directory(), "/app/config.json": file("{}") },
+    });
+    svc.load();
+    expect(svc.wasConfigured()).toBe(true);
+  });
+
+  it("getSource() reports where the effective value came from (precedence)", () => {
+    const svc = createService({
+      fileEntries: {
+        "/app": directory(),
+        "/app/config.json": file(JSON.stringify({ "from.file": "f" })),
+      },
+      env: { CH_FROM__ENV: "e" },
+      argv: ["--from.cli=c"],
+    });
+    svc.register("plain", stringDef("plain", "d"));
+    svc.register("from.file", stringDef("from.file", "d"));
+    svc.register("from.env", stringDef("from.env", "d"));
+    svc.register("from.cli", stringDef("from.cli", "d"));
+    svc.load();
+
+    expect(svc.getSource("plain")).toBe("default");
+    expect(svc.getSource("from.file")).toBe("user");
+    expect(svc.getSource("from.env")).toBe("env");
+    expect(svc.getSource("from.cli")).toBe("cli");
+  });
+
+  it("getSource() flips to user after a runtime set(), stays env-sticky under an override", async () => {
+    const svc = createService({ env: { CH_OVERRIDDEN: "e" } });
+    const plain = svc.register("plain", stringDef("plain", "d"));
+    svc.register("overridden", stringDef("overridden", "d"));
+    svc.load();
+
+    await plain.set("x");
+    expect(svc.getSource("plain")).toBe("user");
+
+    // An env-sourced key stays "env" after a set (the override still wins on reload).
+    await svc.set("overridden", "y");
+    expect(svc.getSource("overridden")).toBe("env");
+  });
+
+  it("getDefinitions() exposes registered keys with their metadata", () => {
+    const svc = createService();
+    svc.register("test.key", stringDef("test.key", "d"));
+    svc.load();
+    const defs = svc.getDefinitions();
+    expect(defs.has("test.key")).toBe(true);
+  });
+});

--- a/src/boundaries/platform/config.test-utils.ts
+++ b/src/boundaries/platform/config.test-utils.ts
@@ -5,8 +5,12 @@
  * store-backed accessors (mirroring production), plus a standalone
  * createMockAccessor() for injecting cross-module accessors into deps.
  */
-import type { Config } from "./config";
-import type { PersistedAccessor, DeprecatedPersistedAccessor } from "./store-definition";
+import type { Config, ConfigSource } from "./config";
+import type {
+  PersistedAccessor,
+  DeprecatedPersistedAccessor,
+  PersistedKeyDefinition,
+} from "./store-definition";
 
 export interface CreateMockConfigOptions {
   /**
@@ -20,6 +24,11 @@ export interface CreateMockConfigOptions {
    * the mock doesn't track.
    */
   overrides?: Record<string, unknown> | undefined;
+  /**
+   * Value returned by wasConfigured(). Defaults to true (a configured install);
+   * set false to simulate a first run (drives agent-selection onboarding).
+   */
+  wasConfigured?: boolean | undefined;
 }
 
 /**
@@ -37,6 +46,7 @@ export function createMockConfig(options?: CreateMockConfigOptions): Config {
   const store = new Map<string, unknown>(Object.entries(options?.defaults ?? {}));
   const overrides = { ...(options?.overrides ?? {}) };
   const defaultsByKey = new Map<string, unknown>();
+  const definitionsByKey = new Map<string, PersistedKeyDefinition<unknown>>();
 
   function makeAccessor(key: string): PersistedAccessor<unknown> {
     return {
@@ -60,6 +70,7 @@ export function createMockConfig(options?: CreateMockConfigOptions): Config {
     definition: { default?: unknown; deprecated?: true }
   ): PersistedAccessor<unknown> | DeprecatedPersistedAccessor => {
     defaultsByKey.set(key, definition.default);
+    definitionsByKey.set(key, definition as PersistedKeyDefinition<unknown>);
     // Mirror production: registered defaults seed the store for unset keys,
     // but never overwrite values pre-populated via the `defaults` option.
     if (!store.has(key) && definition.default !== undefined) {
@@ -86,6 +97,16 @@ export function createMockConfig(options?: CreateMockConfigOptions): Config {
     register,
     load: () => {},
     getEffective: () => Object.fromEntries(store),
+    getDefinitions: () => definitionsByKey,
+    set: async (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+    reset: async (key: string) => {
+      store.set(key, defaultsByKey.get(key));
+    },
+    getSource: (key: string): ConfigSource =>
+      store.get(key) === defaultsByKey.get(key) ? "default" : "user",
+    wasConfigured: () => options?.wasConfigured ?? true,
     getRedactedOverrides: () => ({ ...overrides }),
     getHelpText: () => "",
   };

--- a/src/boundaries/platform/config.ts
+++ b/src/boundaries/platform/config.ts
@@ -43,11 +43,18 @@ import { PersistedStore } from "./persisted-store";
 const BROKEN_CONFIG_FILENAME = "config.json.broken";
 
 /**
- * Agent types that can be selected by the user.
- * null indicates the user hasn't made a selection yet (first-run).
+ * Agent types that can be selected by the user. Non-nullable: the default is
+ * "claude". First-run onboarding is gated on whether config.json existed at load
+ * (Config.wasConfigured()), not on a null agent.
  * Config-specific (not a generic store type), so it lives with the Config service.
  */
-export type ConfigAgentType = "claude" | "opencode" | null;
+export type ConfigAgentType = "claude" | "opencode";
+
+/**
+ * Where a config key's effective value came from, in precedence order.
+ * Surfaced to the settings dialog so it can badge env/CLI-overridden keys.
+ */
+export type ConfigSource = "default" | "user" | "env" | "cli";
 
 // =============================================================================
 // Name Derivation
@@ -148,6 +155,30 @@ export interface Config {
 
   /** Get all effective config values (for help text). */
   getEffective(): Readonly<Record<string, unknown>>;
+
+  /**
+   * The registered key definitions. Used by the settings dialog to enumerate
+   * keys and read each key's `settingsControl` / `applies` metadata.
+   */
+  getDefinitions(): ReadonlyMap<string, PersistedKeyDefinition<unknown>>;
+
+  /**
+   * String-keyed set for the settings dialog (which doesn't hold typed
+   * accessors). Validates and persists to config.json like accessor.set().
+   */
+  set(key: string, value: unknown): Promise<void>;
+
+  /** String-keyed reset to default (deletes the key from config.json). */
+  reset(key: string): Promise<void>;
+
+  /** Where the key's effective value came from (default|user|env|cli). */
+  getSource(key: string): ConfigSource;
+
+  /**
+   * Whether config.json existed at load. false = genuine first run (no config
+   * written yet) → onboarding; true = the user has configured before.
+   */
+  wasConfigured(): boolean;
 
   /**
    * Get the subset of effective values that differ from their defaults, with
@@ -264,12 +295,15 @@ function readConfigFile(
   configPath: Path,
   syncRead: (path: string) => string,
   syncRename: (oldPath: string, newPath: string) => void
-): { data: Record<string, unknown>; issues: PersistedIssue[] } {
+): { data: Record<string, unknown>; issues: PersistedIssue[]; existed: boolean } {
   let content: string;
   try {
     content = syncRead(configPath.toNative());
-  } catch {
-    return { data: {}, issues: [] };
+  } catch (error) {
+    // ENOENT = genuinely first run (no file). Any other read error means the file
+    // is there but unreadable — still "configured" for onboarding purposes.
+    const existed = !(error instanceof Error && "code" in error && error.code === "ENOENT");
+    return { data: {}, issues: [], existed };
   }
 
   let parsed: unknown;
@@ -280,6 +314,7 @@ function readConfigFile(
     syncRename(configPath.toNative(), backupPath.toNative());
     return {
       data: {},
+      existed: true,
       issues: [
         {
           kind: "broken-json",
@@ -292,9 +327,9 @@ function readConfigFile(
   }
 
   if (typeof parsed !== "object" || parsed === null) {
-    return { data: {}, issues: [] };
+    return { data: {}, issues: [], existed: true };
   }
-  return { data: parsed as Record<string, unknown>, issues: [] };
+  return { data: parsed as Record<string, unknown>, issues: [], existed: true };
 }
 
 // =============================================================================
@@ -304,6 +339,8 @@ function readConfigFile(
 export class DefaultConfig implements Config {
   /** Generic typed key-value store backed by config.json. */
   private readonly store: PersistedStore;
+  /** Whether config.json existed at load. Set in load(); read by wasConfigured(). */
+  private configFileExisted = false;
 
   constructor(private readonly deps: ConfigDeps) {
     this.store = new PersistedStore({
@@ -346,6 +383,7 @@ export class DefaultConfig implements Config {
 
     // 2. config.json: read (I/O) → validate (typed values).
     const file = readConfigFile(configPath, syncRead, syncRename);
+    this.configFileExisted = file.existed;
     const fileResult = this.store.validate(file.data);
 
     // 3. env + CLI: tokenize → parse (strings → typed) → validate.
@@ -364,6 +402,12 @@ export class DefaultConfig implements Config {
       ...envResult.values,
       ...cliResult.values,
     });
+
+    // 5b. Record each key's source in the same precedence order (last wins), so
+    //     the settings dialog can badge user/env/CLI-sourced values.
+    this.store.markSources(Object.keys(fileResult.values), "user");
+    this.store.markSources(Object.keys(envResult.values), "env");
+    this.store.markSources(Object.keys(cliResult.values), "cli");
 
     // 6. If config.json contained unknown keys, rewrite it with those stripped
     //    (active, deprecated, and legacy entries are preserved).
@@ -450,6 +494,26 @@ export class DefaultConfig implements Config {
 
   getEffective(): Readonly<Record<string, unknown>> {
     return this.store.getEffective();
+  }
+
+  getDefinitions(): ReadonlyMap<string, PersistedKeyDefinition<unknown>> {
+    return this.store.getDefinitions();
+  }
+
+  set(key: string, value: unknown): Promise<void> {
+    return this.store.setValue(key, value);
+  }
+
+  reset(key: string): Promise<void> {
+    return this.store.resetKey(key);
+  }
+
+  getSource(key: string): ConfigSource {
+    return this.store.getSource(key) as ConfigSource;
+  }
+
+  wasConfigured(): boolean {
+    return this.configFileExisted;
   }
 
   getRedactedOverrides(): Record<string, unknown> {

--- a/src/boundaries/platform/persisted-store.ts
+++ b/src/boundaries/platform/persisted-store.ts
@@ -89,6 +89,11 @@ export class PersistedStore {
   private readonly definitions = new PersistedDefinitions();
   private readonly effective: Record<string, unknown> = {};
   private readonly defaults: Record<string, unknown> = {};
+  // Where each key's effective value came from. Seeded to "default" for every
+  // key by seedDefaults(); the composing service overlays higher-precedence
+  // sources via markSources(). set()/reset() keep it current at runtime. Read by
+  // the settings UI to show a source badge (e.g. env/CLI-overridden keys).
+  private readonly sources: Record<string, string> = {};
   private loaded = false;
   // Tail of the write queue. Every persistMutation() chains off this so writes
   // to the backing file run strictly one-at-a-time, even across owners that
@@ -195,8 +200,38 @@ export class PersistedStore {
     for (const [key, value] of Object.entries(defaults)) {
       this.effective[key] = value;
       this.defaults[key] = value;
+      this.sources[key] = "default";
     }
     return defaults;
+  }
+
+  /**
+   * Mark a set of keys as sourced from `source` (e.g. "user", "env", "cli").
+   * The composing service calls this in precedence order after seedDefaults() so
+   * the last writer wins, matching the effective-value merge.
+   */
+  markSources(keys: Iterable<string>, source: string): void {
+    for (const key of keys) {
+      this.sources[key] = source;
+    }
+  }
+
+  /** Where the key's effective value currently comes from (default if unseeded). */
+  getSource(key: string): string {
+    return this.sources[key] ?? "default";
+  }
+
+  /**
+   * String-keyed set for callers that don't hold the typed accessor (the settings
+   * dialog). Same validation/persistence as PersistedAccessor.set().
+   */
+  setValue(key: string, value: unknown, options?: { persist?: boolean }): Promise<void> {
+    return this.writeValue(key, value, options);
+  }
+
+  /** String-keyed reset for callers that don't hold the typed accessor. */
+  resetKey(key: string, options?: { persist?: boolean }): Promise<void> {
+    return this.resetValue(key, options);
   }
 
   /** Overlay resolved values onto the effective map (highest-precedence last). */
@@ -254,6 +289,12 @@ export class PersistedStore {
       });
     }
     this.effective[key] = validated;
+    // A persisted write lands in config.json, i.e. becomes user-sourced — except
+    // env/CLI overrides, which still win on the next load, so we keep that source
+    // sticky so the settings UI keeps warning about the active override.
+    if (options?.persist !== false && this.sources[key] !== "env" && this.sources[key] !== "cli") {
+      this.sources[key] = "user";
+    }
 
     if (options?.persist !== false) {
       await this.persistMutation((fileContent) => {
@@ -273,6 +314,10 @@ export class PersistedStore {
       });
     }
     this.effective[key] = this.defaults[key];
+    // Deleting the key from config.json reverts it to the default source (env/CLI
+    // overrides would re-apply on next load, but the in-memory value is now the
+    // default, so report it as such).
+    this.sources[key] = "default";
 
     if (options?.persist !== false) {
       await this.persistMutation((fileContent) => {

--- a/src/boundaries/platform/store-definition.ts
+++ b/src/boundaries/platform/store-definition.ts
@@ -21,6 +21,52 @@ export interface ComputedDefaultContext {
   readonly isPackaged: boolean;
 }
 
+// =============================================================================
+// Settings-UI descriptors
+// =============================================================================
+
+/** A single selectable option for an enum control. */
+export interface SettingsOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+/**
+ * How a config key renders in the auto-populated settings dialog.
+ *
+ * Typed builders (storeBoolean/storeNumber/storeEnum/...) attach one of these
+ * automatically, so the settings dialog can render a key without parsing the
+ * `validValues` help string. A key is shown in the dialog iff its definition
+ * carries a `settingsControl` (storeCustom keys opt in by passing one).
+ *
+ * `guarded-text` is the checkbox-guarded text field used by the two keys whose
+ * "off" state is a distinct value rather than empty/null of a simple type
+ * (experimental.busy-during-background-shell → off = false;
+ * electron.disabled-features → off = null). The four functions bridge the
+ * two-widget UI (checkbox + text) to the single typed config value.
+ */
+export type SettingsControl =
+  | { readonly kind: "boolean" }
+  | { readonly kind: "string" }
+  | { readonly kind: "number"; readonly min?: number; readonly max?: number }
+  | {
+      readonly kind: "enum";
+      readonly options: readonly SettingsOption[];
+      readonly nullable: boolean;
+    }
+  | { readonly kind: "enum-list"; readonly options: readonly string[] }
+  | {
+      readonly kind: "guarded-text";
+      /** Value written when the guard checkbox is unchecked. */
+      readonly offValue: unknown;
+      /** Value written when checked with an empty text field. */
+      readonly onEmptyValue: unknown;
+      /** Build the typed value from a non-empty text field. */
+      readonly fromText: (text: string) => unknown;
+      /** Project the current value onto the guard's {active, text} display state. */
+      readonly toText: (value: unknown) => { readonly active: boolean; readonly text: string };
+    };
+
 /**
  * Definition of a single configuration key.
  *
@@ -40,6 +86,18 @@ export interface PersistedKeyDefinition<T> {
   readonly description?: string;
   /** Valid values hint for help text (e.g. "true|false", "claude|opencode"). */
   readonly validValues?: string;
+  /**
+   * How a changed value takes effect. "live" = the app re-reads it and applies
+   * immediately; "restart" = only picked up on next launch (the settings dialog
+   * shows a "Restart to apply" note on changed restart-scoped rows). Absent is
+   * treated as "restart" (the safe default). Purely a settings-UI hint.
+   */
+  readonly applies?: "live" | "restart";
+  /**
+   * How this key renders in the auto-populated settings dialog. Typed builders
+   * attach this automatically; a key without one is not shown. See SettingsControl.
+   */
+  readonly settingsControl?: SettingsControl;
   /**
    * Controls redaction in contexts like bug reports (see getRedactedOverrides).
    * `true` replaces the whole value with the redaction token. A function
@@ -72,6 +130,7 @@ export interface PersistedKeyDefinition<T> {
  */
 export type PersistedTypeBuilder<T> = Pick<PersistedKeyDefinition<T>, "parse" | "validate"> & {
   readonly validValues?: string;
+  readonly settingsControl?: SettingsControl;
 };
 
 // =============================================================================
@@ -138,6 +197,7 @@ export function storeBoolean(): PersistedTypeBuilder<boolean> {
     parse: parseBool,
     validate: (v: unknown) => (typeof v === "boolean" ? v : undefined),
     validValues: "true|false",
+    settingsControl: { kind: "boolean" },
   };
 }
 
@@ -175,6 +235,11 @@ export function storeNumber(options?: {
     parse: (raw: string) => (raw === "" ? undefined : check(Number(raw))),
     validate: (v: unknown) => (typeof v === "number" ? check(v) : undefined),
     validValues,
+    settingsControl: {
+      kind: "number",
+      ...(min !== undefined && { min }),
+      ...(max !== undefined && { max }),
+    },
   };
 }
 
@@ -193,6 +258,11 @@ export function storeEnum<const T extends string>(
 ): PersistedTypeBuilder<T | null> {
   const set = new Set<string>(values);
   const validValues = options?.nullable ? [...values, "null"].join("|") : values.join("|");
+  const enumControl: SettingsControl = {
+    kind: "enum",
+    options: values.map((v) => ({ value: v, label: v })),
+    nullable: options?.nullable === true,
+  };
 
   if (options?.nullable) {
     return {
@@ -201,6 +271,7 @@ export function storeEnum<const T extends string>(
       validate: (v: unknown): T | null | undefined =>
         v === null ? null : typeof v === "string" && set.has(v) ? (v as T) : undefined,
       validValues,
+      settingsControl: enumControl,
     };
   }
 
@@ -209,6 +280,7 @@ export function storeEnum<const T extends string>(
     validate: (v: unknown): T | null | undefined =>
       typeof v === "string" && set.has(v) ? (v as T) : undefined,
     validValues,
+    settingsControl: enumControl,
   };
 }
 
@@ -240,6 +312,7 @@ export function storeEnumList(values: readonly string[]): PersistedTypeBuilder<s
     parse: parseList,
     validate: (v: unknown) => (typeof v === "string" ? parseList(v) : undefined),
     validValues,
+    settingsControl: { kind: "enum-list", options: values },
   };
 }
 
@@ -255,6 +328,7 @@ export function storeString(options?: { nullable: true }): PersistedTypeBuilder<
       validate: (v: unknown): string | null | undefined =>
         v === null ? null : typeof v === "string" ? v : undefined,
       validValues: "<string>",
+      settingsControl: { kind: "string" },
     };
   }
 
@@ -262,6 +336,7 @@ export function storeString(options?: { nullable: true }): PersistedTypeBuilder<
     parse: (s: string): string | null | undefined => (s === "" ? undefined : s),
     validate: (v: unknown): string | null | undefined => (typeof v === "string" ? v : undefined),
     validValues: "<string>",
+    settingsControl: { kind: "string" },
   };
 }
 
@@ -294,6 +369,7 @@ export function storePath(options: { nullable: true }): PersistedTypeBuilder<str
       }
     },
     validValues: "<path>",
+    settingsControl: { kind: "string" },
   };
 }
 
@@ -304,11 +380,13 @@ export function storeCustom<T>(fns: {
   parse: (raw: string) => T | undefined;
   validate: (value: unknown) => T | undefined;
   validValues?: string;
+  settingsControl?: SettingsControl;
 }): PersistedTypeBuilder<T> {
   return {
     parse: fns.parse,
     validate: fns.validate,
     ...(fns.validValues !== undefined && { validValues: fns.validValues }),
+    ...(fns.settingsControl !== undefined && { settingsControl: fns.settingsControl }),
   };
 }
 

--- a/src/boundaries/shell/app.state-mock.ts
+++ b/src/boundaries/shell/app.state-mock.ts
@@ -37,6 +37,8 @@ class AppBoundaryMockStateImpl implements MockState {
   sleepBlockerStarts = 0;
   /** Number of times a blocker transitioned from active → inactive. */
   sleepBlockerStops = 0;
+  /** Number of times relaunch() was called (Save & Restart). */
+  relaunchCount = 0;
   readonly themeUpdatedCallbacks = new CallbackSet();
 
   triggerThemeUpdated(): void {
@@ -164,6 +166,10 @@ export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): Moc
     async openUrl(): Promise<void> {},
     async openPath(): Promise<void> {},
 
+    relaunch(): void {
+      state.relaunchCount += 1;
+    },
+
     shouldUseDarkColors(): boolean {
       return state.shouldUseDarkColors;
     },
@@ -206,6 +212,12 @@ export interface AppBoundaryMatchers {
    * @param count - Expected number of blocker starts
    */
   toHaveSleepBlockerStartCount(count: number): void;
+
+  /**
+   * Assert how many times relaunch() was called (Save & Restart).
+   * @param count - Expected number of relaunch calls
+   */
+  toHaveRelaunchCount(count: number): void;
 }
 
 // Extend vitest's assertion interface
@@ -252,6 +264,11 @@ const appBoundaryMatchers: MatcherImplementationsFor<
   toHaveSleepBlockerStartCount: countMatcher<MockAppBoundary & { $: AppBoundaryMockStateImpl }>(
     "sleep blocker start",
     (mock) => mock.$.sleepBlockerStarts
+  ),
+
+  toHaveRelaunchCount: countMatcher<MockAppBoundary & { $: AppBoundaryMockStateImpl }>(
+    "relaunch",
+    (mock) => mock.$.relaunchCount
   ),
 };
 

--- a/src/boundaries/shell/app.ts
+++ b/src/boundaries/shell/app.ts
@@ -89,6 +89,13 @@ export interface AppBoundary {
   allowPowerSaving(allow: boolean): void;
 
   /**
+   * Relaunch the app: schedule a fresh instance to start on exit, then quit the
+   * current one. Used by the settings dialog's "Save & Restart" to apply
+   * restart-scoped config changes.
+   */
+  relaunch(): void;
+
+  /**
    * Whether the OS is currently using a dark color scheme.
    */
   shouldUseDarkColors(): boolean;
@@ -164,6 +171,12 @@ export class DefaultAppBoundary implements AppBoundary {
     this.logger.debug("Power saving prevented (display-sleep blocker started)", {
       id: this.powerBlockerId,
     });
+  }
+
+  relaunch(): void {
+    this.logger.info("Relaunching app");
+    app.relaunch();
+    app.quit();
   }
 
   shouldUseDarkColors(): boolean {

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -88,7 +88,7 @@ function createTestSetup(
 
   dispatcher.registerOperation(
     INTENT_APP_READY,
-    new AppReadyOperation(createMockAccessor<ConfigAgentType>("agent", null))
+    new AppReadyOperation(createMockAccessor<ConfigAgentType>("agent", "claude"))
   );
   dispatcher.registerOperation(INTENT_OPEN_PROJECT, stub);
 

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -57,9 +57,9 @@ import type { PersistedAccessor } from "../boundaries/platform/store-definition"
 
 /** Mock accessor that seeds the configured agent. Pass null to leave it unset. */
 function createMockAgentAccessor(
-  agent: ConfigAgentType | null = "opencode"
-): PersistedAccessor<ConfigAgentType | null> {
-  return createMockAccessor<ConfigAgentType | null>("agent", agent);
+  agent: ConfigAgentType = "opencode"
+): PersistedAccessor<ConfigAgentType> {
+  return createMockAccessor<ConfigAgentType>("agent", agent);
 }
 
 // =============================================================================
@@ -228,7 +228,10 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(createMockAgentAccessor()));
+  dispatcher.registerOperation(
+    INTENT_APP_START,
+    new AppStartOperation(createMockAgentAccessor(), () => true)
+  );
 
   const allModules = options?.skipDefaultChecks ? modules : [...defaultCheckModules(), ...modules];
   for (const m of allModules) dispatcher.registerModule(m);
@@ -444,10 +447,15 @@ describe("AppStart Operation", () => {
     ): { dispatcher: Dispatcher } {
       const dispatcher = createMockDispatcher();
 
-      const agent = options?.configuredAgent !== undefined ? options.configuredAgent : "opencode";
+      // A null configuredAgent models a first run (config.json absent →
+      // agent-selection onboarding), now driven by wasConfigured() rather than a
+      // null agent value; the stored agent itself is always a valid agent.
+      const configured = options?.configuredAgent;
+      const wasConfigured = configured !== null;
+      const agent: ConfigAgentType = configured && configured !== null ? configured : "opencode";
       dispatcher.registerOperation(
         INTENT_APP_START,
-        new AppStartOperation(createMockAgentAccessor(agent))
+        new AppStartOperation(createMockAgentAccessor(agent), () => wasConfigured)
       );
       if (options?.setupStub) {
         dispatcher.registerOperation(INTENT_SETUP, options.setupStub);

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -144,7 +144,11 @@ interface CheckResult {
 export class AppStartOperation implements Operation<AppStartIntent, void> {
   readonly id = APP_START_OPERATION_ID;
 
-  constructor(private readonly agentConfig: PersistedAccessor<ConfigAgentType | null>) {}
+  constructor(
+    private readonly agentConfig: PersistedAccessor<ConfigAgentType>,
+    /** Whether config.json existed at load; false = first run → agent selection. */
+    private readonly wasConfigured: () => boolean
+  ) {}
 
   async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
     const hookCtx: HookContext = {
@@ -175,8 +179,12 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       if (result.extensionRequirements) extensionRequirements.push(...result.extensionRequirements);
     }
 
-    // configuredAgent comes from Config (loaded before app:start)
-    const configuredAgent = this.agentConfig.get();
+    // On first run (no config.json yet) the agent is treated as "not chosen":
+    // null defers binary checks and drives needsAgentSelection, exactly as a null
+    // agent value used to. Once configured, the real (non-null) agent is used.
+    const configuredAgent: ConfigAgentType | null = this.wasConfigured()
+      ? this.agentConfig.get()
+      : null;
 
     // Hook 3: "show-ui" -- Show starting screen, capture waitForRetry
     const { results: showUiResults, errors: showUiErrors } =

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,6 +192,7 @@ import { createShortcutModule } from "./modules/shortcut-module";
 import { createDevtoolsModule } from "./modules/devtools-module";
 import { createDebugModule } from "./modules/debug-module";
 import { createPresentationModule } from "./modules/presentation/presentation-module";
+import { createSettingsModule } from "./modules/settings-module";
 import { createCloneNotificationModule } from "./modules/clone-notification-module";
 import { createErrorNotificationModule } from "./modules/error-notification-module";
 import { createDeletionDialogModule } from "./modules/deletion-dialog-module";
@@ -244,9 +245,10 @@ const stateMigrations = createStateMigrationRegistry();
 // are threaded into the modules/intents that read or write them, so those
 // consumers never reach into the config service by string key.
 const agentConfig = configService.register("agent", {
-  default: null,
+  default: "claude",
   description: "Agent selection",
-  ...storeEnum(["claude", "opencode"], { nullable: true }),
+  applies: "restart",
+  ...storeEnum(["claude", "opencode"]),
 });
 // telemetry.enabled is read by two modules (telemetry-module gates passive
 // events; error-report-module gates crash reporting), so it is registered here
@@ -254,6 +256,7 @@ const agentConfig = configService.register("agent", {
 const telemetryEnabledConfig = configService.register("telemetry.enabled", {
   default: true,
   description: "Enable telemetry (false in dev/unpackaged)",
+  applies: "live",
   ...storeBoolean(),
   computedDefault: (ctx) => (ctx.isDevelopment || !ctx.isPackaged ? false : undefined),
 });
@@ -271,6 +274,7 @@ const busyDuringBackgroundShellConfig = configService.register(
       "running. true = every background shell; false = never; array of " +
       "regexes (config.json only) = only shells whose command matches " +
       "(e.g. a CI-wait script), so dev servers don't pin the workspace busy.",
+    applies: "live",
     ...configBusyDuringBackgroundShell(),
   }
 );
@@ -294,6 +298,7 @@ const opencodeVersionConfig = configService.register("version.opencode", {
 const sidebarWidthConfig = configService.register("sidebar.width", {
   default: 250,
   description: "Expanded sidebar width in pixels (drag its right edge to resize; min 250)",
+  applies: "live",
   ...storeNumber({ min: 250, max: 100000 }),
 });
 
@@ -476,6 +481,10 @@ const uiHtmlPath = `file://${nodePath.join(__dirname, "../renderer/index.html")}
 // UI-view IPC. It privately owns the dialog/notification registries and exposes
 // .dialog()/.notification() for any module to inject. Constructed early so the
 // consumer modules below can take it as `ui`.
+// Forwards the sidebar gear's open-settings ui event to the settings module.
+// Assigned once the settings module is constructed below (it needs the
+// presenter for its dialog), so the presenter closes over a mutable ref.
+let openSettings: () => void = () => {};
 const presentationModule = createPresentationModule({
   loggingService,
   viewManager,
@@ -485,7 +494,15 @@ const presentationModule = createPresentationModule({
   dispatcher,
   sidebarWidthConfig,
   configService,
+  onOpenSettings: () => openSettings(),
 });
+const settingsModule = createSettingsModule({
+  ui: presentationModule,
+  config: configService,
+  app: appLayer,
+  logger: loggingService.createLogger("settings"),
+});
+openSettings = settingsModule.openSettings;
 const cloneNotificationModule = createCloneNotificationModule({ ui: presentationModule });
 const errorNotificationModule = createErrorNotificationModule({ ui: presentationModule });
 
@@ -780,7 +797,10 @@ const errorReportModule = createErrorReportModule({
 
 dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
 dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
-dispatcher.registerOperation(INTENT_APP_START, new AppStartOperation(agentConfig));
+dispatcher.registerOperation(
+  INTENT_APP_START,
+  new AppStartOperation(agentConfig, () => configService.wasConfigured())
+);
 dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(agentConfig));
 // config:set-values operation removed — config is now a plain service
 dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
@@ -916,6 +936,7 @@ dispatcher.registerModule(shortcutModule);
 dispatcher.registerModule(devtoolsModule);
 dispatcher.registerModule(debugModule);
 dispatcher.registerModule(errorReportModule);
+dispatcher.registerModule(settingsModule.module);
 dispatcher.registerModule(autoWorkspaceModule);
 dispatcher.registerModule(cloneNotificationModule);
 dispatcher.registerModule(errorNotificationModule);

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -312,7 +312,7 @@ class MinimalShutdownOperation implements Operation<
 
 function createTestSetup(providerOverrides: Partial<AgentModuleProvider> = {}) {
   const mockProvider = createMockProvider(providerOverrides);
-  const agentConfig = createMockAccessor<ConfigAgentType>("agent", null);
+  const agentConfig = createMockAccessor<ConfigAgentType>("agent", "claude");
 
   const mockDispatcher = {
     dispatch: vi.fn().mockResolvedValue(undefined),

--- a/src/modules/agent-module/claude/types.ts
+++ b/src/modules/agent-module/claude/types.ts
@@ -184,6 +184,26 @@ export function configBusyDuringBackgroundShell(): PersistedTypeBuilder<BusyDuri
       return v as readonly string[];
     },
     validValues: "true|false|[<regex>, ...] (array via config.json only)",
+    // Settings UI: a checkbox guarding a comma-separated regex field.
+    //   unchecked            → false (never busy)
+    //   checked, empty text  → true  (every background shell keeps busy)
+    //   checked, "a, b"      → ["a","b"] (only matching commands keep busy)
+    settingsControl: {
+      kind: "guarded-text",
+      offValue: false,
+      onEmptyValue: true,
+      fromText: (text: string) =>
+        text
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0),
+      toText: (value: unknown) => {
+        if (value === false) return { active: false, text: "" };
+        if (value === true) return { active: true, text: "" };
+        if (Array.isArray(value)) return { active: true, text: value.join(", ") };
+        return { active: false, text: "" };
+      },
+    },
   });
 }
 

--- a/src/modules/auto-updater-module.ts
+++ b/src/modules/auto-updater-module.ts
@@ -116,6 +116,7 @@ export function createAutoUpdaterModule(deps: AutoUpdaterModuleDeps): IntentModu
   const updateNotificationConfig = deps.configService.register("update.notification", {
     default: true,
     description: "Show a sidebar notification when an update is available",
+    applies: "live",
     ...storeBoolean(),
   });
   // App-written bookkeeping (not user config): persisted in state.json so a

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -53,7 +53,7 @@ import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
 import { listInstalledExtensions, removeFromExtensionsJson } from "../utils/extension";
 import { Path } from "../utils/path/path";
 import { encodePathForUrl } from "../boundaries/platform/paths";
-import { storeString, storeCustom } from "../boundaries/platform/store-definition";
+import { storeString, storeNumber } from "../boundaries/platform/store-definition";
 import type { Config } from "../boundaries/platform/config";
 import { CodeServerError, SetupError, getErrorMessage } from "../shared/errors/service-errors";
 import { waitForHealthy } from "../utils/health-check";
@@ -292,15 +292,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
   const codeServerPortConfig = deps.configService.register("code-server.port", {
     default: getCodeServerPort(deps.buildInfo),
     description: "Code-server port",
-    ...storeCustom<number>({
-      parse: (raw) => {
-        const n = Number(raw);
-        return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : undefined;
-      },
-      validate: (v) =>
-        typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 65535 ? v : undefined,
-      validValues: "1-65535",
-    }),
+    ...storeNumber({ min: 1, max: 65535, integer: true }),
   });
 
   // -------------------------------------------------------------------------

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -150,6 +150,18 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
       "Comma-separated Chromium features to disable via --disable-features. " +
       "null = use curated defaults; empty string = disable nothing; any value fully replaces defaults.",
     ...storeString({ nullable: true }),
+    // Settings UI: a checkbox guarding the feature list, since this key needs
+    // three states (unchecked = null = curated defaults; checked + empty = "" =
+    // disable nothing; checked + value = replace). Overrides the string control
+    // the builder would otherwise attach.
+    settingsControl: {
+      kind: "guarded-text",
+      offValue: null,
+      onEmptyValue: "",
+      fromText: (text: string) => text,
+      toText: (value: unknown) =>
+        value === null ? { active: false, text: "" } : { active: true, text: String(value) },
+    },
   });
 
   return {

--- a/src/modules/logging-module.ts
+++ b/src/modules/logging-module.ts
@@ -75,6 +75,7 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
       parse: parseLogLevelSpec,
       validate: (v: unknown) => (typeof v === "string" ? parseLogLevelSpec(v) : undefined),
       validValues: "silly|debug|info|warn|error[:filter]",
+      settingsControl: { kind: "string" },
     }),
     computedDefault: (ctx) => (ctx.isDevelopment ? "debug" : undefined),
   });

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -160,6 +160,12 @@ export interface PresentationModuleDeps {
    */
   readonly sidebarWidthConfig: Pick<PersistedAccessor<number>, "get" | "set">;
   readonly configService: Pick<Config, "register">;
+  /**
+   * Called when the renderer emits the `open-settings` ui event (the sidebar
+   * gear). Wired in the composition root to the settings module's openSettings;
+   * the presenter itself stays agnostic of the settings dialog.
+   */
+  readonly onOpenSettings?: () => void;
 }
 
 /** Allowed values for the `sidebar.label-scroll` config key. */
@@ -373,6 +379,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     {
       default: "hover",
       description: "How overflowing sidebar row labels scroll: always|hover|off",
+      applies: "live",
       ...storeEnum(LABEL_SCROLL_VALUES),
     }
   );
@@ -1015,6 +1022,10 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     if (event.kind === "hover") {
       hoverRegion = event.region === "sidebar" ? "sidebar" : null;
       scheduleUpdate();
+      return;
+    }
+    if (event.kind === "open-settings") {
+      deps.onOpenSettings?.();
       return;
     }
     if (event.kind === "resize-sidebar") {

--- a/src/modules/settings-module.integration.test.ts
+++ b/src/modules/settings-module.integration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * SettingsModule integration tests.
+ *
+ * Exercises the auto-populated settings dialog against a mock Config (registered
+ * with real type builders, so settingsControl/validate are the production ones),
+ * a mock dialog surface, and a mock AppBoundary: population + exclusions,
+ * group/sub-heading derivation, control mapping, buffered save, Save & Restart
+ * relaunch, live-validation gating, guarded-text decode, and reset.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createSettingsModule } from "./settings-module";
+import { createMockConfig } from "../boundaries/platform/config.test-utils";
+import { createMockDialogManager } from "./presentation/dialog-manager.state-mock";
+import { createAppBoundaryMock } from "../boundaries/shell/app.state-mock";
+import { createMockLogger } from "../boundaries/platform/logging.test-utils";
+import { configBusyDuringBackgroundShell } from "./agent-module/claude/types";
+import {
+  storeBoolean,
+  storeEnum,
+  storeEnumList,
+  storeNumber,
+  storeString,
+} from "../boundaries/platform/store-definition";
+import type { Config } from "../boundaries/platform/config";
+import type { UiPresenter } from "./presentation/presentation-module";
+import type { DialogConfig, DialogSection } from "../shared/dialog-types";
+import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Register the representative key set on a mock config. */
+function registerKeys(config: Config): void {
+  config.register("agent", {
+    default: "claude",
+    description: "Agent selection",
+    applies: "restart",
+    ...storeEnum(["claude", "opencode"]),
+  });
+  config.register("telemetry.enabled", {
+    default: true,
+    description: "Enable telemetry",
+    applies: "live",
+    ...storeBoolean(),
+  });
+  config.register("help", { default: false, ...storeBoolean() });
+  config.register("sidebar.width", {
+    default: 250,
+    applies: "live",
+    ...storeNumber({ min: 250, max: 100000 }),
+  });
+  config.register("log.output", { default: "file", ...storeEnumList(["file", "console"]) });
+  config.register("experimental.youtrack.token", {
+    default: null,
+    redact: true,
+    ...storeString({ nullable: true }),
+  });
+  config.register("experimental.busy-during-background-shell", {
+    default: true,
+    ...configBusyDuringBackgroundShell(),
+  });
+}
+
+function setup(): {
+  openSettings: () => void;
+  config: Config;
+  dialogs: ReturnType<typeof createMockDialogManager>;
+  app: ReturnType<typeof createAppBoundaryMock>;
+} {
+  const config = createMockConfig();
+  registerKeys(config);
+  const dialogs = createMockDialogManager();
+  const app = createAppBoundaryMock({ platform: "linux" });
+  const { openSettings } = createSettingsModule({
+    ui: dialogs.ui as unknown as UiPresenter,
+    config,
+    app,
+    logger: createMockLogger(),
+  });
+  return { openSettings, config, dialogs, app };
+}
+
+/** Flush pending microtasks (the module's async save/reset handlers). */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function sectionsOf(cfg: DialogConfig): readonly DialogSection[] {
+  return cfg.sections;
+}
+
+function rowByLabel(
+  cfg: DialogConfig,
+  label: string
+): Extract<DialogSection, { type: "setting-row" }> | undefined {
+  return cfg.sections.find(
+    (s): s is Extract<DialogSection, { type: "setting-row" }> =>
+      s.type === "setting-row" && s.label === label
+  );
+}
+
+function headings(cfg: DialogConfig): string[] {
+  return cfg.sections
+    .filter(
+      (s): s is Extract<DialogSection, { type: "text" }> =>
+        s.type === "text" && s.style === "heading"
+    )
+    .map((s) => s.content);
+}
+
+function footerButtonIds(cfg: DialogConfig): string[] {
+  const group = cfg.sections.find(
+    (s): s is Extract<DialogSection, { type: "group" }> => s.type === "group"
+  );
+  return (group?.items ?? []).flatMap((i) => (i.type === "button" ? [i.id] : []));
+}
+
+function saveDisabled(cfg: DialogConfig): boolean {
+  const group = cfg.sections.find(
+    (s): s is Extract<DialogSection, { type: "group" }> => s.type === "group"
+  );
+  const save = group?.items.find((i) => i.type === "button" && i.id === "save");
+  return save?.type === "button" ? save.disabled === true : false;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("SettingsModule — population", () => {
+  it("opens a modal form dialog with a row per eligible key", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+
+    expect(dialogs.handles).toHaveLength(1);
+    const cfg = dialogs.lastHandle!.config;
+    expect(cfg.modal).toBe(true);
+    expect(cfg.layout).toBe("form");
+
+    expect(rowByLabel(cfg, "agent")).toBeDefined();
+    expect(rowByLabel(cfg, "enabled")).toBeDefined(); // telemetry.enabled
+    expect(rowByLabel(cfg, "width")).toBeDefined();
+    expect(rowByLabel(cfg, "token")).toBeDefined();
+  });
+
+  it("excludes the `help` pseudo-key", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    expect(rowByLabel(dialogs.lastHandle!.config, "help")).toBeUndefined();
+  });
+
+  it("derives group headings from the key prefix (dotless → General)", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const hs = headings(dialogs.lastHandle!.config);
+    expect(hs).toContain("General"); // agent, telemetry.enabled
+    expect(hs).toContain("sidebar");
+    expect(hs).toContain("log");
+    expect(hs).toContain("experimental");
+  });
+
+  it("renders a sub-heading for a three-segment key", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const sub = sectionsOf(dialogs.lastHandle!.config).find(
+      (s) => s.type === "text" && s.style === "subheading" && s.content === "youtrack"
+    );
+    expect(sub).toBeDefined();
+  });
+
+  it("maps controls: boolean→checkbox, enum→dropdown, number/string→input, enum-list→checkboxes", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const cfg = dialogs.lastHandle!.config;
+    expect(rowByLabel(cfg, "enabled")!.fields[0]!.type).toBe("checkbox");
+    expect(rowByLabel(cfg, "agent")!.fields[0]!.type).toBe("dropdown");
+    expect(rowByLabel(cfg, "width")!.fields[0]!.type).toBe("input");
+    // enum-list → one checkbox per option
+    const output = rowByLabel(cfg, "output")!;
+    expect(output.fields).toHaveLength(2);
+    expect(output.fields.every((f) => f.type === "checkbox")).toBe(true);
+  });
+
+  it("renders a redact key as a masked input", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const token = rowByLabel(dialogs.lastHandle!.config, "token")!;
+    expect(token.fields[0]).toMatchObject({ type: "input", masked: true });
+  });
+
+  it("renders the guarded-text union as a checkbox + input", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const busy = rowByLabel(dialogs.lastHandle!.config, "busy-during-background-shell")!;
+    expect(busy.fields.map((f) => f.type)).toEqual(["checkbox", "input"]);
+  });
+
+  it("footer offers Save / Save & Restart / Cancel / Reset all", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    expect(footerButtonIds(dialogs.lastHandle!.config)).toEqual([
+      "save",
+      "save-restart",
+      "cancel",
+      "reset-all",
+    ]);
+  });
+});
+
+describe("SettingsModule — save", () => {
+  it("persists only changed keys on Save, then closes", async () => {
+    const { openSettings, config, dialogs } = setup();
+    const setSpy = vi.spyOn(config, "set");
+    openSettings();
+    const handle = dialogs.lastHandle!;
+
+    // agent unchanged (claude), telemetry toggled off, width changed.
+    handle.emitAction("save", {
+      agent: "claude",
+      "telemetry.enabled": "false",
+      "sidebar.width": "300",
+      "log.output": "file",
+      "experimental.youtrack.token": "",
+      "experimental.busy-during-background-shell::on": "true",
+      "experimental.busy-during-background-shell": "",
+    });
+    await flush();
+
+    expect(setSpy).toHaveBeenCalledWith("telemetry.enabled", false);
+    expect(setSpy).toHaveBeenCalledWith("sidebar.width", 300);
+    expect(setSpy).not.toHaveBeenCalledWith("agent", expect.anything());
+    expect(handle.closed).toBe(true);
+  });
+
+  it("Save & Restart persists then relaunches", async () => {
+    const { openSettings, config, dialogs, app } = setup();
+    const setSpy = vi.spyOn(config, "set");
+    openSettings();
+    dialogs.lastHandle!.emitAction("save-restart", {
+      agent: "opencode",
+      "telemetry.enabled": "true",
+      "sidebar.width": "250",
+      "log.output": "file",
+      "experimental.youtrack.token": "",
+      "experimental.busy-during-background-shell::on": "true",
+      "experimental.busy-during-background-shell": "",
+    });
+    await flush();
+
+    expect(setSpy).toHaveBeenCalledWith("agent", "opencode");
+    expect(app).toHaveRelaunchCount(1);
+  });
+
+  it("Cancel closes without persisting", async () => {
+    const { openSettings, config, dialogs } = setup();
+    const setSpy = vi.spyOn(config, "set");
+    openSettings();
+    dialogs.lastHandle!.emitAction("cancel", {});
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(dialogs.lastHandle!.closed).toBe(true);
+  });
+
+  it("decodes the guarded union: off → false, on+text → regex array", async () => {
+    const { openSettings, config, dialogs } = setup();
+    const setSpy = vi.spyOn(config, "set");
+    openSettings();
+    dialogs.lastHandle!.emitAction("save", {
+      agent: "claude",
+      "telemetry.enabled": "true",
+      "sidebar.width": "250",
+      "log.output": "file",
+      "experimental.youtrack.token": "",
+      "experimental.busy-during-background-shell::on": "true",
+      "experimental.busy-during-background-shell": "wait, deploy",
+    });
+    await flush();
+    expect(setSpy).toHaveBeenCalledWith("experimental.busy-during-background-shell", [
+      "wait",
+      "deploy",
+    ]);
+  });
+});
+
+describe("SettingsModule — validation", () => {
+  it("disables Save while a field is invalid", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const handle = dialogs.lastHandle!;
+    expect(saveDisabled(handle.config)).toBe(false);
+
+    handle.emitChange("sidebar.width", {
+      agent: "claude",
+      "telemetry.enabled": "true",
+      "sidebar.width": "abc",
+      "log.output": "file",
+      "experimental.youtrack.token": "",
+      "experimental.busy-during-background-shell::on": "true",
+      "experimental.busy-during-background-shell": "",
+    });
+
+    expect(saveDisabled(handle.config)).toBe(true);
+  });
+});
+
+describe("SettingsModule — reset", () => {
+  it("Reset all to defaults reverts every non-default key", async () => {
+    const { openSettings, config, dialogs } = setup();
+    await config.set("sidebar.width", 400);
+    await config.set("telemetry.enabled", false);
+    const resetSpy = vi.spyOn(config, "reset");
+    openSettings();
+
+    dialogs.lastHandle!.emitAction("reset-all", {});
+    await flush();
+
+    expect(resetSpy).toHaveBeenCalledWith("sidebar.width");
+    expect(resetSpy).toHaveBeenCalledWith("telemetry.enabled");
+  });
+
+  it("indents rows by nesting depth (group vs sub-group)", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const cfg = dialogs.lastHandle!.config;
+    expect(rowByLabel(cfg, "width")!.indent).toBe(1); // sidebar.width
+    expect(rowByLabel(cfg, "token")!.indent).toBe(2); // experimental.youtrack.token
+  });
+
+  it("offers per-row reset only for user-set, non-default keys, and resets on click", async () => {
+    const { openSettings, config, dialogs } = setup();
+    await config.set("sidebar.width", 400); // user-set, deviates from default
+    const resetSpy = vi.spyOn(config, "reset");
+    openSettings();
+    const cfg = dialogs.lastHandle!.config;
+
+    expect(rowByLabel(cfg, "width")!.resetId).toBe("reset:sidebar.width");
+    expect(rowByLabel(cfg, "agent")!.resetId).toBeUndefined(); // still default
+
+    dialogs.lastHandle!.emitAction("reset:sidebar.width", {});
+    await flush();
+    expect(resetSpy).toHaveBeenCalledWith("sidebar.width");
+  });
+});
+
+describe("SettingsModule — shortcut", () => {
+  it("opens on the 's' shortcut key", async () => {
+    const { config, dialogs, app } = setup();
+    const { module } = createSettingsModule({
+      ui: dialogs.ui as unknown as UiPresenter,
+      config,
+      app,
+      logger: createMockLogger(),
+    });
+    const event: ShortcutKeyPressedEvent = {
+      type: EVENT_SHORTCUT_KEY_PRESSED,
+      payload: { key: "s" },
+    };
+    await module.events![EVENT_SHORTCUT_KEY_PRESSED]!.handler(event);
+    expect(dialogs.handles).toHaveLength(1);
+  });
+});

--- a/src/modules/settings-module.ts
+++ b/src/modules/settings-module.ts
@@ -1,0 +1,466 @@
+/**
+ * SettingsModule - the auto-populated settings dialog.
+ *
+ * Enumerates the Config registry and builds a declarative settings dialog from
+ * each key's `settingsControl` + `applies` metadata — no hand-maintained list.
+ * Opened two ways, both landing on openSettings():
+ *   - Alt+X then S: the shortcut-key domain event (key "s").
+ *   - the sidebar gear: the renderer's `open-settings` ui event, forwarded by
+ *     the presenter through the injected onOpenSettings callback (main.ts wires
+ *     it to this module's openSettings).
+ *
+ * Grouping is derived verbatim from the dot-separated key (segment 1 = group,
+ * segment 2 = sub-heading, remainder = label; a dotless key falls under
+ * "General"). Controls are inferred from each key's settingsControl. Sensitive
+ * (redact) keys render masked. Editing is buffered: Save / Save & Restart
+ * persist the buffer (Save & Restart then relaunches), Cancel discards. Live
+ * validation disables Save while any field is invalid; per-row reset and "Reset
+ * all to defaults" revert to defaults immediately.
+ */
+
+import type { IntentModule } from "../intents/lib/module";
+import type { DomainEvent } from "../intents/lib/types";
+import type { DialogHandle } from "./presentation/sessions";
+import type { UiPresenter } from "./presentation/presentation-module";
+import type { Logger } from "../boundaries/platform/logging";
+import type { Config, ConfigSource } from "../boundaries/platform/config";
+import type {
+  PersistedKeyDefinition,
+  SettingsControl,
+} from "../boundaries/platform/store-definition";
+import type { AppBoundary } from "../boundaries/shell/app";
+import type { DialogConfig, DialogSection, SettingRowField } from "../shared/dialog-types";
+import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Keys that are registered config but not user settings (excluded from the UI). */
+const EXCLUDED_KEYS = new Set(["help"]);
+
+/** Group heading for dotless (top-level) keys. */
+const GENERAL_GROUP = "General";
+
+const ACTION_SAVE = "save";
+const ACTION_SAVE_RESTART = "save-restart";
+const ACTION_CANCEL = "cancel";
+const ACTION_RESET_ALL = "reset-all";
+/** Per-row reset action ids are `${RESET_PREFIX}${key}`. */
+const RESET_PREFIX = "reset:";
+/** Sub-field id suffix for a guarded-text control's on/off checkbox. */
+const GUARD_ON_SUFFIX = "::on";
+
+// =============================================================================
+// Dependencies
+// =============================================================================
+
+export interface SettingsModuleDeps {
+  readonly ui: UiPresenter;
+  readonly config: Config;
+  readonly app: AppBoundary;
+  readonly logger: Logger;
+}
+
+interface SettingKey {
+  readonly key: string;
+  readonly def: PersistedKeyDefinition<unknown>;
+  readonly control: SettingsControl;
+}
+
+// =============================================================================
+// Key derivation
+// =============================================================================
+
+interface KeyParts {
+  readonly group: string;
+  readonly subheading: string | undefined;
+  readonly label: string;
+}
+
+/**
+ * Group / sub-heading / label from a dot-separated key, verbatim:
+ *   "agent"                        -> General          / -        / agent
+ *   "sidebar.width"                -> sidebar          / -        / width
+ *   "experimental.youtrack.token"  -> experimental     / youtrack / token
+ *   "experimental.busy-...-shell"  -> experimental     / -        / busy-...-shell
+ */
+function keyParts(key: string): KeyParts {
+  const segments = key.split(".");
+  if (segments.length === 1) {
+    return { group: GENERAL_GROUP, subheading: undefined, label: segments[0]! };
+  }
+  if (segments.length === 2) {
+    return { group: segments[0]!, subheading: undefined, label: segments[1]! };
+  }
+  return { group: segments[0]!, subheading: segments[1]!, label: segments.slice(2).join(".") };
+}
+
+// =============================================================================
+// Value <-> field encoding
+// =============================================================================
+
+function asString(value: unknown): string {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+/** Whether the key accepts null (so an empty text field can mean "unset"). */
+function isNullable(def: PersistedKeyDefinition<unknown>): boolean {
+  return def.validate(null) !== undefined;
+}
+
+function csvHas(value: unknown, option: string): boolean {
+  if (typeof value !== "string") return false;
+  return value.split(",").includes(option);
+}
+
+// =============================================================================
+// Module
+// =============================================================================
+
+export function createSettingsModule(deps: SettingsModuleDeps): {
+  module: IntentModule;
+  openSettings: () => void;
+} {
+  const { ui, config, app, logger } = deps;
+
+  let activeHandle: DialogHandle | null = null;
+  /** Effective value per key when the dialog opened, for the restart-note diff. */
+  let openValues: Record<string, unknown> = {};
+
+  /** Settings-eligible keys (has a control, not excluded, not deprecated), sorted. */
+  function settingKeys(): SettingKey[] {
+    const out: SettingKey[] = [];
+    for (const [key, def] of config.getDefinitions()) {
+      if (def.deprecated || def.settingsControl === undefined || EXCLUDED_KEYS.has(key)) continue;
+      out.push({ key, def, control: def.settingsControl });
+    }
+    return out.sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  /** Decode the field data for one key into its typed value; undefined = invalid. */
+  function decode(entry: SettingKey, data: Record<string, string>): unknown {
+    const { key, def, control } = entry;
+    switch (control.kind) {
+      case "boolean":
+        return data[key] === "true";
+      case "number": {
+        const raw = data[key] ?? "";
+        if (raw.trim() === "") return undefined;
+        return def.validate(Number(raw));
+      }
+      case "string": {
+        const raw = data[key] ?? "";
+        if (raw === "" && isNullable(def)) return def.validate(null);
+        return def.validate(raw);
+      }
+      case "enum": {
+        const raw = data[key] ?? "";
+        if (raw === "" && control.nullable) return def.validate(null);
+        return def.validate(raw);
+      }
+      case "enum-list": {
+        const selected = control.options.filter((opt) => data[`${key}::${opt}`] === "true");
+        return def.validate(selected.slice().sort().join(","));
+      }
+      case "guarded-text": {
+        const on = data[`${key}${GUARD_ON_SUFFIX}`] === "true";
+        if (!on) return def.validate(control.offValue);
+        const text = data[key] ?? "";
+        return def.validate(text === "" ? control.onEmptyValue : control.fromText(text));
+      }
+    }
+  }
+
+  /** The value-bearing fields for one key, seeded from `current`, with `error`. */
+  function fieldsFor(
+    entry: SettingKey,
+    current: unknown,
+    liveData: Record<string, string> | undefined,
+    error: string | undefined
+  ): SettingRowField[] {
+    const { key, def, control } = entry;
+    const masked = def.redact === true;
+    switch (control.kind) {
+      case "boolean":
+        return [{ type: "checkbox", id: key, value: current === true, changeEvent: true }];
+      case "number":
+      case "string":
+        return [
+          {
+            type: "input",
+            id: key,
+            // Controlled value (not initialValue) so a reset/rebuild can push the
+            // default back into the field; typing between pushes is preserved.
+            value: asString(current),
+            changeEvent: true,
+            ...(masked && { masked: true }),
+            ...(error !== undefined && { error }),
+          },
+        ];
+      case "enum": {
+        const items = control.options.map((o) => ({ value: o.value, label: o.label }));
+        const suggestions = control.nullable
+          ? [{ items: [{ value: "", label: "(default)" }, ...items] }]
+          : [{ items }];
+        return [
+          {
+            type: "dropdown",
+            id: key,
+            searchable: false,
+            changeEvent: true,
+            suggestions,
+            value: asString(current),
+          },
+        ];
+      }
+      case "enum-list":
+        return control.options.map((opt) => ({
+          type: "checkbox" as const,
+          id: `${key}::${opt}`,
+          label: opt,
+          value: csvHas(current, opt),
+          changeEvent: true,
+        }));
+      case "guarded-text": {
+        const state = control.toText(current);
+        const on = liveData ? liveData[`${key}${GUARD_ON_SUFFIX}`] === "true" : state.active;
+        return [
+          {
+            type: "checkbox",
+            id: `${key}${GUARD_ON_SUFFIX}`,
+            label: "Enabled",
+            value: state.active,
+            changeEvent: true,
+          },
+          {
+            type: "input",
+            id: key,
+            value: state.text,
+            disabled: !on,
+            changeEvent: true,
+            ...(masked && { masked: true }),
+            ...(error !== undefined && { error }),
+          },
+        ];
+      }
+    }
+  }
+
+  /**
+   * Build the full dialog config. `liveData` (present after a field change)
+   * drives validation, guard enable/disable, and the restart-note diff.
+   */
+  function buildConfig(liveData?: Record<string, string>): {
+    config: DialogConfig;
+    invalidCount: number;
+  } {
+    const sections: DialogSection[] = [];
+    let invalidCount = 0;
+    let lastGroup: string | undefined;
+    let lastSubheading: string | undefined;
+
+    for (const entry of settingKeys()) {
+      const { key, def } = entry;
+      const parts = keyParts(key);
+      if (parts.group !== lastGroup) {
+        sections.push({ type: "text", content: parts.group, style: "heading" });
+        lastGroup = parts.group;
+        lastSubheading = undefined;
+      }
+      if (parts.subheading !== undefined && parts.subheading !== lastSubheading) {
+        sections.push({
+          type: "text",
+          content: parts.subheading,
+          style: "subheading",
+          indent: 1,
+        });
+        lastSubheading = parts.subheading;
+      }
+
+      const current = config.getEffective()[key];
+      const source = config.getSource(key);
+
+      // Live validation from the latest field values.
+      let error: string | undefined;
+      if (liveData) {
+        const decoded = decode(entry, liveData);
+        if (decoded === undefined) {
+          error = def.validValues ? `Invalid value (expected ${def.validValues})` : "Invalid value";
+          invalidCount += 1;
+        }
+      }
+
+      // Restart note: shown when a restart-scoped key's buffered value differs
+      // from its value when the dialog opened.
+      const applies = def.applies ?? "restart";
+      let note: string | undefined;
+      if (liveData && applies !== "live" && error === undefined) {
+        const decoded = decode(entry, liveData);
+        if (decoded !== undefined && !valuesEqual(decoded, openValues[key])) {
+          note = "Restart to apply";
+        }
+      }
+
+      const badge = sourceBadge(source);
+      // Reset is offered only when the key is set in config.json ("user") and its
+      // value differs from the default — resetting removes it from config.json.
+      const resettable = source === "user" && !valuesEqual(current, def.default);
+      const row: Extract<DialogSection, { type: "setting-row" }> = {
+        type: "setting-row",
+        label: parts.label,
+        fields: fieldsFor(entry, current, liveData, error),
+        indent: parts.subheading !== undefined ? 2 : 1,
+        ...(def.description !== undefined && { description: def.description }),
+        ...(badge !== undefined && { badge }),
+        ...(note !== undefined && { note }),
+        ...(resettable && { resetId: `${RESET_PREFIX}${key}` }),
+      };
+      sections.push(row);
+    }
+
+    const saveDisabled = invalidCount > 0;
+    sections.push({
+      type: "group",
+      reverse: true,
+      items: [
+        {
+          type: "button",
+          id: ACTION_SAVE,
+          label: "Save",
+          variant: "primary",
+          disabled: saveDisabled,
+        },
+        {
+          type: "button",
+          id: ACTION_SAVE_RESTART,
+          label: "Save & Restart",
+          variant: "secondary",
+          disabled: saveDisabled,
+        },
+        {
+          type: "button",
+          id: ACTION_CANCEL,
+          label: "Cancel",
+          variant: "secondary",
+          role: "cancel",
+        },
+        {
+          type: "button",
+          id: ACTION_RESET_ALL,
+          label: "Reset all to defaults",
+          variant: "secondary",
+        },
+      ],
+    });
+
+    return { config: { sections, layout: "form", modal: true }, invalidCount };
+  }
+
+  /** Small source badge; only env/CLI overrides are noteworthy. */
+  function sourceBadge(source: ConfigSource): string | undefined {
+    return source === "env" || source === "cli" ? source : undefined;
+  }
+
+  function valuesEqual(a: unknown, b: unknown): boolean {
+    return a === b || JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  /** Persist every changed key from the buffered field data. */
+  async function save(data: Record<string, string>): Promise<boolean> {
+    for (const entry of settingKeys()) {
+      const decoded = decode(entry, data);
+      if (decoded === undefined) {
+        logger.warn("Skipping invalid setting on save", { key: entry.key });
+        continue;
+      }
+      if (valuesEqual(decoded, config.getEffective()[entry.key])) continue;
+      try {
+        await config.set(entry.key, decoded);
+      } catch (error) {
+        logger.warn("Failed to persist setting", {
+          key: entry.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function openSettings(): void {
+    if (activeHandle) return;
+
+    openValues = { ...config.getEffective() };
+    const handle = ui.dialog(buildConfig().config);
+    activeHandle = handle;
+
+    const close = (): void => {
+      handle.close();
+      activeHandle = null;
+    };
+
+    handle.onChange((event) => {
+      // Rebuild with the latest field values so validation, guard enable/disable
+      // and restart notes reflect the edit.
+      handle.update(buildConfig(event.data).config);
+    });
+
+    handle.onEvent((event) => {
+      const data = event.data ?? {};
+      if (event.actionId === ACTION_CANCEL) {
+        close();
+        return;
+      }
+      if (event.actionId === ACTION_RESET_ALL) {
+        void (async () => {
+          for (const entry of settingKeys()) {
+            if (config.getSource(entry.key) !== "default") await config.reset(entry.key);
+          }
+          openValues = { ...config.getEffective() };
+          handle.update(buildConfig().config);
+        })();
+        return;
+      }
+      if (event.actionId.startsWith(RESET_PREFIX)) {
+        const key = event.actionId.slice(RESET_PREFIX.length);
+        void (async () => {
+          await config.reset(key);
+          openValues = { ...config.getEffective() };
+          handle.update(buildConfig().config);
+        })();
+        return;
+      }
+      if (event.actionId === ACTION_SAVE || event.actionId === ACTION_SAVE_RESTART) {
+        void (async () => {
+          const ok = await save(data);
+          if (!ok) return;
+          if (event.actionId === ACTION_SAVE_RESTART) {
+            app.relaunch();
+            return;
+          }
+          close();
+        })();
+        return;
+      }
+    });
+
+    void handle.closed.then(() => {
+      activeHandle = null;
+    });
+  }
+
+  const module: IntentModule = {
+    name: "settings",
+    events: {
+      [EVENT_SHORTCUT_KEY_PRESSED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { key } = (event as ShortcutKeyPressedEvent).payload;
+          if (key === "s") openSettings();
+        },
+      },
+    },
+  };
+
+  return { module, openSettings };
+}

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -25,13 +25,24 @@
     const headingSection = config.sections.find((s) => s.type === "text" && s.style === "heading");
     return headingSection?.type === "text" ? headingSection.content : "Dialog";
   });
+
+  /**
+   * A form-layout dialog with a trailing button-only group (the settings dialog)
+   * hands its own scrolling body + pinned footer, so the card drops its padding
+   * and clips instead of scrolling as a whole.
+   */
+  const scrollLayout = $derived.by(() => {
+    if (config.layout !== "form") return false;
+    const last = config.sections[config.sections.length - 1];
+    return last?.type === "group" && last.items.every((i) => i.type === "button");
+  });
 </script>
 
 <div class="dialog-view" role="dialog" aria-label={heading}>
   <div class="backdrop" aria-hidden="true">
     <Logo />
   </div>
-  <div class="card">
+  <div class="card" class:scroll-layout={scrollLayout}>
     <Form {dialogId} {config} />
   </div>
 </div>
@@ -67,11 +78,29 @@
     position: relative;
     max-width: 500px;
     width: 100%;
+    /* Cap tall dialogs (e.g. the settings form) at 80% of the viewport and
+       scroll inside; short dialogs stay their natural height. The card is
+       centered vertically by .dialog-view. */
+    max-height: 80%;
+    overflow-y: auto;
     padding: 2rem;
     text-align: center;
     background: color-mix(in srgb, var(--ch-surface-1, var(--ch-background)) 90%, transparent);
     border: 1px solid var(--ch-border);
     border-radius: var(--ch-radius-lg, 14px);
     box-shadow: var(--ch-shadow);
+  }
+
+  /* Scroll-layout (settings): the Form owns a scrolling body + pinned footer,
+     so the card is a flush flex column that clips rather than scrolls itself.
+     Wider than the default card — it holds denser [label] [control] [reset]
+     rows. */
+  .card.scroll-layout {
+    max-width: 750px;
+    padding: 0;
+    overflow: hidden;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
   }
 </style>

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -169,6 +169,12 @@
     if (!row) return;
     api.emitEvent({ kind: "wake-workspace", key: row.key });
   }
+
+  // Open the settings dialog (sidebar gear). Main forwards this to the settings
+  // module, which opens the declarative settings dialog.
+  function handleOpenSettings(): void {
+    api.emitEvent({ kind: "open-settings" });
+  }
 </script>
 
 <div class="main-view">
@@ -186,6 +192,7 @@
     onSwitchWorkspace={handleSwitchWorkspace}
     onOpenNewWorkspace={handleOpenNewWorkspace}
     onRemoveWorkspace={handleRemoveWorkspace}
+    onOpenSettings={handleOpenSettings}
   />
 
   <ShortcutOverlay

--- a/src/renderer/lib/components/ShortcutOverlay.svelte
+++ b/src/renderer/lib/components/ShortcutOverlay.svelte
@@ -85,6 +85,9 @@
     <vscode-badge>H</vscode-badge>
     {activeHibernated ? "Wake" : "Hibernate"}
   </span>
+  <span class="shortcut-hint" aria-label="S key to open settings">
+    <vscode-badge>S</vscode-badge> Settings
+  </span>
 </div>
 
 <style>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -43,6 +43,8 @@
     onOpenNewWorkspace: () => void;
     /** Request the remove flow for a workspace by its snapshot row key. */
     onRemoveWorkspace: (key: string) => void;
+    /** Open the settings dialog (gear in the PROJECTS header). */
+    onOpenSettings: () => void;
   }
 
   let {
@@ -58,6 +60,7 @@
     onSwitchWorkspace,
     onOpenNewWorkspace,
     onRemoveWorkspace,
+    onOpenSettings,
   }: SidebarProps = $props();
 
   const totalWorkspaces = $derived(
@@ -317,7 +320,17 @@
     <div class="ch-label-cell header-label">
       <h2>PROJECTS</h2>
     </div>
-    {#if !isExpanded}
+    {#if isExpanded}
+      <button
+        type="button"
+        class="header-gear"
+        aria-label="Settings"
+        title="Settings"
+        onclick={() => onOpenSettings()}
+      >
+        <Icon name="gear" size={14} />
+      </button>
+    {:else}
       <span class="ch-icon-cell expand-hint" aria-hidden="true">
         <Icon name="chevron-right" size={12} />
       </span>
@@ -624,6 +637,26 @@
 
   .expand-hint:hover {
     opacity: 1;
+  }
+
+  /* Gear button in the (expanded) PROJECTS header — a global settings entry. */
+  .header-gear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 12px;
+    padding: 2px 6px;
+    color: var(--ch-foreground);
+    background: transparent;
+    border: none;
+    border-radius: var(--ch-radius-sm, 6px);
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  .header-gear:hover {
+    opacity: 1;
+    background: var(--ch-list-hover-bg);
   }
 
   .sidebar-header h2 {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -90,6 +90,7 @@ describe("Sidebar component", () => {
     onSwitchWorkspace: vi.fn(),
     onOpenNewWorkspace: vi.fn(),
     onRemoveWorkspace: vi.fn(),
+    onOpenSettings: vi.fn(),
   };
 
   beforeEach(() => {

--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -78,6 +78,12 @@
             fields.push(item);
           }
         }
+      } else if (section.type === "setting-row") {
+        // A settings row wraps real field controls; collect them so their
+        // values flow through the form exactly like top-level fields.
+        for (const item of section.fields) {
+          fields.push(item);
+        }
       }
     }
     return fields;
@@ -86,6 +92,22 @@
   // Section layout: "centered" (default) keeps the centered stack; "form" lays
   // fields out as left-aligned labeled rows with right-aligned actions.
   const layout = $derived(config.layout ?? "centered");
+
+  /**
+   * Index of a trailing button-only group (the footer/action row), or -1. When
+   * present on a modal form dialog (the settings dialog), the sections above it
+   * scroll in a body and the footer is pinned at the card's bottom.
+   */
+  const footerIndex = $derived.by(() => {
+    const secs = config.sections;
+    const last = secs[secs.length - 1];
+    if (last && last.type === "group" && last.items.every((i) => i.type === "button")) {
+      return secs.length - 1;
+    }
+    return -1;
+  });
+
+  const splitFooter = $derived(surface === "modal" && layout === "form" && footerIndex >= 0);
 
   /**
    * Stable keys for the sections each-block, so a config push that inserts or
@@ -108,7 +130,9 @@
           ? `field:${section.id}`
           : section.type === "group"
             ? `group:${section.items.map((item) => item.id).join("+")}`
-            : section.type;
+            : section.type === "setting-row"
+              ? `setting:${section.fields.map((field) => field.id).join("+")}`
+              : section.type;
       const occurrence = counters[base] ?? 0;
       counters[base] = occurrence + 1;
       return occurrence === 0 ? base : `${base}:${occurrence}`;
@@ -196,8 +220,19 @@
             ? existingDisplay
             : suggestionLabel(section, next[section.id]!);
       } else if (section.type === "input") {
+        // Controlled push with the dropdown/checkbox adopt-once semantics: adopt
+        // a pushed value the renderer has not seen yet (e.g. a reset-to-default);
+        // re-sends preserve the user's edits. Absent value = seed from
+        // initialValue, then user-driven.
         const existing = untrack(() => fieldValues[section.id]);
-        next[section.id] = existing ?? section.initialValue ?? "";
+        const pushed =
+          section.value !== undefined && section.value !== adoptedValues[section.id]
+            ? section.value
+            : undefined;
+        if (pushed !== undefined) {
+          adoptedValues[section.id] = pushed;
+        }
+        next[section.id] = pushed ?? existing ?? section.initialValue ?? "";
       } else if (section.type === "checkbox") {
         // Controlled push with the dropdown's adopt-once semantics: adopt a
         // pushed value the renderer has not seen yet; re-sends preserve the
@@ -351,6 +386,9 @@
 
   // Auto-focus on mount: an explicit autofocus control wins, else the
   // computed default target (first enabled field, else the primary button).
+  // In the form layout (settings) we skip the default target: focusing the
+  // first field would open its dropdown list, so we leave focus unset unless a
+  // control opts in with an explicit autofocus flag.
   onMount(() => {
     setTimeout(() => {
       const explicit = formRef?.querySelector<HTMLElement>("[data-autofocus]");
@@ -358,6 +396,7 @@
         explicit.focus();
         return;
       }
+      if (layout === "form") return;
       defaultFocusTarget()?.focus();
     }, 0);
   });
@@ -561,6 +600,7 @@
 <div
   class="form"
   class:layout-form={layout === "form"}
+  class:split-footer={splitFooter}
   role="none"
   bind:this={formRef}
   onkeydown={handleKeydown}
@@ -583,9 +623,21 @@
       onSubmit={triggerPrimaryAction}
     />
   {/snippet}
-  {#each config.sections as section, sectionIndex (sectionKeys[sectionIndex])}
-    {@render renderSection(section)}
-  {/each}
+  {#if splitFooter}
+    <!-- Scrolling body (everything above the footer) + a pinned footer row. -->
+    <div class="form-body">
+      {#each config.sections.slice(0, footerIndex) as section, sectionIndex (sectionKeys[sectionIndex])}
+        {@render renderSection(section)}
+      {/each}
+    </div>
+    <div class="form-footer">
+      {@render renderSection(config.sections[footerIndex]!)}
+    </div>
+  {:else}
+    {#each config.sections as section, sectionIndex (sectionKeys[sectionIndex])}
+      {@render renderSection(section)}
+    {/each}
+  {/if}
 </div>
 
 <style>
@@ -605,5 +657,66 @@
   .form.layout-form {
     align-items: stretch;
     text-align: left;
+  }
+
+  /* Split-footer mode (modal settings dialog): the form fills the card, its
+     body scrolls, and the footer row stays pinned at the bottom. The card
+     (DialogView) drops its own padding in this mode, so the body/footer carry
+     it. */
+  .form.split-footer {
+    flex: 1;
+    min-height: 0;
+    gap: 0;
+  }
+
+  .form.split-footer .form-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 2rem 2rem 0.75rem;
+  }
+
+  .form.split-footer .form-footer {
+    padding: 1rem 2rem;
+    border-top: 1px solid var(--ch-border);
+  }
+
+  /* Group headings in the settings dialog are section labels, not a dialog
+     title — smaller than the default heading. Uppercase + muted to read as a
+     group header. :global reaches the TextSection child's element. */
+  .form.split-footer :global(.section-heading) {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.6;
+    margin-top: 0.75rem;
+  }
+
+  /* Theme-aware scrollbar for the scrolling body (Chromium/Electron). Defaults
+     to VS Code's scrollbar-slider colors, which follow the active theme, so it
+     is not a bright bar on dark backgrounds. */
+  .form.split-footer .form-body {
+    scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+  }
+
+  .form.split-footer .form-body::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  .form.split-footer .form-body::-webkit-scrollbar-thumb {
+    background: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+    border-radius: 5px;
+  }
+
+  .form.split-footer .form-body::-webkit-scrollbar-thumb:hover {
+    background: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
+  }
+
+  .form.split-footer .form-body::-webkit-scrollbar-track {
+    background: transparent;
   }
 </style>

--- a/src/renderer/lib/components/form/InputSection.svelte
+++ b/src/renderer/lib/components/form/InputSection.svelte
@@ -18,6 +18,9 @@
 
   const { section, value, onInput, onSubmit }: Props = $props();
 
+  // Masked (password) single-line fields start hidden; the eye button reveals.
+  let revealed = $state(false);
+
   /**
    * Focus the textarea and optionally select the seeded text. Also re-focuses
    * the textarea when Alt is released: Chromium's default Alt-up handler
@@ -111,22 +114,36 @@
       }}
     ></textarea>
   {:else}
-    <vscode-textfield
-      class="input-textfield"
-      id={section.id}
-      invalid={section.error ? true : undefined}
-      placeholder={section.placeholder ?? ""}
-      disabled={section.disabled || undefined}
-      data-autofocus={section.autofocus || undefined}
-      aria-label={section.label ? undefined : (section.placeholder ?? "Text input")}
-      aria-invalid={section.error ? "true" : undefined}
-      aria-describedby={section.error ? `${section.id}-error` : undefined}
-      {value}
-      oninput={(e: Event) => {
-        onInput((e.currentTarget as HTMLInputElement).value);
-      }}
-      use:submitOnEnter
-    ></vscode-textfield>
+    <div class="input-row" class:masked={section.masked}>
+      <vscode-textfield
+        class="input-textfield"
+        id={section.id}
+        type={section.masked && !revealed ? "password" : undefined}
+        invalid={section.error ? true : undefined}
+        placeholder={section.placeholder ?? ""}
+        disabled={section.disabled || undefined}
+        data-autofocus={section.autofocus || undefined}
+        aria-label={section.label ? undefined : (section.placeholder ?? "Text input")}
+        aria-invalid={section.error ? "true" : undefined}
+        aria-describedby={section.error ? `${section.id}-error` : undefined}
+        {value}
+        oninput={(e: Event) => {
+          onInput((e.currentTarget as HTMLInputElement).value);
+        }}
+        use:submitOnEnter
+      ></vscode-textfield>
+      {#if section.masked}
+        <button
+          type="button"
+          class="reveal-btn"
+          aria-label={revealed ? "Hide value" : "Reveal value"}
+          aria-pressed={revealed}
+          onclick={() => (revealed = !revealed)}
+        >
+          <vscode-icon name={revealed ? "eye-closed" : "eye"} aria-hidden="true"></vscode-icon>
+        </button>
+      {/if}
+    </div>
   {/if}
   {#if section.error}
     <vscode-form-helper id="{section.id}-error">
@@ -188,5 +205,34 @@
 
   .input-textfield {
     width: 100%;
+  }
+
+  /* Masked field: text field + reveal button share one row. */
+  .input-row {
+    display: contents;
+  }
+
+  .input-row.masked {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .reveal-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    color: var(--ch-foreground);
+    background: transparent;
+    border: none;
+    border-radius: var(--ch-radius-sm, 6px);
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  .reveal-btn:hover {
+    opacity: 1;
+    background: var(--ch-list-hover-bg);
   }
 </style>

--- a/src/renderer/lib/components/form/Section.svelte
+++ b/src/renderer/lib/components/form/Section.svelte
@@ -22,9 +22,10 @@
   import InputSection from "./InputSection.svelte";
   import ProgressSection from "./ProgressSection.svelte";
   import RadioSection from "./RadioSection.svelte";
+  import SettingRow from "./SettingRow.svelte";
   import TableSection from "./TableSection.svelte";
   import TextSection from "./TextSection.svelte";
-  import type { ButtonItem, FormLayout, GroupItem, SectionHandlers } from "./types";
+  import type { ButtonItem, FormLayout, SectionHandlers } from "./types";
   import type { DialogSection } from "@shared/dialog-types";
 
   interface Props extends SectionHandlers {
@@ -34,8 +35,8 @@
     values: Record<string, string>;
     /** Dropdown display text keyed by field id (what the combobox shows). */
     displays: Record<string, string>;
-    /** Renders a group item as an ordinary section (Form's recursive snippet). */
-    renderItem: Snippet<[GroupItem]>;
+    /** Renders a nested item as an ordinary section (Form's recursive snippet). */
+    renderItem: Snippet<[DialogSection | ButtonItem]>;
   }
 
   const {
@@ -89,6 +90,12 @@
   />
 {:else if section.type === "group"}
   <GroupSection {section} {layout} {renderItem} />
+{:else if section.type === "setting-row"}
+  <SettingRow
+    {section}
+    {renderItem}
+    onReset={() => onAction({ type: "button", id: section.resetId ?? "" })}
+  />
 {:else if section.type === "table"}
   <TableSection {section} />
 {:else if section.type === "button"}

--- a/src/renderer/lib/components/form/Section.test.ts
+++ b/src/renderer/lib/components/form/Section.test.ts
@@ -11,11 +11,14 @@ import { render, screen } from "@testing-library/svelte";
 import { createRawSnippet } from "svelte";
 import Section from "./Section.svelte";
 import type { DialogSection } from "@shared/dialog-types";
-import type { ButtonItem, GroupItem } from "./types";
+import type { ButtonItem } from "./types";
 
 /** Stand-in for Form's recursive snippet: renders an identifiable stub. */
-const renderItemStub = createRawSnippet<[GroupItem]>((item) => ({
-  render: () => `<div class="item-stub" data-id="${item().id}"></div>`,
+const renderItemStub = createRawSnippet<[DialogSection | ButtonItem]>((item) => ({
+  render: () => {
+    const s = item();
+    return `<div class="item-stub" data-id="${"id" in s ? s.id : ""}"></div>`;
+  },
 }));
 
 function renderSection(section: DialogSection | ButtonItem) {

--- a/src/renderer/lib/components/form/SettingRow.svelte
+++ b/src/renderer/lib/components/form/SettingRow.svelte
@@ -1,0 +1,157 @@
+<!--
+  SettingRow.svelte
+
+  One auto-populated settings entry. The label and its control(s) sit side by
+  side ([label] [control]); the description and any inline note (e.g. "Restart
+  to apply") sit below, spanning the row. Controls are the real field sections
+  rendered through Form's recursive Section snippet, so their values flow
+  through the form unchanged.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import Icon from "../Icon.svelte";
+  import type { ButtonItem, SettingRowSectionConfig } from "./types";
+  import type { DialogSection } from "@shared/dialog-types";
+
+  interface Props {
+    section: SettingRowSectionConfig;
+    /** Form's recursive section snippet, used to render the wrapped controls. */
+    renderItem: Snippet<[DialogSection | ButtonItem]>;
+    /** Reset this setting to its default. Rendered only when section.resetId is set. */
+    onReset: () => void;
+  }
+
+  const { section, renderItem, onReset }: Props = $props();
+</script>
+
+<div class="setting-row" style={section.indent ? `padding-left: ${section.indent}rem` : undefined}>
+  <div class="setting-main">
+    <div class="setting-label-cell">
+      <span class="setting-label">{section.label}</span>
+      {#if section.badge}
+        <span class="setting-badge">{section.badge}</span>
+      {/if}
+    </div>
+    <div class="setting-controls">
+      {#each section.fields as field, index (field.id + index)}
+        {@render renderItem(field)}
+      {/each}
+    </div>
+    <button
+      type="button"
+      class="setting-reset"
+      class:hidden={!section.resetId}
+      aria-label="Reset to default"
+      title="Reset to default"
+      disabled={!section.resetId}
+      onclick={onReset}
+    >
+      <Icon name="discard" size={14} />
+    </button>
+  </div>
+  {#if section.description}
+    <p class="setting-description">{section.description}</p>
+  {/if}
+  {#if section.note}
+    <p class="setting-note">
+      <Icon name="info" size={12} />
+      {section.note}
+    </p>
+  {/if}
+</div>
+
+<style>
+  .setting-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    width: 100%;
+    /* Separate adjacent entries: bottom padding + a faint divider make the
+       boundary between two settings easy to see. */
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid var(--ch-border);
+  }
+
+  /* [label] [control] on one row: the label takes a fixed share on the left,
+     the control(s) fill the rest on the right. */
+  .setting-main {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .setting-label-cell {
+    flex: 0 0 40%;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .setting-label {
+    font-weight: 500;
+    overflow-wrap: anywhere;
+  }
+
+  /* Source badge (env / cli): a small muted tag. */
+  .setting-badge {
+    padding: 0 6px;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--ch-foreground-dim, rgba(255, 255, 255, 0.6));
+    background: var(--ch-list-hover-bg, rgba(255, 255, 255, 0.08));
+    border-radius: var(--ch-radius-sm, 6px);
+  }
+
+  .setting-description {
+    margin: 0;
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+
+  .setting-controls {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+  }
+
+  /* Reset-to-default, pinned to the row's right edge. Kept in the layout even
+     when inactive (visibility: hidden) so control widths don't jump row to row. */
+  .setting-reset {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    color: var(--ch-foreground);
+    background: transparent;
+    border: none;
+    border-radius: var(--ch-radius-sm, 6px);
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  .setting-reset:hover {
+    opacity: 1;
+    background: var(--ch-list-hover-bg);
+  }
+
+  .setting-reset.hidden {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .setting-note {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--ch-warning-fg, #cca700);
+  }
+</style>

--- a/src/renderer/lib/components/form/TextSection.svelte
+++ b/src/renderer/lib/components/form/TextSection.svelte
@@ -23,6 +23,13 @@
     {/if}
     {section.content}
   </h1>
+{:else if section.style === "subheading"}
+  <h2
+    class="section-subheading"
+    style={section.indent ? `padding-left: ${section.indent}rem` : undefined}
+  >
+    {section.content}
+  </h2>
 {:else if section.style === "subtitle"}
   <p class="section-subtitle">{section.content}</p>
 {:else if section.style === "warning" || section.style === "error"}
@@ -53,6 +60,12 @@
 
   .icon-error {
     color: var(--ch-danger);
+  }
+
+  .section-subheading {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
   }
 
   .section-subtitle {

--- a/src/renderer/lib/components/form/types.ts
+++ b/src/renderer/lib/components/form/types.ts
@@ -13,6 +13,7 @@ export type TableSectionConfig = Extract<DialogSection, { type: "table" }>;
 export type InputSectionConfig = Extract<DialogSection, { type: "input" }>;
 export type CheckboxSectionConfig = Extract<DialogSection, { type: "checkbox" }>;
 export type GroupSectionConfig = Extract<DialogSection, { type: "group" }>;
+export type SettingRowSectionConfig = Extract<DialogSection, { type: "setting-row" }>;
 
 export type GroupItem = GroupSectionConfig["items"][number];
 export type ButtonItem = Extract<GroupItem, { type: "button" }>;

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -17,6 +17,8 @@
  * Text section - displays a text element with optional styling and icon.
  *
  * - style "heading": large + bold (h1-like)
+ * - style "subheading": medium + semibold (h2-like); a subordinate section
+ *   header (e.g. a settings group's nested sub-group).
  * - style "subtitle": small + dim
  * - style "warning" / "error": alert box (icon + tinted background). The two
  *   styles state semantic intent — a caution the user should weigh vs. a
@@ -28,8 +30,10 @@
 interface TextSection {
   readonly type: "text";
   readonly content: string;
-  readonly style?: "heading" | "subtitle" | "warning" | "error";
+  readonly style?: "heading" | "subheading" | "subtitle" | "warning" | "error";
   readonly icon?: string;
+  /** Indentation depth (0 = flush). Each level indents the text left-to-right. */
+  readonly indent?: number;
 }
 
 /**
@@ -185,7 +189,21 @@ interface InputSection extends FieldSection {
   readonly rows?: number;
   readonly initialValue?: string;
   readonly selectInitialValue?: boolean;
+  /**
+   * Controlled value push with the dropdown/checkbox adopt-once semantics: the
+   * renderer adopts a pushed value it has not seen yet; re-sending the same
+   * value preserves the user's edits. Lets the backend force the field (e.g.
+   * reset-to-default) while normal typing stays user-driven. Absent = seed from
+   * initialValue, then fully user-driven.
+   */
+  readonly value?: string;
   readonly changeEvent?: FieldChangeConfig;
+  /**
+   * Render a single-line field as a masked/password input with an eye-toggle to
+   * reveal. Used for sensitive settings (e.g. API tokens). Ignored when
+   * `multiline` is set.
+   */
+  readonly masked?: boolean;
 }
 
 /**
@@ -239,6 +257,36 @@ interface GroupSection {
 
 type GroupItem = InputSection | DropdownSection | ButtonItem;
 
+/** A value-bearing control that can sit inside a settings row. */
+export type SettingRowField = CheckboxSection | InputSection | DropdownSection;
+
+/**
+ * Setting row - one auto-populated settings entry: a labeled row wrapping one
+ * or more real field controls (so the form's value collection and live-change
+ * validation apply unchanged) plus settings-specific chrome.
+ *
+ * - fields: the value-bearing control(s). One for a simple setting; several for
+ *   a multi-value setting (a checkbox per enum-list option) or a guarded field
+ *   (an on/off checkbox + a text input).
+ * - description: muted help text under the label (from the config key's description).
+ * - badge: a small tag by the label naming a non-default source ("env" / "cli").
+ * - note: an inline note under the row (e.g. "Restart to apply").
+ * - indent: indentation depth (0 = flush) mirroring the key's group nesting.
+ * - resetId: when set, a reset-to-default icon button appears at the right of
+ *   the row and emits a DialogActionEvent with this id. Omit to hide it (value
+ *   already at default / not user-set).
+ */
+interface SettingRowSection {
+  readonly type: "setting-row";
+  readonly label: string;
+  readonly fields: readonly SettingRowField[];
+  readonly description?: string;
+  readonly badge?: string;
+  readonly note?: string;
+  readonly indent?: number;
+  readonly resetId?: string;
+}
+
 export type DialogSection =
   | TextSection
   | ProgressSection
@@ -247,7 +295,8 @@ export type DialogSection =
   | TableSection
   | InputSection
   | CheckboxSection
-  | GroupSection;
+  | GroupSection
+  | SettingRowSection;
 
 // ---- Progress Items ----
 

--- a/src/shared/ui-event.ts
+++ b/src/shared/ui-event.ts
@@ -59,6 +59,10 @@ export const uiEventSchema = z.discriminatedUnion("kind", [
     message: z.string(),
     context: logContextSchema.optional(),
   }),
+  // Open the settings dialog (sidebar gear click). The presenter forwards this
+  // to the settings module, which opens the declarative settings dialog. The
+  // Alt+X+S shortcut reaches the same module via the shortcut-key domain event.
+  z.object({ kind: z.literal("open-settings") }),
   // Dialog user interactions. The
   // presenter routes these to the matching open dialog session by `dialogId`
   // (the opaque id echoed from the snapshot's `dialogs`). `data` is the flat


### PR DESCRIPTION
Adds a declarative settings dialog driven entirely by the config registry — no hand-maintained list.

- **Entry points**: a gear in the sidebar PROJECTS header, or Alt+X then S.
- **Auto-populated**: enumerates the config registry; grouped verbatim by key prefix (group › sub-heading › label), controls inferred from each key's `settingsControl`, with an `applies` live/restart hint.
- **Editing**: buffered Save / Save & Restart / Cancel (Save & Restart relaunches); live validation disables Save while invalid; per-row + global reset; source badges (env/cli); masked sensitive fields.
- **Config layer**: `SettingsControl`/`applies` metadata auto-attached by the type builders; `Config.getDefinitions/set/getSource/wasConfigured`; per-key source tracking. `agent` is now non-nullable (default `claude`) with first-run onboarding gated on `wasConfigured()`; `code-server.port` migrated to `storeNumber`; `busy-during-background-shell` and `electron.disabled-features` use a guarded-text control.
- **Dialog framework**: masked input, `subheading` text style, a `setting-row` section with a scrolling body + pinned footer, and `AppBoundary.relaunch()` for Save & Restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)