### PR TITLE
fix: sidebar was blurred on workspace creation dialog

### DIFF
--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -223,18 +223,18 @@ function setup(options?: {
       if (active !== undefined) await emit(EVENT_WORKSPACE_SWITCHED, switchedPayload(active));
     }
     await emit(EVENT_APP_STARTED);
-    const panel = dialogs.panelHandles().find((h) => !h.closed);
-    expect(panel, "open panel session").toBeDefined();
+    const panel = dialogs.modelessHandles().find((h) => !h.closed);
+    expect(panel, "open creation session").toBeDefined();
     return panel!;
   };
 
   return { module, dialogs, dispatcher, openUrl, emit, start };
 }
 
-/** The currently open (non-closed) panel session. */
+/** The currently open (non-closed) creation session. */
 function currentPanel(s: Setup): MockDialogHandle {
-  const panel = s.dialogs.panelHandles().find((h) => !h.closed);
-  expect(panel, "open panel session").toBeDefined();
+  const panel = s.dialogs.modelessHandles().find((h) => !h.closed);
+  expect(panel, "open creation session").toBeDefined();
   return panel!;
 }
 
@@ -255,7 +255,7 @@ describe("CreationModule", () => {
       });
       const panel = await s.start();
 
-      expect(panel.surface).toBe("panel");
+      expect(panel.kind).toBe("modeless");
       const project = field(panel.config, "project");
       expect(project["value"]).toBe(PROJECT_A.path);
       expect(suggestionValues(project)).toEqual([PROJECT_B.path, PROJECT_A.path]);
@@ -773,7 +773,7 @@ describe("CreationModule", () => {
       await flush();
 
       const clone = s.dialogs.modalHandles()[0]!;
-      expect(clone.config.modal).toBe(true);
+      expect(clone.kind).toBe("modal");
       expect(field(clone.config, "do-clone")["disabled"]).toBe(true);
 
       clone.emitChange("url", { url: "not a url" });

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -1,11 +1,12 @@
 /**
  * CreationModule - Backend owner of the "New workspace" creation form.
  *
- * Hosts a declarative Form on the persistent panel surface (the renderer's
- * PanelView). The session is always alive: it opens once on app:started and
+ * Hosts a declarative Form on a "modeless" dialog (a non-blocking popup on top,
+ * above the sidebar — the renderer's PanelView, rendered by MainView in the
+ * ground state). The session is always alive: it opens once on app:started and
  * is reset (close + reopen with fresh config = new dialogId) on every dismiss
- * event. The renderer owns visibility (the new-workspace-view store's isOpen
- * flag) and sends a dismiss both for Escape and when the panel is shown, so a
+ * event. The renderer owns visibility (shown while main.kind === "creation")
+ * and sends a dismiss both for Escape and when the panel is shown, so a
  * dismiss simply means "give me a fresh form".
  *
  * Responsibilities:
@@ -601,7 +602,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
 
     const config = buildConfig();
     lastConfigJson = JSON.stringify(config);
-    const newHandle = ui.dialog(config, { surface: "panel" });
+    const newHandle = ui.dialog(config, { kind: "modeless" });
     handle = newHandle;
     wireSession(newHandle);
 
@@ -910,7 +911,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         };
     sections.push(footer);
 
-    return { sections, layout: "form", modal: true };
+    return { sections, layout: "form" };
   }
 
   function updateCloneDialog(): void {

--- a/src/modules/deletion-dialog-module.integration.test.ts
+++ b/src/modules/deletion-dialog-module.integration.test.ts
@@ -551,7 +551,7 @@ describe("DeletionDialogModule - remove confirm", () => {
 
     const handle = setup.dialogManager.lastHandle!;
     expect(handle).toBeTruthy();
-    expect(handle.config.modal).toBe(true);
+    expect(handle.kind).toBe("modal");
     expect(textsOf(handle.config)).toEqual([
       "Remove Workspace",
       `Remove workspace "${WS_NAME_A}"?`,

--- a/src/modules/deletion-dialog-module.ts
+++ b/src/modules/deletion-dialog-module.ts
@@ -195,7 +195,7 @@ function buildRemoveConfirmConfig(state: RemoveConfirmState): DialogConfig {
     ],
   });
 
-  return { sections, modal: true };
+  return { sections };
 }
 
 function truncate(str: string, max: number): string {
@@ -270,7 +270,7 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
 
   /** Open the deletion dialog for a workspace from its current progress. */
   function showDialog(path: string, progress: DeletionProgress): void {
-    const handle = deps.ui.dialog(buildConfig(progress));
+    const handle = deps.ui.dialog(buildConfig(progress), { kind: "panel" });
     activeDialog = { path, handle };
     wireEvents(handle, path);
   }

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -126,7 +126,6 @@ function buildDialogConfig(): DialogConfig {
         ],
       },
     ],
-    modal: true,
   };
 }
 

--- a/src/modules/local-project-module.ts
+++ b/src/modules/local-project-module.ts
@@ -346,7 +346,6 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
                   ],
                 },
               ],
-              modal: true,
             });
 
             // Escape (dismiss) cancels, same as the Cancel button.

--- a/src/modules/presentation/dialog-manager.integration.test.ts
+++ b/src/modules/presentation/dialog-manager.integration.test.ts
@@ -32,7 +32,7 @@ describe("DialogManager", () => {
       const handle = manager.open(config);
 
       expect(notifyChange).toHaveBeenCalled();
-      expect(manager.getSnapshot()).toEqual([{ id: handle.id, surface: "modal", config }]);
+      expect(manager.getSnapshot()).toEqual([{ id: handle.id, kind: "modal", config }]);
     });
 
     it("should generate unique dialog IDs", () => {
@@ -42,26 +42,26 @@ describe("DialogManager", () => {
       expect(h1.id).not.toBe(h2.id);
     });
 
-    it("records the surface in the snapshot when given", () => {
+    it("records the kind in the snapshot when given", () => {
       const config = createConfig("Panel form");
 
-      const handle = manager.open(config, { surface: "panel" });
+      const handle = manager.open(config, { kind: "panel" });
 
-      expect(manager.getSnapshot()).toEqual([{ id: handle.id, surface: "panel", config }]);
+      expect(manager.getSnapshot()).toEqual([{ id: handle.id, kind: "panel", config }]);
     });
 
-    it("defaults the surface to modal", () => {
+    it("defaults the kind to modal", () => {
       manager.open(createConfig("Modal"));
 
-      expect(manager.getSnapshot()[0]!.surface).toBe("modal");
+      expect(manager.getSnapshot()[0]!.kind).toBe("modal");
     });
 
-    it("keeps the surface across updates (session property, set once)", () => {
-      const handle = manager.open(createConfig("Panel"), { surface: "panel" });
+    it("keeps the kind across updates (session property, set once)", () => {
+      const handle = manager.open(createConfig("Panel"), { kind: "panel" });
 
       handle.update(createConfig("Updated"));
 
-      expect(manager.getSnapshot()[0]!.surface).toBe("panel");
+      expect(manager.getSnapshot()[0]!.kind).toBe("panel");
     });
   });
 
@@ -303,7 +303,7 @@ describe("DialogManager", () => {
 
   describe("onDismiss", () => {
     it("routes a dismiss event to onDismiss listeners only", () => {
-      const handle = manager.open(createConfig("Test"), { surface: "panel" });
+      const handle = manager.open(createConfig("Test"), { kind: "panel" });
       const onAction = vi.fn();
       const onChange = vi.fn();
       const onDismiss = vi.fn();

--- a/src/modules/presentation/dialog-manager.state-mock.ts
+++ b/src/modules/presentation/dialog-manager.state-mock.ts
@@ -13,7 +13,7 @@ import type { DialogManager, DialogHandle } from "./sessions";
 import type { UiPresenter } from "./presentation-module";
 import type {
   DialogConfig,
-  DialogSurface,
+  DialogKind,
   DialogUserEvent,
   DialogActionEvent,
   DialogFieldChangeEvent,
@@ -21,7 +21,7 @@ import type {
 } from "../../shared/dialog-types";
 
 /**
- * Test-side view of an open dialog: latest/full config history, surface,
+ * Test-side view of an open dialog: latest/full config history, kind,
  * closed flag, the handle given to the module under test, and emit helpers
  * that fire the handle's listeners.
  */
@@ -31,7 +31,7 @@ export interface MockDialogHandle {
   config: DialogConfig;
   /** Every config this handle has seen (open + updates), in order. */
   readonly configs: DialogConfig[];
-  readonly surface: DialogSurface;
+  readonly kind: DialogKind;
   closed: boolean;
   /** The DialogHandle handed to the module under test (methods are spies). */
   readonly handle: DialogHandle;
@@ -54,9 +54,11 @@ export interface MockDialogManager {
   readonly handles: MockDialogHandle[];
   /** The most recently opened dialog, or null. */
   readonly lastHandle: MockDialogHandle | null;
-  /** Opened dialogs hosted in the panel surface. */
+  /** Opened dialogs of kind "panel" (deletion progress/failed). */
   panelHandles(): MockDialogHandle[];
-  /** Opened dialogs hosted in the modal surface. */
+  /** Opened dialogs of kind "modeless" (creation ground state). */
+  modelessHandles(): MockDialogHandle[];
+  /** Opened dialogs of kind "modal" (blocking). */
   modalHandles(): MockDialogHandle[];
 }
 
@@ -75,10 +77,10 @@ export function createMockDialogManager(): MockDialogManager {
     for (const listener of modalChangeListeners) listener(open);
   };
 
-  const open = vi.fn((config: DialogConfig, options?: { surface?: DialogSurface }) => {
+  const open = vi.fn((config: DialogConfig, options?: { kind?: DialogKind }) => {
     const id = `dlg-test-${nextId++}`;
-    const isModal = (options?.surface ?? "modal") === "modal";
-    const mock = createMockDialogHandle(id, config, options?.surface);
+    const isModal = (options?.kind ?? "modal") === "modal";
+    const mock = createMockDialogHandle(id, config, options?.kind);
     handles.push(mock);
     if (isModal) {
       const wasOpen = modalIds.size > 0;
@@ -115,8 +117,9 @@ export function createMockDialogManager(): MockDialogManager {
     get lastHandle() {
       return handles[handles.length - 1] ?? null;
     },
-    panelHandles: () => handles.filter((h) => h.surface === "panel"),
-    modalHandles: () => handles.filter((h) => h.surface === "modal"),
+    panelHandles: () => handles.filter((h) => h.kind === "panel"),
+    modelessHandles: () => handles.filter((h) => h.kind === "modeless"),
+    modalHandles: () => handles.filter((h) => h.kind === "modal"),
   };
 }
 
@@ -127,7 +130,7 @@ export function createMockDialogManager(): MockDialogManager {
 export function createMockDialogHandle(
   id: string,
   config: DialogConfig = { sections: [] },
-  surface: DialogSurface = "modal"
+  kind: DialogKind = "modal"
 ): MockDialogHandle {
   const actionListeners = new Set<(event: DialogActionEvent) => void>();
   const changeListeners = new Set<(event: DialogFieldChangeEvent) => void>();
@@ -199,7 +202,7 @@ export function createMockDialogHandle(
     id,
     config,
     configs: [config],
-    surface,
+    kind,
     closed: false,
     handle,
     emitAction(actionId, data = {}) {

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -148,7 +148,7 @@ const LOADING_SPINNER = {
   items: [{ id: "status", label: "Loading workspace...", status: "running" }],
 };
 function systemDialog(sections: unknown[], id = "dlg-1"): unknown {
-  return { id, surface: "modal", config: { sections, modal: true } };
+  return { id, kind: "modal", config: { sections } };
 }
 /** The single open system dialog in the latest snapshot (asserts exactly one). */
 function currentSystemDialog(deps: Deps): { id: string; config: { sections: unknown[] } } {
@@ -1519,7 +1519,7 @@ describe("PresentationModule - close confirm", () => {
 
   // The presenter owns the dialog now; read it from the snapshot and drive user
   // interactions via dialog ui:events (routed to the internal session by id).
-  type SnapshotDialog = { id: string; config: { sections: readonly unknown[]; modal?: boolean } };
+  type SnapshotDialog = { id: string; kind: string; config: { sections: readonly unknown[] } };
   function currentDialog(deps: Deps): SnapshotDialog {
     const dialogs = lastSnapshot(deps).dialogs;
     expect(dialogs.length).toBeGreaterThan(0);
@@ -1546,7 +1546,7 @@ describe("PresentationModule - close confirm", () => {
     await flush();
     const dialog = currentDialog(deps);
 
-    expect(dialog.config.modal).toBe(true);
+    expect(dialog.kind).toBe("modal");
     const texts = (dialog.config.sections as Array<{ type: string; content?: string }>)
       .filter((s) => s.type === "text")
       .map((s) => s.content);
@@ -1701,7 +1701,7 @@ describe("PresentationModule - UI mode", () => {
     expect(mode(deps)).toBe("hover");
 
     // Open a modal dialog → dialogModalOpen flips the mode to "dialog".
-    module.dialog({ sections: [], modal: true });
+    module.dialog({ sections: [] }, { kind: "modal" });
     await flush();
     expect(mode(deps)).toBe("dialog");
   });
@@ -1711,7 +1711,7 @@ describe("PresentationModule - UI mode", () => {
     const module = await startModule(deps);
     await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([makeWorkspace("main")]) });
 
-    module.dialog({ sections: [], modal: true });
+    module.dialog({ sections: [] }, { kind: "modal" });
     await emit(module, EVENT_SHORTCUT_ACTIVE_CHANGED, { active: true });
     await flush();
     expect(mode(deps)).toBe("shortcut");
@@ -1722,7 +1722,7 @@ describe("PresentationModule - UI mode", () => {
     expect(mode(deps)).toBe("dialog");
   });
 
-  it("a panel-surface dialog does NOT count as a modal (no dialog mode)", async () => {
+  it("a panel-kind dialog does NOT count as a modal (no dialog mode)", async () => {
     const deps = createDeps();
     const module = await startModule(deps);
     const workspace = makeWorkspace("main", { url: "http://127.0.0.1:1/main" });
@@ -1730,7 +1730,7 @@ describe("PresentationModule - UI mode", () => {
     await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
     await flush();
 
-    module.dialog({ sections: [] }, { surface: "panel" });
+    module.dialog({ sections: [] }, { kind: "panel" });
     await flush();
     expect(mode(deps)).toBe("workspace");
   });

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -118,7 +118,7 @@ import type {
   DialogActionEvent,
   DialogConfig,
   DialogSection,
-  DialogSurface,
+  DialogKind,
   ProgressItem,
 } from "../../shared/dialog-types";
 import { uiEventSchema } from "../../shared/ui-event";
@@ -179,11 +179,11 @@ const LABEL_SCROLL_VALUES = ["always", "hover", "off"] as const;
  * the snapshot.
  */
 export interface UiPresenter extends IntentModule {
-  /** Open a dialog (modal card or non-modal panel). Returns a handle. */
-  dialog(config: DialogConfig, options?: { surface?: DialogSurface }): DialogHandle;
+  /** Open a dialog (modal, modeless, or panel — see DialogKind). Returns a handle. */
+  dialog(config: DialogConfig, options?: { kind?: DialogKind }): DialogHandle;
   /** Open a sidebar notification. Returns a handle. */
   notification(config: NotificationConfig): NotificationHandle;
-  /** True while a modal-surface dialog is open (the shortcut-module Alt+X guard). */
+  /** True while a blocking modal dialog (kind === "modal") is open (the shortcut-module Alt+X guard). */
   isModalOpen(): boolean;
   /**
    * The current full deletion progress for a workspace path, or undefined when
@@ -365,7 +365,7 @@ function buildCloseConfirmConfig(
     ],
   });
 
-  return { sections, modal: true };
+  return { sections };
 }
 
 export function createPresentationModule(deps: PresentationModuleDeps): UiPresenter {
@@ -702,7 +702,6 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       sections: [
         { type: "progress", style: "spinner", items: [{ id: "status", label, status: "running" }] },
       ],
-      modal: true,
     };
   }
 
@@ -734,7 +733,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
         ],
       });
     }
-    return { sections, modal: true };
+    return { sections };
   }
 
   /**
@@ -761,7 +760,6 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
           items: [{ type: "button", id: "continue", label: "Continue", variant: "primary" }],
         },
       ],
-      modal: true,
     };
   }
 
@@ -838,7 +836,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     if (systemDialog) {
       systemDialog.update(config);
     } else {
-      systemDialog = dialogs.open(config, { surface: "modal" });
+      systemDialog = dialogs.open(config, { kind: "modal" });
       systemDialog.onEvent(handleSystemAction);
     }
   }
@@ -1659,7 +1657,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
 
   return {
     name: "presentation",
-    dialog: (config: DialogConfig, options?: { surface?: DialogSurface }): DialogHandle =>
+    dialog: (config: DialogConfig, options?: { kind?: DialogKind }): DialogHandle =>
       dialogs.open(config, options),
     notification: (config: NotificationConfig): NotificationHandle => notifications.open(config),
     isModalOpen: (): boolean => dialogs.isModalOpen(),

--- a/src/modules/presentation/sessions.ts
+++ b/src/modules/presentation/sessions.ts
@@ -9,14 +9,14 @@
  *
  * The shared registry mechanics (id minting, the handle map, snapshot
  * projection, routing) live in `SessionRegistry`. Dialogs and notifications
- * differ only in their handle richness: a dialog carries a `surface` and a
+ * differ only in their handle richness: a dialog carries a `kind` and a
  * full action/change/dismiss/await contract; a notification is a lightweight
  * sidebar indicator with a single event channel.
  */
 
 import type {
   DialogConfig,
-  DialogSurface,
+  DialogKind,
   DialogUserEvent,
   DialogActionEvent,
   DialogFieldChangeEvent,
@@ -121,20 +121,21 @@ export interface DialogHandle {
 
 /**
  * DialogManager tracks open dialog sessions and exposes a render-ready
- * snapshot. It also exposes a synchronous "modal open" signal (a modal-surface
+ * snapshot. It also exposes a synchronous "modal open" signal (a blocking modal
  * dialog is currently open), consumed by the presenter (mode computation:
- * dialog beats hover/workspace) and the shortcut guard (Alt+X). "modal" means
- * surface === "modal" (the default); panel-surface sessions do NOT count.
+ * dialog beats hover/workspace) and the shortcut guard (Alt+X). Only
+ * kind === "modal" counts; "modeless" (creation) and "panel" (deletion) do NOT
+ * — they are non-blocking and the sidebar stays live.
  */
 export class DialogManager extends SessionRegistry<UiDialog, DialogHandleImpl> {
   constructor(notifyChange: () => void, logger?: Logger) {
     super("dlg", notifyChange, logger);
   }
 
-  /** True while at least one modal-surface dialog is open. Synchronous. */
+  /** True while at least one blocking modal dialog (kind === "modal") is open. Synchronous. */
   isModalOpen(): boolean {
     for (const handle of this.openSessions) {
-      if (handle.surface === "modal") return true;
+      if (handle.kind === "modal") return true;
     }
     return false;
   }
@@ -142,14 +143,14 @@ export class DialogManager extends SessionRegistry<UiDialog, DialogHandleImpl> {
   /**
    * Open a dialog. Returns a handle for updates and events.
    *
-   * The surface is a session property set once here — update commands carry
-   * only the config and cannot move a session between surfaces.
+   * The kind is a session property set once here — update commands carry
+   * only the config and cannot move a session between kinds.
    */
-  open(config: DialogConfig, options?: { surface?: DialogSurface }): DialogHandle {
-    // Default surface is "modal" (matches the renderer DialogHost default).
-    const surface: DialogSurface = options?.surface ?? "modal";
+  open(config: DialogConfig, options?: { kind?: DialogKind }): DialogHandle {
+    // Default kind is "modal" (matches the renderer DialogHost default).
+    const kind: DialogKind = options?.kind ?? "modal";
     return this.register(
-      (id, onRemove) => new DialogHandleImpl(id, surface, config, this.notifyChange, onRemove)
+      (id, onRemove) => new DialogHandleImpl(id, kind, config, this.notifyChange, onRemove)
     );
   }
 
@@ -179,7 +180,7 @@ export class DialogManager extends SessionRegistry<UiDialog, DialogHandleImpl> {
  */
 class DialogHandleImpl implements DialogHandle, RegistrySession<UiDialog> {
   readonly id: string;
-  readonly surface: DialogSurface;
+  readonly kind: DialogKind;
   readonly closed: Promise<void>;
 
   /** Current render config — read by toSnapshot(). */
@@ -195,13 +196,13 @@ class DialogHandleImpl implements DialogHandle, RegistrySession<UiDialog> {
 
   constructor(
     id: string,
-    surface: DialogSurface,
+    kind: DialogKind,
     config: DialogConfig,
     notifyChange: () => void,
     onRemove: () => void
   ) {
     this.id = id;
-    this.surface = surface;
+    this.kind = kind;
     this.config = config;
     this.notifyChange = notifyChange;
     this.onRemove = onRemove;
@@ -211,7 +212,7 @@ class DialogHandleImpl implements DialogHandle, RegistrySession<UiDialog> {
   }
 
   toSnapshot(): UiDialog {
-    return { id: this.id, surface: this.surface, config: this.config };
+    return { id: this.id, kind: this.kind, config: this.config };
   }
 
   update(config: DialogConfig): void {

--- a/src/modules/settings-module.integration.test.ts
+++ b/src/modules/settings-module.integration.test.ts
@@ -160,8 +160,8 @@ describe("SettingsModule — population", () => {
     openSettings();
 
     expect(dialogs.handles).toHaveLength(1);
+    expect(dialogs.lastHandle!.kind).toBe("modal");
     const cfg = dialogs.lastHandle!.config;
-    expect(cfg.modal).toBe(true);
     expect(cfg.layout).toBe("form");
 
     expect(rowByLabel(cfg, "agent")).toBeDefined();

--- a/src/modules/settings-module.ts
+++ b/src/modules/settings-module.ts
@@ -375,7 +375,7 @@ export function createSettingsModule(deps: SettingsModuleDeps): {
       ],
     });
 
-    return { config: { sections, layout: "form", modal: true }, invalidCount };
+    return { config: { sections, layout: "form" }, invalidCount };
   }
 
   /** Small source badge; only env/CLI overrides are noteworthy. */

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -98,7 +98,7 @@ function openCreationPanelSession(dialogId = "dlg-creation-1"): void {
       ...current.dialogs,
       {
         id: dialogId,
-        surface: "panel",
+        kind: "modeless",
         config: {
           layout: "form",
           sections: [{ type: "text", content: "New workspace", style: "heading" }],
@@ -145,9 +145,8 @@ describe("App component", () => {
           dialogs: [
             {
               id: "dlg-startup-1",
-              surface: "modal",
+              kind: "modal",
               config: {
-                modal: true,
                 sections: [
                   {
                     type: "progress",
@@ -180,9 +179,8 @@ describe("App component", () => {
           dialogs: [
             {
               id: "dlg-setup-1",
-              surface: "modal",
+              kind: "modal",
               config: {
-                modal: true,
                 sections: [
                   { type: "text", content: "Setting up CodeHydra", style: "heading" },
                   {
@@ -225,9 +223,8 @@ describe("App component", () => {
           dialogs: [
             {
               id: "dlg-agent-1",
-              surface: "modal",
+              kind: "modal",
               config: {
-                modal: true,
                 sections: [
                   { type: "text", content: "Choose Agent", style: "heading" },
                   {
@@ -272,9 +269,8 @@ describe("App component", () => {
 
       const spinner = {
         id: "dlg-sys",
-        surface: "modal" as const,
+        kind: "modal" as const,
         config: {
-          modal: true,
           sections: [
             {
               type: "progress" as const,
@@ -293,9 +289,8 @@ describe("App component", () => {
       // Same dialog id, config swapped to the agent radio (autofocus opts in).
       const agentDialog = {
         id: "dlg-sys",
-        surface: "modal" as const,
+        kind: "modal" as const,
         config: {
-          modal: true,
           sections: [
             { type: "text" as const, content: "Choose Agent", style: "heading" as const },
             {
@@ -415,9 +410,8 @@ describe("App component", () => {
       // workspace's frame stays in `frames`, so MainView must survive.
       const loadingDialog = {
         id: "dlg-loading-1",
-        surface: "modal" as const,
+        kind: "modal" as const,
         config: {
-          modal: true,
           sections: [
             {
               type: "progress" as const,

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -1,9 +1,9 @@
 <!--
   DialogHost.svelte
 
-  Renders one DialogView per open MODAL dialog from the ui:state snapshot
-  (via the dialog-framework store, a read-only derived view). Panel-surface
-  sessions are rendered by MainView as a PanelView in the content area.
+  Renders one DialogView per open dialog of kind "modal" (the blocking popups)
+  from the ui:state snapshot. The non-blocking kinds — "modeless" (creation) and
+  "panel" (deletion) — are rendered by MainView as PanelViews instead.
 -->
 <script lang="ts">
   import type { UiDialog } from "@shared/ui-state";
@@ -17,6 +17,6 @@
   const { dialogs }: Props = $props();
 </script>
 
-{#each dialogs.filter((d) => d.surface === "modal") as entry (entry.id)}
+{#each dialogs.filter((d) => d.kind === "modal") as entry (entry.id)}
   <DialogView dialogId={entry.id} config={entry.config} />
 {/each}

--- a/src/renderer/lib/components/DialogHost.test.ts
+++ b/src/renderer/lib/components/DialogHost.test.ts
@@ -43,21 +43,25 @@ describe("DialogHost surface routing", () => {
   });
 
   it("renders a DialogView for a modal entry", () => {
-    renderDialogs([{ id: "dlg-1", surface: "modal", config: createConfig("Modal") }]);
+    renderDialogs([{ id: "dlg-1", kind: "modal", config: createConfig("Modal") }]);
 
     expect(screen.getByRole("dialog", { name: "Modal" })).toBeInTheDocument();
   });
 
-  it("does not render panel-surface entries", () => {
-    renderDialogs([{ id: "dlg-1", surface: "panel", config: createConfig("Panel form") }]);
+  it("does not render modeless or panel entries", () => {
+    renderDialogs([
+      { id: "dlg-1", kind: "modeless", config: createConfig("Creation form") },
+      { id: "dlg-2", kind: "panel", config: createConfig("Deletion") },
+    ]);
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("renders only the modal entry when both surfaces are active", () => {
+  it("renders only the modal entry when several kinds are active", () => {
     renderDialogs([
-      { id: "dlg-1", surface: "modal", config: createConfig("Modal") },
-      { id: "dlg-2", surface: "panel", config: createConfig("Panel form") },
+      { id: "dlg-1", kind: "modal", config: createConfig("Modal") },
+      { id: "dlg-2", kind: "panel", config: createConfig("Panel form") },
+      { id: "dlg-3", kind: "modeless", config: createConfig("Creation form") },
     ]);
 
     expect(screen.getAllByRole("dialog")).toHaveLength(1);

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -59,13 +59,19 @@
   /** The single UI mode (main-owned). */
   const mode = $derived(ui.mode);
   /**
-   * The active panel-surface dialog session (the creation form is the only one
-   * today). View-only pick over the snapshot's dialogs; if several are open the
-   * most recently opened wins (snapshot order).
+   * The always-alive creation form session ("modeless" kind), rendered above
+   * the sidebar while main is in the creation ground state. View-only pick over
+   * the snapshot's dialogs.
    */
-  const panelDialog = $derived(ui.dialogs.filter((d) => d.surface === "panel").at(-1));
-  /** Whether any modal dialog is open above the panel (drives panel refocus). */
-  const modalAbove = $derived(ui.dialogs.some((d) => d.surface === "modal"));
+  const creationDialog = $derived(ui.dialogs.find((d) => d.kind === "modeless"));
+  /**
+   * The deletion progress/failed session ("panel" kind), rendered below the
+   * sidebar in place of the (already torn-down) workspace view. The deletion
+   * module opens it only while its workspace is the active one.
+   */
+  const deletionDialog = $derived(ui.dialogs.find((d) => d.kind === "panel"));
+  /** Whether a blocking modal is open above the panels (drives panel refocus). */
+  const modalAbove = $derived(ui.dialogs.some((d) => d.kind === "modal"));
   /** The creation panel is the ground state: shown whenever main says so. */
   const creationShown = $derived(main?.kind === "creation");
 
@@ -114,7 +120,7 @@
     if (shown && !prevShownForDismiss) showDismissPending = true;
     if (!shown) showDismissPending = false;
     prevShownForDismiss = shown;
-    const session = panelDialog;
+    const session = creationDialog;
     if (showDismissPending && session) {
       showDismissPending = false;
       api.sendDialogEvent({ kind: "dismiss", dialogId: session.id });
@@ -204,13 +210,30 @@
     {idleWorkspaceCount}
   />
 
-  <!-- Creation panel: the backend creation module's always-alive form
-       session, shown while the snapshot's main view is "creation" (the
-       ground state when no workspace is active). The creation form is the
-       only panel-surface session today; revisit the gating if another panel
-       session appears. -->
-  {#if creationShown && panelDialog}
-    <PanelView dialogId={panelDialog.id} config={panelDialog.config} {modalAbove} />
+  <!-- Creation panel ("modeless"): the backend creation module's always-alive
+       form session, a popup ABOVE the sidebar, shown while the snapshot's main
+       view is "creation" (the ground state when no workspace is active). -->
+  {#if creationShown && creationDialog}
+    <PanelView
+      dialogId={creationDialog.id}
+      config={creationDialog.config}
+      kind="modeless"
+      {modalAbove}
+    />
+  {/if}
+
+  <!-- Deletion panel ("panel"): the deletion module's progress/failed session,
+       shown in place of the active workspace's (already torn-down) view, BELOW
+       the sidebar so the sidebar stays on top and navigable. The module opens
+       it only while its workspace is the active one, so it never coexists with
+       the creation ground state. -->
+  {#if main?.kind === "workspace" && deletionDialog}
+    <PanelView
+      dialogId={deletionDialog.id}
+      config={deletionDialog.config}
+      kind="panel"
+      {modalAbove}
+    />
   {/if}
 
   {#if main?.kind === "hibernated"}

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -54,8 +54,8 @@ function pushState(state: UiState): Promise<void> {
   return rerenderView({ ui: current });
 }
 
-/** Simulate the backend creation module's always-alive panel session by adding
- *  a panel-surface dialog to the current snapshot. */
+/** Simulate the backend creation module's always-alive session by adding
+ *  a "modeless" dialog to the current snapshot. */
 function openCreationPanelSession(dialogId = "dlg-creation-1"): Promise<void> {
   current = {
     ...current,
@@ -63,7 +63,7 @@ function openCreationPanelSession(dialogId = "dlg-creation-1"): Promise<void> {
       ...current.dialogs,
       {
         id: dialogId,
-        surface: "panel",
+        kind: "modeless",
         config: {
           layout: "form",
           sections: [{ type: "text", content: "New workspace", style: "heading" }],

--- a/src/renderer/lib/components/PanelView.svelte
+++ b/src/renderer/lib/components/PanelView.svelte
@@ -1,35 +1,42 @@
 <!--
   PanelView.svelte
 
-  Panel surface for the declarative form framework: a non-modal, docked panel
-  shown in place of the main content area (the look of NewWorkspaceView), with
-  the sections + actions delegated to <Form>. Rendered by MainView for the
-  active panel-surface session (see dialog-framework's panelDialog).
+  Renderer for the two non-blocking dialog kinds — "modeless" (creation ground
+  state) and "panel" (deletion progress/failed) — with the sections + actions
+  delegated to <Form>. Rendered by MainView; DialogHost handles blocking modals.
 
   Shell behaviour (renderer-owned; the backend owns the form session):
-  - A centered floating card over a translucent scrim, painted above the
-    expanded sidebar but pointer-transparent so the sidebar stays clickable
-    (non-modal ground state); modal dialogs (z 1000) stack above.
-  - Keyboard (Escape -> dismiss, Cmd/Ctrl+Enter -> primary, Tab trap) is owned
-    by Form — shared with the modal surface.
-  - When the last modal stacked above the panel closes, the panel re-places
-    focus on the form's autofocus control (focus would otherwise be lost to
-    <body>, leaving the keyboard flow dead).
+  - "modeless" (creation) is a centered floating card with NO backdrop — the
+    layer is fully transparent and pointer-transparent, sitting ABOVE the
+    sidebar (a popup on top of the UI), so the sidebar and content behind stay
+    crisp and clickable. (No blur/dim: the sidebar is interactive, so dimming it
+    would misleadingly read as disabled.)
+  - "panel" (deletion) REPLACES the workspace view: an OPAQUE layer that masks
+    the torn-down / reconnecting code-server frame behind it, sitting BELOW the
+    sidebar so the sidebar (gutter or hover-expanded) renders on top and stays
+    navigable. It is not dimming a live view — the view is gone; the opacity
+    just keeps the empty/reconnecting frame from flickering through.
+  - Blocking modals (z 1000) stack above both.
+  - Keyboard (Escape, Cmd/Ctrl+Enter -> primary, Tab trap) is owned by Form.
+  - When the last blocking modal stacked above closes, the panel re-places focus
+    on the form's autofocus control (focus would otherwise be lost to <body>).
   - Form is keyed by dialogId: a backend close + reopen remounts it with fresh
     field values (the reset gesture).
 -->
 <script lang="ts">
-  import type { DialogConfig } from "@shared/dialog-types";
+  import type { DialogConfig, DialogKind } from "@shared/dialog-types";
   import Form from "./form/Form.svelte";
 
   interface Props {
     dialogId: string;
     config: DialogConfig;
-    /** Whether a modal dialog is open above the panel (drives refocus on close). */
+    /** "modeless" (creation, above sidebar) or "panel" (deletion, below sidebar). */
+    kind: Extract<DialogKind, "modeless" | "panel">;
+    /** Whether a blocking modal is open above (drives refocus on close). */
     modalAbove: boolean;
   }
 
-  const { dialogId, config, modalAbove }: Props = $props();
+  const { dialogId, config, kind, modalAbove }: Props = $props();
 
   let formRef: Form | undefined = $state();
 
@@ -48,30 +55,47 @@
   });
 </script>
 
-<section class="panel-view" aria-label={heading}>
+<section
+  class="panel-view"
+  class:above={kind === "modeless"}
+  class:below={kind === "panel"}
+  aria-label={heading}
+>
   <div class="panel-card">
     {#key dialogId}
-      <Form bind:this={formRef} {dialogId} {config} surface="panel" />
+      <Form bind:this={formRef} {dialogId} {config} {kind} />
     {/key}
   </div>
 </section>
 
 <style>
-  /* Floating overlay centered over the whole window, above the expanded sidebar
-     (--ch-z-sidebar-expanded: 950), below modals (1000). A translucent scrim
-     dims the sidebar/content behind it, but the layer is pointer-transparent so
-     the sidebar stays clickable (this is the non-modal ground state); only the
-     card captures pointer events. */
   .panel-view {
     position: absolute;
     inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--ch-overlay-bg);
-    backdrop-filter: var(--ch-overlay-blur, blur(8px));
+  }
+
+  /* "modeless" (creation ground state): a popup on top, above the expanded
+     sidebar (--ch-z-sidebar-expanded: 950), with NO backdrop and
+     pointer-transparent so the sidebar/content behind stay crisp and clickable;
+     only the card captures pointer events. */
+  .panel-view.above {
     z-index: 960;
     pointer-events: none;
+  }
+
+  /* "panel" (deletion): replaces the workspace view. An OPAQUE layer painted
+     above the frames (which carry no z-index) but BELOW the sidebar — z-index 0
+     sits under the sidebar's collapsed gutter (--ch-z-sidebar-minimized: 1) and
+     its expanded drawer (--ch-z-sidebar-expanded: 950), so the sidebar renders
+     on top and stays navigable. Opaque + pointer-capturing so the torn-down /
+     reconnecting frame behind neither flickers through nor takes clicks. */
+  .panel-view.below {
+    z-index: 0;
+    background: var(--ch-background);
+    pointer-events: auto;
   }
 
   .panel-card {

--- a/src/renderer/lib/components/PanelView.test.ts
+++ b/src/renderer/lib/components/PanelView.test.ts
@@ -41,8 +41,13 @@ function createConfig(overrides?: Partial<DialogConfig>): DialogConfig {
   };
 }
 
-function renderPanel(config: DialogConfig, dialogId = "panel-1", modalAbove = false) {
-  return render(PanelView, { props: { dialogId, config, modalAbove } });
+function renderPanel(
+  config: DialogConfig,
+  dialogId = "panel-1",
+  modalAbove = false,
+  kind: "modeless" | "panel" = "modeless"
+) {
+  return render(PanelView, { props: { dialogId, config, kind, modalAbove } });
 }
 
 describe("PanelView component (panel surface)", () => {

--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -30,7 +30,7 @@
   import type {
     DialogConfig,
     DialogSection,
-    DialogSurface,
+    DialogKind,
     DialogUserEvent,
   } from "@shared/dialog-types";
   import { onMount, onDestroy, untrack } from "svelte";
@@ -50,13 +50,14 @@
     dialogId: string;
     config: DialogConfig;
     /**
-     * Hosting surface. Governs Escape when no enabled cancel-role button
-     * exists: a "modal" swallows it (no-op); a "panel" emits a dismiss event.
+     * Presentation kind. Governs Escape when no enabled cancel-role button
+     * exists: "modeless" (creation) emits a dismiss event (reset); "modal" and
+     * "panel" swallow it (no-op).
      */
-    surface?: DialogSurface;
+    kind?: DialogKind;
   }
 
-  const { dialogId, config, surface = "modal" }: Props = $props();
+  const { dialogId, config, kind = "modal" }: Props = $props();
 
   /**
    * All field sections of the config in declaration order — top-level
@@ -107,7 +108,7 @@
     return -1;
   });
 
-  const splitFooter = $derived(surface === "modal" && layout === "form" && footerIndex >= 0);
+  const splitFooter = $derived(kind === "modal" && layout === "form" && footerIndex >= 0);
 
   /**
    * Stable keys for the sections each-block, so a config push that inserts or
@@ -556,8 +557,8 @@
    * the app root and replays them target-to-root, so only a delegated handler
    * keeps that ordering with the field components' handlers.
    * - Escape clicks the first enabled cancel-role button (identical to a real
-   *   click). With none, a modal swallows Escape (no-op); a panel emits a
-   *   "dismiss" event the session owner interprets (typically reset).
+   *   click). With none, "modeless" (creation) emits a "dismiss" event the
+   *   session owner interprets as reset; "modal" and "panel" swallow it (no-op).
    * - Cmd/Ctrl+Enter activates the primary button from anywhere in the form.
    * - Tab/Shift+Tab is trapped at the form boundary so focus never leaks out.
    */
@@ -582,11 +583,11 @@
       const cancel = findCancelButton(config);
       if (cancel) {
         handleButton(cancel);
-      } else if (surface === "panel") {
+      } else if (kind === "modeless") {
         const dismiss: DialogUserEvent = { kind: "dismiss", dialogId };
         sendDialogEvent(dismiss);
       }
-      // Modal with no enabled cancel-role button: Escape is a no-op.
+      // "modal"/"panel" with no enabled cancel-role button: Escape is a no-op.
       return;
     }
     if (formRef) {

--- a/src/renderer/lib/components/form/Form.test.ts
+++ b/src/renderer/lib/components/form/Form.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
-import type { DialogConfig, DialogSurface } from "@shared/dialog-types";
+import type { DialogConfig, DialogKind } from "@shared/dialog-types";
 
 // Mock setup - must be hoisted
 const { mockSendDialogEvent } = vi.hoisted(() => ({
@@ -26,15 +26,12 @@ vi.mock("$lib/api", () => ({
 import Form from "./Form.svelte";
 
 /** Helper to render Form with a config. */
-function renderForm(
-  config: DialogConfig,
-  options?: { dialogId?: string; surface?: DialogSurface }
-) {
+function renderForm(config: DialogConfig, options?: { dialogId?: string; kind?: DialogKind }) {
   return render(Form, {
     props: {
       dialogId: options?.dialogId ?? "test-dialog",
       config,
-      ...(options?.surface ? { surface: options.surface } : {}),
+      ...(options?.kind ? { kind: options.kind } : {}),
     },
   });
 }
@@ -1113,17 +1110,20 @@ describe("Form component", () => {
       expect(mockSendDialogEvent).not.toHaveBeenCalled();
     });
 
-    it("Escape emits a dismiss event on the panel surface with no cancel-role button", async () => {
+    it("Escape emits a dismiss event on a modeless dialog with no cancel-role button", async () => {
       renderForm(
         {
           sections: [{ type: "input", id: "name", label: "Name" }],
         },
-        { dialogId: "kb-panel", surface: "panel" }
+        { dialogId: "kb-modeless", kind: "modeless" }
       );
 
       await fireEvent.keyDown(document.querySelector(".form")!, { key: "Escape" });
 
-      expect(mockSendDialogEvent).toHaveBeenCalledWith({ kind: "dismiss", dialogId: "kb-panel" });
+      expect(mockSendDialogEvent).toHaveBeenCalledWith({
+        kind: "dismiss",
+        dialogId: "kb-modeless",
+      });
     });
 
     it("an open dropdown consumes the first Escape; the second clicks cancel-role", async () => {

--- a/src/renderer/lib/integration.test.ts
+++ b/src/renderer/lib/integration.test.ts
@@ -49,10 +49,10 @@ import App from "../App.svelte";
 import { makeUiState, makeUiProjectRow, makeUiWorkspaceRow } from "$lib/test-utils";
 import type { UiDialog } from "@shared/ui-state";
 
-/** The backend creation module's always-alive panel session, as a snapshot entry. */
+/** The backend creation module's always-alive session, as a snapshot entry. */
 const PANEL_DIALOG: UiDialog = {
   id: "dlg-creation",
-  surface: "panel",
+  kind: "modeless",
   config: {
     layout: "form",
     sections: [{ type: "text", content: "New workspace", style: "heading" }],

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -409,8 +409,6 @@ interface ButtonItem extends DialogButton {
  */
 export interface DialogConfig {
   readonly sections: readonly DialogSection[];
-  /** When true, the dialog is on top of everything and blocks keyboard shortcuts (Alt+X). Default: false. */
-  readonly modal?: boolean;
   /**
    * Section layout (renderer hint; the modal shell is unaffected).
    * - "centered" (default): centered stack, no field labels — today's behavior.
@@ -423,16 +421,21 @@ export interface DialogConfig {
 // ---- IPC Protocol ----
 
 /**
- * Surface hosting a form session.
- * - "modal" (default): centered card on a backdrop (DialogView), on top of the UI.
- * - "panel": non-modal docked panel shown in place of the main content area
- *   (PanelView); modal dialogs stack above it.
+ * How a form session is presented. One property, three mutually exclusive kinds
+ * (replaces the old surface + config.modal pair):
+ * - "modal" (default): a blocking popup on top of everything — centered card on
+ *   a dimmed/blurred backdrop that captures clicks and blocks Alt+X (DialogView,
+ *   via DialogHost). Use for anything that must be answered before proceeding.
+ * - "modeless": a non-blocking popup on top, above the sidebar — no backdrop,
+ *   clicks pass through so the sidebar stays live (PanelView). The creation
+ *   ground state: you leave it by clicking a workspace in the sidebar.
+ * - "panel": in place of the workspace view, below the sidebar — no backdrop,
+ *   the sidebar renders on top (PanelView). The deletion progress/failed view.
  *
  * Set once on the open command and immutable for the session's lifetime —
- * update commands carry only the config and cannot move a session between
- * surfaces.
+ * update commands carry only the config and cannot move a session between kinds.
  */
-export type DialogSurface = "modal" | "panel";
+export type DialogKind = "modal" | "modeless" | "panel";
 
 /**
  * Commands sent from main -> renderer to manage dialog lifecycle.
@@ -442,8 +445,8 @@ export type DialogCommand =
       readonly action: "open";
       readonly dialogId: string;
       readonly config: DialogConfig;
-      /** Hosting surface; absent = "modal". See DialogSurface. */
-      readonly surface?: DialogSurface;
+      /** Presentation kind; absent = "modal". See DialogKind. */
+      readonly kind?: DialogKind;
     }
   | { readonly action: "update"; readonly dialogId: string; readonly config: DialogConfig }
   | { readonly action: "close"; readonly dialogId: string };

--- a/src/shared/ui-state.ts
+++ b/src/shared/ui-state.ts
@@ -11,7 +11,7 @@
 
 import type { AgentStatus, WorkspaceTag } from "./api/types";
 import type { UIMode } from "./ipc";
-import type { DialogConfig, DialogSurface } from "./dialog-types";
+import type { DialogConfig, DialogKind } from "./dialog-types";
 import type { NotificationConfig } from "./notification-types";
 
 /** Resolved OS theme (mirrors the shell Theme type without importing it). */
@@ -42,7 +42,7 @@ export type SidebarLabelScroll = "always" | "hover" | "off";
  */
 export interface UiDialog {
   readonly id: string;
-  readonly surface: DialogSurface;
+  readonly kind: DialogKind;
   readonly config: DialogConfig;
 }
 


### PR DESCRIPTION
The "New workspace" creation dialog painted a full-viewport blur+dim scrim over the sidebar, but the sidebar stayed fully clickable (that's how you leave the creation ground state) — so the blur misleadingly read as "disabled".

- Replace the two-axis dialog presentation (`surface: modal|panel` + `config.modal`) with a single immutable `kind`:
  - `modal` — blocking popup on top (backdrop, captures clicks, blocks Alt+X)
  - `modeless` — non-blocking popup above the sidebar, no backdrop (creation)
  - `panel` — replaces the workspace view, below the sidebar (deletion)
- Creation is now `modeless`: crisp, clickable sidebar, no misleading blur.
- Deletion progress/failed is now `panel`: it opaquely replaces the torn-down workspace view below the sidebar, so the reconnecting code-server iframe no longer flickers through it and the sidebar stays navigable.
- `isModalOpen()` (Alt+X guard / dialog-mode) now counts only `kind: modal`, so the modeless creation dialog no longer forces dialog-mode.