### PR TITLE
fix(ci): source code-server from GitHub releases instead of npm

### DIFF
--- a/.github/workflows/build-code-server-windows.yaml
+++ b/.github/workflows/build-code-server-windows.yaml
@@ -52,18 +52,17 @@ jobs:
             exit 1
           fi
 
-      - name: Verify version exists on npm
-        shell: bash
-        run: |
-          if ! npm view "code-server@$VERSION" version &>/dev/null; then
-            echo "::error::code-server@$VERSION not found on npm"
-            exit 1
-          fi
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Upgrade npm
+        # The windows-2025 image ships Visual Studio 2026 (v18). node-gyp only
+        # detects it from >= 12.1.0 (bundled in npm >= 11.6.3), so upgrade npm
+        # before the code-server postinstall compiles its native modules.
+        shell: bash
+        run: npm install -g npm@latest
 
       - name: Create build directory
         shell: bash
@@ -72,7 +71,12 @@ jobs:
       - name: Install code-server
         shell: bash
         working-directory: build
-        run: npm install "code-server@$VERSION"
+        run: |
+          # npm no longer publishes code-server; install from the package.tar.gz
+          # asset attached to every upstream GitHub release. This is the same
+          # package the npm registry served, so its postinstall still builds the
+          # Windows-native modules on this runner.
+          npm install "https://github.com/coder/code-server/releases/download/v$VERSION/package.tar.gz"
 
       - name: Download Node.js for Windows
         shell: bash

--- a/.github/workflows/check-code-server-releases.yaml
+++ b/.github/workflows/check-code-server-releases.yaml
@@ -28,15 +28,28 @@ jobs:
             echo "::notice::DRY RUN MODE - will not trigger builds"
           fi
 
-      - name: Get code-server releases from npm
+      - name: Get code-server releases from GitHub
         id: upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get all versions from npm
-          ALL_VERSIONS=$(npm view code-server versions --json | jq -r '.[]')
+          # Get all release tags from the upstream repo (npm no longer publishes).
+          # Exclude drafts and pre-releases; strip the leading "v".
+          ALL_VERSIONS=$(gh release list \
+            --repo coder/code-server \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --limit 1000 \
+            --json tagName \
+            --jq '.[].tagName | ltrimstr("v")')
 
           # Filter to versions >= MIN_VERSION
           MIN="${{ env.MIN_VERSION }}"
           FILTERED_VERSIONS=$(echo "$ALL_VERSIONS" | while read -r version; do
+            # Keep only plain semver tags (X.Y.Z), skip anything else
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              continue
+            fi
             # Compare versions using sort -V
             if [ "$(printf '%s\n' "$MIN" "$version" | sort -V | head -n1)" = "$MIN" ]; then
               # Exclude pre-release versions (containing -)


### PR DESCRIPTION
code-server stopped publishing to npm after 4.117.0, so the daily discovery check and the Windows build both silently stopped picking up new versions (existing Windows releases stop at exactly 4.117.0).

- **Discovery** (`check-code-server-releases`): find versions via `gh release list --repo coder/code-server` (exclude drafts/pre-releases) instead of `npm view code-server versions`.
- **Build** (`build-code-server-windows`): install from the release `package.tar.gz` asset URL instead of `npm install code-server@X` — the same package npm served, so its postinstall still compiles the Windows-native modules on the runner. Dropped the now-moot npm-existence guard.
- **Build toolchain**: upgrade npm before that postinstall runs. `windows-2025` ships Visual Studio 2026 (v18), which node-gyp only detects from ≥ 12.1.0 (bundled in npm ≥ 11.6.3); Node 22's default npm is too old and the native compile fails without it. (Node stays pinned to 22 — code-server's `engines`/postinstall require it.)

Verified with a dry-run build of the latest release (4.127.0) on `windows-2025` end-to-end: install → native compile → `code-server.cmd --version` → package.

After merge, the next discovery run backfills 4.118.0–4.127.0.