### PR TITLE
fix: workspace stays busy while sub-agents are still running

### DIFF
--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -1328,19 +1328,56 @@ describe("ClaudeCodeServerManager integration", () => {
         workspacePath: "/workspace/feature-a",
         agent_id: "sub-orphan",
       });
-      // Turn completes via Notification (idle_prompt) — bypasses sub-agent guard
+      // idle_prompt while a sub-agent is still tracked stays busy (Gap 1 guard),
+      // so an orphaned sub-agent keeps the workspace busy until the next turn.
       await sendHook(port, "Notification", {
         workspacePath: "/workspace/feature-a",
         notification_type: "idle_prompt",
       });
 
-      expect(lastStatus(statusChanges)).toBe("idle");
+      expect(lastStatus(statusChanges)).toBe("busy");
 
-      // Turn 2: normal turn, no sub-agents — Stop must go idle
+      // Turn 2: UserPromptSubmit clears the orphan, so Stop goes idle normally
       await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
 
-      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy", "idle"]);
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+    });
+
+    it("idle_prompt Notification stays busy while a sub-agent is active", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Matches real log trace: main agent dispatches a sub-agent then goes quiet;
+      // Claude Code fires idle_prompt ~60s later while the sub-agent still runs.
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SubagentStart", {
+        workspacePath: "/workspace/feature-a",
+        agent_id: "sub-1",
+      });
+      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+      // idle_prompt must NOT blip to idle — the sub-agent is still working
+      await sendHook(port, "Notification", {
+        workspacePath: "/workspace/feature-a",
+        notification_type: "idle_prompt",
+      });
+
+      expect(lastStatus(statusChanges)).toBe("busy");
+
+      // Sub-agent finishes, main agent resumes and finishes → single idle transition
+      await sendHook(port, "SubagentStop", {
+        workspacePath: "/workspace/feature-a",
+        agent_id: "sub-1",
+      });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+
+      // No false idle blip across the whole sub-agent run
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
     it("Stop without sub-agents still transitions to idle normally", async () => {

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -710,8 +710,21 @@ export class ClaudeCodeServerManager implements AgentServerManager {
         payload.notification_type === "permission_prompt" ||
         payload.notification_type === "elicitation_dialog")
     ) {
-      newStatus = "idle";
-      state.ignoreNextSessionStart = false;
+      // idle_prompt fires ~60s after the main thread goes quiet, which is exactly
+      // what happens while the main agent waits on active sub-agents. Suppress it
+      // while sub-agents are still tracked so the workspace stays busy instead of
+      // blipping to idle — mirrors the background-shell guard below. The other two
+      // types genuinely need the user, so they still transition to idle.
+      if (payload.notification_type === "idle_prompt" && state.activeSubagents.size > 0) {
+        newStatus = null;
+        this.logger.debug("Idle suppressed for active sub-agents", {
+          workspacePath: normalizedPath,
+          activeSubagents: state.activeSubagents.size,
+        });
+      } else {
+        newStatus = "idle";
+        state.ignoreNextSessionStart = false;
+      }
     }
 
     // Sub-agent lifecycle tracking:


### PR DESCRIPTION
- Guard the `idle_prompt` Notification handler with the same `activeSubagents` check that `Stop` already uses, so a workspace stays busy while the main agent waits on parallel sub-agents instead of blipping to idle every ~60s.
- Mirrors the existing background-shell idle-suppression guard. `permission_prompt` and `elicitation_dialog` notifications still transition to idle — they genuinely need the user.
- Added an integration test reproducing the real log trace (SubagentStart → Stop suppressed → idle_prompt stays busy → SubagentStop → Stop idle) and updated the orphan-recovery test, since recovery now happens on the next turn's `UserPromptSubmit` clear rather than via idle_prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJQdXzV7RQrmPea3iNPWe6