### PR TITLE
refactor(intents): data-only handler contract via async-generator streaming

### DIFF
--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -278,6 +278,18 @@ The `ANY_VALUE` sentinel (exported from `operation.ts`) matches any value for a 
 
 Capabilities accumulate across handlers within a single `collect()` call and are available on `HookResult.capabilities` for the operation to inspect.
 
+### Capability vs. result: when to use which
+
+A `HookOutput` has two channels — `result` (accumulated into `results[]` for the **operation** to read after the wave) and `provides` (merged into the capability bag for **sibling handlers** to read during the wave). They are not interchangeable, and the choice follows one rule:
+
+> **A value is a capability if and only if a sibling handler `requires` it** (i.e. it exists to order handlers). Everything the operation consumes but no sibling requires is a **`result`**.
+
+Capabilities exist for ordering; results carry data out to the operation. Emitting a value as a capability that nothing requires couples the operation to the capability bag for no ordering benefit, and — because capabilities are keyed while results are positional — hides that the value is really operation output. (Example: `workspaceUrl` and `agentType` in `workspace:open` are read only by the operation, so they are results, not capabilities.)
+
+**Rider (multiple result-producers):** results are a positional array. If more than one handler on a hook point returns a result, the operation cannot pick one by key — type the result as a discriminated union (`collect<T>` with a discriminant), or keep the value keyed as a capability. When a single handler produces the result, `results[0]` is unambiguous.
+
+**Federation note:** this keeps the wire clean — `result` and `provides` are both plain data on the returned `HookOutput`, and `requires` is evaluated host-side by the single dispatcher (the `ANY_VALUE` symbol never crosses the wire). See `planning/REMOTE_WORKSPACES_FEDERATION.md`.
+
 ---
 
 ## Hook Result Policies

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -1,241 +1,335 @@
-# Remote & Container Workspaces via a Federated Dispatcher
+# Remote Workspaces via a Federated Dispatcher
 
 Status: **design / exploration** (not yet approved for implementation)
 
-Goal: let users create workspaces on a **remote machine (SSH-first)** and, later,
-in **containers** — surfaced in the create-workspace dialog as a target selection
-(image starts a new container / running container / remote machine).
+Goal: let a user create workspaces on a **remote machine (SSH-first)** — surfaced in
+the create-workspace dialog as a target-machine selection — with the workspace's
+worktree, agent, and code-server all running on that machine, while a single
+dispatcher on the host stays the sole orchestrator.
+
+> This document leads with **what lives where** — the data, config, and module
+> placement decisions — and only then covers the implementation punch list. An
+> earlier revision inverted that order; the placement model is the thing to agree on
+> first, because every implementation choice hangs off it.
+
+> ⚠️ Requires explicit approval per CLAUDE.md before implementing: (a) any
+> intent-contract / `OpenWorkspacePayload` change, (b) any **new boundary interface**
+> for the transport, and (c) the new host-side modules and `state.json` keys named below.
 
 ---
 
-## 1. Goal & scope (decided)
+## 1. Terminology (corrected)
 
-- **Remote machine over SSH first**, extensible to containers.
-- **Both agents** (Claude + OpenCode) supported from the start.
-- **Projects live on the remote** — managed (CodeHydra clones the repo) _or_ an
-  existing checkout already on the remote, mirroring today's local behavior.
-  - Rationale: git worktrees require the parent repo on the same filesystem, so a
-    remote **workspace** implies a remote **project**.
-- **Dialog change is cheap:** the target selector (image/container/remote) is a
-  `radio` section added in `creation-module` `buildConfig()` plus one optional
-  field on `OpenWorkspacePayload` — **no Svelte and no IPC-channel changes**.
+Two **independent** dimensions describe a project. The old plan conflated them.
 
-> ⚠️ Requires explicit approval per CLAUDE.md before implementing: (a) the
-> `OpenWorkspacePayload` / intent-contract change, and (b) any **new boundary
-> interface** introduced for the transport.
+- **How the checkout is obtained**
+  - **Managed** — CodeHydra cloned it from an origin URL and owns the bare clone.
+    (This is today's misnamed "remote project"; **rename → managed**.)
+  - **Existing checkout** — a path the user points CodeHydra at.
+- **Which machine it lives on**
+  - **Local** — the host.
+  - **Remote** — an SSH-reachable box. The worktree, agent, and code-server all run
+    there (git worktrees require the parent repo on the same filesystem).
 
----
+They cross freely: `local+existing` (today's default), `local+managed` (today's URL
+clone), `remote+existing`, `remote+managed`. A **remote workspace** is simply a
+workspace whose project lives on a remote machine.
 
-## 2. Architecture (converged): intent-seam federation, single host dispatcher
-
-Keep **one dispatcher, on the host**, as the sole orchestrator — ordering,
-capability merging, causation, and event emission all stay in-process on the host.
-Remote **modules** register their handlers into that dispatcher; a remote handler
-executes against the remote machine's own native boundaries (fs/process/git/port)
-in a small module-host process.
-
-Why this seam (vs. a "boundary-seam" that swaps fs/process/git per-call over SSH):
-the wire sits at a **coarse, serializable, already-mostly-data layer** (intents,
-events, hook results) instead of hundreds of fine-grained syscalls per workspace.
-
-### Module registration
-
-- **Static proxy, version-locked** to start: the host knows the module set at build
-  time; a host-side proxy forwards to the remote; connection state is just up/down.
-- Dynamic registration (remote pushes its handler list at connect) is the general
-  form — defer until heterogeneous remotes are actually needed.
-
-### Wire protocol (asymmetric, minimal)
-
-- **host → remote:** operation/hook invocations + domain events (to remote subscribers)
-- **remote → host:** intents (the only thing a remote handler _initiates_)
-- **handler results + provided data** ride the invocation response
-
-Notably, `agent:update-status` is already an intent, so a remote agent signaling a
-status change is just "dispatch that intent back to the host" — no new concept.
+**v1 scope cut:** on a remote, **managed only**. `remote+existing` (and the remote
+folder-browse / `path-probe` it needs) is **deferred**. Existing-checkout identity
+stays a local-only concept in v1.
 
 ---
 
-## 3. The structural model: two boundary tiers, two module tiers
+## 2. Project identity & the machine model (decided)
 
-Placement is a **per-handler property**. The clean-up target is to make it so.
+### Project identity depends on how it was obtained
 
-### Boundaries
+- **Managed → identity is the origin URL** (`sha256(normalizedUrl)`). The same origin
+  cloned on the host *and* on a remote box (and, later, mounted into a container) is
+  **one project**; its workspaces just live on different machines. Grouped under a
+  single project node in the UI.
+- **Existing checkout → identity is `(machine, path)`.** No shared origin to unify on.
+  Inherently single-machine. (Local-only in v1.)
 
-- **Host-only** — `WindowBoundary`, `ViewBoundary`, `SessionBoundary`, `IpcBoundary`,
-  `DialogBoundary`, `ImageBoundary`, `AppBoundary`(+power), `MenuBoundary`,
-  `PostHogBoundary`. (The Electron/UI surface + telemetry.)
-- **Both-sides** — `FileSystemBoundary`, `ProcessRunner`, `PortManager`,
-  `IGitClient`/`GitWorktreeProvider`, `HttpClient`, `PathProvider`,
-  `AgentServerManager`, code-server. (Run where the files live.)
-  - `SdkClientFactory` / `AgentProvider` _client_ is host-side but reaches a
-    both-sides server over the `-L` tunnel.
+Consequence: for managed projects **(project × machine) is many-to-many** — one
+project spans machines, one machine hosts many projects — with **workspaces at the
+intersection**. So **machine is a property of the workspace**, not the project (except
+for existing checkouts, where it is part of identity).
 
-### Modules
+### Machine is a first-class, host-persisted registry
 
-- **Host-only** — `view`, `presentation`, `creation`, `deletion-dialog`/`dialog-manager`,
-  `badge`, `power`, window-title/shortcut/selection, `electron-lifecycle`, menu,
-  `auto-updater`, `telemetry`, `error-report`, and the host-resident servers
-  `mcp-module` / `plugin-server-module` (remotes reach them via `-R`).
-- **Both-sides** — `git-worktree-workspace`, `keepfiles`, `code-server`,
-  `remote-project`, `workspace-agent-resolver` (all clean), plus:
-  - `agent-module` — **split by design** (server=remote, provider/status=host). The
-    healthy reference shape.
-  - `local-project-module` — **leaky** (FS/Git + `DialogBoundary`).
-  - `hibernation-screenshot-module` — **leaky** (FS + `ViewBoundary`/`ImageBoundary`).
+Because it's many-to-many, a machine cannot be a field on a project. The host keeps a
+**machine registry** — the set of SSH boxes to reconnect to on startup — plus a
+project registry. On startup it connects each machine and **discovers** that machine's
+worktrees, then groups them by project identity. Which machines a managed project lives
+on is **discovered on connect, never persisted** — consistent with today's invariant
+that workspaces are never stored, always re-derived from `git worktree list`.
 
-**A "leaky" module is a both-sides module whose handler also touches a host-only
-boundary (or receives a host callback).** Fixing them makes every handler single-tier
-and therefore cleanly placeable.
+### Reconnect story (reuses today's project-reopen machinery)
 
----
-
-## 4. Audit verdict
-
-The value surface (intent payloads, hook results, capability values, event payloads)
-is overwhelmingly plain serializable data. No structural blockers. What remains is a
-bounded punch list.
-
-Non-JSON carriers found, all convertible:
-
-- `Path` instances in `OpenProjectPayload.path`, `ProjectOpenedPayload.path`,
-  `ProjectOpenFailedPayload.path` (convertible via `toString()` / `new Path()`).
-- `Error[]` in `HookResult.errors`.
-- Capability values are primitives (enforced by strict `===` matching in `requires`).
-
-Orchestration facts that shape the work:
-
-- `collect()` ordering/merging is **centralizable** (single host dispatcher is natural).
-- The `provides`→returned-data reshape is **already done** (commit `d871aea6`): handlers
-  return a `HookOutput { result?, provides? }` and the dispatcher merges provided data as
-  plain data, no closure — the merge loop is already wire-ready. (The original audit
-  branched from a pre-`d871aea6` `origin/main` and mischaracterized this as an open
-  closure.)
-- **Handler emit invariant:** a handler's invocation payload and returned `HookOutput`
-  must be pure data; emitting/dispatching is sanctioned but must route through the
-  remote→host **channel** (an `emit`/`dispatch` shim), never a captured host closure. The
-  lone handler holding a live `emit` is code-server's app-resume handler → tracked under
-  item 3. (Operation bodies use `ctx.emit`/`ctx.dispatch` freely — they stay host-side.)
+Today, open projects are persisted as one `config.json` per project under the host's
+`projects/` dir; on launch the app scans that dir and re-dispatches `project:open` for
+each, then discovers worktrees via `git worktree list`. Remote reconnect is the same
+loop with one addition: a project on a remote machine triggers an **SSH connect**, and
+the *remote* runs the discovery. Machine connect happens in the same post-`app-ready`
+phase as project reopen (the `machines` registry is in `state.json`, which loads async).
 
 ---
 
-## 5. Punch list (sequenced 1 → 2 → 3, plus 4 & 5)
+## 3. What data lives where (decided)
 
-Sequencing rationale: the handler/capability **contract came first** so the wire schemas
-(2) are written against the final data shape; only then are the leaky-module splits (3)
-worth doing, since they depend on both the reshaped contract and the validated wire
-boundary.
+| Data | Lives | Persisted? | Owner |
+| --- | --- | --- | --- |
+| User config (UI, `agent`, `version.*`, telemetry toggle, electron/log) | **Host** `config.json` | yes | existing owners |
+| Identity, telemetry id, `update.dismissed-version`, `auto-workspaces` | **Host** `state.json` | yes | existing owners |
+| **`machines` registry** (SSH boxes) + **`host.id`** | **Host** `state.json` — *new* | yes | **`machine-registry` (new)** |
+| Project registry (managed→`{originUrl}`; local existing→`{machineId:local, path}`) | **Host** `projects/<id>/config.json` | yes | **`project-registry` (new, from local-project)** |
+| Screenshots, `electron/`, host logs, host temp | **Host** `dataRoot` | yes | existing owners |
+| Worktrees, managed clones, `vscode/`, `bin/`, `runtime/`, `claude/configs/`, remote logs/temp | **Remote** `<remoteBase>/<hostId>/…` | on box | remote-instanced modules |
+| Binaries (code-server, agents) | **Remote** `<remoteBase>/bundles/` (**shared** across hosts) | on box | code-server / agent modules |
+| The workspace list | nowhere — **discovered** per machine, grouped by origin | no | git-worktree (per machine) |
 
-**1. Reshape the capability contract — ✅ DONE.** The `provides()` closure → returned
-`HookOutput` reshape landed in commit `d871aea6` (pre-session). Remaining step-1 work,
-now also complete:
+Notes:
 
-- **Rule adopted & recorded** in `docs/INTENTS.md`: *a value is a capability iff a sibling
-  handler `requires` it (ordering); everything else the operation consumes is a `result`*
-  — with the rider that a hook point with multiple result-producers needs a discriminated
-  result type.
-- **Migration applied** (behavior-preserving, full suite green): `workspaceUrl`
-  (code-server finalize) and `agentType` (agent setup + the app:setup picker) moved from
-  operation-consumed capabilities to hook results.
-- `requires` unchanged — host-evaluated; `ANY_VALUE` never crosses the wire.
+- A **managed project may have no host clone at all** — materialized only on a remote.
+  Its host `projects/<id>/` then holds `config.json` only (no `workspaces/` subdir).
+- **`host.id`** is a dedicated, stable, unique per-install id in host `state.json`
+  (owned by `machine-registry`), presented to the remote at connect. Stable ⇒ reconnect
+  finds the same namespace; unique ⇒ two hosts don't collide. Not derived from
+  hostname/user (both collide or are shared).
 
-(The `research-provides-closures` workspace is now moot — its subject is done.)
+---
 
-**2. Wire codecs + schema validation (zod).** Define zod schemas for every
-wire-crossing type (intent payloads, hook results, provided-capability data, event
-payloads), with `Path ↔ string` and `Error ↔ object` **transforms** baked into the
-schemas. Validate + (de)serialize at the boundary so a malformed or hostile remote
-message is **rejected at the edge**, not deep inside a handler. Two alignments make
-this a natural fit:
+## 4. app-data split & the remote layout (decided)
 
-- zod is **already a project dependency** (e.g. the `AgentSpec` discriminated union
-  in `src/shared/api/types.ts`), so no new dependency is added.
-- schema parsing **replaces unsafe `as` casts** (the audit found handlers do
-  `ctx.capabilities?.X as number`) with validated parsing — aligned with CLAUDE.md's
-  no-type-assertions rule, and it makes the guarded intent/event types a single
-  source of truth for the wire contract.
+The app already has **two independent roots** — `dataRoot` (`dataPath()`) and
+`bundlesRoot` (`bundlePath()`, already special-cased + `_CH_BUNDLE_DIR`-overridable).
+That separation is reused on the remote:
 
-Full sweep for any other non-JSON leaks (Maps/Sets/Buffers/class instances/functions).
-→ research workspace `research-wire-codecs` (seeded before this reframing — its brief
-covers the `Path`/`Error` codecs and the leak sweep; the zod-validation framing is an
-addition to fold in when it reports).
+```
+<remoteBase>/
+  bundles/<agent|code-server>/<version>/   ← SHARED across all hosts on the box
+                                             (dedupe downloads; idempotent/locked install)
+  <hostId>/                                 ← PER-HOST dataRoot + its own module-host process
+    projects/  remotes/  vscode/  bin/  runtime/  claude/configs/  temp/  logs/
+```
+
+- **No `config.json` on the remote.** The remote holds files only; its data root and
+  settings are injected at connect (§5).
+- **Multi-host isolation.** Two hosts often SSH in as the *same* unix user, so unix-user
+  separation can't be relied on; a managed clone keys off `sha256(origin)` and would
+  otherwise be shared, leaking one host's worktrees into the other's `git worktree list`.
+  Isolation is therefore structural: **per-host `dataRoot` namespace + a per-host
+  module-host process**, each rooted at `<remoteBase>/<hostId>/`. Discovery is scoped to
+  the subtree by construction — a host cannot see another host's workspaces.
+- **Ports** are the one genuinely shared resource on the box; handled by the
+  "allocate at runtime, report back" handshake (§5), which avoids cross-host collision
+  without per-host port ranges.
+
+---
+
+## 5. Config: host-authoritative, injected at connect (decided)
+
+- **Host is the sole authority** for user config/state. The remote persists **no**
+  config.
+- A **defined subset is pushed to the remote at connect**: the injected data root
+  (`<remoteBase>/<hostId>`), `log.level`, `agent` (default), `version.*`, keepfiles
+  behavior, `experimental.busy-during-background-shell`. (Exact key list = an open
+  detail, see §8.)
+- **Inherently-per-machine values are decided on the remote at runtime**, not stored as
+  user config: `code-server.port` and other allocated ports are chosen on the box and
+  **reported back** — a runtime handshake, not persisted config, so "remote persists only
+  files" holds.
+- **Per-machine agent availability is discovered on connect.** Which agents are
+  installed can differ per box (shared `bundles/` on that box). Each per-host remote
+  process reports its available agents; the host keeps a per-machine availability map,
+  and the create-workspace dialog offers agents per target machine. The `agent` config
+  stays a global default pushed down; per-workspace agent type still lives in worktree
+  metadata on the machine.
+
+---
+
+## 6. Module placement (decided)
+
+The **both-sides** set runs as **one host instance** (for local workspaces) **plus one
+instance per connected remote box**, each executing against that machine's native
+boundaries inside the per-host module-host process.
+
+### Host-only
+
+All UI/Electron modules (presentation, view, settings, creation, deletion-dialog,
+clone/error-notification, workspace-selection, window-title, shortcut, devtools, badge,
+power), **hibernation-screenshot** *(reclassified host-only — the code-server iframe
+still renders in the host window even for a remote workspace)*, electron-lifecycle,
+host-logging, state, idempotency, debug, telemetry, **error-report** *(pulls a remote
+log bundle on demand, §7)*, auto-updater, and **mcp + plugin-server** *(host-central;
+remotes reach them via a reverse tunnel → the single host dispatcher)*.
+
+Plus two **new** host-only modules:
+
+- **`project-registry`** — extracted from `local-project`: persist/resolve/list projects
+  + the folder-picker Dialog (host-only). Single-tier.
+- **`machine-registry`** — owns `machines` + `host.id`; connection lifecycle
+  (bootstrap, heartbeat, reconnect-reconcile, deregister-on-drop); launches the per-host
+  remote process; proxies remote module registration into the host dispatcher.
+
+### Remote-instanced (per-host process)
+
+git-worktree, keepfiles, code-server, extension, metadata, workspace-agent-resolver,
+script, temp-dir, posix-process-cleanup, **managed-project** *(renamed from
+remote-project)*, and the **agent ServerManager**.
+
+### Split (each resulting handler single-tier)
+
+- **agent** — ServerManager = remote-instanced (co-located with the CLI); provider
+  registration + availability + status intake = host. Status flows back as a dispatched
+  `agent:update-status` intent (already an intent — no new concept). *The healthy
+  reference shape for a split module.*
+- **local-project → `project-registry` (host) + machine-instanced clone/discover.** The
+  FS/git work — cloning a managed repo, discovering worktrees — runs where the repo lives.
+- *(`path-probe` for `remote+existing` — deferred to post-v1.)*
+
+### auto-workspace
+
+Stays host-side but becomes **machine-targetable per source**
+(`experimental.<source>.machine`) so auto-created workspaces can land on a remote —
+which pulls remote connect/materialize into the auto-workspace path.
+
+---
+
+## 7. Observability (decided)
+
+Remote workspaces run their agent + code-server on the box, so failures originate there.
+
+- Remote logs **stay on the box** at `<hostId>/logs/`.
+- On `$exception` or a manual bug-report, the per-host remote process **ships a
+  compressed log bundle + its redacted config context up the channel**; the host-only
+  **error-report** module attaches it to the PostHog `$exception` alongside host context.
+- One reporting pipeline (host); remote data pulled **only on demand** (no continuous
+  log streaming over the tunnel).
+
+---
+
+## 8. Implementation punch list (subordinate to the model above)
+
+The value surface (intent payloads, hook results, capability values, event payloads) is
+overwhelmingly plain serializable data — no structural blockers, given the **data-only
+contract invariant** (item 2a) that forbids the few remaining function fields. What remains
+is a bounded, sequenced list. Sequencing rationale unchanged: the handler/capability
+**contract** first, then the **wire schemas** against the final shape, then the leaky-module
+**splits**.
+
+**1. Reshape the capability contract — ✅ DONE** (commit `d871aea6`, pre-session).
+Handlers return a `HookOutput { result?, provides? }`; the merge loop is wire-ready. Rule
+recorded in `docs/INTENTS.md` (*a value is a capability iff a sibling handler `requires`
+it; everything else consumed is a `result`*). `workspaceUrl`/`agentType` migrated from
+capabilities to results. `requires` stays host-evaluated; `ANY_VALUE` never crosses the wire.
+
+**2. Wire codecs + zod validation (decided design).** The seam is **asymmetric**, and
+the untrusted direction is **remote→host**, which carries **three** independently-defined
+type families — not just intents: **intent payloads** (a remote handler dispatches),
+**hook results** (`HookOutput.result`, which *ride the invocation response* back — 6+ per
+op, e.g. `delete-workspace`), and **provided data** (`HookOutput.provides`). Event payloads
+travel host→remote (trusted). Today the dispatcher does **zero** validation
+(`dispatcher.ts:397`): intent payloads are `unknown`, hook results are merged via an
+unchecked `output.result as T` cast (`dispatcher.ts:290`), and capability values are read
+via `as number` casts (`code-server-module.ts:706`, `agent-module.ts:211`). So "just
+schematize intents" under-scopes the actual attack surface.
+
+Resolved design:
+
+- **Schemas live on the Operation.** Each operation declares zod schemas for its intent
+  payload, its per-hook-point results, its provided-data, and its events — colocated with
+  the `*_OPERATION_ID` / hook-point / `EVENT_*` definitions it already owns. TS types
+  become `z.infer<schema>`, so the schema is the single source of truth (no separate
+  hand-synced registry like today's `plugin-protocol.ts`).
+- **Data-only contract (global invariant — see item 2a).** With no functions anywhere in
+  the contract, the *entire* operation surface is schematizable; scope is not bounded by
+  serializability.
+- **Validate + transform anywhere.** Every dispatch runs `schema.parse` — validation *and*
+  `Path↔string` / `Error↔object` transforms — whether or not the message crosses the wire.
+  **One code path, no local-vs-wire branch**, so the wire path is exercised on every local
+  dispatch and a remote-only serialization bug cannot hide. This is safe because `Path` is a
+  value object compared via `.equals()` / `.toString()` (never by reference) and
+  `HookResult.errors` are data-only reports — a `Path` round-tripped through `string` back to
+  a fresh `new Path()`, or an `Error` through `{message,stack}`, is *equivalent*; instance
+  identity never mattered. *(Doc note for implementers: don't rely on `Path`/`Error`
+  instance identity or live `Error` prototypes across a dispatch — reconstructed instances
+  are equivalent by value only.)*
+- **The dispatcher is the validation home** — "the intent system handles validation,"
+  literally. This replaces the unsafe `as` casts everywhere (aligned with CLAUDE.md's
+  no-assertions rule), not only at the wire.
+- **`requires` stays host-evaluated** with the `ANY_VALUE` sentinel — it never needs a value
+  schema and never crosses the wire; only `provides` *data* is schematized.
+
+Cost: a `schema.parse` per dispatch, including the hot path (`project:resolve`) — mitigated
+by the item-4 host-cached projections; zod v4 (already imported for `agentSpecSchema`) is
+fast. Still do the full sweep for other non-JSON leaks (Maps/Sets/Buffers/class instances)
+so every carrier has a transform.
+→ research workspace `research-wire-codecs`.
+
+**2a. Enforce the data-only contract invariant.** *A handler's invocation payload and
+returned `HookOutput` (result + provides), and every event payload, must be pure data — no
+functions, no host closures.* This is the precondition that makes item 2 total. The one
+known violation is `ShowUIHookResult.waitForRetry` (`app-start.ts:124`), a callback field on
+a host-only hook result; **refactor it into an emitted retry-request event / data flag**
+(host-only, low risk). The leak sweep in item 2 confirms there are no others. (Operation
+bodies still use `ctx.emit` / `ctx.dispatch` freely — those stay host-side and are not part
+of the wire contract.)
 
 **3. Split the leaky handlers (results-first)** so every handler is single-tier:
-
-- **git-init dialog** (`local-project-module.prepare`): host `confirm` handler returns
-  the decision; the operation runs the remote `git init` step. (results-first;
-  `requires`/`provides` optional.)
-- **hibernation capture** (`hibernation-screenshot.capture`): likely **reclassify
-  host-only** (the screenshot is a host-UI artifact) → no split; otherwise split
-  host-capture / remote-write with the PNG bytes crossing as base64.
-- **clone progress** (`remote-project-module`): invert the pushed-down `report`
-  callback into a remote→host `emit` of `clone:progress`.
-- **app-resume health/restart** (`code-server-module` app-resume handler): runs remote
-  (health-probe + restart code-server); its `CODE_SERVER_RESTARTED` / `APP_RESUME_FAILED`
-  emits become remote→host channel events instead of the captured `ResumeHookContext.emit`
-  closure — same fix family as clone-progress.
-- → research workspaces `research-leaky-git-init-dialog`,
-  `research-leaky-hibernation-capture`, `research-leaky-clone-progress`.
+- **git-init dialog** (`local-project`): host `confirm` handler returns the decision; the
+  operation runs the remote `git init` step. *(Folds into the `project-registry` split.)*
+- **hibernation capture**: **reclassified host-only** (§6) — no split.
+- **clone progress** (`managed-project`): invert the pushed-down `report` callback into a
+  remote→host `emit` of `clone:progress`.
+- **app-resume health/restart** (`code-server`): runs remote; its `CODE_SERVER_RESTARTED`
+  / `APP_RESUME_FAILED` emits become remote→host channel events, not a captured closure.
+→ research workspaces `research-leaky-*`.
 
 **4. Pin replicated indices host-side.** The `project:resolve` identity map
-(`path → projectId`, a pure `sha256`-derived function) and the workspace inventory
-used by `switch`'s auto-select are consulted on the hot path of nearly every dispatch.
-Keep them as **host-cached projections refreshed by domain events** so the hot path
-never round-trips to the remote.
+(`origin/path → projectId`, pure `sha256`) and the per-machine workspace inventory (for
+`switch`'s auto-select) are host-cached projections **refreshed by domain events**, so the
+hot path never round-trips to a remote. The inventory is **ephemeral** — rebuilt from
+discovery on each connect, never persisted (§2).
 
-**5. Registration lifecycle + partial-failure handling** (the one "engineering, not
-audited" area). RPC-with-reconnect: bootstrap, heartbeat/liveness, deregister-on-drop,
-reconnect-with-reconcile, **per-call timeouts**. Recovery leans on existing machinery:
-worktree **rollback**, `cleanupOrphanedWorkspaces` (reconciliation precedent), and the
-**idempotency** module (safe re-drive on reconnect). The single-dispatcher model keeps
-this to client/server reconnect, **not** distributed consensus.
-
-### The fix recipe for leaky handlers (general)
-
-Split a leaky handler along the boundary tier so each resulting handler is single-tier,
-and move **serializable data** between them (never host behavior into a remote handler):
-
-1. **No cross-handler dependency** → each handler just returns its result (or `emit`s).
-2. **Sequential/conditional dependency** → prefer **operation-coordinated results**
-   (host handler returns → operation threads it into the resource step).
-3. **Reclassify** → if the "resource" half is actually host-consumed, make the whole
-   module host-only (no split).
-4. **Invert-callback** → replace a pushed-down host closure with the resource handler
-   `emit`-ing up the remote→host channel.
-5. Reach for `requires`/`provides` only when you want the dispatcher to own intra-hook
-   ordering declaratively — and item 2 makes that federate.
+**5. Registration lifecycle + partial-failure handling** (owned by `machine-registry`,
+§6). Per-host RPC-with-reconnect: bootstrap, heartbeat/liveness, deregister-on-drop,
+reconnect-with-reconcile, per-call timeouts, per-host process launch + binary
+provisioning + idempotent/locked shared-`bundles/` install. Recovery leans on existing
+machinery: worktree rollback, `cleanupOrphanedWorkspaces` (reconciliation precedent), and
+the idempotency module (safe re-drive on reconnect). Single-dispatcher model keeps this to
+client/server reconnect, not distributed consensus.
 
 ---
 
-## 6. Control plane vs. data plane (independent)
+## 9. Control plane vs. data plane (independent)
 
-- **Control plane** = the federated dispatcher (sections 2–5).
+- **Control plane** = the federated dispatcher: one dispatcher on the host, remote
+  handlers registered via a per-host proxy (`machine-registry`). Wire is asymmetric —
+  host→remote: operation/hook invocations + domain events; remote→host: intents (the only
+  thing a remote handler initiates); results + provided data ride the invocation response.
 - **Data plane** = tunnels:
-  - `-L` (host → remote): editor iframe → remote code-server; host agent-client →
-    remote `opencode serve`.
-  - `-R` remote → host (or, better, the remote→host **intent channel**): Claude bridge
-    callbacks, OpenCode MCP, plugin (sidekick) Socket.IO.
-  - Plus binary provisioning (code-server, agent binaries, git) and git auth on the
-    remote.
+  - `-L` (host→remote): editor iframe → remote code-server; host agent-client → remote
+    `opencode serve`.
+  - `-R` / the remote→host **intent channel**: Claude bridge callbacks, OpenCode MCP,
+    plugin (sidekick) Socket.IO. If `agent-module`'s ServerManager runs on the remote, its
+    Claude bridge co-locates with the CLI and status flows back as an `agent:update-status`
+    intent — potentially removing a raw `-R` socket in favor of the control-plane channel.
+  - Plus binary provisioning and git auth on the remote.
 
-These are separable and can be built/de-risked independently.
-
-Note: if `agent-module` runs on the remote, its Claude bridge co-locates with the CLI
-there, and status flows back as a dispatched `agent:update-status` intent — potentially
-removing a raw `-R` socket in favor of the control-plane intent channel.
+Separable, buildable/de-riskable independently.
 
 ---
 
-## 7. In flight / next steps
+## 10. Next steps
 
-- **Step 1 is complete** (reshape pre-existing; rule recorded in `docs/INTENTS.md`; the
-  `workspaceUrl`/`agentType` migration landed, full suite green). Next open item is
-  **step 2** (wire codecs + zod validation).
-- **Research workspaces:** `research-wire-codecs` (item 2) and the three
-  `research-leaky-*` (item 3) are still relevant. `research-provides-closures` is **moot**
-  (item 1 done) and can be discarded.
-- **Recommended spike:** prove the reverse channel by hand — run code-server + one
-  agent on a remote box with `ssh -L`/`-R` and confirm the Claude bridge callback and
-  the OpenCode MCP round-trip both work through the tunnel — before committing.
-- **Then:** fold research findings into a phased implementation plan
-  (2 → 3, then 4/5), with the data-plane spike alongside.
+- **Recommended spike:** prove the reverse channel by hand — run code-server + one agent
+  on a remote box with `ssh -L`/`-R`, confirm the Claude bridge callback and the OpenCode
+  MCP round-trip both work through the tunnel — before committing.
+- **Then:** fold `research-wire-codecs` + `research-leaky-*` findings into a phased
+  implementation plan (2 → 3, then 4/5), with the data-plane spike alongside.
+- **Open details not yet drilled:** the exact config-injection key list (§5), the
+  connection/registration lifecycle mechanics (§8 item 5), and the data-plane tunnel choice
+  (§9). `research-provides-closures` is **moot** (item 1 done) and can be discarded.

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -1,0 +1,209 @@
+# Remote & Container Workspaces via a Federated Dispatcher
+
+Status: **design / exploration** (not yet approved for implementation)
+
+Goal: let users create workspaces on a **remote machine (SSH-first)** and, later,
+in **containers** — surfaced in the create-workspace dialog as a target selection
+(image starts a new container / running container / remote machine).
+
+---
+
+## 1. Goal & scope (decided)
+
+- **Remote machine over SSH first**, extensible to containers.
+- **Both agents** (Claude + OpenCode) supported from the start.
+- **Projects live on the remote** — managed (CodeHydra clones the repo) *or* an
+  existing checkout already on the remote, mirroring today's local behavior.
+  - Rationale: git worktrees require the parent repo on the same filesystem, so a
+    remote **workspace** implies a remote **project**.
+- **Dialog change is cheap:** the target selector (image/container/remote) is a
+  `radio` section added in `creation-module` `buildConfig()` plus one optional
+  field on `OpenWorkspacePayload` — **no Svelte and no IPC-channel changes**.
+
+> ⚠️ Requires explicit approval per CLAUDE.md before implementing: (a) the
+> `OpenWorkspacePayload` / intent-contract change, and (b) any **new boundary
+> interface** introduced for the transport.
+
+---
+
+## 2. Architecture (converged): intent-seam federation, single host dispatcher
+
+Keep **one dispatcher, on the host**, as the sole orchestrator — ordering,
+capability merging, causation, and event emission all stay in-process on the host.
+Remote **modules** register their handlers into that dispatcher; a remote handler
+executes against the remote machine's own native boundaries (fs/process/git/port)
+in a small module-host process.
+
+Why this seam (vs. a "boundary-seam" that swaps fs/process/git per-call over SSH):
+the wire sits at a **coarse, serializable, already-mostly-data layer** (intents,
+events, hook results) instead of hundreds of fine-grained syscalls per workspace.
+
+### Module registration
+- **Static proxy, version-locked** to start: the host knows the module set at build
+  time; a host-side proxy forwards to the remote; connection state is just up/down.
+- Dynamic registration (remote pushes its handler list at connect) is the general
+  form — defer until heterogeneous remotes are actually needed.
+
+### Wire protocol (asymmetric, minimal)
+- **host → remote:** operation/hook invocations + domain events (to remote subscribers)
+- **remote → host:** intents (the only thing a remote handler *initiates*)
+- **handler results + provided data** ride the invocation response
+
+Notably, `agent:update-status` is already an intent, so a remote agent signaling a
+status change is just "dispatch that intent back to the host" — no new concept.
+
+---
+
+## 3. The structural model: two boundary tiers, two module tiers
+
+Placement is a **per-handler property**. The clean-up target is to make it so.
+
+### Boundaries
+- **Host-only** — `WindowBoundary`, `ViewBoundary`, `SessionBoundary`, `IpcBoundary`,
+  `DialogBoundary`, `ImageBoundary`, `AppBoundary`(+power), `MenuBoundary`,
+  `PostHogBoundary`. (The Electron/UI surface + telemetry.)
+- **Both-sides** — `FileSystemBoundary`, `ProcessRunner`, `PortManager`,
+  `IGitClient`/`GitWorktreeProvider`, `HttpClient`, `PathProvider`,
+  `AgentServerManager`, code-server. (Run where the files live.)
+  - `SdkClientFactory` / `AgentProvider` *client* is host-side but reaches a
+    both-sides server over the `-L` tunnel.
+
+### Modules
+- **Host-only** — `view`, `presentation`, `creation`, `deletion-dialog`/`dialog-manager`,
+  `badge`, `power`, window-title/shortcut/selection, `electron-lifecycle`, menu,
+  `auto-updater`, `telemetry`, `error-report`, and the host-resident servers
+  `mcp-module` / `plugin-server-module` (remotes reach them via `-R`).
+- **Both-sides** — `git-worktree-workspace`, `keepfiles`, `code-server`,
+  `remote-project`, `workspace-agent-resolver` (all clean), plus:
+  - `agent-module` — **split by design** (server=remote, provider/status=host). The
+    healthy reference shape.
+  - `local-project-module` — **leaky** (FS/Git + `DialogBoundary`).
+  - `hibernation-screenshot-module` — **leaky** (FS + `ViewBoundary`/`ImageBoundary`).
+
+**A "leaky" module is a both-sides module whose handler also touches a host-only
+boundary (or receives a host callback).** Fixing them makes every handler single-tier
+and therefore cleanly placeable.
+
+---
+
+## 4. Audit verdict
+
+The value surface (intent payloads, hook results, capability values, event payloads)
+is overwhelmingly plain serializable data. No structural blockers. What remains is a
+bounded punch list.
+
+Non-JSON carriers found, all convertible:
+- `Path` instances in `OpenProjectPayload.path`, `ProjectOpenedPayload.path`,
+  `ProjectOpenFailedPayload.path` (convertible via `toString()` / `new Path()`).
+- `Error[]` in `HookResult.errors`.
+- Capability values are primitives (enforced by strict `===` matching in `requires`).
+
+Orchestration facts that shape the work:
+- `collect()` ordering/merging is **centralizable** (single host dispatcher is natural).
+- `provides` is a **closure over handler-local mutable state** → must be reshaped to
+  returned data to federate.
+- Operations cast-inject `emit`/`dispatch` callbacks into extended hook contexts (not
+  in the core `create/setup/finalize` handlers) → remote signaling becomes a
+  dispatched-back intent, which is the model's `remote → host` channel.
+
+---
+
+## 5. Punch list (sequenced 1 → 2 → 3, plus 4 & 5)
+
+Sequencing rationale: reshape the handler/capability **contract first** (1), so the
+wire schemas (2) are written against the final data shape rather than the
+closure-based one; only then are the leaky-module splits (3) worth doing, since they
+depend on both the reshaped contract and the validated wire boundary.
+
+**1. Reshape the capability contract.** Handlers **return** their provided data
+instead of a `provides()` closure. Going forward, **prefer hook results over
+`requires`/`provides`** — results federate for free (they ride the response);
+reserve capabilities for genuine declarative intra-hook ordering.
+→ research workspace `research-provides-closures`.
+
+**2. Wire codecs + schema validation (zod).** Define zod schemas for every
+wire-crossing type (intent payloads, hook results, provided-capability data, event
+payloads), with `Path ↔ string` and `Error ↔ object` **transforms** baked into the
+schemas. Validate + (de)serialize at the boundary so a malformed or hostile remote
+message is **rejected at the edge**, not deep inside a handler. Two alignments make
+this a natural fit:
+- zod is **already a project dependency** (e.g. the `AgentSpec` discriminated union
+  in `src/shared/api/types.ts`), so no new dependency is added.
+- schema parsing **replaces unsafe `as` casts** (the audit found handlers do
+  `ctx.capabilities?.X as number`) with validated parsing — aligned with CLAUDE.md's
+  no-type-assertions rule, and it makes the guarded intent/event types a single
+  source of truth for the wire contract.
+
+Full sweep for any other non-JSON leaks (Maps/Sets/Buffers/class instances/functions).
+→ research workspace `research-wire-codecs` (seeded before this reframing — its brief
+covers the `Path`/`Error` codecs and the leak sweep; the zod-validation framing is an
+addition to fold in when it reports).
+
+**3. Split the three leaky handlers (results-first)** so every handler is single-tier:
+- **git-init dialog** (`local-project-module.prepare`): host `confirm` handler returns
+  the decision; the operation runs the remote `git init` step. (results-first;
+  `requires`/`provides` optional.)
+- **hibernation capture** (`hibernation-screenshot.capture`): likely **reclassify
+  host-only** (the screenshot is a host-UI artifact) → no split; otherwise split
+  host-capture / remote-write with the PNG bytes crossing as base64.
+- **clone progress** (`remote-project-module`): invert the pushed-down `report`
+  callback into a remote→host `emit` of `clone:progress`.
+- → research workspaces `research-leaky-git-init-dialog`,
+  `research-leaky-hibernation-capture`, `research-leaky-clone-progress`.
+
+**4. Pin replicated indices host-side.** The `project:resolve` identity map
+(`path → projectId`, a pure `sha256`-derived function) and the workspace inventory
+used by `switch`'s auto-select are consulted on the hot path of nearly every dispatch.
+Keep them as **host-cached projections refreshed by domain events** so the hot path
+never round-trips to the remote.
+
+**5. Registration lifecycle + partial-failure handling** (the one "engineering, not
+audited" area). RPC-with-reconnect: bootstrap, heartbeat/liveness, deregister-on-drop,
+reconnect-with-reconcile, **per-call timeouts**. Recovery leans on existing machinery:
+worktree **rollback**, `cleanupOrphanedWorkspaces` (reconciliation precedent), and the
+**idempotency** module (safe re-drive on reconnect). The single-dispatcher model keeps
+this to client/server reconnect, **not** distributed consensus.
+
+### The fix recipe for leaky handlers (general)
+Split a leaky handler along the boundary tier so each resulting handler is single-tier,
+and move **serializable data** between them (never host behavior into a remote handler):
+1. **No cross-handler dependency** → each handler just returns its result (or `emit`s).
+2. **Sequential/conditional dependency** → prefer **operation-coordinated results**
+   (host handler returns → operation threads it into the resource step).
+3. **Reclassify** → if the "resource" half is actually host-consumed, make the whole
+   module host-only (no split).
+4. **Invert-callback** → replace a pushed-down host closure with the resource handler
+   `emit`-ing up the remote→host channel.
+5. Reach for `requires`/`provides` only when you want the dispatcher to own intra-hook
+   ordering declaratively — and item 2 makes that federate.
+
+---
+
+## 6. Control plane vs. data plane (independent)
+
+- **Control plane** = the federated dispatcher (sections 2–5).
+- **Data plane** = tunnels:
+  - `-L` (host → remote): editor iframe → remote code-server; host agent-client →
+    remote `opencode serve`.
+  - `-R` remote → host (or, better, the remote→host **intent channel**): Claude bridge
+    callbacks, OpenCode MCP, plugin (sidekick) Socket.IO.
+  - Plus binary provisioning (code-server, agent binaries, git) and git auth on the
+    remote.
+
+These are separable and can be built/de-risked independently.
+
+Note: if `agent-module` runs on the remote, its Claude bridge co-locates with the CLI
+there, and status flows back as a dispatched `agent:update-status` intent — potentially
+removing a raw `-R` socket in favor of the control-plane intent channel.
+
+---
+
+## 7. In flight / next steps
+
+- **5 research workspaces** running, each producing a `RESEARCH-*.md` for punch-list
+  items 1–3 (provides-reshape, wire codecs + zod validation, three leaky handlers).
+- **Recommended spike:** prove the reverse channel by hand — run code-server + one
+  agent on a remote box with `ssh -L`/`-R` and confirm the Claude bridge callback and
+  the OpenCode MCP round-trip both work through the tunnel — before committing.
+- **Then:** fold research findings into a phased implementation plan
+  (1 → 2 → 3, then 4/5), with the data-plane spike alongside.

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -12,7 +12,7 @@ in **containers** — surfaced in the create-workspace dialog as a target select
 
 - **Remote machine over SSH first**, extensible to containers.
 - **Both agents** (Claude + OpenCode) supported from the start.
-- **Projects live on the remote** — managed (CodeHydra clones the repo) *or* an
+- **Projects live on the remote** — managed (CodeHydra clones the repo) _or_ an
   existing checkout already on the remote, mirroring today's local behavior.
   - Rationale: git worktrees require the parent repo on the same filesystem, so a
     remote **workspace** implies a remote **project**.
@@ -39,14 +39,16 @@ the wire sits at a **coarse, serializable, already-mostly-data layer** (intents,
 events, hook results) instead of hundreds of fine-grained syscalls per workspace.
 
 ### Module registration
+
 - **Static proxy, version-locked** to start: the host knows the module set at build
   time; a host-side proxy forwards to the remote; connection state is just up/down.
 - Dynamic registration (remote pushes its handler list at connect) is the general
   form — defer until heterogeneous remotes are actually needed.
 
 ### Wire protocol (asymmetric, minimal)
+
 - **host → remote:** operation/hook invocations + domain events (to remote subscribers)
-- **remote → host:** intents (the only thing a remote handler *initiates*)
+- **remote → host:** intents (the only thing a remote handler _initiates_)
 - **handler results + provided data** ride the invocation response
 
 Notably, `agent:update-status` is already an intent, so a remote agent signaling a
@@ -59,16 +61,18 @@ status change is just "dispatch that intent back to the host" — no new concept
 Placement is a **per-handler property**. The clean-up target is to make it so.
 
 ### Boundaries
+
 - **Host-only** — `WindowBoundary`, `ViewBoundary`, `SessionBoundary`, `IpcBoundary`,
   `DialogBoundary`, `ImageBoundary`, `AppBoundary`(+power), `MenuBoundary`,
   `PostHogBoundary`. (The Electron/UI surface + telemetry.)
 - **Both-sides** — `FileSystemBoundary`, `ProcessRunner`, `PortManager`,
   `IGitClient`/`GitWorktreeProvider`, `HttpClient`, `PathProvider`,
   `AgentServerManager`, code-server. (Run where the files live.)
-  - `SdkClientFactory` / `AgentProvider` *client* is host-side but reaches a
+  - `SdkClientFactory` / `AgentProvider` _client_ is host-side but reaches a
     both-sides server over the `-L` tunnel.
 
 ### Modules
+
 - **Host-only** — `view`, `presentation`, `creation`, `deletion-dialog`/`dialog-manager`,
   `badge`, `power`, window-title/shortcut/selection, `electron-lifecycle`, menu,
   `auto-updater`, `telemetry`, `error-report`, and the host-resident servers
@@ -93,33 +97,49 @@ is overwhelmingly plain serializable data. No structural blockers. What remains 
 bounded punch list.
 
 Non-JSON carriers found, all convertible:
+
 - `Path` instances in `OpenProjectPayload.path`, `ProjectOpenedPayload.path`,
   `ProjectOpenFailedPayload.path` (convertible via `toString()` / `new Path()`).
 - `Error[]` in `HookResult.errors`.
 - Capability values are primitives (enforced by strict `===` matching in `requires`).
 
 Orchestration facts that shape the work:
+
 - `collect()` ordering/merging is **centralizable** (single host dispatcher is natural).
-- `provides` is a **closure over handler-local mutable state** → must be reshaped to
-  returned data to federate.
-- Operations cast-inject `emit`/`dispatch` callbacks into extended hook contexts (not
-  in the core `create/setup/finalize` handlers) → remote signaling becomes a
-  dispatched-back intent, which is the model's `remote → host` channel.
+- The `provides`→returned-data reshape is **already done** (commit `d871aea6`): handlers
+  return a `HookOutput { result?, provides? }` and the dispatcher merges provided data as
+  plain data, no closure — the merge loop is already wire-ready. (The original audit
+  branched from a pre-`d871aea6` `origin/main` and mischaracterized this as an open
+  closure.)
+- **Handler emit invariant:** a handler's invocation payload and returned `HookOutput`
+  must be pure data; emitting/dispatching is sanctioned but must route through the
+  remote→host **channel** (an `emit`/`dispatch` shim), never a captured host closure. The
+  lone handler holding a live `emit` is code-server's app-resume handler → tracked under
+  item 3. (Operation bodies use `ctx.emit`/`ctx.dispatch` freely — they stay host-side.)
 
 ---
 
 ## 5. Punch list (sequenced 1 → 2 → 3, plus 4 & 5)
 
-Sequencing rationale: reshape the handler/capability **contract first** (1), so the
-wire schemas (2) are written against the final data shape rather than the
-closure-based one; only then are the leaky-module splits (3) worth doing, since they
-depend on both the reshaped contract and the validated wire boundary.
+Sequencing rationale: the handler/capability **contract came first** so the wire schemas
+(2) are written against the final data shape; only then are the leaky-module splits (3)
+worth doing, since they depend on both the reshaped contract and the validated wire
+boundary.
 
-**1. Reshape the capability contract.** Handlers **return** their provided data
-instead of a `provides()` closure. Going forward, **prefer hook results over
-`requires`/`provides`** — results federate for free (they ride the response);
-reserve capabilities for genuine declarative intra-hook ordering.
-→ research workspace `research-provides-closures`.
+**1. Reshape the capability contract — ✅ DONE.** The `provides()` closure → returned
+`HookOutput` reshape landed in commit `d871aea6` (pre-session). Remaining step-1 work,
+now also complete:
+
+- **Rule adopted & recorded** in `docs/INTENTS.md`: *a value is a capability iff a sibling
+  handler `requires` it (ordering); everything else the operation consumes is a `result`*
+  — with the rider that a hook point with multiple result-producers needs a discriminated
+  result type.
+- **Migration applied** (behavior-preserving, full suite green): `workspaceUrl`
+  (code-server finalize) and `agentType` (agent setup + the app:setup picker) moved from
+  operation-consumed capabilities to hook results.
+- `requires` unchanged — host-evaluated; `ANY_VALUE` never crosses the wire.
+
+(The `research-provides-closures` workspace is now moot — its subject is done.)
 
 **2. Wire codecs + schema validation (zod).** Define zod schemas for every
 wire-crossing type (intent payloads, hook results, provided-capability data, event
@@ -127,6 +147,7 @@ payloads), with `Path ↔ string` and `Error ↔ object` **transforms** baked in
 schemas. Validate + (de)serialize at the boundary so a malformed or hostile remote
 message is **rejected at the edge**, not deep inside a handler. Two alignments make
 this a natural fit:
+
 - zod is **already a project dependency** (e.g. the `AgentSpec` discriminated union
   in `src/shared/api/types.ts`), so no new dependency is added.
 - schema parsing **replaces unsafe `as` casts** (the audit found handlers do
@@ -139,7 +160,8 @@ Full sweep for any other non-JSON leaks (Maps/Sets/Buffers/class instances/funct
 covers the `Path`/`Error` codecs and the leak sweep; the zod-validation framing is an
 addition to fold in when it reports).
 
-**3. Split the three leaky handlers (results-first)** so every handler is single-tier:
+**3. Split the leaky handlers (results-first)** so every handler is single-tier:
+
 - **git-init dialog** (`local-project-module.prepare`): host `confirm` handler returns
   the decision; the operation runs the remote `git init` step. (results-first;
   `requires`/`provides` optional.)
@@ -148,6 +170,10 @@ addition to fold in when it reports).
   host-capture / remote-write with the PNG bytes crossing as base64.
 - **clone progress** (`remote-project-module`): invert the pushed-down `report`
   callback into a remote→host `emit` of `clone:progress`.
+- **app-resume health/restart** (`code-server-module` app-resume handler): runs remote
+  (health-probe + restart code-server); its `CODE_SERVER_RESTARTED` / `APP_RESUME_FAILED`
+  emits become remote→host channel events instead of the captured `ResumeHookContext.emit`
+  closure — same fix family as clone-progress.
 - → research workspaces `research-leaky-git-init-dialog`,
   `research-leaky-hibernation-capture`, `research-leaky-clone-progress`.
 
@@ -165,8 +191,10 @@ worktree **rollback**, `cleanupOrphanedWorkspaces` (reconciliation precedent), a
 this to client/server reconnect, **not** distributed consensus.
 
 ### The fix recipe for leaky handlers (general)
+
 Split a leaky handler along the boundary tier so each resulting handler is single-tier,
 and move **serializable data** between them (never host behavior into a remote handler):
+
 1. **No cross-handler dependency** → each handler just returns its result (or `emit`s).
 2. **Sequential/conditional dependency** → prefer **operation-coordinated results**
    (host handler returns → operation threads it into the resource step).
@@ -200,10 +228,14 @@ removing a raw `-R` socket in favor of the control-plane intent channel.
 
 ## 7. In flight / next steps
 
-- **5 research workspaces** running, each producing a `RESEARCH-*.md` for punch-list
-  items 1–3 (provides-reshape, wire codecs + zod validation, three leaky handlers).
+- **Step 1 is complete** (reshape pre-existing; rule recorded in `docs/INTENTS.md`; the
+  `workspaceUrl`/`agentType` migration landed, full suite green). Next open item is
+  **step 2** (wire codecs + zod validation).
+- **Research workspaces:** `research-wire-codecs` (item 2) and the three
+  `research-leaky-*` (item 3) are still relevant. `research-provides-closures` is **moot**
+  (item 1 done) and can be discarded.
 - **Recommended spike:** prove the reverse channel by hand — run code-server + one
   agent on a remote box with `ssh -L`/`-R` and confirm the Claude bridge callback and
   the OpenCode MCP round-trip both work through the tunnel — before committing.
 - **Then:** fold research findings into a phased implementation plan
-  (1 → 2 → 3, then 4/5), with the data-plane spike alongside.
+  (2 → 3, then 4/5), with the data-plane spike alongside.

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -46,7 +46,7 @@ stays a local-only concept in v1.
 ### Project identity depends on how it was obtained
 
 - **Managed → identity is the origin URL** (`sha256(normalizedUrl)`). The same origin
-  cloned on the host *and* on a remote box (and, later, mounted into a container) is
+  cloned on the host _and_ on a remote box (and, later, mounted into a container) is
   **one project**; its workspaces just live on different machines. Grouped under a
   single project node in the UI.
 - **Existing checkout → identity is `(machine, path)`.** No shared origin to unify on.
@@ -72,23 +72,23 @@ Today, open projects are persisted as one `config.json` per project under the ho
 `projects/` dir; on launch the app scans that dir and re-dispatches `project:open` for
 each, then discovers worktrees via `git worktree list`. Remote reconnect is the same
 loop with one addition: a project on a remote machine triggers an **SSH connect**, and
-the *remote* runs the discovery. Machine connect happens in the same post-`app-ready`
+the _remote_ runs the discovery. Machine connect happens in the same post-`app-ready`
 phase as project reopen (the `machines` registry is in `state.json`, which loads async).
 
 ---
 
 ## 3. What data lives where (decided)
 
-| Data | Lives | Persisted? | Owner |
-| --- | --- | --- | --- |
-| User config (UI, `agent`, `version.*`, telemetry toggle, electron/log) | **Host** `config.json` | yes | existing owners |
-| Identity, telemetry id, `update.dismissed-version`, `auto-workspaces` | **Host** `state.json` | yes | existing owners |
-| **`machines` registry** (SSH boxes) + **`host.id`** | **Host** `state.json` — *new* | yes | **`machine-registry` (new)** |
-| Project registry (managed→`{originUrl}`; local existing→`{machineId:local, path}`) | **Host** `projects/<id>/config.json` | yes | **`project-registry` (new, from local-project)** |
-| Screenshots, `electron/`, host logs, host temp | **Host** `dataRoot` | yes | existing owners |
-| Worktrees, managed clones, `vscode/`, `bin/`, `runtime/`, `claude/configs/`, remote logs/temp | **Remote** `<remoteBase>/<hostId>/…` | on box | remote-instanced modules |
-| Binaries (code-server, agents) | **Remote** `<remoteBase>/bundles/` (**shared** across hosts) | on box | code-server / agent modules |
-| The workspace list | nowhere — **discovered** per machine, grouped by origin | no | git-worktree (per machine) |
+| Data                                                                                          | Lives                                                        | Persisted? | Owner                                            |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------- | ------------------------------------------------ |
+| User config (UI, `agent`, `version.*`, telemetry toggle, electron/log)                        | **Host** `config.json`                                       | yes        | existing owners                                  |
+| Identity, telemetry id, `update.dismissed-version`, `auto-workspaces`                         | **Host** `state.json`                                        | yes        | existing owners                                  |
+| **`machines` registry** (SSH boxes) + **`host.id`**                                           | **Host** `state.json` — _new_                                | yes        | **`machine-registry` (new)**                     |
+| Project registry (managed→`{originUrl}`; local existing→`{machineId:local, path}`)            | **Host** `projects/<id>/config.json`                         | yes        | **`project-registry` (new, from local-project)** |
+| Screenshots, `electron/`, host logs, host temp                                                | **Host** `dataRoot`                                          | yes        | existing owners                                  |
+| Worktrees, managed clones, `vscode/`, `bin/`, `runtime/`, `claude/configs/`, remote logs/temp | **Remote** `<remoteBase>/<hostId>/…`                         | on box     | remote-instanced modules                         |
+| Binaries (code-server, agents)                                                                | **Remote** `<remoteBase>/bundles/` (**shared** across hosts) | on box     | code-server / agent modules                      |
+| The workspace list                                                                            | nowhere — **discovered** per machine, grouped by origin      | no         | git-worktree (per machine)                       |
 
 Notes:
 
@@ -117,7 +117,7 @@ That separation is reused on the remote:
 
 - **No `config.json` on the remote.** The remote holds files only; its data root and
   settings are injected at connect (§5).
-- **Multi-host isolation.** Two hosts often SSH in as the *same* unix user, so unix-user
+- **Multi-host isolation.** Two hosts often SSH in as the _same_ unix user, so unix-user
   separation can't be relied on; a managed clone keys off `sha256(origin)` and would
   otherwise be shared, leaking one host's worktrees into the other's `git worktree list`.
   Isolation is therefore structural: **per-host `dataRoot` namespace + a per-host
@@ -160,16 +160,16 @@ boundaries inside the per-host module-host process.
 
 All UI/Electron modules (presentation, view, settings, creation, deletion-dialog,
 clone/error-notification, workspace-selection, window-title, shortcut, devtools, badge,
-power), **hibernation-screenshot** *(reclassified host-only — the code-server iframe
-still renders in the host window even for a remote workspace)*, electron-lifecycle,
-host-logging, state, idempotency, debug, telemetry, **error-report** *(pulls a remote
-log bundle on demand, §7)*, auto-updater, and **mcp + plugin-server** *(host-central;
-remotes reach them via a reverse tunnel → the single host dispatcher)*.
+power), **hibernation-screenshot** _(reclassified host-only — the code-server iframe
+still renders in the host window even for a remote workspace)_, electron-lifecycle,
+host-logging, state, idempotency, debug, telemetry, **error-report** _(pulls a remote
+log bundle on demand, §7)_, auto-updater, and **mcp + plugin-server** _(host-central;
+remotes reach them via a reverse tunnel → the single host dispatcher)_.
 
 Plus two **new** host-only modules:
 
 - **`project-registry`** — extracted from `local-project`: persist/resolve/list projects
-  + the folder-picker Dialog (host-only). Single-tier.
+  - the folder-picker Dialog (host-only). Single-tier.
 - **`machine-registry`** — owns `machines` + `host.id`; connection lifecycle
   (bootstrap, heartbeat, reconnect-reconcile, deregister-on-drop); launches the per-host
   remote process; proxies remote module registration into the host dispatcher.
@@ -177,18 +177,18 @@ Plus two **new** host-only modules:
 ### Remote-instanced (per-host process)
 
 git-worktree, keepfiles, code-server, extension, metadata, workspace-agent-resolver,
-script, temp-dir, posix-process-cleanup, **managed-project** *(renamed from
-remote-project)*, and the **agent ServerManager**.
+script, temp-dir, posix-process-cleanup, **managed-project** _(renamed from
+remote-project)_, and the **agent ServerManager**.
 
 ### Split (each resulting handler single-tier)
 
 - **agent** — ServerManager = remote-instanced (co-located with the CLI); provider
   registration + availability + status intake = host. Status flows back as a dispatched
-  `agent:update-status` intent (already an intent — no new concept). *The healthy
-  reference shape for a split module.*
+  `agent:update-status` intent (already an intent — no new concept). _The healthy
+  reference shape for a split module._
 - **local-project → `project-registry` (host) + machine-instanced clone/discover.** The
   FS/git work — cloning a managed repo, discovering worktrees — runs where the repo lives.
-- *(`path-probe` for `remote+existing` — deferred to post-v1.)*
+- _(`path-probe` for `remote+existing` — deferred to post-v1.)_
 
 ### auto-workspace
 
@@ -222,14 +222,14 @@ is a bounded, sequenced list. Sequencing rationale unchanged: the handler/capabi
 
 **1. Reshape the capability contract — ✅ DONE** (commit `d871aea6`, pre-session).
 Handlers return a `HookOutput { result?, provides? }`; the merge loop is wire-ready. Rule
-recorded in `docs/INTENTS.md` (*a value is a capability iff a sibling handler `requires`
-it; everything else consumed is a `result`*). `workspaceUrl`/`agentType` migrated from
+recorded in `docs/INTENTS.md` (_a value is a capability iff a sibling handler `requires`
+it; everything else consumed is a `result`_). `workspaceUrl`/`agentType` migrated from
 capabilities to results. `requires` stays host-evaluated; `ANY_VALUE` never crosses the wire.
 
 **2. Wire codecs + zod validation (decided design).** The seam is **asymmetric**, and
 the untrusted direction is **remote→host**, which carries **three** independently-defined
 type families — not just intents: **intent payloads** (a remote handler dispatches),
-**hook results** (`HookOutput.result`, which *ride the invocation response* back — 6+ per
+**hook results** (`HookOutput.result`, which _ride the invocation response_ back — 6+ per
 op, e.g. `delete-workspace`), and **provided data** (`HookOutput.provides`). Event payloads
 travel host→remote (trusted). Today the dispatcher does **zero** validation
 (`dispatcher.ts:397`): intent payloads are `unknown`, hook results are merged via an
@@ -245,23 +245,23 @@ Resolved design:
   become `z.infer<schema>`, so the schema is the single source of truth (no separate
   hand-synced registry like today's `plugin-protocol.ts`).
 - **Data-only contract (global invariant — see item 2a).** With no functions anywhere in
-  the contract, the *entire* operation surface is schematizable; scope is not bounded by
+  the contract, the _entire_ operation surface is schematizable; scope is not bounded by
   serializability.
-- **Validate + transform anywhere.** Every dispatch runs `schema.parse` — validation *and*
+- **Validate + transform anywhere.** Every dispatch runs `schema.parse` — validation _and_
   `Path↔string` / `Error↔object` transforms — whether or not the message crosses the wire.
   **One code path, no local-vs-wire branch**, so the wire path is exercised on every local
   dispatch and a remote-only serialization bug cannot hide. This is safe because `Path` is a
   value object compared via `.equals()` / `.toString()` (never by reference) and
   `HookResult.errors` are data-only reports — a `Path` round-tripped through `string` back to
-  a fresh `new Path()`, or an `Error` through `{message,stack}`, is *equivalent*; instance
-  identity never mattered. *(Doc note for implementers: don't rely on `Path`/`Error`
+  a fresh `new Path()`, or an `Error` through `{message,stack}`, is _equivalent_; instance
+  identity never mattered. _(Doc note for implementers: don't rely on `Path`/`Error`
   instance identity or live `Error` prototypes across a dispatch — reconstructed instances
-  are equivalent by value only.)*
+  are equivalent by value only.)_
 - **The dispatcher is the validation home** — "the intent system handles validation,"
   literally. This replaces the unsafe `as` casts everywhere (aligned with CLAUDE.md's
   no-assertions rule), not only at the wire.
 - **`requires` stays host-evaluated** with the `ANY_VALUE` sentinel — it never needs a value
-  schema and never crosses the wire; only `provides` *data* is schematized.
+  schema and never crosses the wire; only `provides` _data_ is schematized.
 
 Cost: a `schema.parse` per dispatch, including the hot path (`project:resolve`) — mitigated
 by the item-4 host-cached projections; zod v4 (already imported for `agentSpecSchema`) is
@@ -269,9 +269,9 @@ fast. Still do the full sweep for other non-JSON leaks (Maps/Sets/Buffers/class 
 so every carrier has a transform.
 → research workspace `research-wire-codecs`.
 
-**2a. Enforce the data-only handler contract.** *Both a handler's `HookContext` (in) and its
+**2a. Enforce the data-only handler contract.** _Both a handler's `HookContext` (in) and its
 `HookOutput` (result + provides) — and every event payload — must be pure data: no
-functions, no host closures in either direction.* This is the precondition that makes item 2
+functions, no host closures in either direction._ This is the precondition that makes item 2
 total **and** the thing that makes a handler location-transparent: with a uniform data
 contract, the dispatch mechanism is identical local or remote, so **you never reason about
 placement when writing a handler**. Operations are exempt — they are the host-side
@@ -290,13 +290,14 @@ The closure fields to remove from the contract: `emit` (`app-resume.ts`), `repor
 (`open-project.ts`, `setup.ts` ×2), and the outbound `waitForRetry` (`app-start.ts`). The
 item-2 leak sweep confirms there are no other function carriers.
 
-**3. Make every handler single-tier + pure (operations own emits).** This is *not* a
+**3. Make every handler single-tier + pure (operations own emits).** This is _not_ a
 per-handler splitting exercise. "Operations own emits/dispatch; handlers return data" is
 already the **dominant pattern** (~61 of ~69 emit/dispatch sites are operation-side;
 `HookContext`/`HookOutput` carry no `emit`/`dispatch` by design). The work is to pull the
-**8 straggler hook handlers** back in line with item 2a, in two groups:
+**straggler hook handlers** back in line with item 2a, in two groups (one more — `delete
+confirm` — turned out to already satisfy the invariant; see below):
 
-- **Operation-owns (4 handlers, mechanical):**
+- **Operation-owns (3 handlers, mechanical):**
   - **resume** (`code-server` `resume`): handler returns outcome data (`{restarted}` /
     `{failed, error}`); the operation emits. Because `app-resume` now **fans out to N
     machines + local**, the `code-server:restarted` / `app:resume-failed` payloads gain a
@@ -305,9 +306,6 @@ already the **dominant pattern** (~61 of ~69 emit/dispatch sites are operation-s
     retry loop; the handler returns a data flag.
   - **appStartStart** (`presentation` `start`): the **operation** dispatches `app:ready`,
     not the handler.
-  - **delete `confirm`** (`deletion-dialog`): the operation gathers status/metadata
-    (dispatch) and threads that **data** into the confirm context; the host-pinned handler
-    renders the dialog and returns the decision.
 - **Streaming progress → async generators (4 handlers):** clone (`managed-project`) plus
   three provisioning reporters — agent-binary download (`agent-module`), code-server
   binary + extensions (`code-server`), debug binary (`debug-module`). Each becomes an
@@ -319,16 +317,25 @@ already the **dominant pattern** (~61 of ~69 emit/dispatch sites are operation-s
   first-connect provisioning, so progress streams remote→host.)
 
 **Not in scope / already right:**
+
 - **hibernation capture**: host-only (§6) — capture renders the host UI iframe, PNG →
   host `screenshots/`. No split; the sibling hibernate teardown handlers are the remote ones.
+- **delete `confirm`** (`deletion-dialog`): its `HookContext` (`DeletePipelineHookInput`) and
+  result (`ConfirmHookResult`) are **already pure data**, so the invariant holds. It is
+  **host-pinned** (`ui.dialog`) and its `deps.dispatcher` sub-dispatches (status/metadata) are
+  host-side UI orchestration that drives the _progressive_ dialog fill — the dialog opens
+  immediately and fills warnings in when the slow `refresh:true` git-fetch lands. Moving those
+  dispatches to the operation would block the dialog on that fetch (a UX regression) for no
+  invariant gain (host-pinned ⇒ never remote; the host dispatcher already federates the target
+  operations). Left as-is.
 - **git-init** (`local-project` `prepare`): the **sole** handler mixing a host-only boundary
   (`ui.dialog`) with both-sides work (`gitClient.init`). It only fires for **local**
   existing-checkouts in v1 (managed-on-remote clones instead), so the mix is harmless and
   host-local. **Deferred** — its `confirm`(host-pinned) / `init`(anywhere) split lands with
   `path-probe` + remote folder-browse when **remote+existing** checkout support arrives.
-→ research workspaces `research-leaky-*`.
+  → research workspaces `research-leaky-*`.
 
-*Implementation (decided):* the streaming framework change is an **`onYield` host-callback
+_Implementation (decided):_ the streaming framework change is an **`onYield` host-callback
 on `collect()`** — a handler may be an `async function*` that yields neutral progress data
 and returns its `HookOutput`; the operation passes `collect(hookPoint, ctx, { onYield })`,
 `collect` iterates the generator and calls `onYield(y)` per frame while the operation maps it

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -269,23 +269,63 @@ fast. Still do the full sweep for other non-JSON leaks (Maps/Sets/Buffers/class 
 so every carrier has a transform.
 → research workspace `research-wire-codecs`.
 
-**2a. Enforce the data-only contract invariant.** *A handler's invocation payload and
-returned `HookOutput` (result + provides), and every event payload, must be pure data — no
-functions, no host closures.* This is the precondition that makes item 2 total. The one
-known violation is `ShowUIHookResult.waitForRetry` (`app-start.ts:124`), a callback field on
-a host-only hook result; **refactor it into an emitted retry-request event / data flag**
-(host-only, low risk). The leak sweep in item 2 confirms there are no others. (Operation
-bodies still use `ctx.emit` / `ctx.dispatch` freely — those stay host-side and are not part
-of the wire contract.)
+**2a. Enforce the data-only handler contract.** *Both a handler's `HookContext` (in) and its
+`HookOutput` (result + provides) — and every event payload — must be pure data: no
+functions, no host closures in either direction.* This is the precondition that makes item 2
+total **and** the thing that makes a handler location-transparent: with a uniform data
+contract, the dispatch mechanism is identical local or remote, so **you never reason about
+placement when writing a handler**. Operations are exempt — they are the host-side
+orchestrators and keep `ctx.emit` / `ctx.dispatch`.
 
-**3. Split the leaky handlers (results-first)** so every handler is single-tier:
-- **git-init dialog** (`local-project`): host `confirm` handler returns the decision; the
-  operation runs the remote `git init` step. *(Folds into the `project-registry` split.)*
-- **hibernation capture**: **reclassified host-only** (§6) — no split.
-- **clone progress** (`managed-project`): invert the pushed-down `report` callback into a
-  remote→host `emit` of `clone:progress`.
-- **app-resume health/restart** (`code-server`): runs remote; its `CODE_SERVER_RESTARTED`
-  / `APP_RESUME_FAILED` emits become remote→host channel events, not a captured closure.
+Placement then reduces to one mechanical rule (no per-handler judgement): **a handler is
+host-pinned iff its module injects a host-only boundary** (Dialog / View / Image / Window /
+Menu / Session / App); a handler that injects only both-sides boundaries runs anywhere.
+Host-pinned handlers are legitimate and already coexist with anywhere-handlers on the same
+operation (e.g. `delete-workspace` = host `confirm` dialog + remote teardown; `hibernate` =
+host screenshot + remote agent/code-server teardown; `setup` = host UI phases + both-sides
+downloads). The **only forbidden shape** is a single handler mixing a host-only boundary with
+both-sides work — see item 3, git-init, the sole instance.
+
+The closure fields to remove from the contract: `emit` (`app-resume.ts`), `report`
+(`open-project.ts`, `setup.ts` ×2), and the outbound `waitForRetry` (`app-start.ts`). The
+item-2 leak sweep confirms there are no other function carriers.
+
+**3. Make every handler single-tier + pure (operations own emits).** This is *not* a
+per-handler splitting exercise. "Operations own emits/dispatch; handlers return data" is
+already the **dominant pattern** (~61 of ~69 emit/dispatch sites are operation-side;
+`HookContext`/`HookOutput` carry no `emit`/`dispatch` by design). The work is to pull the
+**8 straggler hook handlers** back in line with item 2a, in two groups:
+
+- **Operation-owns (4 handlers, mechanical):**
+  - **resume** (`code-server` `resume`): handler returns outcome data (`{restarted}` /
+    `{failed, error}`); the operation emits. Because `app-resume` now **fans out to N
+    machines + local**, the `code-server:restarted` / `app:resume-failed` payloads gain a
+    **machine/workspace scope** so the host reloads only the affected iframes.
+  - **waitForRetry** (`presentation` `show-ui`, outbound closure): the operation owns the
+    retry loop; the handler returns a data flag.
+  - **appStartStart** (`presentation` `start`): the **operation** dispatches `app:ready`,
+    not the handler.
+  - **delete `confirm`** (`deletion-dialog`): the operation gathers status/metadata
+    (dispatch) and threads that **data** into the confirm context; the host-pinned handler
+    renders the dialog and returns the decision.
+- **Streaming progress → async generators (4 handlers):** clone (`managed-project`) plus
+  three provisioning reporters — agent-binary download (`agent-module`), code-server
+  binary + extensions (`code-server`), debug binary (`debug-module`). Each becomes an
+  `async function*` that **yields progress frames (data)** and **returns its result**; the
+  dispatcher consumes the stream (local: direct iteration; remote: wire frames) and the
+  **operation emits** the progress event. This is the streaming generalization of the
+  existing collect→emit pattern, and it removes the `report` closure from the
+  `open-project` / `setup` hook contexts. (These run where the files/binaries live, incl.
+  first-connect provisioning, so progress streams remote→host.)
+
+**Not in scope / already right:**
+- **hibernation capture**: host-only (§6) — capture renders the host UI iframe, PNG →
+  host `screenshots/`. No split; the sibling hibernate teardown handlers are the remote ones.
+- **git-init** (`local-project` `prepare`): the **sole** handler mixing a host-only boundary
+  (`ui.dialog`) with both-sides work (`gitClient.init`). It only fires for **local**
+  existing-checkouts in v1 (managed-on-remote clones instead), so the mix is harmless and
+  host-local. **Deferred** — its `confirm`(host-pinned) / `init`(anywhere) split lands with
+  `path-probe` + remote folder-browse when **remote+existing** checkout support arrives.
 → research workspaces `research-leaky-*`.
 
 **4. Pin replicated indices host-side.** The `project:resolve` identity map

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -328,6 +328,19 @@ already the **dominant pattern** (~61 of ~69 emit/dispatch sites are operation-s
   `path-probe` + remote folder-browse when **remote+existing** checkout support arrives.
 → research workspaces `research-leaky-*`.
 
+*Implementation (decided):* the streaming framework change is an **`onYield` host-callback
+on `collect()`** — a handler may be an `async function*` that yields neutral progress data
+and returns its `HookOutput`; the operation passes `collect(hookPoint, ctx, { onYield })`,
+`collect` iterates the generator and calls `onYield(y)` per frame while the operation maps it
+to the right event and emits. The callback lives **operation ↔ `collect`** (both host), never
+in the handler's `HookContext`, so the data-only-context invariant holds by construction, and
+a remote proxy later forwards yield-frames into the same `onYield` with zero operation rework.
+(A hook point has one progress semantic — `resolve`→clone, `binary`/`extensions`→download — so
+`onYield` is unambiguous; assert it.) Landed as **one PR** (the local refactor is self-contained
+and needs no transport): the framework change + all 8 straggler conversions + the four
+closure-field removals together, so the data-only invariant lands atomically and CI proves the
+whole surface at once.
+
 **4. Pin replicated indices host-side.** The `project:resolve` identity map
 (`origin/path → projectId`, pure `sha256`) and the per-machine workspace inventory (for
 `switch`'s auto-select) are host-cached projections **refreshed by domain events**, so the

--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -3,11 +3,12 @@
  *
  * Single hook point:
  * - "resume" - Probe code-server health and restart it if the probe fails.
- *              The hook context includes `emit` so handlers can fire their own
- *              domain events: code-server-module emits `code-server:restarted`
- *              on a successful restart (view-module reacts by reloading the
- *              workspace iframes, whose connections to the replaced server are
- *              stale) and `app:resume-failed` if the restart fails.
+ *              Handlers return a `ResumeHookResult` (data only, no closures):
+ *              `{ restarted: true }` when a stale code-server was replaced, or
+ *              `{ failed: { error } }` when recovery failed. The operation turns
+ *              those results into domain events — `code-server:restarted`
+ *              (view-module reloads the workspace iframes whose connections to the
+ *              replaced server are stale) and `app:resume-failed`.
  *
  * After hooks complete, emits `app:resumed` for telemetry subscribers
  * (telemetry-module) that don't depend on server state.
@@ -35,11 +36,15 @@ export const APP_RESUME_OPERATION_ID = "app-resume";
 export const APP_RESUME_HOOK_RESUME = "resume";
 
 /**
- * Extended context for the "resume" hook point.
- * Exposes `emit` so handlers can fire domain events (e.g., restart failures).
+ * Per-handler result for the "resume" hook point (data only).
+ * A handler reports the outcome of its recovery attempt; the operation maps it to
+ * domain events. Omit both fields (return void) when there was nothing to recover.
  */
-export interface ResumeHookContext extends HookContext {
-  readonly emit: (event: DomainEvent) => Promise<void>;
+export interface ResumeHookResult {
+  /** A stale server was killed and a fresh one is now listening (→ code-server:restarted). */
+  readonly restarted?: boolean;
+  /** Recovery failed; human-readable error for display (→ app:resume-failed). */
+  readonly failed?: { readonly error: string };
 }
 
 // =============================================================================
@@ -87,11 +92,22 @@ export class AppResumeOperation implements Operation<AppResumeIntent, void> {
   readonly id = APP_RESUME_OPERATION_ID;
 
   async execute(ctx: OperationContext<AppResumeIntent>): Promise<void> {
-    const hookCtx: ResumeHookContext = {
-      intent: ctx.intent,
-      emit: ctx.emit,
-    };
-    await ctx.hooks.collect(APP_RESUME_HOOK_RESUME, hookCtx);
+    const hookCtx: HookContext = { intent: ctx.intent };
+    const { results } = await ctx.hooks.collect<ResumeHookResult>(APP_RESUME_HOOK_RESUME, hookCtx);
+
+    // Turn handler outcomes into domain events (operation owns emits).
+    for (const result of results) {
+      if (result.restarted) {
+        await ctx.emit({ type: EVENT_CODE_SERVER_RESTARTED, payload: {} });
+      }
+      if (result.failed) {
+        await ctx.emit({
+          type: EVENT_APP_RESUME_FAILED,
+          payload: { error: result.failed.error },
+        });
+      }
+    }
+
     await ctx.emit({ type: EVENT_APP_RESUMED, payload: {} });
   }
 }

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -59,7 +59,8 @@ export interface ExtensionInstallEntry {
   readonly vsixPath: string;
 }
 import { INTENT_SETUP } from "./setup";
-import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
+import { INTENT_APP_READY, type AppReadyIntent } from "./app-ready";
+import { throwHookErrors } from "./lib/hook-helpers";
 
 // =============================================================================
 // Intent Types
@@ -118,10 +119,13 @@ export interface InitResult {
 
 /**
  * Per-handler result for "show-ui" hook point.
- * Only the retry module returns a value; UI module returns void.
+ * The UI module returns `{ retrySupported: true }` when it can host a setup retry loop;
+ * other handlers return void. Data-only: the actual "wait for the user to click Retry"
+ * is a separate `await-retry` hook point (the handler blocks internally and returns data),
+ * not a closure handed back to the operation.
  */
 export interface ShowUIHookResult {
-  readonly waitForRetry?: () => Promise<void>;
+  readonly retrySupported?: boolean;
 }
 
 // ActivateHookContext removed — ports are now read from capabilities within the "start" hook point.
@@ -186,18 +190,18 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       ? this.agentConfig.get()
       : null;
 
-    // Hook 3: "show-ui" -- Show starting screen, capture waitForRetry
+    // Hook 3: "show-ui" -- Show starting screen; learn whether a retry loop is supported.
     const { results: showUiResults, errors: showUiErrors } =
       await ctx.hooks.collect<ShowUIHookResult>("show-ui", hookCtx);
     throwHookErrors(showUiErrors, "app:start show-ui hooks failed");
-    const waitForRetry = lastDefined(showUiResults, (r) => r.waitForRetry);
+    const retrySupported = showUiResults.some((r) => r.retrySupported === true);
 
     // Hook 4: "check-deps" (collect, isolated contexts)
     let checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
 
     // Dispatch app:setup if needed (blocking sub-operation)
     // Setup manages its own UI (shows/hides setup screen)
-    // Retry loop: if setup fails and waitForRetry is available, wait for user retry signal
+    // Retry loop: if setup fails and retry is supported, wait via the await-retry hook
     if (checkResult.needsSetup) {
       let setupComplete = false;
       while (!setupComplete) {
@@ -216,9 +220,12 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
           setupComplete = true;
         } catch (error) {
           // Setup failed -- error event already emitted by SetupOperation
-          // If retry is supported, wait for user to click retry
-          if (waitForRetry) {
-            await waitForRetry();
+          // If retry is supported, wait for user to click retry. The "await-retry"
+          // hook point blocks (host-side, in the UI handler) until the user clicks
+          // Retry and returns data — no closure crosses the hook contract.
+          if (retrySupported) {
+            const { errors: retryErrors } = await ctx.hooks.collect<void>("await-retry", hookCtx);
+            throwHookErrors(retryErrors, "app:start await-retry hooks failed");
             // Re-run check hooks to get fresh preflight state for retry
             checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
             if (!checkResult.needsSetup) {
@@ -239,6 +246,18 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
     // separate "activate" hook point.
     const { errors: startErrors } = await ctx.hooks.collect<void>("start", hookCtx);
     throwHookErrors(startErrors, "app:start start hooks failed");
+
+    // After all start handlers (code-server included) are up, load initial projects.
+    // Fire-and-forget: the snapshot stream carries the result, so startup must not
+    // block on projects finishing. (Operation owns this dispatch; the presentation
+    // start handler only advances the UI phase.)
+    const readyHandle = ctx.dispatch<AppReadyIntent>({
+      type: INTENT_APP_READY,
+      payload: {},
+    });
+    void readyHandle.catch(() => {
+      // app:ready failures surface via its own events/logging; don't fail startup.
+    });
   }
 
   /**

--- a/src/intents/lib/dispatcher.ts
+++ b/src/intents/lib/dispatcher.ts
@@ -21,8 +21,10 @@ import type {
   OperationContext,
   DispatchFn,
   ResolvedHooks,
+  CollectOptions,
   HookContext,
   HookHandler,
+  HookHandlerReturn,
   HookOutput,
   HookResult,
 } from "./operation";
@@ -260,7 +262,8 @@ export class Dispatcher implements IDispatcher {
   private async collectHookResults<T>(
     hookHandlers: HookHandler[],
     inputCtx: HookContext,
-    initialCaps: Readonly<Record<string, unknown>>
+    initialCaps: Readonly<Record<string, unknown>>,
+    onYield?: (frame: unknown) => void | Promise<void>
   ): Promise<CollectResult<T>> {
     const capabilities: Record<string, unknown> = {
       ...initialCaps,
@@ -284,8 +287,15 @@ export class Dispatcher implements IDispatcher {
           });
           try {
             // A handler returns a HookOutput (result and/or provided capabilities);
-            // void is shorthand for an empty output.
-            const output: HookOutput = (await entry.handler(frozenCtx)) ?? {};
+            // void is shorthand for an empty output. A streaming handler is an
+            // async generator: drain its yielded progress frames to onYield (host-side),
+            // and use its return value as the output. The non-generator path stays a
+            // plain await (no extra microtask hop) to preserve emit/dispatch timing.
+            const invoked = entry.handler(frozenCtx);
+            const output: HookOutput =
+              (isAsyncGenerator(invoked)
+                ? await drainGenerator(invoked, onYield)
+                : await invoked) ?? {};
             if (output.result !== undefined && output.result !== null) {
               results.push(output.result as T);
             }
@@ -339,7 +349,11 @@ export class Dispatcher implements IDispatcher {
     const initCaps = this.initialCapabilities;
     const logger = this.logger;
     return {
-      collect: async <T>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>> => {
+      collect: async <T>(
+        hookPointId: string,
+        ctx: HookContext,
+        options?: CollectOptions
+      ): Promise<HookResult<T>> => {
         const hookHandlers = opMap?.get(hookPointId);
         if (!hookHandlers) {
           return { results: [], errors: [], capabilities: initCaps };
@@ -348,7 +362,8 @@ export class Dispatcher implements IDispatcher {
         const { ran, skipped, ...hookResult } = await this.collectHookResults<T>(
           hookHandlers,
           ctx,
-          initCaps
+          initCaps,
+          options?.onYield
         );
         const duration = Math.round(performance.now() - start);
 
@@ -472,6 +487,33 @@ export class Dispatcher implements IDispatcher {
       handle.reject(e);
     }
   }
+}
+
+// =============================================================================
+// Hook handler draining
+// =============================================================================
+
+/** True when a handler's invocation returned an async generator (a streaming handler). */
+function isAsyncGenerator(
+  value: HookHandlerReturn
+): value is AsyncGenerator<unknown, HookOutput | void, void> {
+  return typeof value === "object" && value !== null && Symbol.asyncIterator in value;
+}
+
+/**
+ * Drain a streaming (`async function*`) handler: forward each yielded frame to `onYield`
+ * and return the generator's return value (its `HookOutput`).
+ */
+async function drainGenerator(
+  gen: AsyncGenerator<unknown, HookOutput | void, void>,
+  onYield?: (frame: unknown) => void | Promise<void>
+): Promise<HookOutput | void> {
+  let next = await gen.next();
+  while (!next.done) {
+    if (onYield) await onYield(next.value);
+    next = await gen.next();
+  }
+  return next.value;
 }
 
 // =============================================================================

--- a/src/intents/lib/hook-helpers.ts
+++ b/src/intents/lib/hook-helpers.ts
@@ -15,6 +15,9 @@
  *   each contribute a disjoint subset of fields).
  * - `collectErrorMessages` — fold collect() errors plus per-result `error`
  *   strings into one list (best-effort pipelines that report instead of throw).
+ * - `streamProgress` — bridge a progress-callback API into an async generator of
+ *   frames, so a streaming hook handler can `yield*` its progress while a
+ *   callback-driven task (binary download, git clone) runs.
  */
 
 /**
@@ -82,4 +85,59 @@ export function collectErrorMessages(
     if (result.error) errors.push(result.error);
   }
   return errors;
+}
+
+/**
+ * Bridge a callback-driven async task into an async generator of progress frames.
+ *
+ * A streaming hook handler `yield*`s this while `run` executes: `run` receives an
+ * `emit(frame)` callback (a plain local function — no host closure) and drives the
+ * underlying callback-based work (e.g. `downloadBinary`, `gitClient.clone`). Frames
+ * are buffered and yielded in order as they arrive; when `run` settles the generator
+ * finishes, re-throwing any error `run` produced (after draining remaining frames).
+ *
+ * Yielding is race-free: `emit` only runs on a later async tick, never interleaved
+ * within the synchronous stretch where the drain loop parks a `wake` resolver, so a
+ * frame emitted while parked always wakes the loop.
+ */
+export async function* streamProgress<F>(
+  run: (emit: (frame: F) => void) => Promise<void>
+): AsyncGenerator<F, void, void> {
+  const buffer: F[] = [];
+  let wake: (() => void) | null = null;
+  let done = false;
+  let failure: unknown;
+
+  const emit = (frame: F): void => {
+    buffer.push(frame);
+    if (wake) {
+      wake();
+      wake = null;
+    }
+  };
+
+  void run(emit)
+    .catch((err: unknown) => {
+      failure = err ?? new Error("progress task failed");
+    })
+    .finally(() => {
+      done = true;
+      if (wake) {
+        wake();
+        wake = null;
+      }
+    });
+
+  while (true) {
+    if (buffer.length > 0) {
+      yield buffer.shift()!;
+      continue;
+    }
+    if (done) break;
+    await new Promise<void>((resolve) => {
+      wake = resolve;
+    });
+  }
+
+  if (failure !== undefined) throw failure;
 }

--- a/src/intents/lib/operation.ts
+++ b/src/intents/lib/operation.ts
@@ -60,17 +60,38 @@ export interface HookOutput<T = unknown> {
 }
 
 /**
+ * Return type of a hook handler.
+ *
+ * A handler is either:
+ *  - a plain async function returning a `HookOutput<T>` (or `void` for an empty output), or
+ *  - an `async function*` that **yields** progress frames of type `Y` (pure data) and
+ *    **returns** its `HookOutput<T>`. The dispatcher drains the generator, forwarding each
+ *    yielded frame to the `onYield` callback the operation passed to `collect()`, and uses
+ *    the generator's return value as the handler's output.
+ *
+ * The streaming form lets a long-running handler (clone, binary download) surface progress
+ * without holding a closure: it yields neutral data, and the host-side operation maps each
+ * frame to a domain event and emits it. The `onYield` callback lives operation ↔ `collect`,
+ * never in the handler's `HookContext`, so the data-only-context invariant holds.
+ */
+export type HookHandlerReturn<T = unknown, Y = unknown> =
+  | Promise<HookOutput<T> | void>
+  | AsyncGenerator<Y, HookOutput<T> | void, void>;
+
+/**
  * A handler registered for a hook point.
  *
  * Generic parameter `T` is the unwrapped result type for `collect()` — defaults to `unknown`
  * so that `HookDeclarations` (which uses `HookHandler`) accepts handlers with any result type.
+ * Generic parameter `Y` is the progress-frame type for streaming (`async function*`) handlers;
+ * it defaults to `unknown` and is irrelevant to non-streaming handlers.
  * A handler returns a `HookOutput<T>` (result and/or provided capabilities); returning `void`
  * is shorthand for an empty output (no result, no capabilities).
  */
-export interface HookHandler<T = unknown> {
+export interface HookHandler<T = unknown, Y = unknown> {
   /** Module name — set by the Dispatcher during registerModule(). */
   readonly name?: string;
-  readonly handler: (ctx: HookContext) => Promise<HookOutput<T> | void>;
+  readonly handler: (ctx: HookContext) => HookHandlerReturn<T, Y>;
   /** Capabilities this handler requires before it can execute.
    *  Key = capability name. Value = required value, or ANY_VALUE for "must exist, any value". */
   readonly requires?: Readonly<Record<string, unknown>>;
@@ -87,13 +108,32 @@ export interface HookResult<T = unknown> {
 }
 
 /**
+ * Options for `collect()`.
+ *
+ * `onYield` receives each progress frame yielded by a streaming (`async function*`) handler
+ * on this hook point. It runs host-side (operation ↔ dispatcher) — the operation typically
+ * narrows the frame and maps it to a domain event, then emits it. The frame is typed
+ * `unknown` because the dispatcher stores handlers without their yield type; a hook point
+ * carries a single progress semantic, so the operation knows how to narrow it (and a remote
+ * proxy will validate it against the wire schema before it reaches here).
+ */
+export interface CollectOptions {
+  readonly onYield?: (frame: unknown) => void | Promise<void>;
+}
+
+/**
  * Resolved hooks for a specific operation.
  *
  * `collect()` provides isolated-context execution: each handler receives a frozen
  * clone of the input context. All handlers always run. Returns typed results + errors.
+ * Streaming handlers' yielded frames are delivered to `options.onYield` as they occur.
  */
 export interface ResolvedHooks {
-  collect<T = unknown>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>>;
+  collect<T = unknown>(
+    hookPointId: string,
+    ctx: HookContext,
+    options?: CollectOptions
+  ): Promise<HookResult<T>>;
 }
 
 // =============================================================================

--- a/src/intents/lib/workspace-operation.integration.test.ts
+++ b/src/intents/lib/workspace-operation.integration.test.ts
@@ -136,7 +136,9 @@ function createSetup(opts: {
         [TEST_OPERATION_ID]: {
           work: {
             ...h,
-            handler: async (ctx) => {
+            // Non-async so a streaming (async-generator) handler is forwarded as-is
+            // rather than wrapped in a Promise.
+            handler: (ctx) => {
               runs++;
               return h.handler(ctx);
             },

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -497,9 +497,9 @@ function createTestHarness(options?: {
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          handler: async (ctx: HookContext): Promise<HookOutput> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<string>> => {
             void (ctx as FinalizeHookInput).envVars;
-            return { provides: { workspaceUrl: WORKSPACE_URL } };
+            return { result: WORKSPACE_URL };
           },
         },
       },

--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -129,12 +129,28 @@ export interface DiscoverHookInput extends HookContext {
   readonly projectPath: string;
 }
 
-/** Callback for reporting clone progress from a resolve hook. */
-export type CloneProgressReporter = (stage: string, progress: number, name: string) => void;
+/**
+ * Progress frame yielded by the "resolve" hook while cloning (data only, no closure).
+ * The operation adds the `url` it knows and emits `clone:progress`.
+ */
+export interface CloneProgressFrame {
+  readonly stage: string;
+  readonly progress: number;
+  readonly name: string;
+}
 
-/** Input context for the "resolve" hook point. */
-export interface ResolveHookInput extends HookContext {
-  readonly report: CloneProgressReporter;
+/** Narrow an onYield frame to a CloneProgressFrame (plain-typed fields → cast-free). */
+export function isCloneProgressFrame(frame: unknown): frame is CloneProgressFrame {
+  return (
+    typeof frame === "object" &&
+    frame !== null &&
+    "stage" in frame &&
+    typeof frame.stage === "string" &&
+    "progress" in frame &&
+    typeof frame.progress === "number" &&
+    "name" in frame &&
+    typeof frame.name === "string"
+  );
 }
 
 // =============================================================================
@@ -211,19 +227,29 @@ export class OpenProjectOperation implements Operation<OpenProjectIntent, Projec
     }
 
     try {
-      // Create clone progress reporter that emits domain events
+      // The resolve hook streams clone progress by yielding CloneProgressFrame data;
+      // the operation adds the url it knows and emits clone:progress (operation owns emits).
       const gitUrl = effectiveIntent.payload.git ?? "";
-      const report: CloneProgressReporter = (stage, progress, name) => {
-        ctx.emit({
-          type: EVENT_CLONE_PROGRESS,
-          payload: { stage, progress, name, url: gitUrl },
-        } as CloneProgressEvent);
+      const emitCloneProgress = (frame: unknown): void => {
+        if (isCloneProgressFrame(frame)) {
+          void ctx.emit({
+            type: EVENT_CLONE_PROGRESS,
+            payload: {
+              stage: frame.stage,
+              progress: frame.progress,
+              name: frame.name,
+              url: gitUrl,
+            },
+          } satisfies CloneProgressEvent);
+        }
       };
 
       // 1. Resolve: clone if URL, validate git, return projectPath + remoteUrl
-      const resolveCtx: ResolveHookInput = { intent: effectiveIntent, report };
+      const resolveCtx: HookContext = { intent: effectiveIntent };
       const { results: resolveResults, errors: resolveErrors } =
-        await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+        await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx, {
+          onYield: emitCloneProgress,
+        });
       throwHookErrors(resolveErrors, "project:open resolve hooks failed");
       let projectPath: string | undefined;
       let resolvedRemoteUrl: string | undefined;

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -333,15 +333,15 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
       }
     : null;
 
-  // CodeServerModule: "finalize" hook — provides workspaceUrl capability
+  // CodeServerModule: "finalize" hook — returns workspaceUrl as its result
   const codeServerModule: IntentModule = {
     name: "test",
     hooks: {
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          handler: async (ctx: HookContext): Promise<HookOutput> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<string>> => {
             void (ctx as FinalizeHookInput).envVars;
-            return { provides: { workspaceUrl } };
+            return { result: workspaceUrl };
           },
         },
       },
@@ -991,9 +991,9 @@ describe("OpenWorkspace Operation", () => {
         hooks: {
           [OPEN_WORKSPACE_OPERATION_ID]: {
             finalize: {
-              handler: async (ctx: HookContext): Promise<HookOutput> => {
+              handler: async (ctx: HookContext): Promise<HookOutput<string>> => {
                 capturedEnvVars = (ctx as FinalizeHookInput).envVars;
-                return { provides: { workspaceUrl: WORKSPACE_URL } };
+                return { result: WORKSPACE_URL };
               },
             },
           },

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -174,6 +174,9 @@ export interface SetupHookInput extends HookContext {
 /** Result from the "setup" hook point. */
 export interface SetupHookResult {
   readonly envVars?: Record<string, string>;
+  /** Selected agent backend, contributed by the active agent module.
+   *  Operation-consumed (no sibling requires), so a result — not a capability. */
+  readonly agentType?: AgentType | null;
 }
 
 /** Input context for the "finalize" hook point (enriched with create+setup results). */
@@ -256,16 +259,19 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
 
     throwHookErrors(setupResult.errors, "workspace:open setup hooks failed");
 
-    // Accumulate env vars from all setup hook results (multiple modules can contribute)
+    // Accumulate env vars and read agentType from setup hook results. Multiple
+    // modules can contribute env vars; the active agent module contributes agentType
+    // (a result, not a capability — nothing in the hook point requires it).
     const envVars: Record<string, string> = {};
+    let agentType: AgentType | null = null;
     for (const result of setupResult.results) {
       if (result.envVars) {
         Object.assign(envVars, result.envVars);
       }
+      if (result.agentType != null) {
+        agentType = result.agentType;
+      }
     }
-
-    // Read agentType from capabilities (provided by active agent module)
-    const agentType = (setupResult.capabilities.agentType as AgentType) ?? null;
 
     // Hook 3c: "finalize" — workspace URL (fatal on error)
     const finalizeCtx: FinalizeHookInput = {
@@ -274,14 +280,16 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
       envVars,
       agentType,
     };
-    const { errors: finalizeErrors, capabilities: finalizeCaps } = await ctx.hooks.collect<void>(
+    const { errors: finalizeErrors, results: finalizeResults } = await ctx.hooks.collect<string>(
       "finalize",
       finalizeCtx
     );
 
     throwHookErrors(finalizeErrors, "workspace:open finalize hooks failed");
 
-    const workspaceUrl = finalizeCaps.workspaceUrl as string | undefined;
+    // Only code-server produces a finalize result (the workspace URL); the other
+    // finalize handler (plugin-server) returns void, so results[0] is the URL.
+    const workspaceUrl = finalizeResults[0];
     if (!workspaceUrl) {
       throw new Error("Finalize hook did not provide workspaceUrl");
     }

--- a/src/intents/setup.ts
+++ b/src/intents/setup.ts
@@ -66,7 +66,8 @@ export interface RegisterAgentResult {
   readonly icon: string;
 }
 
-// AgentSelectionHookResult removed — selectedAgent is now the `agentType` capability.
+// selectedAgent is the agent-selection hook *result* (operation-consumed, not a
+// capability — nothing in the hook point requires it).
 
 /**
  * Input context for the "agent-selection" hook — carries available agents from register-agents.
@@ -171,12 +172,11 @@ export class SetupOperation implements Operation<SetupIntent, void> {
 
         // 2b: Show agent selection UI with collected agents
         const selectionCtx: AgentSelectionHookContext = { ...hookCtx, availableAgents: agentInfos };
-        const { errors: agentErrors, capabilities: agentCaps } = await ctx.hooks.collect<void>(
-          "agent-selection",
-          selectionCtx
-        );
+        const { errors: agentErrors, results: agentResults } =
+          await ctx.hooks.collect<LifecycleAgentType>("agent-selection", selectionCtx);
         throwHookErrors(agentErrors, "app:setup agent-selection hooks failed");
-        selectedAgent = agentCaps.agentType as ConfigAgentType | undefined;
+        // Single result-producer (the picker); results[0] is the chosen agent.
+        selectedAgent = agentResults[0] as ConfigAgentType | undefined;
       }
 
       // Hook 3: "save-agent" -- (conditional) Persist agent selection

--- a/src/intents/setup.ts
+++ b/src/intents/setup.ts
@@ -85,20 +85,21 @@ export interface SaveAgentHookInput extends HookContext {
 
 /**
  * Input context for the "binary" hook — carries agent and binary info from payload/selection.
+ * Progress is streamed by the handler (an async generator that yields `SetupProgressPayload`
+ * frames); the operation emits `setup:progress` for each — no `report` closure in the context.
  */
 export interface BinaryHookInput extends HookContext {
   readonly selectedAgent?: ConfigAgentType;
   readonly configuredAgent?: ConfigAgentType | null;
   readonly missingBinaries?: readonly BinaryType[];
-  readonly report: SetupProgressReporter;
 }
 
 /**
  * Input context for the "extensions" hook — carries install plan from payload.
+ * Progress streams the same way as the "binary" hook (yielded frames, not a closure).
  */
 export interface ExtensionsHookInput extends HookContext {
   readonly extensionInstallPlan?: readonly ExtensionInstallEntry[];
-  readonly report: SetupProgressReporter;
 }
 
 // =============================================================================
@@ -119,18 +120,6 @@ export interface SetupProgressEvent {
   readonly type: typeof EVENT_SETUP_PROGRESS;
   readonly payload: SetupProgressPayload;
 }
-
-/**
- * Progress reporter callback for setup screen rows.
- * Injected into hook contexts by SetupOperation.execute().
- */
-export type SetupProgressReporter = (
-  id: SetupRowId,
-  status: SetupRowStatus,
-  message?: string,
-  error?: string,
-  progress?: number
-) => void;
 
 export const EVENT_SETUP_ERROR = "setup:error" as const;
 
@@ -189,40 +178,36 @@ export class SetupOperation implements Operation<SetupIntent, void> {
         throwHookErrors(saveErrors, "app:setup save-agent hooks failed");
       }
 
-      // Create progress reporter that emits domain events
-      const report: SetupProgressReporter = (id, status, message?, error?, progress?) => {
-        const progressPayload: SetupProgressPayload = {
-          id,
-          status,
-          ...(message !== undefined && { message }),
-          ...(error !== undefined && { error }),
-          ...(progress !== undefined && { progress }),
-        };
-        ctx.emit({ type: EVENT_SETUP_PROGRESS, payload: progressPayload });
+      // Streaming handlers (binary/extensions) yield SetupProgressPayload frames;
+      // the operation emits setup:progress for each. DomainEvent.payload is unknown,
+      // so the frame forwards straight through — the handler owns its typed yields.
+      const emitProgress = (frame: unknown): void => {
+        void ctx.emit({ type: EVENT_SETUP_PROGRESS, payload: frame });
       };
 
       // Hook 4: "binary" -- Update binary progress (downloads if needed)
       const binaryInput: BinaryHookInput = {
         intent: ctx.intent,
-        report,
         ...(selectedAgent !== undefined && { selectedAgent }),
         ...(payload.configuredAgent !== undefined && { configuredAgent: payload.configuredAgent }),
         ...(payload.missingBinaries !== undefined && { missingBinaries: payload.missingBinaries }),
       };
-      const { errors: binaryErrors } = await ctx.hooks.collect<void>("binary", binaryInput);
+      const { errors: binaryErrors } = await ctx.hooks.collect<void>("binary", binaryInput, {
+        onYield: emitProgress,
+      });
       throwHookErrors(binaryErrors, "app:setup binary hooks failed");
 
       // Hook 5: "extensions" -- Update extension progress (installs if needed)
       const extensionsInput: ExtensionsHookInput = {
         intent: ctx.intent,
-        report,
         ...(payload.extensionInstallPlan !== undefined && {
           extensionInstallPlan: payload.extensionInstallPlan,
         }),
       };
       const { errors: extensionsErrors } = await ctx.hooks.collect<void>(
         "extensions",
-        extensionsInput
+        extensionsInput,
+        { onYield: emitProgress }
       );
       throwHookErrors(extensionsErrors, "app:setup extensions hooks failed");
 

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -250,24 +250,21 @@ class MinimalSetupOperation implements Operation<
   async execute(
     ctx: OperationContext<OpenWorkspaceIntent>
   ): Promise<SetupOperationResult | undefined> {
-    const { results, errors, capabilities } = await ctx.hooks.collect<SetupHookResult | undefined>(
-      "setup",
-      {
-        intent: ctx.intent,
-        workspacePath: "/test/workspace",
-        projectPath: "/test/project",
-        ...this.hookInput,
-        ...(this.agentCapability !== null && {
-          capabilities: { agent: this.agentCapability },
-        }),
-      }
-    );
+    const { results, errors } = await ctx.hooks.collect<SetupHookResult | undefined>("setup", {
+      intent: ctx.intent,
+      workspacePath: "/test/workspace",
+      projectPath: "/test/project",
+      ...this.hookInput,
+      ...(this.agentCapability !== null && {
+        capabilities: { agent: this.agentCapability },
+      }),
+    });
     if (errors.length > 0) throw errors[0]!;
     const result = results[0];
     if (result === undefined) return undefined;
     return {
-      ...result,
-      ...(capabilities.agentType !== undefined && { agentType: capabilities.agentType as string }),
+      ...(result.envVars !== undefined && { envVars: result.envVars }),
+      ...(result.agentType != null && { agentType: result.agentType }),
     };
   }
 }

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -25,7 +25,12 @@ import type {
 } from "../../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
-import type { RegisterAgentResult, SaveAgentHookInput, BinaryHookInput } from "../../intents/setup";
+import type {
+  RegisterAgentResult,
+  SaveAgentHookInput,
+  BinaryHookInput,
+  SetupProgressPayload,
+} from "../../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
 import type {
   SetupHookResult,
@@ -212,19 +217,26 @@ class MinimalSaveAgentOperation implements Operation<Intent, void> {
 class MinimalBinaryOperation implements Operation<Intent, void> {
   readonly id = SETUP_OPERATION_ID;
   private readonly hookInput: Partial<BinaryHookInput>;
-  readonly report: ReturnType<typeof vi.fn>;
+  /** Progress frames yielded by the streaming binary handler. */
+  readonly frames: SetupProgressPayload[] = [];
 
   constructor(hookInput: Partial<BinaryHookInput> = {}) {
-    this.report = (hookInput.report as ReturnType<typeof vi.fn>) ?? vi.fn();
     this.hookInput = hookInput;
   }
 
   async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("binary", {
-      intent: ctx.intent,
-      report: this.report,
-      ...this.hookInput,
-    });
+    const { errors } = await ctx.hooks.collect(
+      "binary",
+      {
+        intent: ctx.intent,
+        ...this.hookInput,
+      },
+      {
+        onYield: (frame) => {
+          this.frames.push(frame as SetupProgressPayload);
+        },
+      }
+    );
     if (errors.length > 0) throw errors[0]!;
   }
 }
@@ -720,7 +732,7 @@ describe("createAgentModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(mockProvider.downloadBinary).toHaveBeenCalled();
-      expect(op.report).toHaveBeenCalledWith("agent", "done");
+      expect(op.frames).toContainEqual({ id: "agent", status: "done" });
     });
 
     it("reports done when agent matches but binary not missing", async () => {
@@ -734,7 +746,7 @@ describe("createAgentModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(mockProvider.downloadBinary).not.toHaveBeenCalled();
-      expect(op.report).toHaveBeenCalledWith("agent", "done");
+      expect(op.frames).toContainEqual({ id: "agent", status: "done" });
     });
 
     it("skips download and report when agent does not match", async () => {
@@ -748,7 +760,7 @@ describe("createAgentModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(mockProvider.downloadBinary).not.toHaveBeenCalled();
-      expect(op.report).not.toHaveBeenCalled();
+      expect(op.frames).toHaveLength(0);
     });
 
     it("reports progress during download", async () => {
@@ -772,8 +784,17 @@ describe("createAgentModule", () => {
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
-      expect(op.report).toHaveBeenCalledWith("agent", "running", "Downloading...", undefined, 50);
-      expect(op.report).toHaveBeenCalledWith("agent", "running", "Extracting...");
+      expect(op.frames).toContainEqual({
+        id: "agent",
+        status: "running",
+        message: "Downloading...",
+        progress: 50,
+      });
+      expect(op.frames).toContainEqual({
+        id: "agent",
+        status: "running",
+        message: "Extracting...",
+      });
     });
 
     it("throws SetupError on download failure", async () => {
@@ -787,7 +808,7 @@ describe("createAgentModule", () => {
       dispatcher.registerOperation("setup", op);
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
-      expect(op.report).toHaveBeenCalledWith("agent", "failed", undefined, "network error");
+      expect(op.frames).toContainEqual({ id: "agent", status: "failed", error: "network error" });
     });
 
     it("uses configuredAgent when selectedAgent not provided", async () => {

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -356,8 +356,7 @@ export function createAgentModule(
             });
 
             return {
-              result: { envVars: result.envVars },
-              provides: { agentType: provider.type },
+              result: { envVars: result.envVars, agentType: provider.type },
             };
           },
         },

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -25,7 +25,12 @@ import type {
   CheckDepsResult,
   ConfigureResult,
 } from "../../intents/app-start";
-import type { RegisterAgentResult, SaveAgentHookInput, BinaryHookInput } from "../../intents/setup";
+import type {
+  RegisterAgentResult,
+  SaveAgentHookInput,
+  BinaryHookInput,
+  SetupProgressPayload,
+} from "../../intents/setup";
 import type {
   SetupHookInput,
   SetupHookResult,
@@ -58,6 +63,7 @@ import {
   type LaunchOptionsHookResult,
 } from "../../intents/agent-launch-options";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
+import { streamProgress } from "../../intents/lib/hook-helpers";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
 import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../../intents/get-workspace-status";
@@ -303,35 +309,45 @@ export function createAgentModule(
         },
 
         binary: {
-          handler: async (ctx: HookContext) => {
+          // Streaming handler: yield progress frames; the setup operation emits them.
+          handler: async function* (
+            ctx: HookContext
+          ): AsyncGenerator<SetupProgressPayload, void, void> {
             const hookCtx = ctx as BinaryHookInput;
             const missingBinaries = hookCtx.missingBinaries ?? [];
-            const { report } = hookCtx;
 
             const agentType = hookCtx.selectedAgent ?? hookCtx.configuredAgent;
             if (agentType !== provider.type) return;
 
-            if (missingBinaries.includes(provider.binaryType)) {
-              report("agent", "running", "Downloading...");
-              try {
+            if (!missingBinaries.includes(provider.binaryType)) {
+              yield { id: "agent", status: "done" };
+              return;
+            }
+
+            yield { id: "agent", status: "running", message: "Downloading..." };
+            try {
+              yield* streamProgress<SetupProgressPayload>(async (emit) => {
                 await provider.downloadBinary((p) => {
                   if (p.phase === "downloading" && p.totalBytes) {
                     const pct = Math.floor((p.bytesDownloaded / p.totalBytes) * 100);
-                    report("agent", "running", "Downloading...", undefined, pct);
+                    emit({
+                      id: "agent",
+                      status: "running",
+                      message: "Downloading...",
+                      progress: pct,
+                    });
                   } else if (p.phase === "extracting") {
-                    report("agent", "running", "Extracting...");
+                    emit({ id: "agent", status: "running", message: "Extracting..." });
                   }
                 });
-                report("agent", "done");
-              } catch (error) {
-                report("agent", "failed", undefined, getErrorMessage(error));
-                throw new SetupError(
-                  `Failed to download ${provider.binaryType}: ${getErrorMessage(error)}`,
-                  "BINARY_DOWNLOAD_FAILED"
-                );
-              }
-            } else {
-              report("agent", "done");
+              });
+              yield { id: "agent", status: "done" };
+            } catch (error) {
+              yield { id: "agent", status: "failed", error: getErrorMessage(error) };
+              throw new SetupError(
+                `Failed to download ${provider.binaryType}: ${getErrorMessage(error)}`,
+                "BINARY_DOWNLOAD_FAILED"
+              );
             }
           },
         },

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../intents/app-resume";
 import type { DomainEvent } from "../intents/lib/types";
 import { SETUP_OPERATION_ID } from "../intents/setup";
-import type { BinaryHookInput, ExtensionsHookInput } from "../intents/setup";
+import type { BinaryHookInput, ExtensionsHookInput, SetupProgressPayload } from "../intents/setup";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import type { FinalizeHookInput, OpenWorkspaceIntent } from "../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
@@ -117,19 +117,23 @@ class MinimalStartOperation implements Operation<Intent, number | undefined> {
 class MinimalBinaryOperation implements Operation<Intent, void> {
   readonly id = SETUP_OPERATION_ID;
   private readonly hookInput: Partial<BinaryHookInput>;
-  readonly report: ReturnType<typeof vi.fn>;
+  /** Progress frames yielded by the streaming binary handler. */
+  readonly frames: SetupProgressPayload[] = [];
 
   constructor(hookInput: Partial<BinaryHookInput> = {}) {
-    this.report = (hookInput.report as ReturnType<typeof vi.fn>) ?? vi.fn();
     this.hookInput = hookInput;
   }
 
   async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("binary", {
-      intent: ctx.intent,
-      report: this.report,
-      ...this.hookInput,
-    });
+    const { errors } = await ctx.hooks.collect(
+      "binary",
+      { intent: ctx.intent, ...this.hookInput },
+      {
+        onYield: (frame) => {
+          this.frames.push(frame as SetupProgressPayload);
+        },
+      }
+    );
     if (errors.length > 0) throw errors[0]!;
   }
 }
@@ -137,19 +141,23 @@ class MinimalBinaryOperation implements Operation<Intent, void> {
 class MinimalExtensionsOperation implements Operation<Intent, void> {
   readonly id = SETUP_OPERATION_ID;
   private readonly hookInput: Partial<ExtensionsHookInput>;
-  readonly report: ReturnType<typeof vi.fn>;
+  /** Progress frames yielded by the streaming extensions handler. */
+  readonly frames: SetupProgressPayload[] = [];
 
   constructor(hookInput: Partial<ExtensionsHookInput> = {}) {
-    this.report = (hookInput.report as ReturnType<typeof vi.fn>) ?? vi.fn();
     this.hookInput = hookInput;
   }
 
   async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect("extensions", {
-      intent: ctx.intent,
-      report: this.report,
-      ...this.hookInput,
-    });
+    const { errors } = await ctx.hooks.collect(
+      "extensions",
+      { intent: ctx.intent, ...this.hookInput },
+      {
+        onYield: (frame) => {
+          this.frames.push(frame as SetupProgressPayload);
+        },
+      }
+    );
     if (errors.length > 0) throw errors[0]!;
   }
 }
@@ -600,7 +608,7 @@ describe("CodeServerModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(archiveExtractor.$.extractions.length).toBeGreaterThan(0);
-      expect(op.report).toHaveBeenCalledWith("vscode", "done");
+      expect(op.frames).toContainEqual({ id: "vscode", status: "done" });
     });
 
     it("skips download when not missing", async () => {
@@ -613,7 +621,7 @@ describe("CodeServerModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(archiveExtractor).toHaveNoExtractions();
-      expect(op.report).toHaveBeenCalledWith("vscode", "done");
+      expect(op.frames).toContainEqual({ id: "vscode", status: "done" });
     });
 
     it("reports progress during download", async () => {
@@ -631,8 +639,17 @@ describe("CodeServerModule", () => {
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
-      expect(op.report).toHaveBeenCalledWith("vscode", "running", "Downloading...", undefined, 50);
-      expect(op.report).toHaveBeenCalledWith("vscode", "running", "Extracting...");
+      expect(op.frames).toContainEqual({
+        id: "vscode",
+        status: "running",
+        message: "Downloading...",
+        progress: 50,
+      });
+      expect(op.frames).toContainEqual({
+        id: "vscode",
+        status: "running",
+        message: "Extracting...",
+      });
     });
 
     it("throws SetupError on download failure", async () => {
@@ -645,11 +662,12 @@ describe("CodeServerModule", () => {
       dispatcher.registerOperation("setup", op);
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
-      expect(op.report).toHaveBeenCalledWith(
-        "vscode",
-        "failed",
-        undefined,
-        expect.stringContaining("Failed to download code-server")
+      expect(op.frames).toContainEqual(
+        expect.objectContaining({
+          id: "vscode",
+          status: "failed",
+          error: expect.stringContaining("Failed to download code-server"),
+        })
       );
     });
   });
@@ -679,7 +697,7 @@ describe("CodeServerModule", () => {
           ]) as unknown as string[],
         },
       ]);
-      expect(op.report).toHaveBeenCalledWith("setup", "done");
+      expect(op.frames).toContainEqual({ id: "setup", status: "done" });
     });
 
     it("removes old extension dir before reinstalling", async () => {
@@ -717,7 +735,7 @@ describe("CodeServerModule", () => {
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
       expect(() => asMockRunner(deps).$.spawned(0)).toThrow();
-      expect(op.report).toHaveBeenCalledWith("setup", "done");
+      expect(op.frames).toContainEqual({ id: "setup", status: "done" });
     });
 
     it("throws SetupError on install failure", async () => {
@@ -741,11 +759,12 @@ describe("CodeServerModule", () => {
       dispatcher.registerOperation("setup", op);
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
-      expect(op.report).toHaveBeenCalledWith(
-        "setup",
-        "failed",
-        undefined,
-        expect.stringContaining("Failed to install extension")
+      expect(op.frames).toContainEqual(
+        expect.objectContaining({
+          id: "setup",
+          status: "failed",
+          error: expect.stringContaining("Failed to install extension"),
+        })
       );
     });
   });

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -163,7 +163,7 @@ class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, string 
   }
 
   async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<string | undefined> {
-    const { errors, capabilities } = await ctx.hooks.collect<void>("finalize", {
+    const { errors, results } = await ctx.hooks.collect<string>("finalize", {
       intent: ctx.intent,
       workspacePath: "/test/project/.worktrees/feature-1",
       envVars: { OPENCODE_PORT: "8080" },
@@ -171,7 +171,7 @@ class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, string 
       ...this.hookInput,
     });
     if (errors.length > 0) throw errors[0]!;
-    return capabilities.workspaceUrl as string | undefined;
+    return results[0];
   }
 }
 

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -34,7 +34,7 @@ import { downloadBinary, isBinaryInstalled } from "../utils/binary-download";
 import type { ArchiveExtractor } from "../boundaries/platform/archive-extractor";
 import type { BinaryType } from "../utils/binary-resolution/types";
 import type { CheckDepsHookContext, CheckDepsResult, ConfigureResult } from "../intents/app-start";
-import type { BinaryHookInput, ExtensionsHookInput } from "../intents/setup";
+import type { BinaryHookInput, ExtensionsHookInput, SetupProgressPayload } from "../intents/setup";
 import type { FinalizeHookInput } from "../intents/open-workspace";
 import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import type { DeleteHookResult, DeletePipelineHookInput } from "../intents/delete-workspace";
@@ -43,11 +43,10 @@ import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
 import {
   APP_RESUME_OPERATION_ID,
   APP_RESUME_HOOK_RESUME,
-  EVENT_APP_RESUME_FAILED,
-  EVENT_CODE_SERVER_RESTARTED,
-  type ResumeHookContext,
+  type ResumeHookResult,
 } from "../intents/app-resume";
 import { SETUP_OPERATION_ID } from "../intents/setup";
+import { streamProgress } from "../intents/lib/hook-helpers";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
 import { listInstalledExtensions, removeFromExtensionsJson } from "../utils/extension";
@@ -732,11 +731,11 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [APP_RESUME_OPERATION_ID]: {
         [APP_RESUME_HOOK_RESUME]: {
-          handler: async (ctx: HookContext): Promise<void> => {
+          handler: async (): Promise<HookOutput<ResumeHookResult>> => {
             const port = currentPort;
             if (port === null) {
               // Never started — nothing to probe or restart.
-              return;
+              return {};
             }
 
             try {
@@ -746,13 +745,12 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
                 intervalMs: 500,
                 errorMessage: "Code-server health check timed out after 5s",
               });
-              return;
+              return {};
             } catch {
               // Fall through to restart
             }
 
             logger.warn("Code-server unhealthy after resume, restarting");
-            const resumeCtx = ctx as ResumeHookContext;
             try {
               await stop();
               await ensureRunning();
@@ -760,20 +758,15 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             } catch (error) {
               const message = getErrorMessage(error);
               logger.error("Code-server restart failed after resume", { error: message });
-              await resumeCtx.emit({
-                type: EVENT_APP_RESUME_FAILED,
-                payload: { error: message },
-              });
-              throw error;
+              // Report the failure as data; the operation emits app:resume-failed.
+              return { result: { failed: { error: message } } };
             }
 
             // The fresh process invalidates every workspace iframe's connection
-            // to the old server. Tell view-module to reload them before
-            // code-server's client surfaces its own "Reload" dialog.
-            await resumeCtx.emit({
-              type: EVENT_CODE_SERVER_RESTARTED,
-              payload: {},
-            });
+            // to the old server. The operation emits code-server:restarted so
+            // view-module reloads them before code-server surfaces its own
+            // "Reload" dialog.
+            return { result: { restarted: true } };
           },
         },
       },
@@ -794,32 +787,42 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [SETUP_OPERATION_ID]: {
         binary: {
-          handler: async (ctx: HookContext) => {
+          // Streaming handler: yield progress frames; the setup operation emits them.
+          handler: async function* (
+            ctx: HookContext
+          ): AsyncGenerator<SetupProgressPayload, void, void> {
             const hookCtx = ctx as BinaryHookInput;
             const missingBinaries = hookCtx.missingBinaries ?? [];
-            const { report } = hookCtx;
 
-            if (missingBinaries.includes("code-server")) {
-              report("vscode", "running", "Downloading...");
-              try {
+            if (!missingBinaries.includes("code-server")) {
+              yield { id: "vscode", status: "done" };
+              return;
+            }
+
+            yield { id: "vscode", status: "running", message: "Downloading..." };
+            try {
+              yield* streamProgress<SetupProgressPayload>(async (emit) => {
                 await downloadCodeServer((p) => {
                   if (p.phase === "downloading" && p.totalBytes) {
                     const pct = Math.floor((p.bytesDownloaded / p.totalBytes) * 100);
-                    report("vscode", "running", "Downloading...", undefined, pct);
+                    emit({
+                      id: "vscode",
+                      status: "running",
+                      message: "Downloading...",
+                      progress: pct,
+                    });
                   } else if (p.phase === "extracting") {
-                    report("vscode", "running", "Extracting...");
+                    emit({ id: "vscode", status: "running", message: "Extracting..." });
                   }
                 });
-                report("vscode", "done");
-              } catch (error) {
-                report("vscode", "failed", undefined, getErrorMessage(error));
-                throw new SetupError(
-                  `Failed to download code-server: ${getErrorMessage(error)}`,
-                  "BINARY_DOWNLOAD_FAILED"
-                );
-              }
-            } else {
-              report("vscode", "done");
+              });
+              yield { id: "vscode", status: "done" };
+            } catch (error) {
+              yield { id: "vscode", status: "failed", error: getErrorMessage(error) };
+              throw new SetupError(
+                `Failed to download code-server: ${getErrorMessage(error)}`,
+                "BINARY_DOWNLOAD_FAILED"
+              );
             }
           },
         },
@@ -828,17 +831,19 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
         // setup -> extensions: install extensions from install plan
         // -------------------------------------------------------------------
         extensions: {
-          handler: async (ctx: HookContext) => {
+          // Streaming handler: yield progress frames; the setup operation emits them.
+          handler: async function* (
+            ctx: HookContext
+          ): AsyncGenerator<SetupProgressPayload, void, void> {
             const hookCtx = ctx as ExtensionsHookInput;
             const installPlan = hookCtx.extensionInstallPlan ?? [];
-            const { report } = hookCtx;
 
             if (installPlan.length === 0) {
-              report("setup", "done");
+              yield { id: "setup", status: "done" };
               return;
             }
 
-            report("setup", "running", "Installing extensions...");
+            yield { id: "setup", status: "running", message: "Installing extensions..." };
 
             const extensionsDir = deps.pathProvider.dataPath("vscode/extensions");
 
@@ -847,7 +852,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
               const installed = await listInstalledExtensions(fileSystemLayer, extensionsDir);
 
               for (const entry of installPlan) {
-                report("setup", "running", `Installing ${entry.id}...`);
+                yield { id: "setup", status: "running", message: `Installing ${entry.id}...` };
 
                 // Remove old directory if present
                 const oldVersion = installed.get(entry.id);
@@ -881,9 +886,9 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
                 }
                 logger.info("Extension installed", { extId: entry.id });
               }
-              report("setup", "done");
+              yield { id: "setup", status: "done" };
             } catch (error) {
-              report("setup", "failed", undefined, getErrorMessage(error));
+              yield { id: "setup", status: "failed", error: getErrorMessage(error) };
               throw new SetupError(
                 `Failed to install extensions: ${getErrorMessage(error)}`,
                 "EXTENSION_INSTALL_FAILED"

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -898,7 +898,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
       // -------------------------------------------------------------------
       [OPEN_WORKSPACE_OPERATION_ID]: {
         finalize: {
-          handler: async (ctx: HookContext): Promise<HookOutput> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<string>> => {
             let workspaceUrl: string;
             const finalizeCtx = ctx as FinalizeHookInput;
 
@@ -926,7 +926,7 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
               workspaceUrl = urlForFolder(codeServerPort, finalizeCtx.workspacePath);
             }
 
-            return { provides: { workspaceUrl } };
+            return { result: workspaceUrl };
           },
         },
       },

--- a/src/modules/debug-module.integration.test.ts
+++ b/src/modules/debug-module.integration.test.ts
@@ -13,7 +13,7 @@ import type { HookHandler, HookContext, HookOutput } from "../intents/lib/operat
 import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { Config } from "../boundaries/platform/config";
 import type { CheckDepsResult } from "../intents/app-start";
-import type { SetupProgressReporter } from "../intents/setup";
+import type { SetupProgressPayload } from "../intents/setup";
 import type { DeleteHookResult, DetectHookResult } from "../intents/delete-workspace";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
 import { RESOLVE_WORKSPACE_OPERATION_ID } from "../intents/resolve-workspace";
@@ -36,23 +36,18 @@ function makeHookContext(): HookContext {
   return { intent: { type: "test", payload: {} } };
 }
 
-interface ReportCall {
-  id: string;
-  status: string;
-  message: string | undefined;
-  error: string | undefined;
-  progress: number | undefined;
-}
-
-function makeReportSpy(): {
-  report: SetupProgressReporter;
-  calls: ReportCall[];
-} {
-  const calls: ReportCall[] = [];
-  const report: SetupProgressReporter = (id, status, message?, error?, progress?) => {
-    calls.push({ id, status, message, error, progress });
-  };
-  return { report, calls };
+/** Drive a streaming (async-generator) binary hook, advancing fake timers per step. */
+async function collectSetupFrames(hook: HookHandler): Promise<SetupProgressPayload[]> {
+  const gen = hook.handler(makeHookContext()) as AsyncGenerator<SetupProgressPayload, void, void>;
+  const frames: SetupProgressPayload[] = [];
+  while (true) {
+    const nextPromise = gen.next();
+    await vi.advanceTimersByTimeAsync(300);
+    const res = await nextPromise;
+    if (res.done) break;
+    frames.push(res.value);
+  }
+  return frames;
 }
 
 // =============================================================================
@@ -186,13 +181,16 @@ describe("DebugModule Integration", () => {
       expect(result).toEqual({});
     });
 
-    it("binary hook returns immediately", async () => {
-      const module = createDebugModule({ configService: createMockConfig() });
-      const hook = getHook(module, SETUP_OPERATION_ID, "binary");
-      const { report, calls } = makeReportSpy();
-      const ctx = { ...makeHookContext(), report } as unknown as HookContext;
-      await hook.handler(ctx);
-      expect(calls).toHaveLength(0);
+    it("binary hook yields nothing when inactive", async () => {
+      vi.useFakeTimers();
+      try {
+        const module = createDebugModule({ configService: createMockConfig() });
+        const hook = getHook(module, SETUP_OPERATION_ID, "binary");
+        const frames = await collectSetupFrames(hook);
+        expect(frames).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -207,44 +205,20 @@ describe("DebugModule Integration", () => {
       expect(result.missingBinaries).toEqual(["claude"]);
     });
 
-    it("binary hook calls report with progress increments", async () => {
+    it("binary hook yields progress increments", async () => {
       vi.useFakeTimers();
       try {
         const module = createDebugModule({
           configService: createMockConfig({ defaults: { "debug.setup": true } }),
         });
         const hook = getHook(module, SETUP_OPERATION_ID, "binary");
-        const { report, calls } = makeReportSpy();
-        const ctx = { ...makeHookContext(), report } as unknown as HookContext;
 
-        const promise = hook.handler(ctx);
+        const frames = await collectSetupFrames(hook);
 
-        // Initial report("agent", "running", ..., 0)
-        expect(calls).toHaveLength(1);
-        expect(calls[0]).toEqual({
-          id: "agent",
-          status: "running",
-          message: undefined,
-          error: undefined,
-          progress: 0,
-        });
-
-        // Advance through all 10 increments (300ms each)
-        for (let i = 0; i < 10; i++) {
-          await vi.advanceTimersByTimeAsync(300);
-        }
-
-        await promise;
-
-        // 1 initial + 10 progress + 1 done = 12 calls
-        expect(calls).toHaveLength(12);
-        expect(calls[calls.length - 1]).toEqual({
-          id: "agent",
-          status: "done",
-          message: undefined,
-          error: undefined,
-          progress: undefined,
-        });
+        // 1 initial + 10 progress + 1 done = 12 frames
+        expect(frames).toHaveLength(12);
+        expect(frames[0]).toEqual({ id: "agent", status: "running", progress: 0 });
+        expect(frames[frames.length - 1]).toEqual({ id: "agent", status: "done" });
       } finally {
         vi.useRealTimers();
       }

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -29,7 +29,7 @@ import {
   type ResolveHookResult,
 } from "../intents/resolve-workspace";
 import type { WorkspaceName } from "../shared/api/types";
-import { SETUP_OPERATION_ID, type BinaryHookInput } from "../intents/setup";
+import { SETUP_OPERATION_ID, type SetupProgressPayload } from "../intents/setup";
 import type { NotificationHandle } from "./presentation/sessions";
 import type { UiPresenter } from "./presentation/presentation-module";
 import type { NotificationConfig } from "../shared/notification-types";
@@ -155,15 +155,15 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
       // --- Setup: binary download simulation ---
       [SETUP_OPERATION_ID]: {
         binary: {
-          handler: async (ctx: HookContext): Promise<void> => {
+          // Streaming handler: yield progress frames; the setup operation emits them.
+          handler: async function* (): AsyncGenerator<SetupProgressPayload, void, void> {
             if (!isActive("debug.setup")) return;
-            const { report } = ctx as BinaryHookInput;
-            report("agent", "running", undefined, undefined, 0);
+            yield { id: "agent", status: "running", progress: 0 };
             for (let progress = 10; progress <= 100; progress += 10) {
               await delay(300);
-              report("agent", "running", undefined, undefined, progress);
+              yield { id: "agent", status: "running", progress };
             }
-            report("agent", "done");
+            yield { id: "agent", status: "done" };
           },
         },
       },

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -1225,7 +1225,7 @@ describe("PresentationModule - startup flow", () => {
     expect(currentSystemDialog(deps).config.sections).toEqual([STARTING_SPINNER]);
   });
 
-  it("app:start show-ui sets the starting phase and returns waitForRetry", async () => {
+  it("app:start show-ui sets the starting phase and advertises retry support", async () => {
     const deps = createDeps();
     const module = createPresentationModule(deps);
     connect(deps);
@@ -1237,7 +1237,7 @@ describe("PresentationModule - startup flow", () => {
     ).result!;
     await flush();
 
-    expect(typeof result.waitForRetry).toBe("function");
+    expect(result.retrySupported).toBe(true);
     expect(lastSnapshot(deps).main).toEqual({ kind: "starting" });
   });
 
@@ -1369,7 +1369,7 @@ describe("PresentationModule - startup flow", () => {
     expect(currentSystemDialog(deps).config.sections).toEqual([STARTING_SPINNER]);
   });
 
-  it("app:start start dispatches app:ready and shows the loading dialog until app:started", async () => {
+  it("app:start start shows the loading dialog until app:started", async () => {
     const deps = createDeps();
     const dispatched: Array<{ type: string }> = [];
     deps.dispatcher = {
@@ -1386,7 +1386,9 @@ describe("PresentationModule - startup flow", () => {
     });
     await flush();
 
-    expect(dispatched).toEqual([{ type: "app:ready", payload: {} }]);
+    // app:ready is dispatched by the app:start operation (after all start handlers),
+    // not by this handler — the handler only advances the UI phase.
+    expect(dispatched).toEqual([]);
     expect(lastSnapshot(deps).main).toEqual({ kind: "starting" });
     expect(currentSystemDialog(deps).config.sections).toEqual([LOADING_SPINNER]);
 
@@ -1397,15 +1399,13 @@ describe("PresentationModule - startup flow", () => {
     expect(lastSnapshot(deps).dialogs).toEqual([]);
   });
 
-  it("the setup-error Retry action resolves the parked waitForRetry", async () => {
+  it("the setup-error Retry action resolves the parked await-retry hook", async () => {
     const deps = createDeps();
     const module = createPresentationModule(deps);
     connect(deps);
-    const result = (
-      (await runHook(module, APP_START_OPERATION_ID, "show-ui", {
-        intent: { type: "app:start", payload: {} },
-      })) as HookOutput<ShowUIHookResult>
-    ).result!;
+    await runHook(module, APP_START_OPERATION_ID, "show-ui", {
+      intent: { type: "app:start", payload: {} },
+    });
     // Enter setup + fail so the dialog shows the Retry button.
     await runHook(module, SETUP_OPERATION_ID, "show-ui", {
       intent: { type: "app:setup", payload: {} },
@@ -1413,10 +1413,15 @@ describe("PresentationModule - startup flow", () => {
     await emit(module, EVENT_SETUP_ERROR, { message: "boom" });
     await flush();
 
+    // The operation waits by collecting the await-retry hook; the handler parks
+    // until the Retry action resolves it, then returns.
     let resolved = false;
-    void result.waitForRetry!().then(() => {
+    void runHook(module, APP_START_OPERATION_ID, "await-retry", {
+      intent: { type: "app:start", payload: {} },
+    }).then(() => {
       resolved = true;
     });
+    await flush();
     action(deps, "retry");
     await flush();
 
@@ -1752,13 +1757,13 @@ describe("PresentationModule - hibernation capture hooks", () => {
     } as HibernatePipelineHookInput;
   }
 
-  function prepare(module: UiPresenter, active: boolean): Promise<unknown> {
+  async function prepare(module: UiPresenter, active: boolean): Promise<unknown> {
     return module.hooks![HIBERNATE_WORKSPACE_OPERATION_ID]!["prepare-capture"]!.handler(
       captureInput(active)
     );
   }
 
-  function cleanup(module: UiPresenter, active: boolean): Promise<unknown> {
+  async function cleanup(module: UiPresenter, active: boolean): Promise<unknown> {
     return module.hooks![HIBERNATE_WORKSPACE_OPERATION_ID]!["cleanup-capture"]!.handler(
       captureInput(active)
     );

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -1348,8 +1348,8 @@ describe("PresentationModule - startup flow", () => {
     action(deps, "continue", { agent: "opencode" });
     const output = await pending;
 
-    // The handler returns the chosen agent as the agentType capability.
-    expect(output).toEqual({ provides: { agentType: "opencode" } });
+    // The handler returns the chosen agent as the agent-selection hook result.
+    expect(output).toEqual({ result: "opencode" });
   });
 
   it("app:setup hide-ui returns to the boot-splash dialog", async () => {

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -1632,11 +1632,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * app:setup `agent-selection`: show the picker (a radio system dialog) and
    * park until the user clicks Continue, which arrives as a system-dialog
    * action and resolves the parked promise with the chosen agent (returned as
-   * the `agentType` capability to app:setup). app:shutdown REJECTS the promise
+   * the agent-selection hook result to app:setup). app:shutdown REJECTS the promise
    * so a quit-during-selection throws here — app:setup unwinds without reaching
    * save-agent, so no agent is persisted and the next launch re-prompts.
    */
-  async function setupAgentSelection(ctx: HookContext): Promise<HookOutput> {
+  async function setupAgentSelection(ctx: HookContext): Promise<HookOutput<LifecycleAgentType>> {
     const { availableAgents } = ctx as AgentSelectionHookContext;
     agentOptions = availableAgents;
     startupPhase = "agent-selection";
@@ -1646,7 +1646,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       agentSelectionResolve = resolve;
       agentSelectionReject = reject;
     });
-    return { provides: { agentType: agent } };
+    return { result: agent };
   }
 
   /** app:setup `hide-ui`: return to the boot-splash phase. */

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -46,7 +46,7 @@ import {
   INTENT_APP_SHUTDOWN,
   type AppShutdownIntent,
 } from "../../intents/app-shutdown";
-import { EVENT_APP_STARTED, INTENT_APP_READY, type AppReadyIntent } from "../../intents/app-ready";
+import { EVENT_APP_STARTED } from "../../intents/app-ready";
 import { APP_START_OPERATION_ID, type ShowUIHookResult } from "../../intents/app-start";
 import {
   SETUP_OPERATION_ID,
@@ -1590,35 +1590,32 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   async function appStartShowUi(): Promise<HookOutput<ShowUIHookResult>> {
     startupPhase = "starting";
     scheduleUpdate();
-    return {
-      result: {
-        waitForRetry: () =>
-          new Promise<void>((resolve, reject) => {
-            retryResolve = resolve;
-            retryReject = reject;
-          }),
-      },
-    };
+    // Advertise that this (UI) module can host a setup retry loop. The actual wait
+    // happens in the `await-retry` hook below — data in, data out, no closure.
+    return { result: { retrySupported: true } };
   }
 
   /**
-   * app:start `start`: dispatch app:ready (load projects → app:started). Gated
-   * on code-server being up (mirrors view-module's old start hook ordering).
-   * The "running" phase shows the unified loading screen until app:started.
-   * Fire-and-forget: app:ready is awaited internally by the dispatcher, but the
-   * hook must not block startup on the projects finishing — the snapshot stream
-   * carries the result.
+   * app:start `await-retry`: block until the user clicks Retry (a system-dialog
+   * action resolves `retryResolve`), then return. app:shutdown rejects the parked
+   * promise so a quit-during-retry unwinds app:start instead of hanging. The promise
+   * is module-internal state; nothing crosses the hook contract but the returned void.
+   */
+  async function awaitRetry(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      retryResolve = resolve;
+      retryReject = reject;
+    });
+  }
+
+  /**
+   * app:start `start`: advance to the "running" phase (unified loading screen until
+   * app:started). The app:ready dispatch that loads projects is owned by the app:start
+   * operation now (fired after all start handlers), so this handler is pure UI state.
    */
   async function appStartStart(): Promise<void> {
     startupPhase = "running";
     scheduleUpdate();
-    const handle = deps.dispatcher.dispatch({
-      type: INTENT_APP_READY,
-      payload: {},
-    } as AppReadyIntent);
-    void handle.catch((error: unknown) => {
-      logger.debug("app:ready dispatch rejected", { error: getErrorMessage(error) });
-    });
   }
 
   /** app:setup `show-ui`: enter the setup phase with fresh pending rows. */
@@ -1682,9 +1679,12 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
           },
         },
         "show-ui": { handler: appStartShowUi },
+        "await-retry": { handler: awaitRetry },
         start: {
-          // Gate on code-server: app:ready dispatches project:open, whose
-          // workspace URLs must be servable when the renderer mounts iframes.
+          // Gate on code-server: the operation dispatches app:ready (→ project:open,
+          // whose workspace URLs must be servable when the renderer mounts iframes)
+          // only after this hook point completes, so advancing the phase here waits
+          // for code-server too.
           requires: { codeServerPort: ANY_VALUE },
           handler: appStartStart,
         },

--- a/src/modules/remote-project-module.integration.test.ts
+++ b/src/modules/remote-project-module.integration.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { HookContext, ResolvedHooks, HookResult, HookOutput } from "../intents/lib/operation";
+import type {
+  HookContext,
+  ResolvedHooks,
+  HookResult,
+  HookOutput,
+  CollectOptions,
+} from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
@@ -21,9 +27,8 @@ import { createRemoteProjectModule } from "./remote-project-module";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
 import type {
   ResolveHookResult,
-  ResolveHookInput,
   OpenProjectIntent,
-  CloneProgressReporter,
+  CloneProgressFrame,
 } from "../intents/open-project";
 import { CLOSE_PROJECT_OPERATION_ID } from "../intents/close-project";
 import type { CloseHookInput, CloseHookResult, CloseProjectIntent } from "../intents/close-project";
@@ -36,28 +41,44 @@ const URL_PROJECT_ID = "repo-4c06e3f1" as ProjectId;
 
 expect.extend(gitClientMatchers);
 
-const noopReport: CloneProgressReporter = () => {};
-
 // =============================================================================
 // Test Setup
 // =============================================================================
 
 /**
  * Build a ResolvedHooks from a module's hook declarations for a given operation.
+ * Mirrors the Dispatcher: awaits a plain handler, or drains a streaming
+ * (async-generator) handler, forwarding yielded frames to options.onYield.
  */
 function resolveHooksFromModule(module: IntentModule, operationId: string): ResolvedHooks {
   const opHooks = module.hooks?.[operationId] ?? {};
   return {
-    collect: async <T>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>> => {
+    collect: async <T>(
+      hookPointId: string,
+      ctx: HookContext,
+      options?: CollectOptions
+    ): Promise<HookResult<T>> => {
       const hookHandler = opHooks[hookPointId];
       if (!hookHandler) {
         return { results: [], errors: [], capabilities: {} };
       }
       try {
-        const output = await hookHandler.handler(ctx);
+        const invoked = hookHandler.handler(ctx);
+        let output: HookOutput<T> | void;
+        if (typeof invoked === "object" && invoked !== null && Symbol.asyncIterator in invoked) {
+          const gen = invoked as AsyncGenerator<unknown, HookOutput<T> | void, void>;
+          let next = await gen.next();
+          while (!next.done) {
+            if (options?.onYield) await options.onYield(next.value);
+            next = await gen.next();
+          }
+          output = next.value;
+        } else {
+          output = (await invoked) as HookOutput<T> | void;
+        }
         // Unwrap HookOutput.result; filter out undefined/null to match Dispatcher
         // behavior (undefined/null = "not handled")
-        const result = (output as HookOutput<T> | undefined)?.result;
+        const result = output?.result;
         const results: T[] = result !== undefined && result !== null ? [result] : [];
         return { results, errors: [], capabilities: {} };
       } catch (error) {
@@ -97,11 +118,8 @@ function openProjectIntent(payload: { git?: string; path?: Path }): OpenProjectI
   };
 }
 
-function resolveContext(
-  intent: OpenProjectIntent,
-  report: CloneProgressReporter = noopReport
-): ResolveHookInput {
-  return { intent, report };
+function resolveContext(intent: OpenProjectIntent): HookContext {
+  return { intent };
 }
 
 function closeProjectIntent(payload: {
@@ -218,13 +236,10 @@ describe("RemoteProjectModule Integration", () => {
       (gitClient as { clone: typeof gitClient.clone }).clone = originalClone;
     });
 
-    it("reports clone progress via report callback", async () => {
+    it("streams clone progress frames via onYield", async () => {
       const { hookRegistry, gitClient } = createTestSetup();
 
-      const progressEvents: Array<{ stage: string; progress: number; name: string }> = [];
-      const report: CloneProgressReporter = (stage, progress, name) => {
-        progressEvents.push({ stage, progress, name });
-      };
+      const progressFrames: CloneProgressFrame[] = [];
 
       // Override mock clone to invoke onProgress
       const originalClone = gitClient.clone.bind(gitClient);
@@ -241,9 +256,13 @@ describe("RemoteProjectModule Integration", () => {
       const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
       const intent = openProjectIntent({ git: "https://github.com/org/repo.git" });
 
-      await hooks.collect<ResolveHookResult | undefined>("resolve", resolveContext(intent, report));
+      await hooks.collect<ResolveHookResult | undefined>("resolve", resolveContext(intent), {
+        onYield: (frame) => {
+          progressFrames.push(frame as CloneProgressFrame);
+        },
+      });
 
-      expect(progressEvents).toEqual([
+      expect(progressFrames).toEqual([
         { stage: "receiving", progress: 0.5, name: "repo" },
         { stage: "resolving", progress: 1, name: "repo" },
       ]);

--- a/src/modules/remote-project-module.ts
+++ b/src/modules/remote-project-module.ts
@@ -24,9 +24,10 @@ import { expandGitUrl, normalizeGitUrl, extractRepoName } from "../utils/url-uti
 import type {
   OpenProjectIntent,
   ResolveHookResult,
-  ResolveHookInput,
+  CloneProgressFrame,
 } from "../intents/open-project";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
+import { streamProgress } from "../intents/lib/hook-helpers";
 import type { CloseHookInput, CloseHookResult } from "../intents/close-project";
 import { CLOSE_PROJECT_OPERATION_ID } from "../intents/close-project";
 
@@ -69,10 +70,13 @@ export function createRemoteProjectModule(deps: {
       // -----------------------------------------------------------------------
       [OPEN_PROJECT_OPERATION_ID]: {
         resolve: {
-          handler: async (ctx: HookContext): Promise<HookOutput<ResolveHookResult>> => {
+          // Streaming handler: yield clone-progress frames; the open-project operation
+          // adds the url and emits clone:progress. Returns the resolved paths.
+          handler: async function* (
+            ctx: HookContext
+          ): AsyncGenerator<CloneProgressFrame, HookOutput<ResolveHookResult>, void> {
             const intent = ctx.intent as OpenProjectIntent;
             const { git } = intent.payload;
-            const { report } = ctx as ResolveHookInput;
 
             if (!git) {
               return {};
@@ -109,8 +113,10 @@ export function createRemoteProjectModule(deps: {
               gitPath: gitPath.toString(),
             });
 
-            await gitClient.clone(expanded, gitPath, (event) => {
-              report(event.stage, event.progress / 100, repoName);
+            yield* streamProgress<CloneProgressFrame>(async (emit) => {
+              await gitClient.clone(expanded, gitPath, (event) => {
+                emit({ stage: event.stage, progress: event.progress / 100, name: repoName });
+              });
             });
 
             // No saveProject call — LocalProjectModule.register handles persistence


### PR DESCRIPTION
Makes every hook handler pure data-in/data-out so placement is decided solely by the boundaries a module injects — the leaky-handler refactor — plus the supporting planning docs.

**Framework**
- `HookHandler` may now be an async generator that yields progress frames and returns its `HookOutput`; `collect()` gains an `onYield` option. The dispatcher drains generators (non-generator path unchanged — no extra microtask hop, preserving emit/dispatch timing).
- New `streamProgress()` helper bridges callback-driven work (binary download, git clone) into generator yields.

**Operations own emits/dispatch** (removed handler-held closures)
- `app-resume`: handler returns `{restarted}`/`{failed}` data; operation emits `code-server:restarted` / `app:resume-failed`.
- `app-start`: `waitForRetry` closure → an `await-retry` hook point; the operation (not the presentation handler) dispatches `app:ready`.

**Streaming progress** (removed `report` closure from the hook context)
- setup binary/extensions (agent, code-server, debug) and open-project clone (remote-project) become async generators; operations emit `setup:progress` / `clone:progress` via `onYield`.
- `delete confirm` left as-is: already pure data + host-pinned (progressive dialog fill).

**Also in branch**
- Earlier reshape: operation-consumed hook values moved from capabilities to results.
- Planning: remote-workspaces federation plan re-grounded on data/module placement, the wire-codec/zod design, and the leaky-handler design.