### PR TITLE
fix: sidebar was blurred when workspace was loading

### DIFF
--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -151,10 +151,18 @@ function systemDialog(sections: unknown[], id = "dlg-1"): unknown {
   return { id, kind: "modal", config: { sections } };
 }
 /** The single open system dialog in the latest snapshot (asserts exactly one). */
-function currentSystemDialog(deps: Deps): { id: string; config: { sections: unknown[] } } {
+function currentSystemDialog(deps: Deps): {
+  id: string;
+  kind: string;
+  config: { sections: unknown[] };
+} {
   const dialogs = lastSnapshot(deps).dialogs;
   expect(dialogs).toHaveLength(1);
-  return dialogs[0]! as unknown as { id: string; config: { sections: unknown[] } };
+  return dialogs[0]! as unknown as {
+    id: string;
+    kind: string;
+    config: { sections: unknown[] };
+  };
 }
 
 function makeWorkspace(
@@ -512,7 +520,12 @@ describe("PresentationModule - ui:state snapshots", () => {
     // system dialog covers it.
     expect(snapshot.frames).toEqual({});
     expect(snapshot.main).toEqual({ kind: "workspace", frameKey: `${PROJECT_ID}/feat` });
+    // Mid-session loading is a "panel" (no blur/dim over the live sidebar), not a
+    // blocking modal — rendered below the sidebar by PanelView, like the deletion
+    // panel. A panel does not count as a modal, so the mode is not "dialog".
+    expect(currentSystemDialog(deps).kind).toBe("panel");
     expect(currentSystemDialog(deps).config.sections).toEqual([LOADING_SPINNER]);
+    expect(snapshot.mode).not.toBe("dialog");
   });
 
   it("workspace:created swaps the creating placeholder in place (same key)", async () => {
@@ -1390,6 +1403,9 @@ describe("PresentationModule - startup flow", () => {
     // not by this handler — the handler only advances the UI phase.
     expect(dispatched).toEqual([]);
     expect(lastSnapshot(deps).main).toEqual({ kind: "starting" });
+    // Boot-phase loading stays a blocking modal (MainView is unmounted while
+    // main is "starting", so DialogHost must own the screen).
+    expect(currentSystemDialog(deps).kind).toBe("modal");
     expect(currentSystemDialog(deps).config.sections).toEqual([LOADING_SPINNER]);
 
     // app:started leaves the startup flow: the dialog closes, creation is ground.

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -427,9 +427,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   // ---------------------------------------------------------------------------
   // Startup flow view-model (boot splash, first-run setup, agent-selection,
   // workspace loading). Everything the user sees before app:started — and the
-  // mid-session "workspace still creating" overlay — is a single modal dialog
-  // (the "system dialog") layered over a blank `main: { kind: "starting" }`
-  // base; `reconcileSystemDialog()` (run inside push) projects it from state.
+  // mid-session "workspace still creating" overlay — is a single reconciled
+  // "system dialog". The startup surfaces are modals over a blank
+  // `main: { kind: "starting" }` base; the mid-session loading overlay is a
+  // "panel" (no blur/dim) below the sidebar over the not-yet-mounted frame.
+  // `reconcileSystemDialog()` (run inside push) projects it from state.
   // ---------------------------------------------------------------------------
 
   /**
@@ -497,6 +499,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   /** JSON of the last-applied system-dialog config (null = closed). Guards
    *  reconcile against redundant updates (and thus push loops). */
   let systemDialogConfigJson: string | null = null;
+  /** Kind of the currently-open system dialog (null = closed). A dialog's kind
+   *  is immutable, so a kind change (e.g. boot "running" loading modal → the
+   *  mid-session loading panel, both carrying the identical spinner config)
+   *  forces a close + reopen rather than an update(). */
+  let systemDialogKind: DialogKind | null = null;
   /** True only while push() is reconciling: suppresses the dialog mutations'
    *  own scheduleUpdate (the in-flight push already carries them). */
   let inPush = false;
@@ -676,9 +683,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * Alt+X still works.
    */
   function buildMode(main: UiMainView): UIMode {
-    // The startup surfaces and the mid-session loading overlay are modal system
-    // dialogs now, so isModalOpen() already yields "dialog" for them — no
-    // startup special-case needed.
+    // The startup surfaces are modal system dialogs, so isModalOpen() already
+    // yields "dialog" for them — no startup special-case needed. The mid-session
+    // loading surface is a "panel" (not modal), so it falls through to the
+    // active workspace's mode, keeping the sidebar navigable — same as the
+    // deletion panel.
     if (shortcutActive) return "shortcut";
     if (dialogs.isModalOpen()) return "dialog";
     if (main.kind === "creation" || hoverRegion === "sidebar") return "hover";
@@ -688,12 +697,13 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   // ---------------------------------------------------------------------------
   // System dialog (startup surfaces + mid-session loading)
   //
-  // One modal dialog projects the whole pre-`app:started` flow and the
+  // One dialog handle projects the whole pre-`app:started` flow and the
   // still-creating-workspace overlay. It is reconciled from state in push():
-  // computeSystemDialogConfig() maps the current phase (or mid-session loading)
-  // to a DialogConfig, or null when nothing should show. reconcileSystemDialog()
-  // opens/updates/closes the handle to match, guarded by a JSON compare so an
-  // unchanged config never re-pushes.
+  // computeSystemDialog() maps the current phase (or mid-session loading) to a
+  // { config, kind } (modal for startup, panel for mid-session loading), or null
+  // when nothing should show. reconcileSystemDialog() opens/updates/closes the
+  // handle to match, guarded by a JSON+kind compare so an unchanged state never
+  // re-pushes; a kind change forces close + reopen (kind is immutable).
   // ---------------------------------------------------------------------------
 
   /** A centered spinner + label (boot splash / loading), via a spinner row. */
@@ -763,23 +773,33 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     };
   }
 
-  /** The desired system-dialog config for the current state, or null for none. */
-  function computeSystemDialogConfig(): DialogConfig | null {
+  /**
+   * The desired system-dialog config + kind for the current state, or null for
+   * none. All startup-phase surfaces are blocking modals (MainView is unmounted
+   * then, so DialogHost must own the screen). The mid-session loading surface is
+   * a "panel" instead: MainView is mounted, so blurring/dimming the live sidebar
+   * would wrongly read as disabled — the workspace frame is simply not up yet,
+   * exactly like the deletion panel masking a torn-down frame. Both render via
+   * PanelView, below the sidebar, with no backdrop.
+   */
+  function computeSystemDialog(): { config: DialogConfig; kind: DialogKind } | null {
     if (shuttingDown) return null;
     switch (startupPhase) {
       case "starting":
-        return spinnerConfig("CodeHydra is starting…");
+        return { config: spinnerConfig("CodeHydra is starting…"), kind: "modal" };
       case "setup":
-        return setupConfig();
+        return { config: setupConfig(), kind: "modal" };
       case "agent-selection":
-        return agentConfig();
+        return { config: agentConfig(), kind: "modal" };
       case "running":
-        return spinnerConfig("Loading workspace...");
+        return { config: spinnerConfig("Loading workspace..."), kind: "modal" };
       case "done": {
         // Mid-session: a still-creating active workspace has no frame yet.
         if (activeKey === null) return null;
         const active = findByKey(activeKey);
-        return active?.workspace.creating ? spinnerConfig("Loading workspace...") : null;
+        return active?.workspace.creating
+          ? { config: spinnerConfig("Loading workspace..."), kind: "panel" }
+          : null;
       }
     }
   }
@@ -824,19 +844,25 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * config a no-op, so this never loops.
    */
   function reconcileSystemDialog(): void {
-    const config = computeSystemDialogConfig();
-    const json = config === null ? null : JSON.stringify(config);
-    if (json === systemDialogConfigJson) return;
+    const desired = computeSystemDialog();
+    const json = desired === null ? null : JSON.stringify(desired.config);
+    const kind = desired?.kind ?? null;
+    if (json === systemDialogConfigJson && kind === systemDialogKind) return;
+    const kindChanged = kind !== systemDialogKind;
     systemDialogConfigJson = json;
-    if (config === null) {
+    systemDialogKind = kind;
+    if (desired === null) {
       systemDialog?.close();
       systemDialog = null;
       return;
     }
-    if (systemDialog) {
-      systemDialog.update(config);
+    // Kind is immutable per session: a kind change (config may be identical, as
+    // on the boot "running" → mid-session loading transition) needs close + reopen.
+    if (systemDialog && !kindChanged) {
+      systemDialog.update(desired.config);
     } else {
-      systemDialog = dialogs.open(config, { kind: "modal" });
+      systemDialog?.close();
+      systemDialog = dialogs.open(desired.config, { kind: desired.kind });
       systemDialog.onEvent(handleSystemAction);
     }
   }
@@ -1730,6 +1756,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
             systemDialog?.close();
             systemDialog = null;
             systemDialogConfigJson = null;
+            systemDialogKind = null;
             unsubscribeFromUI();
             if (themeUnsubscribe) {
               themeUnsubscribe();

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -65,11 +65,15 @@
    */
   const creationDialog = $derived(ui.dialogs.find((d) => d.kind === "modeless"));
   /**
-   * The deletion progress/failed session ("panel" kind), rendered below the
-   * sidebar in place of the (already torn-down) workspace view. The deletion
-   * module opens it only while its workspace is the active one.
+   * The "panel" kind session, rendered below the sidebar in place of the
+   * workspace view (opaque, no blur/dim). Two mutually-exclusive producers use
+   * it for the active workspace: the deletion module (progress/failed over the
+   * already-torn-down frame) and the presenter's mid-session "Loading
+   * workspace…" overlay (over the not-yet-mounted frame of a still-creating
+   * workspace). An active workspace is only ever creating xor deleting, so at
+   * most one panel dialog exists at a time.
    */
-  const deletionDialog = $derived(ui.dialogs.find((d) => d.kind === "panel"));
+  const panelDialog = $derived(ui.dialogs.find((d) => d.kind === "panel"));
   /** Whether a blocking modal is open above the panels (drives panel refocus). */
   const modalAbove = $derived(ui.dialogs.some((d) => d.kind === "modal"));
   /** The creation panel is the ground state: shown whenever main says so. */
@@ -95,10 +99,11 @@
   const activeFrameKey = $derived(main?.kind === "workspace" ? main.frameKey : null);
 
   // The mid-session "Loading workspace…" surface (a still-creating active
-  // workspace, no frame yet) is a modal system dialog now, driven by the
-  // presenter and rendered by App's DialogHost over the kept-alive frames —
-  // MainView no longer renders it. `main` reads `workspace` with a frameKey
-  // whose iframe is not mounted yet, so the workspace area is blank underneath.
+  // workspace, no frame yet) is a "panel" kind system dialog driven by the
+  // presenter, rendered by the panelDialog branch below (NOT a blurring modal:
+  // the sidebar stays crisp and navigable). `main` reads `workspace` with a
+  // frameKey whose iframe is not mounted yet, so the workspace area is blank
+  // underneath and the opaque panel masks it.
 
   // Mode (including dialog/hover z-order) is now computed in main and shipped
   // in the snapshot; the renderer no longer mirrors dialog/hover state back.
@@ -222,18 +227,14 @@
     />
   {/if}
 
-  <!-- Deletion panel ("panel"): the deletion module's progress/failed session,
-       shown in place of the active workspace's (already torn-down) view, BELOW
-       the sidebar so the sidebar stays on top and navigable. The module opens
-       it only while its workspace is the active one, so it never coexists with
-       the creation ground state. -->
-  {#if main?.kind === "workspace" && deletionDialog}
-    <PanelView
-      dialogId={deletionDialog.id}
-      config={deletionDialog.config}
-      kind="panel"
-      {modalAbove}
-    />
+  <!-- Panel ("panel"): the deletion module's progress/failed session OR the
+       presenter's mid-session "Loading workspace…" overlay, shown in place of
+       the active workspace's (torn-down or not-yet-mounted) view, BELOW the
+       sidebar so the sidebar stays on top and navigable. Both target the active
+       workspace and are mutually exclusive, so they never coexist with the
+       creation ground state or each other. -->
+  {#if main?.kind === "workspace" && panelDialog}
+    <PanelView dialogId={panelDialog.id} config={panelDialog.config} kind="panel" {modalAbove} />
   {/if}
 
   {#if main?.kind === "hibernated"}


### PR DESCRIPTION
- The mid-session "Loading workspace…" overlay (a still-creating active workspace) was opened as a modal system dialog, so DialogView painted a blurred/dimmed scrim over the live, navigable sidebar — misleadingly reading as disabled.
- Render mid-session loading as a `panel` kind dialog instead (opaque layer below the sidebar, no blur/dim), exactly like the deletion panel that masks a torn-down frame. The sidebar stays crisp and interactive.
- Startup-phase surfaces (boot splash, setup, agent picker, boot "running" load) stay modal — MainView is unmounted then, so DialogHost must own the screen.
- The presenter now tracks the desired dialog kind and close+reopens the handle when only the kind changes (the loading spinner config is byte-identical across the boot→first-workspace transition, and a dialog's kind is immutable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)