### PR TITLE
feat: file picker for file-based settings

### DIFF
--- a/src/boundaries/platform/filesystem.boundary.test.ts
+++ b/src/boundaries/platform/filesystem.boundary.test.ts
@@ -197,6 +197,32 @@ describe("DefaultFileSystemBoundary", () => {
         expect((error as FileSystemError).path).toBe(dirPath);
       }
     });
+
+    it("creates a new file when exclusive", async () => {
+      const filePath = join(tempDir.path, "new.txt");
+
+      await fs.writeFile(filePath, "seed", { exclusive: true });
+
+      expect(await fs.readFile(filePath)).toBe("seed");
+    });
+
+    it("throws EEXIST when exclusive and the file already exists", async () => {
+      const filePath = join(tempDir.path, "existing.txt");
+      await nodeWriteFile(filePath, "original", "utf-8");
+
+      await expect(fs.writeFile(filePath, "seed", { exclusive: true })).rejects.toThrow(
+        FileSystemError
+      );
+
+      try {
+        await fs.writeFile(filePath, "seed", { exclusive: true });
+      } catch (error) {
+        expect((error as FileSystemError).fsCode).toBe("EEXIST");
+        expect((error as FileSystemError).path).toBe(filePath);
+      }
+      // The original content must be untouched.
+      expect(await fs.readFile(filePath)).toBe("original");
+    });
   });
 
   describe("mkdir", () => {

--- a/src/boundaries/platform/filesystem.state-mock.ts
+++ b/src/boundaries/platform/filesystem.state-mock.ts
@@ -418,13 +418,22 @@ export function createFileSystemMock(options?: MockFileSystemOptions): MockFileS
       return typeof fileContent === "string" ? Buffer.from(fileContent, "utf-8") : fileContent;
     },
 
-    async writeFile(pathLike: PathLike, content: string): Promise<void> {
+    async writeFile(
+      pathLike: PathLike,
+      content: string,
+      options?: { exclusive?: boolean }
+    ): Promise<void> {
       const path = normalizePath(pathLike);
       const existing = state.entries.get(path);
 
       // Check if path is a directory
       if (existing?.type === "directory") {
         throw new FileSystemError("EISDIR", path, `Is a directory: ${path}`);
+      }
+
+      // Exclusive (wx) write: fail if the file already exists.
+      if (options?.exclusive === true && existing !== undefined) {
+        throw new FileSystemError("EEXIST", path, `File already exists: ${path}`);
       }
 
       // Check if parent exists

--- a/src/boundaries/platform/filesystem.ts
+++ b/src/boundaries/platform/filesystem.ts
@@ -98,18 +98,26 @@ export interface FileSystemBoundary {
   readFile(path: PathLike): Promise<string>;
 
   /**
-   * Write content to file. Overwrites existing file.
+   * Write content to file. Overwrites existing file by default.
+   *
+   * Pass `{ exclusive: true }` for an atomic create-if-absent write (the `wx`
+   * flag): it throws FileSystemError with code EEXIST when the file already
+   * exists instead of overwriting. This lets callers seed a file only when it is
+   * new without a separate (TOCTOU-prone) existence check.
    *
    * @param path - Absolute path to file (Path object or string)
    * @param content - String content to write (UTF-8)
+   * @param options.exclusive - Fail with EEXIST if the file already exists
    * @throws FileSystemError with code ENOENT if parent directory doesn't exist
    * @throws FileSystemError with code EACCES if permission denied
    * @throws FileSystemError with code EISDIR if path is a directory
+   * @throws FileSystemError with code EEXIST if exclusive and the file exists
    *
    * @example
    * await fs.writeFile('/path/to/config.json', JSON.stringify(data, null, 2));
+   * await fs.writeFile('/path/to/new.txt', tpl, { exclusive: true }); // create-only
    */
-  writeFile(path: PathLike, content: string): Promise<void>;
+  writeFile(path: PathLike, content: string, options?: { exclusive?: boolean }): Promise<void>;
 
   /**
    * Create directory. Creates parent directories as needed.
@@ -357,11 +365,18 @@ export class DefaultFileSystemBoundary implements FileSystemBoundary {
     }
   }
 
-  async writeFile(filePath: PathLike, content: string): Promise<void> {
+  async writeFile(
+    filePath: PathLike,
+    content: string,
+    options?: { exclusive?: boolean }
+  ): Promise<void> {
     const nativePath = toNativePath(filePath);
-    this.logger.debug("Write", { path: nativePath });
+    this.logger.debug("Write", { path: nativePath, exclusive: options?.exclusive ?? false });
     try {
-      await fs.writeFile(nativePath, content, "utf-8");
+      await fs.writeFile(nativePath, content, {
+        encoding: "utf-8",
+        ...(options?.exclusive === true && { flag: "wx" }),
+      });
     } catch (error) {
       throw mapError(error, nativePath);
     }

--- a/src/boundaries/platform/store-definition.ts
+++ b/src/boundaries/platform/store-definition.ts
@@ -48,6 +48,18 @@ export interface SettingsOption {
 export type SettingsControl =
   | { readonly kind: "boolean" }
   | { readonly kind: "string" }
+  | {
+      /**
+       * A filesystem path with a native "Browse…" picker. Renders as a text
+       * field plus a trailing picker action in the settings dialog. `extensions`
+       * scopes the picker's file filter (an "All Files" fallback is always
+       * offered); `template` is the default content seeded into a newly-named
+       * file via the picker's save flow.
+       */
+      readonly kind: "path";
+      readonly extensions?: readonly string[];
+      readonly template?: string;
+    }
   | { readonly kind: "number"; readonly min?: number; readonly max?: number }
   | {
       readonly kind: "enum";
@@ -342,10 +354,17 @@ export function storeString(options?: { nullable: true }): PersistedTypeBuilder<
 
 /**
  * Builder for nullable path config values.
- * Validates that the string has no null bytes and is a valid path.
+ *
+ * Validates that the string has no null bytes and is a valid path. Renders in
+ * the settings dialog as a `path` control (text field + native "Browse…"
+ * picker). `extensions` scopes the picker's file filter; `template` is the
+ * default content seeded into a newly-named file via the picker's save flow.
  */
-export function storePath(options: { nullable: true }): PersistedTypeBuilder<string | null> {
-  void options;
+export function storePath(options: {
+  nullable: true;
+  extensions?: readonly string[];
+  template?: string;
+}): PersistedTypeBuilder<string | null> {
   return {
     parse: (s: string) => {
       if (s === "") return null;
@@ -369,7 +388,11 @@ export function storePath(options: { nullable: true }): PersistedTypeBuilder<str
       }
     },
     validValues: "<path>",
-    settingsControl: { kind: "string" },
+    settingsControl: {
+      kind: "path",
+      ...(options.extensions !== undefined && { extensions: options.extensions }),
+      ...(options.template !== undefined && { template: options.template }),
+    },
   };
 }
 

--- a/src/boundaries/shell/dialog.integration.test.ts
+++ b/src/boundaries/shell/dialog.integration.test.ts
@@ -15,9 +15,9 @@ describe("DialogBoundary (behavioral mock)", () => {
     dialogLayer = createBehavioralDialogBoundary();
   });
 
-  describe("showOpenDialog", () => {
+  describe("showDialog", () => {
     it("returns canceled by default", async () => {
-      const result = await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+      const result = await dialogLayer.showDialog({ properties: ["openDirectory"] });
 
       expect(result.canceled).toBe(true);
       expect(result.filePaths).toHaveLength(0);
@@ -29,7 +29,7 @@ describe("DialogBoundary (behavioral mock)", () => {
         filePaths: ["/path/to/folder"],
       });
 
-      const result = await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+      const result = await dialogLayer.showDialog({ properties: ["openDirectory"] });
 
       expect(result.canceled).toBe(false);
       expect(result.filePaths).toHaveLength(1);
@@ -42,7 +42,7 @@ describe("DialogBoundary (behavioral mock)", () => {
         filePaths: ["/home/user/documents"],
       });
 
-      const result = await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+      const result = await dialogLayer.showDialog({ properties: ["openDirectory"] });
 
       // Verify it's a Path object with expected methods
       const path = result.filePaths[0];
@@ -52,13 +52,13 @@ describe("DialogBoundary (behavioral mock)", () => {
 
     it("records call in state", async () => {
       const options = { title: "Select Folder", properties: ["openDirectory"] as const };
-      await dialogLayer.showOpenDialog(options);
+      await dialogLayer.showDialog(options);
 
       const state = dialogLayer._getState();
       expect(state.openDialogCount).toBe(1);
       expect(state.calls).toHaveLength(1);
       expect(state.calls[0]).toEqual({
-        method: "showOpenDialog",
+        method: "showDialog",
         options,
       });
     });
@@ -69,8 +69,8 @@ describe("DialogBoundary (behavioral mock)", () => {
         filePaths: ["/first/path"],
       });
 
-      const first = await dialogLayer.showOpenDialog({ properties: ["openFile"] });
-      const second = await dialogLayer.showOpenDialog({ properties: ["openFile"] });
+      const first = await dialogLayer.showDialog({ properties: ["openFile"] });
+      const second = await dialogLayer.showDialog({ properties: ["openFile"] });
 
       expect(first.canceled).toBe(false);
       expect(second.canceled).toBe(true); // Back to default
@@ -82,10 +82,28 @@ describe("DialogBoundary (behavioral mock)", () => {
         filePaths: ["/path/a", "/path/b", "/path/c"],
       });
 
-      const result = await dialogLayer.showOpenDialog({ properties: ["multiSelections"] });
+      const result = await dialogLayer.showDialog({ properties: ["multiSelections"] });
 
       expect(result.filePaths).toHaveLength(3);
       expect(result.filePaths.map((p) => p.toString())).toEqual(["/path/a", "/path/b", "/path/c"]);
+    });
+
+    it("records the save mode and returns the chosen path", async () => {
+      dialogLayer._setNextOpenDialogResponse({
+        canceled: false,
+        filePaths: ["/new/template.liquid"],
+      });
+
+      const options = {
+        mode: "save" as const,
+        filters: [{ name: "Liquid", extensions: ["liquid"] }],
+      };
+      const result = await dialogLayer.showDialog(options);
+
+      expect(result.canceled).toBe(false);
+      expect(result.filePaths).toHaveLength(1);
+      expect(result.filePaths[0]?.toString()).toBe("/new/template.liquid");
+      expect(dialogLayer._getState().calls[0]).toEqual({ method: "showDialog", options });
     });
   });
 
@@ -154,7 +172,7 @@ describe("DialogBoundary (behavioral mock)", () => {
 
   describe("_getState", () => {
     it("tracks all call types", async () => {
-      await dialogLayer.showOpenDialog({ properties: ["openFile"] });
+      await dialogLayer.showDialog({ properties: ["openFile"] });
       await dialogLayer.showMessageBox({ message: "Hello" });
       dialogLayer.showErrorBox("Error", "Details");
 
@@ -166,10 +184,10 @@ describe("DialogBoundary (behavioral mock)", () => {
     });
 
     it("returns copies of arrays (not mutable references)", async () => {
-      await dialogLayer.showOpenDialog({ properties: ["openFile"] });
+      await dialogLayer.showDialog({ properties: ["openFile"] });
 
       const state1 = dialogLayer._getState();
-      await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+      await dialogLayer.showDialog({ properties: ["openDirectory"] });
       const state2 = dialogLayer._getState();
 
       // state1 should not have been modified
@@ -181,7 +199,7 @@ describe("DialogBoundary (behavioral mock)", () => {
   describe("_reset", () => {
     it("clears all state", async () => {
       dialogLayer._setNextOpenDialogResponse({ canceled: false, filePaths: ["/path"] });
-      await dialogLayer.showOpenDialog({ properties: ["openFile"] });
+      await dialogLayer.showDialog({ properties: ["openFile"] });
       dialogLayer.showErrorBox("Error", "Details");
 
       dialogLayer._reset();
@@ -196,7 +214,7 @@ describe("DialogBoundary (behavioral mock)", () => {
       dialogLayer._setNextOpenDialogResponse({ canceled: false, filePaths: ["/path"] });
       dialogLayer._reset();
 
-      const result = await dialogLayer.showOpenDialog({ properties: ["openFile"] });
+      const result = await dialogLayer.showDialog({ properties: ["openFile"] });
       expect(result.canceled).toBe(true); // Default, not the configured response
     });
   });

--- a/src/boundaries/shell/dialog.test-utils.ts
+++ b/src/boundaries/shell/dialog.test-utils.ts
@@ -5,8 +5,8 @@
 
 import type {
   DialogBoundary,
-  OpenDialogOptions,
-  OpenDialogResult,
+  ShowDialogOptions,
+  ShowDialogResult,
   DialogMessageBoxOptions,
   MessageBoxResult,
 } from "./dialog";
@@ -17,9 +17,9 @@ import { Path } from "../../utils/path/path";
 // ============================================================================
 
 /**
- * Configured response for open dialog.
+ * Configured response for a file dialog.
  */
-export interface OpenDialogResponse {
+export interface ShowDialogResponse {
   readonly canceled: boolean;
   /** File paths as strings (will be converted to Path objects) */
   readonly filePaths: readonly string[];
@@ -37,8 +37,8 @@ export interface MessageBoxResponse {
  * Call record for dialog operations.
  */
 export interface DialogCall {
-  readonly method: "showOpenDialog" | "showMessageBox" | "showErrorBox";
-  readonly options?: OpenDialogOptions | DialogMessageBoxOptions;
+  readonly method: "showDialog" | "showMessageBox" | "showErrorBox";
+  readonly options?: ShowDialogOptions | DialogMessageBoxOptions;
   readonly title?: string;
   readonly content?: string;
 }
@@ -49,7 +49,7 @@ export interface DialogCall {
 export interface DialogBoundaryState {
   /** All dialog calls in order */
   readonly calls: readonly DialogCall[];
-  /** Count of showOpenDialog calls */
+  /** Count of showDialog calls */
   readonly openDialogCount: number;
   /** Count of showMessageBox calls */
   readonly messageBoxCount: number;
@@ -67,10 +67,10 @@ export interface BehavioralDialogBoundary extends DialogBoundary {
   _getState(): DialogBoundaryState;
 
   /**
-   * Set the next response for showOpenDialog.
+   * Set the next response for showDialog.
    * @param response - Response to return (used once, then returns to default)
    */
-  _setNextOpenDialogResponse(response: OpenDialogResponse): void;
+  _setNextOpenDialogResponse(response: ShowDialogResponse): void;
 
   /**
    * Set the next response for showMessageBox.
@@ -97,11 +97,11 @@ export interface BehavioralDialogBoundary extends DialogBoundary {
  * @example Basic usage - verify dialog was shown
  * ```typescript
  * const dialogLayer = createBehavioralDialogBoundary();
- * await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+ * await dialogLayer.showDialog({ properties: ["openDirectory"] });
  *
  * const state = dialogLayer._getState();
  * expect(state.openDialogCount).toBe(1);
- * expect(state.calls[0].method).toBe("showOpenDialog");
+ * expect(state.calls[0].method).toBe("showDialog");
  * ```
  *
  * @example Configure response
@@ -112,7 +112,7 @@ export interface BehavioralDialogBoundary extends DialogBoundary {
  *   filePaths: ["/path/to/folder"],
  * });
  *
- * const result = await dialogLayer.showOpenDialog({ properties: ["openDirectory"] });
+ * const result = await dialogLayer.showDialog({ properties: ["openDirectory"] });
  * expect(result.canceled).toBe(false);
  * expect(result.filePaths[0].toString()).toBe("/path/to/folder");
  * ```
@@ -125,12 +125,12 @@ export function createBehavioralDialogBoundary(): BehavioralDialogBoundary {
   let errorBoxCount = 0;
 
   // Pending responses (used once then cleared)
-  let nextOpenDialogResponse: OpenDialogResponse | null = null;
+  let nextOpenDialogResponse: ShowDialogResponse | null = null;
   let nextMessageBoxResponse: MessageBoxResponse | null = null;
 
   return {
-    async showOpenDialog(options: OpenDialogOptions): Promise<OpenDialogResult> {
-      calls.push({ method: "showOpenDialog", options });
+    async showDialog(options: ShowDialogOptions): Promise<ShowDialogResult> {
+      calls.push({ method: "showDialog", options });
       openDialogCount++;
 
       // Use configured response or default to canceled
@@ -171,7 +171,7 @@ export function createBehavioralDialogBoundary(): BehavioralDialogBoundary {
       };
     },
 
-    _setNextOpenDialogResponse(response: OpenDialogResponse): void {
+    _setNextOpenDialogResponse(response: ShowDialogResponse): void {
       nextOpenDialogResponse = response;
     },
 

--- a/src/boundaries/shell/dialog.ts
+++ b/src/boundaries/shell/dialog.ts
@@ -15,9 +15,17 @@ import type { Logger } from "../platform/logging";
 // ============================================================================
 
 /**
- * Options for open file/directory dialogs.
+ * Options for a native file dialog.
+ *
+ * `mode` selects the underlying Electron dialog: "open" (default) maps to
+ * `dialog.showOpenDialog` (pick existing files/directories); "save" maps to
+ * `dialog.showSaveDialog` (name a file that may not exist yet — the only
+ * cross-platform way to let the user create a new file). `properties` apply to
+ * open mode only.
  */
-export interface OpenDialogOptions {
+export interface ShowDialogOptions {
+  /** Which native dialog to show. Defaults to "open". */
+  readonly mode?: "open" | "save";
   /** Title of the dialog window */
   readonly title?: string;
   /** Default path to open dialog at */
@@ -26,7 +34,7 @@ export interface OpenDialogOptions {
   readonly buttonLabel?: string;
   /** Filter files by type */
   readonly filters?: readonly DialogFileFilter[];
-  /** Dialog behavior properties */
+  /** Dialog behavior properties (open mode only) */
   readonly properties?: readonly OpenDialogProperty[];
   /** Message to show above input boxes (macOS only) */
   readonly message?: string;
@@ -55,9 +63,13 @@ export type OpenDialogProperty =
   | "dontAddToRecent";
 
 /**
- * Result from an open dialog.
+ * Result from a file dialog.
+ *
+ * Unified across open and save modes: save mode yields a single chosen path (or
+ * none when canceled), surfaced as a 0-or-1 element `filePaths` array so callers
+ * read the result the same way regardless of mode.
  */
-export interface OpenDialogResult {
+export interface ShowDialogResult {
   /** Whether the dialog was canceled */
   readonly canceled: boolean;
   /** Selected file paths (as Path objects for normalized handling) */
@@ -107,12 +119,13 @@ export interface MessageBoxResult {
  */
 export interface DialogBoundary {
   /**
-   * Show an open file/directory dialog.
+   * Show a native file dialog. `options.mode` selects open (pick existing) or
+   * save (name a possibly-new file); defaults to open.
    *
    * @param options - Dialog options
    * @returns Result with selected paths as Path objects
    */
-  showOpenDialog(options: OpenDialogOptions): Promise<OpenDialogResult>;
+  showDialog(options: ShowDialogOptions): Promise<ShowDialogResult>;
 
   /**
    * Show a message box dialog.
@@ -143,7 +156,7 @@ import { dialog } from "electron";
  * Helper to build Electron dialog options, excluding undefined values.
  * This satisfies exactOptionalPropertyTypes requirements.
  */
-function buildOpenDialogOptions(options: OpenDialogOptions): Electron.OpenDialogOptions {
+function buildOpenDialogOptions(options: ShowDialogOptions): Electron.OpenDialogOptions {
   const result: Electron.OpenDialogOptions = {};
   if (options.title !== undefined) result.title = options.title;
   if (options.defaultPath !== undefined) result.defaultPath = options.defaultPath;
@@ -157,6 +170,21 @@ function buildOpenDialogOptions(options: OpenDialogOptions): Electron.OpenDialog
   }
   if (options.properties !== undefined) {
     result.properties = [...options.properties];
+  }
+  return result;
+}
+
+function buildSaveDialogOptions(options: ShowDialogOptions): Electron.SaveDialogOptions {
+  const result: Electron.SaveDialogOptions = {};
+  if (options.title !== undefined) result.title = options.title;
+  if (options.defaultPath !== undefined) result.defaultPath = options.defaultPath;
+  if (options.buttonLabel !== undefined) result.buttonLabel = options.buttonLabel;
+  if (options.message !== undefined) result.message = options.message;
+  if (options.filters !== undefined) {
+    result.filters = options.filters.map((f) => ({
+      name: f.name,
+      extensions: [...f.extensions],
+    }));
   }
   return result;
 }
@@ -183,17 +211,27 @@ function buildMessageBoxOptions(options: DialogMessageBoxOptions): Electron.Mess
 export class DefaultDialogBoundary implements DialogBoundary {
   constructor(private readonly logger: Logger) {}
 
-  async showOpenDialog(options: OpenDialogOptions): Promise<OpenDialogResult> {
-    this.logger.debug("Showing open dialog", { title: options.title ?? null });
+  async showDialog(options: ShowDialogOptions): Promise<ShowDialogResult> {
+    const mode = options.mode ?? "open";
+    this.logger.debug("Showing dialog", { mode, title: options.title ?? null });
 
-    const electronOptions = buildOpenDialogOptions(options);
-    const result = await dialog.showOpenDialog(electronOptions);
+    if (mode === "save") {
+      const result = await dialog.showSaveDialog(buildSaveDialogOptions(options));
+      this.logger.debug("Save dialog result", {
+        canceled: result.canceled,
+        hasPath: result.filePath !== undefined,
+      });
+      return {
+        canceled: result.canceled,
+        filePaths: result.filePath !== undefined ? [new Path(result.filePath)] : [],
+      };
+    }
 
+    const result = await dialog.showOpenDialog(buildOpenDialogOptions(options));
     this.logger.debug("Open dialog result", {
       canceled: result.canceled,
       count: result.filePaths.length,
     });
-
     return {
       canceled: result.canceled,
       filePaths: result.filePaths.map((p) => new Path(p)),

--- a/src/main.ts
+++ b/src/main.ts
@@ -500,6 +500,8 @@ const settingsModule = createSettingsModule({
   ui: presentationModule,
   config: configService,
   app: appLayer,
+  dialog: dialogLayer,
+  fs: fileSystemLayer,
   logger: loggingService.createLogger("settings"),
 });
 openSettings = settingsModule.openSettings;

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -49,6 +49,7 @@ import {
   storeCustom,
   type PersistedAccessor,
 } from "../../boundaries/platform/store-definition";
+import { TEMPLATE_DEFAULTS } from "./template-defaults";
 import type { StateService } from "../../boundaries/platform/state-service";
 import type { FileSystemBoundary } from "../../boundaries/platform/filesystem";
 import type { Logger } from "../../boundaries/platform/logging-types";
@@ -184,11 +185,16 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
   // Register template-path config keys (sources register their own keys)
   const templatePathConfigs = new Map<string, PersistedAccessor<string | null>>();
   for (const source of deps.sources) {
+    const template = TEMPLATE_DEFAULTS[source.name];
     const tplConfig = deps.configService.register(`experimental.${source.name}.template-path`, {
       default: null,
       description: `Path to Liquid template for ${source.name} auto-workspaces`,
       redact: true,
-      ...storePath({ nullable: true }),
+      ...storePath({
+        nullable: true,
+        extensions: ["liquid"],
+        ...(template !== undefined && { template }),
+      }),
     });
     templatePathConfigs.set(source.name, tplConfig);
   }

--- a/src/modules/auto-workspace/template-defaults.ts
+++ b/src/modules/auto-workspace/template-defaults.ts
@@ -1,0 +1,36 @@
+/**
+ * Default Liquid templates seeded into a newly-created auto-workspace template
+ * file (via the settings file picker's "create" flow). Keyed by source name.
+ *
+ * Each is a minimal, valid starting point: front-matter (name/tracking) plus a
+ * prompt body, using the fields each source exposes on its poll item's `data`
+ * (see github-source.ts / youtrack-source.ts). Users are expected to refine
+ * these — they are scaffolding, not a finished workflow.
+ */
+
+/** GitHub PR data exposes number, title, html_url, user.login, body, head.ref, base.ref, clone_url. */
+const GITHUB_TEMPLATE = `---
+name: {{ title }}
+tracking: {{ html_url }}
+---
+Review pull request #{{ number }} "{{ title }}" opened by {{ user.login }}.
+
+{{ body }}
+
+PR: {{ html_url }}
+`;
+
+/** YouTrack issue data exposes idReadable, summary, description, project.name, reporter.fullName. */
+const YOUTRACK_TEMPLATE = `---
+name: {{ summary }}
+tracking: {{ idReadable }}
+---
+Work on {{ idReadable }} "{{ summary }}" in {{ project.name }}.
+
+{{ description }}
+`;
+
+export const TEMPLATE_DEFAULTS: Readonly<Record<string, string>> = {
+  github: GITHUB_TEMPLATE,
+  youtrack: YOUTRACK_TEMPLATE,
+};

--- a/src/modules/settings-module.integration.test.ts
+++ b/src/modules/settings-module.integration.test.ts
@@ -13,6 +13,12 @@ import { createSettingsModule } from "./settings-module";
 import { createMockConfig } from "../boundaries/platform/config.test-utils";
 import { createMockDialogManager } from "./presentation/dialog-manager.state-mock";
 import { createAppBoundaryMock } from "../boundaries/shell/app.state-mock";
+import { createBehavioralDialogBoundary } from "../boundaries/shell/dialog.test-utils";
+import {
+  createFileSystemMock,
+  file,
+  directory,
+} from "../boundaries/platform/filesystem.state-mock";
 import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 import { configBusyDuringBackgroundShell } from "./agent-module/claude/types";
 import {
@@ -20,8 +26,10 @@ import {
   storeEnum,
   storeEnumList,
   storeNumber,
+  storePath,
   storeString,
 } from "../boundaries/platform/store-definition";
+import type { Entry } from "../boundaries/platform/filesystem.state-mock";
 import type { Config } from "../boundaries/platform/config";
 import type { UiPresenter } from "./presentation/presentation-module";
 import type { DialogConfig, DialogSection } from "../shared/dialog-types";
@@ -61,25 +69,42 @@ function registerKeys(config: Config): void {
     default: true,
     ...configBusyDuringBackgroundShell(),
   });
+  config.register("experimental.github.template-path", {
+    default: null,
+    description: "Path to Liquid template for github auto-workspaces",
+    redact: true,
+    ...storePath({ nullable: true, extensions: ["liquid"], template: TEMPLATE_CONTENT }),
+  });
 }
 
-function setup(): {
+const TEMPLATE_CONTENT = "---\nname: {{ title }}\n---\nReview {{ title }}\n";
+const PICK_ID = "pick:experimental.github.template-path";
+
+function setup(options?: { fsEntries?: Record<string, Entry> }): {
   openSettings: () => void;
   config: Config;
   dialogs: ReturnType<typeof createMockDialogManager>;
   app: ReturnType<typeof createAppBoundaryMock>;
+  dialog: ReturnType<typeof createBehavioralDialogBoundary>;
+  fs: ReturnType<typeof createFileSystemMock>;
+  openPath: ReturnType<typeof vi.spyOn>;
 } {
   const config = createMockConfig();
   registerKeys(config);
   const dialogs = createMockDialogManager();
   const app = createAppBoundaryMock({ platform: "linux" });
+  const openPath = vi.spyOn(app, "openPath");
+  const dialog = createBehavioralDialogBoundary();
+  const fs = createFileSystemMock({ entries: options?.fsEntries ?? {} });
   const { openSettings } = createSettingsModule({
     ui: dialogs.ui as unknown as UiPresenter,
     config,
     app,
+    dialog,
+    fs,
     logger: createMockLogger(),
   });
-  return { openSettings, config, dialogs, app };
+  return { openSettings, config, dialogs, app, dialog, fs, openPath };
 }
 
 /** Flush pending microtasks (the module's async save/reset handlers). */
@@ -343,13 +368,109 @@ describe("SettingsModule — reset", () => {
   });
 });
 
+describe("SettingsModule — path picker", () => {
+  const NEW_PATH = "/home/me/templates/gh.liquid";
+
+  it("renders a path key as a masked input with a Browse action", () => {
+    const { openSettings, dialogs } = setup();
+    openSettings();
+    const row = rowByLabel(dialogs.lastHandle!.config, "template-path")!;
+    expect(row.fields[0]!.type).toBe("input");
+    expect((row.fields[0] as { masked?: boolean }).masked).toBe(true);
+    expect(row.action).toEqual({ id: PICK_ID, label: "Browse…", icon: "folder" });
+  });
+
+  it("shows a save-mode dialog with the extension filter", async () => {
+    const { openSettings, dialogs, dialog } = setup();
+    openSettings();
+    dialogs.lastHandle!.emitAction(PICK_ID, {});
+    await flush();
+
+    const call = dialog._getState().calls[0]!;
+    expect(call.method).toBe("showDialog");
+    const opts = call.options as { mode?: string; filters?: { extensions: string[] }[] };
+    expect(opts.mode).toBe("save");
+    expect(opts.filters?.[0]?.extensions).toEqual(["liquid"]);
+    expect(opts.filters?.[1]?.extensions).toEqual(["*"]); // All Files fallback
+  });
+
+  it("seeds the template and opens a newly-named file, then buffers the path", async () => {
+    const { openSettings, dialogs, dialog, fs, openPath, config } = setup({
+      fsEntries: { "/home/me": directory(), "/home/me/templates": directory() },
+    });
+    openSettings();
+    dialog._setNextOpenDialogResponse({ canceled: false, filePaths: [NEW_PATH] });
+
+    dialogs.lastHandle!.emitAction(PICK_ID, {});
+    await flush();
+
+    // Template seeded and the new file opened in the default app.
+    expect(await fs.readFile(NEW_PATH)).toBe(TEMPLATE_CONTENT);
+    expect(openPath).toHaveBeenCalledWith(NEW_PATH);
+    // Path is buffered into the field but not yet persisted.
+    const row = rowByLabel(dialogs.lastHandle!.config, "template-path")!;
+    expect((row.fields[0] as { value?: string }).value).toBe(NEW_PATH);
+    expect(config.getEffective()["experimental.github.template-path"]).toBeNull();
+
+    // Save persists it.
+    dialogs.lastHandle!.emitAction("save", {});
+    await flush();
+    expect(config.getEffective()["experimental.github.template-path"]).toBe(NEW_PATH);
+  });
+
+  it("adopts an existing file without overwriting or opening it", async () => {
+    const existing = "/home/me/existing.liquid";
+    const { openSettings, dialogs, dialog, fs, openPath } = setup({
+      fsEntries: { [existing]: file("USER CONTENT") },
+    });
+    openSettings();
+    dialog._setNextOpenDialogResponse({ canceled: false, filePaths: [existing] });
+
+    dialogs.lastHandle!.emitAction(PICK_ID, {});
+    await flush();
+
+    // The user's file is untouched and not opened (EEXIST → adopt).
+    expect(await fs.readFile(existing)).toBe("USER CONTENT");
+    expect(openPath).not.toHaveBeenCalled();
+    const row = rowByLabel(dialogs.lastHandle!.config, "template-path")!;
+    expect((row.fields[0] as { value?: string }).value).toBe(existing);
+  });
+
+  it("does nothing when the picker is canceled", async () => {
+    const { openSettings, dialogs, openPath, config } = setup();
+    openSettings();
+    // Default behavioral response is canceled.
+    dialogs.lastHandle!.emitAction(PICK_ID, {});
+    await flush();
+
+    expect(openPath).not.toHaveBeenCalled();
+    dialogs.lastHandle!.emitAction("save", {});
+    await flush();
+    expect(config.getEffective()["experimental.github.template-path"]).toBeNull();
+  });
+
+  it("does not persist a picked path when the dialog is canceled", async () => {
+    const { openSettings, dialogs, dialog, config } = setup();
+    openSettings();
+    dialog._setNextOpenDialogResponse({ canceled: false, filePaths: [NEW_PATH] });
+    dialogs.lastHandle!.emitAction(PICK_ID, {});
+    await flush();
+
+    dialogs.lastHandle!.emitAction("cancel", {});
+    await flush();
+    expect(config.getEffective()["experimental.github.template-path"]).toBeNull();
+  });
+});
+
 describe("SettingsModule — shortcut", () => {
   it("opens on the 's' shortcut key", async () => {
-    const { config, dialogs, app } = setup();
+    const { config, dialogs, app, dialog, fs } = setup();
     const { module } = createSettingsModule({
       ui: dialogs.ui as unknown as UiPresenter,
       config,
       app,
+      dialog,
+      fs,
       logger: createMockLogger(),
     });
     const event: ShortcutKeyPressedEvent = {

--- a/src/modules/settings-module.ts
+++ b/src/modules/settings-module.ts
@@ -29,8 +29,11 @@ import type {
   SettingsControl,
 } from "../boundaries/platform/store-definition";
 import type { AppBoundary } from "../boundaries/shell/app";
+import type { DialogBoundary } from "../boundaries/shell/dialog";
+import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { DialogConfig, DialogSection, SettingRowField } from "../shared/dialog-types";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
+import { FileSystemError } from "../shared/errors/service-errors";
 
 // =============================================================================
 // Constants
@@ -48,6 +51,8 @@ const ACTION_CANCEL = "cancel";
 const ACTION_RESET_ALL = "reset-all";
 /** Per-row reset action ids are `${RESET_PREFIX}${key}`. */
 const RESET_PREFIX = "reset:";
+/** Per-row path-picker action ids are `${PICK_PREFIX}${key}`. */
+const PICK_PREFIX = "pick:";
 /** Sub-field id suffix for a guarded-text control's on/off checkbox. */
 const GUARD_ON_SUFFIX = "::on";
 
@@ -58,7 +63,9 @@ const GUARD_ON_SUFFIX = "::on";
 export interface SettingsModuleDeps {
   readonly ui: UiPresenter;
   readonly config: Config;
-  readonly app: AppBoundary;
+  readonly app: Pick<AppBoundary, "relaunch" | "openPath">;
+  readonly dialog: Pick<DialogBoundary, "showDialog">;
+  readonly fs: Pick<FileSystemBoundary, "writeFile">;
   readonly logger: Logger;
 }
 
@@ -122,11 +129,20 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
   module: IntentModule;
   openSettings: () => void;
 } {
-  const { ui, config, app, logger } = deps;
+  const { ui, config, app, dialog, fs, logger } = deps;
 
   let activeHandle: DialogHandle | null = null;
   /** Effective value per key when the dialog opened, for the restart-note diff. */
   let openValues: Record<string, unknown> = {};
+  /**
+   * Values set programmatically (by the file picker) that aren't yet persisted
+   * and don't come from the renderer's field data. Merged into each row's
+   * controlled value so a pick shows up immediately; persisted on Save, cleared
+   * on reset. Keyed by config key.
+   */
+  let pickedValues: Record<string, string | null> = {};
+  /** Latest renderer field data (from onChange), so a pick can rebuild without losing edits. */
+  let latestData: Record<string, string> | undefined;
 
   /** Settings-eligible keys (has a control, not excluded, not deprecated), sorted. */
   function settingKeys(): SettingKey[] {
@@ -149,7 +165,8 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
         if (raw.trim() === "") return undefined;
         return def.validate(Number(raw));
       }
-      case "string": {
+      case "string":
+      case "path": {
         const raw = data[key] ?? "";
         if (raw === "" && isNullable(def)) return def.validate(null);
         return def.validate(raw);
@@ -186,6 +203,7 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
         return [{ type: "checkbox", id: key, value: current === true, changeEvent: true }];
       case "number":
       case "string":
+      case "path":
         return [
           {
             type: "input",
@@ -278,7 +296,7 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
         lastSubheading = parts.subheading;
       }
 
-      const current = config.getEffective()[key];
+      const current = key in pickedValues ? pickedValues[key] : config.getEffective()[key];
       const source = config.getSource(key);
 
       // Live validation from the latest field values.
@@ -314,6 +332,9 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
         ...(def.description !== undefined && { description: def.description }),
         ...(badge !== undefined && { badge }),
         ...(note !== undefined && { note }),
+        ...(entry.control.kind === "path" && {
+          action: { id: `${PICK_PREFIX}${key}`, label: "Browse…", icon: "folder" },
+        }),
         ...(resettable && { resetId: `${RESET_PREFIX}${key}` }),
       };
       sections.push(row);
@@ -366,6 +387,59 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
     return a === b || JSON.stringify(a) === JSON.stringify(b);
   }
 
+  /** File-type filters for the picker: the key's extensions plus an All-Files fallback. */
+  function pickerFilters(extensions: readonly string[] | undefined) {
+    if (!extensions || extensions.length === 0) return undefined;
+    return [
+      { name: extensions.map((e) => `.${e}`).join(", "), extensions: [...extensions] },
+      { name: "All Files", extensions: ["*"] },
+    ];
+  }
+
+  /**
+   * Run the native file picker (save mode, so the user can name a new file) for a
+   * path key. When the chosen path is new, atomically seed the key's template and
+   * open the file in the OS default app; when it already exists, adopt the path
+   * untouched. The chosen path is buffered (persisted on Save). Returns true when
+   * a path was chosen so the caller rebuilds the dialog.
+   */
+  async function pickPath(key: string): Promise<boolean> {
+    const entry = settingKeys().find((e) => e.key === key);
+    if (!entry || entry.control.kind !== "path") return false;
+    const { control } = entry;
+
+    const current = key in pickedValues ? pickedValues[key] : config.getEffective()[key];
+    const filters = pickerFilters(control.extensions);
+    const result = await dialog.showDialog({
+      mode: "save",
+      ...(typeof current === "string" && current !== "" && { defaultPath: current }),
+      ...(filters !== undefined && { filters }),
+    });
+    if (result.canceled || result.filePaths.length === 0) return false;
+    const picked = result.filePaths[0]!.toString();
+
+    // Seed the template only when the file is new (exclusive write → EEXIST means
+    // it already exists, so adopt it untouched). Open a freshly-created file so
+    // the user can edit it right away.
+    if (control.template !== undefined) {
+      try {
+        await fs.writeFile(picked, control.template, { exclusive: true });
+        await app.openPath(picked);
+      } catch (error) {
+        if (!(error instanceof FileSystemError && error.fsCode === "EEXIST")) {
+          logger.warn("Failed to seed template file", {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    pickedValues[key] = picked;
+    if (latestData) latestData[key] = picked;
+    return true;
+  }
+
   /** Persist every changed key from the buffered field data. */
   async function save(data: Record<string, string>): Promise<boolean> {
     for (const entry of settingKeys()) {
@@ -392,6 +466,8 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
     if (activeHandle) return;
 
     openValues = { ...config.getEffective() };
+    pickedValues = {};
+    latestData = undefined;
     const handle = ui.dialog(buildConfig().config);
     activeHandle = handle;
 
@@ -403,6 +479,7 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
     handle.onChange((event) => {
       // Rebuild with the latest field values so validation, guard enable/disable
       // and restart notes reflect the edit.
+      latestData = { ...event.data };
       handle.update(buildConfig(event.data).config);
     });
 
@@ -417,6 +494,7 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
           for (const entry of settingKeys()) {
             if (config.getSource(entry.key) !== "default") await config.reset(entry.key);
           }
+          pickedValues = {};
           openValues = { ...config.getEffective() };
           handle.update(buildConfig().config);
         })();
@@ -426,14 +504,29 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
         const key = event.actionId.slice(RESET_PREFIX.length);
         void (async () => {
           await config.reset(key);
+          delete pickedValues[key];
           openValues = { ...config.getEffective() };
           handle.update(buildConfig().config);
         })();
         return;
       }
+      if (event.actionId.startsWith(PICK_PREFIX)) {
+        const key = event.actionId.slice(PICK_PREFIX.length);
+        void (async () => {
+          const picked = await pickPath(key);
+          if (picked) handle.update(buildConfig(latestData).config);
+        })();
+        return;
+      }
       if (event.actionId === ACTION_SAVE || event.actionId === ACTION_SAVE_RESTART) {
         void (async () => {
-          const ok = await save(data);
+          // Merge buffered picks (not necessarily reflected in the renderer data)
+          // so a picked path persists even if the field hasn't re-reported it.
+          const merged: Record<string, string> = { ...data };
+          for (const [key, value] of Object.entries(pickedValues)) {
+            merged[key] = value ?? "";
+          }
+          const ok = await save(merged);
           if (!ok) return;
           if (event.actionId === ACTION_SAVE_RESTART) {
             app.relaunch();

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -600,7 +600,7 @@ describe("ViewModule Integration", () => {
   describe("open-project/select-folder", () => {
     it("returns selected folder path from dialog", async () => {
       const mockDialogBoundary = {
-        showOpenDialog: vi.fn().mockResolvedValue({
+        showDialog: vi.fn().mockResolvedValue({
           canceled: false,
           filePaths: [{ toString: () => "/selected/project" }],
         }),
@@ -617,14 +617,14 @@ describe("ViewModule Integration", () => {
       })) as SelectFolderHookResult;
 
       expect(result.folderPath).toBe("/selected/project");
-      expect(mockDialogBoundary.showOpenDialog).toHaveBeenCalledWith({
+      expect(mockDialogBoundary.showDialog).toHaveBeenCalledWith({
         properties: ["openDirectory"],
       });
     });
 
     it("returns null when dialog canceled", async () => {
       const mockDialogBoundary = {
-        showOpenDialog: vi.fn().mockResolvedValue({
+        showDialog: vi.fn().mockResolvedValue({
           canceled: true,
           filePaths: [],
         }),

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -71,7 +71,7 @@ export interface ViewModuleDeps {
   readonly viewLayer: ViewBoundary | null;
   readonly windowLayer: WindowBoundary | null;
   readonly sessionLayer: SessionBoundary | null;
-  readonly dialogLayer?: Pick<DialogBoundary, "showOpenDialog"> | null;
+  readonly dialogLayer?: Pick<DialogBoundary, "showDialog"> | null;
   readonly menuLayer?: { setApplicationMenu(menu: null): void } | null;
   readonly windowManager?: {
     create(): void;
@@ -253,7 +253,7 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             if (!deps.dialogLayer) {
               return { result: { folderPath: null } };
             }
-            const result = await deps.dialogLayer.showOpenDialog({
+            const result = await deps.dialogLayer.showDialog({
               properties: ["openDirectory"] as const,
             });
             if (result.canceled || result.filePaths.length === 0) {

--- a/src/renderer/lib/components/form/Section.svelte
+++ b/src/renderer/lib/components/form/Section.svelte
@@ -95,6 +95,7 @@
     {section}
     {renderItem}
     onReset={() => onAction({ type: "button", id: section.resetId ?? "" })}
+    onRowAction={() => onAction({ type: "button", id: section.action?.id ?? "" })}
   />
 {:else if section.type === "table"}
   <TableSection {section} />

--- a/src/renderer/lib/components/form/SettingRow.svelte
+++ b/src/renderer/lib/components/form/SettingRow.svelte
@@ -19,9 +19,11 @@
     renderItem: Snippet<[DialogSection | ButtonItem]>;
     /** Reset this setting to its default. Rendered only when section.resetId is set. */
     onReset: () => void;
+    /** Trigger the row's inline action (e.g. a file picker). Rendered only when section.action is set. */
+    onRowAction: () => void;
   }
 
-  const { section, renderItem, onReset }: Props = $props();
+  const { section, renderItem, onReset, onRowAction }: Props = $props();
 </script>
 
 <div class="setting-row" style={section.indent ? `padding-left: ${section.indent}rem` : undefined}>
@@ -37,6 +39,14 @@
         {@render renderItem(field)}
       {/each}
     </div>
+    {#if section.action}
+      <button type="button" class="setting-action" onclick={onRowAction}>
+        {#if section.action.icon}
+          <Icon name={section.action.icon} size={14} />
+        {/if}
+        {section.action.label}
+      </button>
+    {/if}
     <button
       type="button"
       class="setting-reset"
@@ -144,6 +154,25 @@
   .setting-reset.hidden {
     visibility: hidden;
     pointer-events: none;
+  }
+
+  /* Inline row action (e.g. "Browse…" file picker), pinned right, before reset. */
+  .setting-action {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 2px 10px;
+    font-size: 0.8rem;
+    color: var(--ch-foreground);
+    background: var(--ch-list-hover-bg, rgba(255, 255, 255, 0.08));
+    border: 1px solid var(--ch-border);
+    border-radius: var(--ch-radius-sm, 6px);
+    cursor: pointer;
+  }
+
+  .setting-action:hover {
+    background: var(--ch-list-active-bg, rgba(255, 255, 255, 0.12));
   }
 
   .setting-note {

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -275,6 +275,10 @@ export type SettingRowField = CheckboxSection | InputSection | DropdownSection;
  * - resetId: when set, a reset-to-default icon button appears at the right of
  *   the row and emits a DialogActionEvent with this id. Omit to hide it (value
  *   already at default / not user-set).
+ * - action: an optional inline action button at the right of the row (before the
+ *   reset icon), e.g. a "Browse…" file picker for a path setting. Clicking it
+ *   emits a DialogActionEvent with `action.id`. `icon` is a codicon name shown
+ *   before the label.
  */
 interface SettingRowSection {
   readonly type: "setting-row";
@@ -285,6 +289,11 @@ interface SettingRowSection {
   readonly note?: string;
   readonly indent?: number;
   readonly resetId?: string;
+  readonly action?: {
+    readonly id: string;
+    readonly label: string;
+    readonly icon?: string;
+  };
 }
 
 export type DialogSection =


### PR DESCRIPTION
Turn file-path config values (the auto-workspace template-path keys) into a first-class path type in the settings dialog: a native "Browse…" picker that can name a new file and seed it from a per-key template.

- **DialogBoundary**: unify `showOpenDialog` into `showDialog(mode: open|save)`, mapping to Electron `showOpenDialog`/`showSaveDialog`; save mode gives a cross-platform "name a new file" flow. Unified `ShowDialogResult`.
- **FileSystemBoundary.writeFile**: add `{ exclusive }` (wx) for atomic create-if-absent, so a template seeds only when the file is new.
- **storePath({ extensions, template })** → `{ kind: "path" }` `SettingsControl`; `SettingRowSection.action` renders a trailing Browse button.
- **Settings module**: `pick:<key>` runs a save-mode dialog, exclusive-writes the template and opens the new file (`app.openPath`) on success, adopts silently on `EEXIST`; path buffered, persisted on Save.
- Minimal Liquid template defaults for github/youtrack.