### PR TITLE
feat: shows download/extraction progress during setup

### DIFF
--- a/src/boundaries/platform/archive-extractor.boundary.test.ts
+++ b/src/boundaries/platform/archive-extractor.boundary.test.ts
@@ -84,6 +84,26 @@ describe("TarExtractor (boundary)", () => {
     expect(nestedContent).toBe("Nested content");
   });
 
+  it("reports extraction progress ending at 100% of the archive size", async () => {
+    const sourceDir = path.join(tempDir, "source");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "test.txt"), "Hello, World!");
+    await tar.create({ gzip: true, file: archivePath, cwd: sourceDir }, ["."]);
+
+    const archiveSize = (await fs.stat(archivePath)).size;
+    const updates: { processed: number; total: number }[] = [];
+
+    const extractor = new TarExtractor();
+    await extractor.extract(archivePath, new Path(destDir), (processed, total) => {
+      updates.push({ processed, total });
+    });
+
+    expect(updates.length).toBeGreaterThan(0);
+    // Total is the archive's compressed byte size, monotonic and terminating at 100%.
+    expect(updates.every((u) => u.total === archiveSize)).toBe(true);
+    expect(updates[updates.length - 1]?.processed).toBe(archiveSize);
+  });
+
   it("preserves file permissions", async () => {
     // Skip on Windows where permissions work differently
     if (process.platform === "win32") {
@@ -210,6 +230,26 @@ describe("ZipExtractor (boundary)", () => {
 
     const nestedContent = await fs.readFile(path.join(destDir, "subdir", "nested.txt"), "utf-8");
     expect(nestedContent).toBe("Nested zip content");
+  });
+
+  it("reports extraction progress by entry count", async () => {
+    const sourceDir = path.join(tempDir, "source");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "a.txt"), "one");
+    await fs.writeFile(path.join(sourceDir, "b.txt"), "two");
+    await fs.writeFile(path.join(sourceDir, "c.txt"), "three");
+    await createTestZip(sourceDir, archivePath);
+
+    const updates: { processed: number; total: number }[] = [];
+    const extractor = new ZipExtractor();
+    await extractor.extract(archivePath, new Path(destDir), (processed, total) => {
+      updates.push({ processed, total });
+    });
+
+    // One update per entry (3 files), each reporting the same total, ending at total.
+    expect(updates.length).toBe(3);
+    expect(updates.every((u) => u.total === 3)).toBe(true);
+    expect(updates.map((u) => u.processed)).toEqual([1, 2, 3]);
   });
 
   it("throws ArchiveError for corrupt zip file", async () => {

--- a/src/boundaries/platform/archive-extractor.state-mock.ts
+++ b/src/boundaries/platform/archive-extractor.state-mock.ts
@@ -10,7 +10,7 @@
  */
 
 import { expect } from "vitest";
-import type { ArchiveExtractor } from "./archive-extractor";
+import type { ArchiveExtractor, ExtractProgressCallback } from "./archive-extractor";
 import type { ArchiveErrorCode } from "../../shared/errors/service-errors";
 import { ArchiveError } from "../../shared/errors/service-errors";
 import { Path } from "../../utils/path/path";
@@ -40,6 +40,12 @@ export interface ExtractionResult {
     readonly message: string;
     readonly code: ArchiveErrorCode;
   };
+  /**
+   * Progress frames `[processed, total]` to feed to the extract `onProgress`
+   * callback (in order) before the extraction resolves. Lets tests drive
+   * extraction-progress behavior without a real archive.
+   */
+  readonly progressFrames?: ReadonlyArray<readonly [number, number]>;
 }
 
 /** Mock state - pure data, logic in matchers. */
@@ -132,7 +138,11 @@ export function createArchiveExtractorMock(
   const mock: MockArchiveExtractor = {
     $: state,
 
-    async extract(archivePath: string, destDir: Path): Promise<void> {
+    async extract(
+      archivePath: string,
+      destDir: Path,
+      onProgress?: ExtractProgressCallback
+    ): Promise<void> {
       // Normalize the archive path for lookup
       const normalizedArchivePath = new Path(archivePath).toString();
       const normalizedDestDir = destDir.toString();
@@ -143,6 +153,13 @@ export function createArchiveExtractorMock(
       // If error is configured, throw without recording
       if (result.error) {
         throw new ArchiveError(result.error.message, result.error.code);
+      }
+
+      // Drive any configured progress frames through the callback
+      if (onProgress && result.progressFrames) {
+        for (const [processed, total] of result.progressFrames) {
+          onProgress(processed, total);
+        }
       }
 
       // Record successful extraction

--- a/src/boundaries/platform/archive-extractor.ts
+++ b/src/boundaries/platform/archive-extractor.ts
@@ -6,9 +6,18 @@ import * as tar from "tar";
 import yauzl from "yauzl";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { ArchiveError, getErrorMessage } from "../../shared/errors/service-errors.js";
 import { Path } from "../../utils/path/path.js";
+
+/**
+ * Progress callback for archive extraction. Unit-agnostic: `processed`/`total`
+ * are compressed bytes for tar (bytes consumed from the archive) and entry
+ * counts for zip (entries extracted / total entries). Either way
+ * `processed / total` yields a valid completion fraction.
+ */
+export type ExtractProgressCallback = (processed: number, total: number) => void;
 
 /**
  * Interface for extracting archives.
@@ -19,23 +28,37 @@ export interface ArchiveExtractor {
    *
    * @param archivePath - Path to the archive file
    * @param destDir - Directory to extract to (will be created if it doesn't exist)
+   * @param onProgress - Optional callback invoked with extraction progress
    * @throws ArchiveError on extraction failure
    */
-  extract(archivePath: string, destDir: Path): Promise<void>;
+  extract(archivePath: string, destDir: Path, onProgress?: ExtractProgressCallback): Promise<void>;
 }
 
 /**
  * Extractor for .tar.gz archives using the `tar` package.
  */
 export class TarExtractor implements ArchiveExtractor {
-  async extract(archivePath: string, destDir: Path): Promise<void> {
+  async extract(
+    archivePath: string,
+    destDir: Path,
+    onProgress?: ExtractProgressCallback
+  ): Promise<void> {
     const destPath = destDir.toNative();
     try {
       await fs.promises.mkdir(destPath, { recursive: true });
-      await tar.extract({
-        file: archivePath,
-        cwd: destPath,
+      // Stream from disk so we can count compressed bytes consumed against the
+      // archive's total size. `tar.extract` with no `file` returns a writable
+      // Unpack stream; pipeline waits for all entries to be written to disk.
+      const { size: total } = await fs.promises.stat(archivePath);
+      let processed = 0;
+      const counter = new Transform({
+        transform(chunk: Buffer, _enc, cb): void {
+          processed += chunk.length;
+          onProgress?.(processed, total);
+          cb(null, chunk);
+        },
       });
+      await pipeline(fs.createReadStream(archivePath), counter, tar.extract({ cwd: destPath }));
     } catch (error) {
       const message = getErrorMessage(error);
       if (message.includes("EACCES") || message.includes("EPERM")) {
@@ -63,11 +86,15 @@ export class TarExtractor implements ArchiveExtractor {
  * Extractor for .zip archives using the `yauzl` package.
  */
 export class ZipExtractor implements ArchiveExtractor {
-  async extract(archivePath: string, destDir: Path): Promise<void> {
+  async extract(
+    archivePath: string,
+    destDir: Path,
+    onProgress?: ExtractProgressCallback
+  ): Promise<void> {
     const destPath = destDir.toNative();
     try {
       await fs.promises.mkdir(destPath, { recursive: true });
-      await this.extractZip(archivePath, destDir);
+      await this.extractZip(archivePath, destDir, onProgress);
     } catch (error) {
       if (error instanceof ArchiveError) {
         throw error;
@@ -83,7 +110,11 @@ export class ZipExtractor implements ArchiveExtractor {
     }
   }
 
-  private extractZip(archivePath: string, destDir: Path): Promise<void> {
+  private extractZip(
+    archivePath: string,
+    destDir: Path,
+    onProgress?: ExtractProgressCallback
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
       yauzl.open(archivePath, { lazyEntries: true }, (err, zipfile) => {
         if (err) {
@@ -104,6 +135,16 @@ export class ZipExtractor implements ArchiveExtractor {
           }
           return;
         }
+
+        // zip's central directory gives the total entry count upfront, so we
+        // report progress by entries completed rather than bytes.
+        const total = zipfile.entryCount;
+        let processed = 0;
+        const advance = (): void => {
+          processed += 1;
+          onProgress?.(processed, total);
+          zipfile.readEntry();
+        };
 
         zipfile.readEntry();
         zipfile.on("entry", (entry) => {
@@ -142,7 +183,7 @@ export class ZipExtractor implements ArchiveExtractor {
             // Directory entry
             fs.promises
               .mkdir(nativeEntryPath, { recursive: true })
-              .then(() => zipfile.readEntry())
+              .then(() => advance())
               .catch(reject);
           } else {
             // File entry
@@ -169,7 +210,7 @@ export class ZipExtractor implements ArchiveExtractor {
                         await fs.promises.chmod(nativeEntryPath, mode);
                       }
                     })
-                    .then(() => zipfile.readEntry())
+                    .then(() => advance())
                     .catch(reject);
                 });
               })
@@ -200,15 +241,19 @@ export class DefaultArchiveExtractor implements ArchiveExtractor {
     this.zipExtractor = new ZipExtractor();
   }
 
-  async extract(archivePath: string, destDir: Path): Promise<void> {
+  async extract(
+    archivePath: string,
+    destDir: Path,
+    onProgress?: ExtractProgressCallback
+  ): Promise<void> {
     const lowerPath = archivePath.toLowerCase();
 
     if (lowerPath.endsWith(".tar.gz") || lowerPath.endsWith(".tgz")) {
-      return this.tarExtractor.extract(archivePath, destDir);
+      return this.tarExtractor.extract(archivePath, destDir, onProgress);
     }
 
     if (lowerPath.endsWith(".zip")) {
-      return this.zipExtractor.extract(archivePath, destDir);
+      return this.zipExtractor.extract(archivePath, destDir, onProgress);
     }
 
     throw new ArchiveError(

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -794,6 +794,7 @@ describe("createAgentModule", () => {
         id: "agent",
         status: "running",
         message: "Extracting...",
+        progress: 100,
       });
     });
 

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -327,18 +327,22 @@ export function createAgentModule(
             yield { id: "agent", status: "running", message: "Downloading..." };
             try {
               yield* streamProgress<SetupProgressPayload>(async (emit) => {
+                let lastKey = "";
                 await provider.downloadBinary((p) => {
-                  if (p.phase === "downloading" && p.totalBytes) {
-                    const pct = Math.floor((p.bytesDownloaded / p.totalBytes) * 100);
-                    emit({
-                      id: "agent",
-                      status: "running",
-                      message: "Downloading...",
-                      progress: pct,
-                    });
-                  } else if (p.phase === "extracting") {
-                    emit({ id: "agent", status: "running", message: "Extracting..." });
-                  }
+                  const pct = p.totalBytes
+                    ? Math.floor((p.bytesDownloaded / p.totalBytes) * 100)
+                    : undefined;
+                  // Throttle: only forward when the phase or integer % changes.
+                  const key = `${p.phase}:${pct ?? "x"}`;
+                  if (key === lastKey) return;
+                  lastKey = key;
+                  const message = p.phase === "downloading" ? "Downloading..." : "Extracting...";
+                  emit({
+                    id: "agent",
+                    status: "running",
+                    message,
+                    ...(pct !== undefined && { progress: pct }),
+                  });
                 });
               });
               yield { id: "agent", status: "done" };

--- a/src/modules/code-server-module.integration.test.ts
+++ b/src/modules/code-server-module.integration.test.ts
@@ -652,6 +652,36 @@ describe("CodeServerModule", () => {
       });
     });
 
+    it("reports extraction progress on the vscode row", async () => {
+      const archiveExtractor = createArchiveExtractorMock({
+        defaultResult: {
+          progressFrames: [
+            [50, 100],
+            [100, 100],
+          ],
+        },
+      });
+      const deps = createDownloadDeps({ archiveExtractor });
+      const { dispatcher } = createTestSetup(deps);
+      const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
+      dispatcher.registerOperation("setup", op);
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(op.frames).toContainEqual({
+        id: "vscode",
+        status: "running",
+        message: "Extracting...",
+        progress: 50,
+      });
+      expect(op.frames).toContainEqual({
+        id: "vscode",
+        status: "running",
+        message: "Extracting...",
+        progress: 100,
+      });
+    });
+
     it("throws SetupError on download failure", async () => {
       const archiveExtractor = createArchiveExtractorMock({
         defaultResult: { error: { message: "corrupt archive", code: "INVALID_ARCHIVE" } },

--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -802,18 +802,22 @@ export function createCodeServerModule(deps: CodeServerModuleDeps): IntentModule
             yield { id: "vscode", status: "running", message: "Downloading..." };
             try {
               yield* streamProgress<SetupProgressPayload>(async (emit) => {
+                let lastKey = "";
                 await downloadCodeServer((p) => {
-                  if (p.phase === "downloading" && p.totalBytes) {
-                    const pct = Math.floor((p.bytesDownloaded / p.totalBytes) * 100);
-                    emit({
-                      id: "vscode",
-                      status: "running",
-                      message: "Downloading...",
-                      progress: pct,
-                    });
-                  } else if (p.phase === "extracting") {
-                    emit({ id: "vscode", status: "running", message: "Extracting..." });
-                  }
+                  const pct = p.totalBytes
+                    ? Math.floor((p.bytesDownloaded / p.totalBytes) * 100)
+                    : undefined;
+                  // Throttle: only forward when the phase or integer % changes.
+                  const key = `${p.phase}:${pct ?? "x"}`;
+                  if (key === lastKey) return;
+                  lastKey = key;
+                  const message = p.phase === "downloading" ? "Downloading..." : "Extracting...";
+                  emit({
+                    id: "vscode",
+                    status: "running",
+                    message,
+                    ...(pct !== undefined && { progress: pct }),
+                  });
                 });
               });
               yield { id: "vscode", status: "done" };

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -1270,7 +1270,7 @@ describe("PresentationModule - startup flow", () => {
       { type: "text", content: "This is only required on first startup.", style: "subtitle" },
       {
         type: "progress",
-        style: "spinner",
+        style: "bar",
         items: [
           { id: "vscode", label: "VSCode", status: "pending" },
           { id: "agent", label: "Agent", status: "pending" },
@@ -1300,7 +1300,7 @@ describe("PresentationModule - startup flow", () => {
 
     expect(currentSystemDialog(deps).config.sections).toContainEqual({
       type: "progress",
-      style: "spinner",
+      style: "bar",
       items: [
         { id: "vscode", label: "VSCode", status: "done" },
         { id: "agent", label: "Agent", status: "running", message: "Downloading", progress: 42 },

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -727,7 +727,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     const sections: DialogSection[] = [
       { type: "text", content: "Setting up CodeHydra", style: "heading" },
       { type: "text", content: "This is only required on first startup.", style: "subtitle" },
-      { type: "progress", style: "spinner", items },
+      { type: "progress", style: "bar", items },
     ];
     if (setupError !== undefined) {
       sections.push({ type: "text", content: setupError.message, style: "error" });

--- a/src/utils/binary-download/download.integration.test.ts
+++ b/src/utils/binary-download/download.integration.test.ts
@@ -238,9 +238,14 @@ describe("downloadBinary (integration)", () => {
         expect(lastDownloadProgress?.bytesDownloaded).toBe(archiveContent.length);
         expect(lastDownloadProgress?.totalBytes).toBe(archiveContent.length);
 
-        // Should have extracting phase at the end
+        // Should report the extracting phase, ending at 100% (compressed bytes
+        // consumed == archive size).
         const extractUpdates = progressUpdates.filter((p) => p.phase === "extracting");
-        expect(extractUpdates.length).toBe(1);
+        expect(extractUpdates.length).toBeGreaterThan(0);
+        const measuredExtract = extractUpdates.filter((p) => p.totalBytes !== null);
+        expect(measuredExtract.length).toBeGreaterThan(0);
+        const lastExtract = measuredExtract[measuredExtract.length - 1];
+        expect(lastExtract?.bytesDownloaded).toBe(lastExtract?.totalBytes);
       } finally {
         await cleanupTestArchive(archivePath);
       }

--- a/src/utils/binary-download/download.ts
+++ b/src/utils/binary-download/download.ts
@@ -76,13 +76,17 @@ export async function downloadBinary(
     // Download to temp file
     await downloadToFile(url, tempFile, deps, onProgress);
 
-    // Signal extraction phase before starting
+    // Signal extraction phase before starting so the UI flips to "Extracting..."
+    // immediately, even before the first progress callback arrives.
     if (onProgress) {
       onProgress({ phase: "extracting", bytesDownloaded: 0, totalBytes: null });
     }
 
-    // Extract archive
-    await deps.archiveExtractor.extract(tempFile, new Path(destDir));
+    // Extract archive, forwarding extraction progress (unit-agnostic:
+    // compressed bytes for tar, entry counts for zip).
+    await deps.archiveExtractor.extract(tempFile, new Path(destDir), (processed, total) => {
+      onProgress?.({ phase: "extracting", bytesDownloaded: processed, totalBytes: total });
+    });
 
     // Promote subPath contents to destDir root if specified
     await extractSubPath(destDir, request.subPath ?? "", deps);

--- a/src/utils/binary-download/types.ts
+++ b/src/utils/binary-download/types.ts
@@ -18,9 +18,16 @@ export type DownloadPhase = "downloading" | "extracting";
 export interface DownloadProgress {
   /** Current phase of operation */
   phase: DownloadPhase;
-  /** Number of bytes downloaded so far (only for downloading phase) */
+  /**
+   * Units processed so far: bytes downloaded (downloading phase), or extraction
+   * progress (extracting phase) — compressed bytes for tar, entry count for zip.
+   */
   bytesDownloaded: number;
-  /** Total bytes to download, null if Content-Length not provided (only for downloading phase) */
+  /**
+   * Total units to process: Content-Length (downloading, null if not provided),
+   * or the extraction total (extracting) — archive size for tar, entry count for
+   * zip. null when unknown.
+   */
   totalBytes: number | null;
 }
 


### PR DESCRIPTION
During first-run setup, download progress was computed but hidden (the setup dialog used a spinner style that suppressed the bar), and extraction had no progress data at all. Now both phases report a real percentage rendered as a determinate bar.

- `ArchiveExtractor.extract` gains an optional `onProgress(processed, total)` callback: tar reports compressed bytes consumed vs archive size (streamed extraction); zip reports entries done vs `entryCount`.
- `download.ts` forwards extraction progress; the code-server and agent binary setup hooks now emit a percentage for both phases, throttled to integer-% changes.
- Setup dialog switches from spinner to bar style so the percentages render (resets and refills per phase).
- Added tar/zip progress boundary tests, extraction-progress integration coverage, and a `progressFrames` hook on the archive-extractor state mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)