### PR TITLE
feat(shortcut): make bug reports (Alt+X+B) reachable in every state

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "Bash(pnpm validate:*)",
       "Bash(pnpm build:*)",
       "Bash(pnpm --version:*)",
-      "Bash(tsc --version:*)"
+      "Bash(tsc --version:*)",
+      "Bash(gh pr merge:*)"
     ]
   },
   "enabledPlugins": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -661,12 +661,12 @@ See [VS Code Setup](#vs-code-setup) for the main process side of this flow.
 
 The application uses a unified UI mode system with four modes:
 
-| Mode        | UI Z-Order | Focus          | Description                              |
-| ----------- | ---------- | -------------- | ---------------------------------------- |
-| `workspace` | Behind     | Workspace view | Normal editing mode                      |
-| `shortcut`  | On top     | UI layer       | Shortcut overlay visible                 |
-| `dialog`    | On top     | Dialog (no-op) | Modal dialog open (blocks Alt+X)         |
-| `hover`     | On top     | No change      | Sidebar expanded on hover (allows Alt+X) |
+| Mode        | UI Z-Order | Focus          | Description                               |
+| ----------- | ---------- | -------------- | ----------------------------------------- |
+| `workspace` | Behind     | Workspace view | Normal editing mode                       |
+| `shortcut`  | On top     | UI layer       | Shortcut overlay visible                  |
+| `dialog`    | On top     | Dialog (no-op) | Modal open (Alt+X → restricted: `b` only) |
+| `hover`     | On top     | No change      | Sidebar expanded on hover (allows Alt+X)  |
 
 ```
 WORKSPACE MODE (normal):
@@ -702,12 +702,18 @@ SHORTCUT/DIALOG MODE (overlay):
 | Sidebar hover stops  | hover → workspace    |
 | Dialog opens (hover) | hover → dialog       |
 
-**Alt+X Blocking:**
+**Alt+X over a modal (restricted mode):**
 
-Alt+X is blocked when `mode === "dialog"` but allowed for all other modes including `"hover"`. This allows:
-
-- Activating shortcut mode while hovering over the expanded sidebar
-- Blocking shortcut mode when a modal dialog is open (focus trap is active)
+Alt+X is never fully blocked. When a modal is open (`isModalOpen()`), Alt+X still
+activates but in a **restricted** mode: only the bug-report key (`b`) is forwarded
+and the module does **not** broadcast `ui:set-shortcut-active`, so the presenter is
+untouched — no overlay, no sidebar badges, no ARIA, no workspace blur, and `mode`
+stays `dialog`. This keeps a **bug report reachable in every state**, including over
+the startup/setup screens (themselves modal system dialogs) and over ordinary
+modals like settings. `isModalOpen()` is read live per key press, so a modal opening
+mid-gesture transparently narrows to `b`. With no modal open, Alt+X behaves as
+before (full mode, all keys + affordances) — including while hovering the expanded
+sidebar. See `shortcut-module.ts`.
 
 **Computation:** mode is derived in main by the presenter, not commanded by the
 renderer. The presenter folds it into the `UiState` snapshot as `ui.mode`; the
@@ -1425,7 +1431,8 @@ CodeHydra uses a **unified main-process keyboard capture system** where all shor
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ Main Process — capture: shortcut-module                                  │
 │  ├─ Registers before-input-event on ALL WebViews (workspace + UI)       │
-│  ├─ Alt+X (unless presenter.isModalOpen) → dispatch set-shortcut-active │
+│  ├─ Alt+X → dispatch set-shortcut-active (skipped if isModalOpen:       │
+│  │    restricted mode, only "b" forwarded, no broadcast)                │
 │  ├─ Action keys while active → dispatch shortcut:key                    │
 │  └─ Alt release / Escape / blur → dispatch set-shortcut-active(false)   │
 ├─────────────────────────────────────────────────────────────────────────┤
@@ -1490,7 +1497,7 @@ CodeHydra uses a **unified main-process keyboard capture system** where all shor
 
 1. **Main owns detection AND interpretation**: capture (shortcut-module) and navigation/mode (presenter) both live in main — no renderer shortcut logic, eliminating focus/key races.
 2. **Mode is computed, not commanded**: the presenter derives `ui.mode` from its own state and ships it in the snapshot; the renderer never sets mode.
-3. **Alt+X guard**: the presenter's `isModalOpen()` blocks Alt+X while a modal dialog is open (focus trap active).
+3. **Alt+X over a modal**: `isModalOpen()` doesn't block Alt+X — it downgrades it to restricted mode (only the bug-report key `b` forwarded, no `set-shortcut-active` broadcast), so a bug report stays reachable over any modal / the startup screens without lighting up the overlay or trapping focus.
 4. **Coalesced pushes**: snapshot pushes batch per microtask, so mode recomputes that don't change anything are collapsed.
 
 ## Data Flow

--- a/src/modules/shortcut-module.integration.test.ts
+++ b/src/modules/shortcut-module.integration.test.ts
@@ -4,9 +4,11 @@
  *
  * The module owns the Alt+X state machine and the local `shortcutActive` flag,
  * broadcasting entry/exit via the ui:set-shortcut-active intent and forwarding
- * keys (while active) via shortcut:key. The Alt+X guard reads the
- * dialog-manager's synchronous isModalOpen() signal. Escape and window blur
- * exit shortcut mode (blur is suppressed briefly after a navigation switch).
+ * keys (while active) via shortcut:key. When a modal is open (isModalOpen()),
+ * Alt+X still activates but in a restricted mode: only the bug-report key ("b")
+ * is forwarded and nothing is broadcast (no UI affordances) — so a bug report is
+ * reachable over any modal / the startup screens. Escape and window blur exit
+ * shortcut mode (blur is suppressed briefly after a navigation switch).
  *
  * IMPORTANT: These tests verify that NO keys are prevented via preventDefault().
  * Electron bug #37336 causes keyUp events to not fire when keyDown was
@@ -295,7 +297,7 @@ describe("ShortcutModule integration", () => {
       expect(setActiveCalls(dispatchSpy)).toEqual([{ active: true }]);
     });
 
-    it("does not activate when a modal dialog is open", async () => {
+    it("does not broadcast when a modal dialog is open (enters restricted mode)", async () => {
       const { callbacks, dispatchSpy } = await createHarness(true);
       activate(callbacks);
       expect(dispatchSpy).not.toHaveBeenCalledWith(
@@ -456,6 +458,65 @@ describe("ShortcutModule integration", () => {
       expect(dispatchSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: INTENT_SHORTCUT_KEY })
       );
+    });
+  });
+
+  describe("restricted mode (modal open)", () => {
+    it("forwards the bug-report key 'b' while a modal is open", async () => {
+      const { callbacks, dispatchSpy } = await createHarness(true);
+      activate(callbacks);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("b", "keyDown"));
+      expect(dispatchSpy).toHaveBeenCalledWith({
+        type: INTENT_SHORTCUT_KEY,
+        payload: { key: "b" },
+      });
+    });
+
+    it("drops non-'b' keys while a modal is open", async () => {
+      const { callbacks, dispatchSpy } = await createHarness(true);
+      activate(callbacks);
+      for (const key of ["ArrowUp", "s", "h", "1"]) {
+        simulateInput(callbacks, "ui-view", createKeyboardInput(key, "keyDown"));
+      }
+      expect(dispatchSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: INTENT_SHORTCUT_KEY })
+      );
+    });
+
+    it("Escape exits restricted mode without a broadcast or a forwarded key", async () => {
+      const { callbacks, dispatchSpy } = await createHarness(true);
+      activate(callbacks);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("Escape", "keyDown"));
+      // Never broadcast on entry → nothing to reverse on exit.
+      expect(setActiveCalls(dispatchSpy)).toEqual([]);
+      expect(dispatchSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: INTENT_SHORTCUT_KEY })
+      );
+    });
+
+    it("Alt keyUp exits restricted mode without a broadcast", async () => {
+      const { callbacks, dispatchSpy } = await createHarness(true);
+      activate(callbacks);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("Alt", "keyUp"));
+      expect(setActiveCalls(dispatchSpy)).toEqual([]);
+    });
+
+    it("a modal opening mid-gesture narrows full mode to 'b' only", async () => {
+      const { callbacks, dispatchSpy, setModalOpen } = await createHarness(false);
+      activate(callbacks);
+      // Full mode broadcast on entry (no modal at activation).
+      expect(setActiveCalls(dispatchSpy)).toEqual([{ active: true }]);
+      // A modal opens while shortcut mode is still active.
+      setModalOpen(true);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("ArrowUp", "keyDown"));
+      expect(dispatchSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: INTENT_SHORTCUT_KEY, payload: { key: "up" } })
+      );
+      simulateInput(callbacks, "ui-view", createKeyboardInput("b", "keyDown"));
+      expect(dispatchSpy).toHaveBeenCalledWith({
+        type: INTENT_SHORTCUT_KEY,
+        payload: { key: "b" },
+      });
     });
   });
 

--- a/src/modules/shortcut-module.ts
+++ b/src/modules/shortcut-module.ts
@@ -1,18 +1,25 @@
 /**
  * ShortcutModule - Owns the Alt+X shortcut-mode state machine.
  *
- * It detects Alt+X activation, owns the `shortcutActive` flag (it is the one
- * toggling it), and broadcasts entry/exit via the ui:set-shortcut-active
- * intent (→ ui:shortcut-active-changed, which the presenter folds into its UI
- * mode computation). While shortcut mode is active, every key press is
- * forwarded as a shortcut:key intent — the presenter runs navigation over its
- * authoritative model. Escape exits shortcut mode; so does window blur (unless
- * a navigation-initiated workspace switch is in flight — Electron fires blur
- * when the view bounds change during a switch).
+ * It detects Alt+X activation, owns the local `shortcutActive` flag (it is the
+ * one toggling it), and — in full mode — broadcasts entry/exit via the
+ * ui:set-shortcut-active intent (→ ui:shortcut-active-changed, which the
+ * presenter folds into its UI mode computation). While shortcut mode is active,
+ * every key press is forwarded as a shortcut:key intent — the presenter runs
+ * navigation over its authoritative model. Escape exits shortcut mode; so does
+ * window blur (unless a navigation-initiated workspace switch is in flight —
+ * Electron fires blur when the view bounds change during a switch).
  *
- * The Alt+X guard reads the dialog-manager's synchronous "modal open" signal
- * instead of a mirrored view-manager mode (dialog and shortcut modes are
- * mutually exclusive).
+ * Restricted (over-a-modal) mode: a bug report must be reachable in EVERY state,
+ * including while a modal is open (the startup/setup screens are themselves modal
+ * system dialogs). So Alt+X is no longer blocked when a modal is open — instead
+ * it enters a restricted mode that forwards ONLY the bug-report key ("b") and
+ * does NOT broadcast ui:set-shortcut-active. Not broadcasting keeps the presenter
+ * untouched: no overlay, no sidebar badges, no ARIA announcement, no workspace
+ * blur — the modal stays exactly as it was, with the bug dialog layered on top.
+ * The broadcast (full mode, all keys + affordances) fires only when no modal is
+ * open. `isModalOpen()` is read live per key press, so a modal opening mid-gesture
+ * transparently narrows to the bug-report key.
  *
  * IMPORTANT: Does NOT call event.preventDefault() on any keys.
  * Electron bug #37336 causes keyUp events to not fire when keyDown was
@@ -48,6 +55,14 @@ type ShortcutActivationState = "NORMAL" | "ALT_WAITING";
 
 const SHORTCUT_MODIFIER_KEY = "Alt";
 const SHORTCUT_ACTIVATION_KEY = "x";
+
+/**
+ * The only shortcut honored while a modal is open (restricted mode): opens the
+ * bug report dialog (handled by error-report-module on shortcut:key-pressed).
+ * Every other key is dropped so nav/settings/hibernate/devtools stay inert over
+ * a modal or the startup/setup screens.
+ */
+const BUG_REPORT_KEY = "b";
 
 /**
  * Window (ms) after a navigation-initiated workspace switch during which a
@@ -94,20 +109,46 @@ export interface ShortcutModuleDeps {
 
 export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
   let state: ShortcutActivationState = "NORMAL";
-  /** Locally-owned shortcut-mode flag (this module is the sole toggler). */
+  /** Locally-owned shortcut-mode flag: while true, key presses are forwarded. */
   let shortcutActive = false;
+  /**
+   * Whether entry broadcast ui:set-shortcut-active (active:true) — i.e. full mode
+   * with UI affordances. False for a restricted (over-a-modal) activation, which
+   * forwards only the bug-report key and leaves the presenter untouched. Mirrored
+   * on exit so we only broadcast active:false when we broadcast active:true.
+   */
+  let broadcasted = false;
   /** Timestamp (ms) of the last navigation-initiated workspace switch. */
   let lastSwitchAt = 0;
   let unsubscribeBeforeInput: Unsubscribe | null = null;
   let unsubscribeDestroyed: Unsubscribe | null = null;
   let unsubscribeBlur: Unsubscribe | null = null;
 
-  function setShortcutActive(active: boolean): void {
-    if (shortcutActive === active) return;
-    shortcutActive = active;
+  /**
+   * Enter shortcut mode. `restricted` (a modal is open) forwards only the
+   * bug-report key and does NOT broadcast — the UI stays exactly as the modal
+   * left it. Full activation broadcasts so the overlay/nav affordances light up.
+   */
+  function enterShortcut(restricted: boolean): void {
+    if (shortcutActive) return;
+    shortcutActive = true;
+    if (restricted) return;
+    broadcasted = true;
     void deps.dispatcher.dispatch({
       type: INTENT_SET_SHORTCUT_ACTIVE,
-      payload: { active },
+      payload: { active: true },
+    } as SetShortcutActiveIntent);
+  }
+
+  /** Exit shortcut mode. Broadcasts active:false only if entry broadcast true. */
+  function exitShortcut(): void {
+    if (!shortcutActive) return;
+    shortcutActive = false;
+    if (!broadcasted) return;
+    broadcasted = false;
+    void deps.dispatcher.dispatch({
+      type: INTENT_SET_SHORTCUT_ACTIVE,
+      payload: { active: false },
     } as SetShortcutActiveIntent);
   }
 
@@ -143,9 +184,11 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
    * Algorithm:
    * 1. Handle keyUp: Alt release exits shortcut mode
    * 2. Skip auto-repeat events
-   * 3. In shortcut mode: Escape exits, every other key is forwarded
+   * 3. In shortcut mode: Escape exits; otherwise the key is forwarded — but while
+   *    a modal is open (restricted mode) only the bug-report key gets through
    * 4. Alt keydown: NORMAL → ALT_WAITING
-   * 5. In ALT_WAITING + X keydown: activate shortcut (unless a modal is open)
+   * 5. In ALT_WAITING + X keydown: activate shortcut — full mode, or restricted
+   *    (bug-report key only, no broadcast) when a modal is open. Never blocked.
    * 6. In ALT_WAITING + other key: exit to NORMAL, let through
    */
   function handleInput(input: KeyboardInput): void {
@@ -162,9 +205,7 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     // Handle Alt keyUp: exit shortcut mode
     if (input.type === "keyUp" && isAltKey) {
       deps.logger.debug("Alt keyUp detected", { willExitShortcutMode: shortcutActive });
-      if (shortcutActive) {
-        setShortcutActive(false);
-      }
+      exitShortcut();
       state = "NORMAL";
       return;
     }
@@ -181,14 +222,20 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     // NOTE: This runs before Alt+X detection because shortcut mode is already active
     if (shortcutActive) {
       const normalized = normalizeKey(input.key);
-      // Escape exits shortcut mode (no preventDefault — see #37336). Dialog
-      // and shortcut modes are mutually exclusive, so this never steals a
-      // dialog's Escape.
+      // Escape exits shortcut mode (no preventDefault — see #37336). In full
+      // mode dialog and shortcut modes are mutually exclusive, so this never
+      // steals a dialog's Escape; in restricted mode (bug dialog not yet open)
+      // there is no dialog to steal from either.
       if (normalized === "escape") {
-        setShortcutActive(false);
+        exitShortcut();
         state = "NORMAL";
         return;
       }
+      // Restricted mode: while a modal is open, only the bug-report key is
+      // honored (so a report is reachable over any modal / the startup screens);
+      // every other key is dropped. Read isModalOpen() live so a modal opening
+      // mid-gesture narrows to "b" from that point on.
+      if (deps.ui.isModalOpen() && normalized !== BUG_REPORT_KEY) return;
       // NOTE: Do NOT call event.preventDefault() - see Electron bug #37336
       dispatchShortcutKey(normalized);
       return;
@@ -203,16 +250,15 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     // ALT_WAITING state
     if (state === "ALT_WAITING") {
       if (isActivationKey) {
-        // Don't activate shortcut mode if a modal dialog is open.
-        if (deps.ui.isModalOpen()) {
-          state = "NORMAL";
-          return;
-        }
+        // A modal open at activation → restricted mode (bug-report key only, no
+        // broadcast). Otherwise full mode. Never blocked: a bug report must be
+        // reachable in every state, including over the startup/setup screens.
+        const restricted = deps.ui.isModalOpen();
 
         // Defer activation to next tick to avoid interfering with keyboard
         // event delivery.
         setImmediate(() => {
-          setShortcutActive(true);
+          enterShortcut(restricted);
         });
 
         state = "NORMAL";
@@ -235,9 +281,7 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
       deps.logger.debug("Blur during workspace switch ignored");
       return;
     }
-    if (shortcutActive) {
-      setShortcutActive(false);
-    }
+    exitShortcut();
     state = "NORMAL";
   }
 
@@ -249,6 +293,7 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     unsubscribeBlur = null;
     state = "NORMAL";
     shortcutActive = false;
+    broadcasted = false;
   }
 
   // While shortcut mode is active, a workspace:switched is navigation-initiated

--- a/src/modules/telemetry-module.integration.test.ts
+++ b/src/modules/telemetry-module.integration.test.ts
@@ -80,6 +80,8 @@ function createTestSetup(overrides?: {
   agent?: ConfigAgentType;
   configOverrides?: Record<string, unknown>;
   workspacePayload?: WorkspaceCreatedPayload;
+  /** Which app:start hook point the minimal operation runs (default "start"). */
+  startHookPoint?: "before-ready" | "start";
 }): TestSetup {
   const platformInfo = createMockPlatformInfo({ platform: "darwin", arch: "arm64" });
   const buildInfo = { version: "1.0.0", isDevelopment: true, isPackaged: false, appPath: "/app" };
@@ -119,7 +121,7 @@ function createTestSetup(overrides?: {
 
   dispatcher.registerOperation(
     INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, "start")
+    createMinimalOperation(APP_START_OPERATION_ID, overrides?.startHookPoint ?? "start")
   );
   dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
   dispatcher.registerOperation(
@@ -252,6 +254,30 @@ describe("TelemetryModule Integration", () => {
       await dispatcher.dispatch(startIntent());
 
       expect(boundary.$.identifyCalls).toHaveLength(0);
+    });
+  });
+
+  describe("app:start before-ready (early metadata)", () => {
+    it("configures commonProps before 'start' so early reports/crashes carry build + OS", async () => {
+      // Even with telemetry disabled: a manual bug report sends unconditionally,
+      // so commonProps must be stamped regardless of `enabled`.
+      const { dispatcher, boundary } = createTestSetup({
+        telemetryEnabled: false,
+        agent: "claude",
+        startHookPoint: "before-ready",
+      });
+
+      await dispatcher.dispatch(startIntent());
+
+      // Simulate an early bug report / crash, before the "start" hook has run.
+      boundary.captureException(new Error("early failure"));
+
+      expect(boundary).toHaveCaptured("$exception", {
+        version: "1.0.0",
+        platform: "darwin",
+        arch: "arm64",
+        agent: "claude",
+      });
     });
   });
 

--- a/src/modules/telemetry-module.ts
+++ b/src/modules/telemetry-module.ts
@@ -6,8 +6,13 @@
  * shares the same boundary instance.
  *
  * Hooks:
+ * - app:start → "before-ready": configure the boundary with commonProps only, as
+ *   early as possible, so a bug report or crash during the setup/boot phases (before
+ *   "start" runs) still carries version/platform/arch/agent. The distinct id is not
+ *   resolved yet → anonymous fallback at send time, which is correct for first-run
+ *   (no id exists yet anyway).
  * - app:start → "start": resolve distinct id (generate+persist if needed),
- *   configure the boundary (commonProps + distinct id), capture "app_launched",
+ *   re-configure the boundary (commonProps + distinct id), capture "app_launched",
  *   and sync config overrides as person properties.
  * - app:shutdown → "stop": flush + close the boundary (best-effort).
  *
@@ -98,6 +103,14 @@ export function createTelemetryModule(deps: TelemetryModuleDeps): IntentModule {
     name: "telemetry",
     hooks: {
       [APP_START_OPERATION_ID]: {
+        // Stamp commonProps onto the boundary before any dependency check or setup
+        // screen, so early reports/crashes are triageable (build + OS). distinctId
+        // stays null here; "start" resolves and re-configures it below.
+        "before-ready": {
+          handler: async (): Promise<void> => {
+            deps.boundary.configure({ commonProps: commonProps() });
+          },
+        },
         start: {
           handler: async (): Promise<void> => {
             enabled = deps.telemetryEnabled.get();


### PR DESCRIPTION
- Stop blocking Alt+X when a modal is open. When a modal is open (including the startup/setup system dialogs), Alt+X now enters a **restricted** mode: only the bug-report key (`b`) is forwarded and `ui:set-shortcut-active` is **not** broadcast, so the presenter stays untouched (no overlay, sidebar badges, ARIA, or workspace blur) and the bug dialog layers on top. With no modal open, Alt+X behaves exactly as before.
- `isModalOpen()` is read live per key press, so a modal opening mid-gesture transparently narrows to `b`.
- Configure the PostHog boundary's `commonProps` in a new `app:start` `before-ready` hook so early reports/crashes (before the `start` hook) carry version/platform/arch/agent. `distinctId` resolution stays in `start`.
- Tests: restricted-mode coverage in `shortcut-module.integration.test.ts`; early-`commonProps` coverage in `telemetry-module.integration.test.ts`.
- Docs: updated the Alt+X / mode sections in `ARCHITECTURE.md`.