### PR TITLE
feat(startup): report bug on fatal app:start failure

### DIFF
--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -31,9 +31,15 @@ import { createMockDispatcher } from "./lib/dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 
-import { AppStartOperation, INTENT_APP_START, APP_START_OPERATION_ID } from "./app-start";
+import {
+  AppStartOperation,
+  INTENT_APP_START,
+  APP_START_OPERATION_ID,
+  APP_START_ERROR_HOOK,
+} from "./app-start";
 import type {
   AppStartIntent,
+  AppStartErrorHookContext,
   CheckDepsHookContext,
   CheckDepsResult,
   ConfigureResult,
@@ -900,6 +906,89 @@ describe("AppStart Operation", () => {
       await dispatcher.dispatch(appStartIntent());
 
       expect(capturedScripts).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // Startup failure "error" hook (#19)
+  // ===========================================================================
+
+  describe("startup failure error hook (#19)", () => {
+    function createErrorHookCaptureModule(captured: {
+      ctx?: AppStartErrorHookContext;
+    }): IntentModule {
+      return {
+        name: "test",
+        hooks: {
+          [APP_START_OPERATION_ID]: {
+            [APP_START_ERROR_HOOK]: {
+              handler: async (ctx: HookContext): Promise<void> => {
+                captured.ctx = ctx as AppStartErrorHookContext;
+              },
+            },
+          },
+        },
+      };
+    }
+
+    it("runs the error hook with the failing error + phase, then still rejects", async () => {
+      const state = createTestState();
+      const captured: { ctx?: AppStartErrorHookContext } = {};
+      const { dispatcher } = createTestSetup([
+        createErrorHookCaptureModule(captured),
+        createCodeServerModule(state, { fail: true }),
+        createMcpModule(state),
+        createDataModule(state),
+        createViewModule(state),
+      ]);
+
+      await expect(dispatcher.dispatch(appStartIntent())).rejects.toThrow(
+        "CodeServer failed to start"
+      );
+
+      expect(captured.ctx).toBeDefined();
+      expect(captured.ctx!.phase).toBe("start");
+      expect(captured.ctx!.error).toBeInstanceOf(Error);
+      expect(captured.ctx!.error.message).toBe("CodeServer failed to start");
+    });
+
+    it("attributes an early before-ready failure to the before-ready phase", async () => {
+      const captured: { ctx?: AppStartErrorHookContext } = {};
+      const failingBeforeReady: IntentModule = {
+        name: "test",
+        hooks: {
+          [APP_START_OPERATION_ID]: {
+            "before-ready": {
+              handler: async (): Promise<void> => {
+                throw new Error("early boom");
+              },
+            },
+          },
+        },
+      };
+
+      const { dispatcher } = createTestSetup([
+        createErrorHookCaptureModule(captured),
+        failingBeforeReady,
+      ]);
+
+      await expect(dispatcher.dispatch(appStartIntent())).rejects.toThrow("early boom");
+      expect(captured.ctx!.phase).toBe("before-ready");
+    });
+
+    it("does not run the error hook on a successful startup", async () => {
+      const state = createTestState();
+      const captured: { ctx?: AppStartErrorHookContext } = {};
+      const { dispatcher } = createTestSetup([
+        createErrorHookCaptureModule(captured),
+        createCodeServerModule(state),
+        createMcpModule(state),
+        createDataModule(state),
+        createViewModule(state),
+      ]);
+
+      await dispatcher.dispatch(appStartIntent());
+      expect(captured.ctx).toBeUndefined();
     });
   });
 });

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -128,6 +128,27 @@ export interface ShowUIHookResult {
   readonly retrySupported?: boolean;
 }
 
+/** The app:start hook point that runs when startup fails fatally. */
+export const APP_START_ERROR_HOOK = "error" as const;
+
+/**
+ * The startup phase in which a fatal error occurred. Mirrors the hook-point
+ * sequence, plus "setup" for the app:setup sub-operation region. Attached to the
+ * startup failure report so a crash can be attributed to a phase.
+ */
+export type AppStartPhase = "before-ready" | "init" | "show-ui" | "check-deps" | "setup" | "start";
+
+/**
+ * Input context for the "error" hook point. Carries the fatal error and the
+ * phase it occurred in. Run inside execute()'s catch — awaited, so a handler can
+ * report + flush — before the operation re-throws to the composition root, which
+ * shows the native failure box and quits.
+ */
+export interface AppStartErrorHookContext extends HookContext {
+  readonly error: Error;
+  readonly phase: AppStartPhase;
+}
+
 // ActivateHookContext removed — ports are now read from capabilities within the "start" hook point.
 
 /** Merged check results produced by runChecks(). */
@@ -159,105 +180,134 @@ export class AppStartOperation implements Operation<AppStartIntent, void> {
       intent: ctx.intent,
     };
 
-    // --- Hook 1: "before-ready" (pre-ready) ---
-    // Script declarations, noAsar, data paths, electron flags. All independent.
-    const { results: configResults, errors: configErrors } =
-      await ctx.hooks.collect<ConfigureResult>("before-ready", hookCtx);
-    throwHookErrors(configErrors, "app:start before-ready hooks failed");
-    const requiredScripts = configResults.flatMap((r) => r.scripts ?? []);
+    // Track the current phase so a fatal failure can be attributed to it in the
+    // startup report (crash_source: "startup"). The catch runs the "error" hook —
+    // awaited, so its handler can capture + flush — before re-throwing to the
+    // composition root, which shows the native failure box and quits.
+    let phase: AppStartPhase = "before-ready";
+    try {
+      // --- Hook 1: "before-ready" (pre-ready) ---
+      // Script declarations, noAsar, data paths, electron flags. All independent.
+      phase = "before-ready";
+      const { results: configResults, errors: configErrors } =
+        await ctx.hooks.collect<ConfigureResult>("before-ready", hookCtx);
+      throwHookErrors(configErrors, "app:start before-ready hooks failed");
+      const requiredScripts = configResults.flatMap((r) => r.scripts ?? []);
 
-    // --- Hook 2: "init" ---
-    // Electron lifecycle module provides "app-ready" capability after whenReady().
-    // Handlers needing Electron declare requires: { "app-ready": ANY_VALUE }.
-    // Receives requiredScripts from before-ready results.
-    const initCtx: InitHookContext = { ...hookCtx, requiredScripts };
-    const { results: initResults, errors: initErrors } = await ctx.hooks.collect<InitResult>(
-      "init",
-      initCtx
-    );
-    throwHookErrors(initErrors, "app:start init hooks failed");
+      // --- Hook 2: "init" ---
+      // Electron lifecycle module provides "app-ready" capability after whenReady().
+      // Handlers needing Electron declare requires: { "app-ready": ANY_VALUE }.
+      // Receives requiredScripts from before-ready results.
+      phase = "init";
+      const initCtx: InitHookContext = { ...hookCtx, requiredScripts };
+      const { results: initResults, errors: initErrors } = await ctx.hooks.collect<InitResult>(
+        "init",
+        initCtx
+      );
+      throwHookErrors(initErrors, "app:start init hooks failed");
 
-    // Extract extensionRequirements from init results
-    const extensionRequirements: ExtensionRequirement[] = [];
-    for (const result of initResults) {
-      if (result.extensionRequirements) extensionRequirements.push(...result.extensionRequirements);
-    }
+      // Extract extensionRequirements from init results
+      const extensionRequirements: ExtensionRequirement[] = [];
+      for (const result of initResults) {
+        if (result.extensionRequirements)
+          extensionRequirements.push(...result.extensionRequirements);
+      }
 
-    // On first run (no config.json yet) the agent is treated as "not chosen":
-    // null defers binary checks and drives needsAgentSelection, exactly as a null
-    // agent value used to. Once configured, the real (non-null) agent is used.
-    const configuredAgent: ConfigAgentType | null = this.wasConfigured()
-      ? this.agentConfig.get()
-      : null;
+      // On first run (no config.json yet) the agent is treated as "not chosen":
+      // null defers binary checks and drives needsAgentSelection, exactly as a null
+      // agent value used to. Once configured, the real (non-null) agent is used.
+      const configuredAgent: ConfigAgentType | null = this.wasConfigured()
+        ? this.agentConfig.get()
+        : null;
 
-    // Hook 3: "show-ui" -- Show starting screen; learn whether a retry loop is supported.
-    const { results: showUiResults, errors: showUiErrors } =
-      await ctx.hooks.collect<ShowUIHookResult>("show-ui", hookCtx);
-    throwHookErrors(showUiErrors, "app:start show-ui hooks failed");
-    const retrySupported = showUiResults.some((r) => r.retrySupported === true);
+      // Hook 3: "show-ui" -- Show starting screen; learn whether a retry loop is supported.
+      phase = "show-ui";
+      const { results: showUiResults, errors: showUiErrors } =
+        await ctx.hooks.collect<ShowUIHookResult>("show-ui", hookCtx);
+      throwHookErrors(showUiErrors, "app:start show-ui hooks failed");
+      const retrySupported = showUiResults.some((r) => r.retrySupported === true);
 
-    // Hook 4: "check-deps" (collect, isolated contexts)
-    let checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
+      // Hook 4: "check-deps" (collect, isolated contexts)
+      phase = "check-deps";
+      let checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
 
-    // Dispatch app:setup if needed (blocking sub-operation)
-    // Setup manages its own UI (shows/hides setup screen)
-    // Retry loop: if setup fails and retry is supported, wait via the await-retry hook
-    if (checkResult.needsSetup) {
-      let setupComplete = false;
-      while (!setupComplete) {
-        try {
-          await ctx.dispatch({
-            type: INTENT_SETUP,
-            payload: {
-              needsAgentSelection: checkResult.needsAgentSelection,
-              needsBinaryDownload: checkResult.needsBinaryDownload,
-              missingBinaries: checkResult.missingBinaries,
-              needsExtensions: checkResult.needsExtensions,
-              extensionInstallPlan: checkResult.extensionInstallPlan,
-              configuredAgent: checkResult.configuredAgent,
-            },
-          });
-          setupComplete = true;
-        } catch (error) {
-          // Setup failed -- error event already emitted by SetupOperation
-          // If retry is supported, wait for user to click retry. The "await-retry"
-          // hook point blocks (host-side, in the UI handler) until the user clicks
-          // Retry and returns data — no closure crosses the hook contract.
-          if (retrySupported) {
-            const { errors: retryErrors } = await ctx.hooks.collect<void>("await-retry", hookCtx);
-            throwHookErrors(retryErrors, "app:start await-retry hooks failed");
-            // Re-run check hooks to get fresh preflight state for retry
-            checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
-            if (!checkResult.needsSetup) {
-              setupComplete = true;
+      // Dispatch app:setup if needed (blocking sub-operation)
+      // Setup manages its own UI (shows/hides setup screen)
+      // Retry loop: if setup fails and retry is supported, wait via the await-retry hook
+      if (checkResult.needsSetup) {
+        phase = "setup";
+        let setupComplete = false;
+        while (!setupComplete) {
+          try {
+            await ctx.dispatch({
+              type: INTENT_SETUP,
+              payload: {
+                needsAgentSelection: checkResult.needsAgentSelection,
+                needsBinaryDownload: checkResult.needsBinaryDownload,
+                missingBinaries: checkResult.missingBinaries,
+                needsExtensions: checkResult.needsExtensions,
+                extensionInstallPlan: checkResult.extensionInstallPlan,
+                configuredAgent: checkResult.configuredAgent,
+              },
+            });
+            setupComplete = true;
+          } catch (setupError) {
+            // Setup failed -- error event already emitted by SetupOperation
+            // If retry is supported, wait for user to click retry. The "await-retry"
+            // hook point blocks (host-side, in the UI handler) until the user clicks
+            // Retry and returns data — no closure crosses the hook contract.
+            if (retrySupported) {
+              const { errors: retryErrors } = await ctx.hooks.collect<void>("await-retry", hookCtx);
+              throwHookErrors(retryErrors, "app:start await-retry hooks failed");
+              // Re-run check hooks to get fresh preflight state for retry
+              checkResult = await this.runChecks(ctx, configuredAgent, extensionRequirements);
+              if (!checkResult.needsSetup) {
+                setupComplete = true;
+              }
+              // Otherwise loop continues to retry app:setup
+            } else {
+              // No retry support -- propagate the error with original cause
+              throw new Error("Setup failed and no retry mechanism available", {
+                cause: setupError,
+              });
             }
-            // Otherwise loop continues to retry app:setup
-          } else {
-            // No retry support -- propagate the error with original cause
-            throw new Error("Setup failed and no retry mechanism available", { cause: error });
           }
         }
       }
+
+      // Hook 5: "start" -- Start servers, wire callbacks, mount renderer
+      // Handlers that need ports (mcpPort, codeServerPort) declare `requires` and
+      // read from ctx.capabilities. Capability-based ordering replaces the former
+      // separate "activate" hook point.
+      phase = "start";
+      const { errors: startErrors } = await ctx.hooks.collect<void>("start", hookCtx);
+      throwHookErrors(startErrors, "app:start start hooks failed");
+
+      // After all start handlers (code-server included) are up, load initial projects.
+      // Fire-and-forget: the snapshot stream carries the result, so startup must not
+      // block on projects finishing. (Operation owns this dispatch; the presentation
+      // start handler only advances the UI phase.)
+      const readyHandle = ctx.dispatch<AppReadyIntent>({
+        type: INTENT_APP_READY,
+        payload: {},
+      });
+      void readyHandle.catch(() => {
+        // app:ready failures surface via its own events/logging; don't fail startup.
+      });
+    } catch (error) {
+      // Fatal startup failure. Run the "error" hook so the failure is captured and
+      // flushed (hook collection is awaited, unlike fire-and-forget events) before
+      // we re-throw. collect() never throws — it swallows handler errors — so the
+      // ORIGINAL error is what propagates, leaving the composition root's native
+      // box + app.quit path unchanged.
+      const errorCtx: AppStartErrorHookContext = {
+        intent: ctx.intent,
+        error: error instanceof Error ? error : new Error(String(error)),
+        phase,
+      };
+      await ctx.hooks.collect(APP_START_ERROR_HOOK, errorCtx);
+      throw error;
     }
-
-    // Hook 5: "start" -- Start servers, wire callbacks, mount renderer
-    // Handlers that need ports (mcpPort, codeServerPort) declare `requires` and
-    // read from ctx.capabilities. Capability-based ordering replaces the former
-    // separate "activate" hook point.
-    const { errors: startErrors } = await ctx.hooks.collect<void>("start", hookCtx);
-    throwHookErrors(startErrors, "app:start start hooks failed");
-
-    // After all start handlers (code-server included) are up, load initial projects.
-    // Fire-and-forget: the snapshot stream carries the result, so startup must not
-    // block on projects finishing. (Operation owns this dispatch; the presentation
-    // start handler only advances the UI phase.)
-    const readyHandle = ctx.dispatch<AppReadyIntent>({
-      type: INTENT_APP_READY,
-      payload: {},
-    });
-    void readyHandle.catch(() => {
-      // app:ready failures surface via its own events/logging; don't fail startup.
-    });
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -980,7 +980,14 @@ void dispatcher
       error instanceof Error ? error : undefined
     );
 
-    dialogLayer.showErrorBox("Startup Failed", getErrorMessage(error));
+    // The app:start "error" hook has already captured + flushed a diagnostic
+    // report when telemetry is on (see error-report-module). Only tell the user a
+    // report was sent when it actually was — with telemetry off nothing left the
+    // machine, so we keep the bare message.
+    const message = telemetryEnabledConfig.get()
+      ? `${getErrorMessage(error)}\n\nA diagnostic report has been sent to the developers.`
+      : getErrorMessage(error);
+    dialogLayer.showErrorBox("Startup Failed", message);
 
     app.quit();
   });

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -15,8 +15,11 @@ import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import {
   APP_START_OPERATION_ID,
+  APP_START_ERROR_HOOK,
   INTENT_APP_START,
   type AppStartIntent,
+  type AppStartErrorHookContext,
+  type AppStartPhase,
 } from "../intents/app-start";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 import {
@@ -135,6 +138,20 @@ async function registerCrashHandlers(
     process.on = originalOn;
   }
   return handlers;
+}
+
+/** Run the app:start "error" hook with a fatal error + phase (as the operation does). */
+async function runStartupErrorHook(
+  module: ReturnType<typeof setup>["module"],
+  error: Error,
+  phase: AppStartPhase
+): Promise<void> {
+  const ctx: AppStartErrorHookContext = {
+    intent: { type: INTENT_APP_START, payload: {} } as AppStartIntent,
+    error,
+    phase,
+  };
+  await module.hooks![APP_START_OPERATION_ID]![APP_START_ERROR_HOOK]!.handler(ctx);
 }
 
 // =============================================================================
@@ -484,5 +501,41 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
     s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "crashed", exitCode: 1 });
 
     expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
+  });
+});
+
+// =============================================================================
+// Startup failure report (app:start "error" hook)
+// =============================================================================
+
+describe("ErrorReportModule — startup failure report", () => {
+  it("reports crash_source:startup + phase with logs/config on a fatal startup failure", async () => {
+    const { module, boundary } = setup({
+      telemetryEnabled: true,
+      configOverrides: { "log.level": "debug" },
+    });
+
+    await runStartupErrorHook(module, new Error("Failed to start code-server"), "start");
+
+    const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
+    expect(captured).toBeDefined();
+    expect(captured!.properties["crash_source"]).toBe("startup");
+    expect(captured!.properties["phase"]).toBe("start");
+    expect(captured!.properties["logs_format"]).toBe("gzip+base64");
+    expect(captured!.properties["config"]).toEqual({ "log.level": "debug" });
+    expect(captured!.properties["$exception_list"]).toEqual([
+      { type: "Error", value: "Failed to start code-server" },
+    ]);
+    // flushed (shutdown) so the report lands before the app quits
+    expect(boundary.$.shutdownCalled).toBe(true);
+  });
+
+  it("does NOT report when telemetry is off", async () => {
+    const { module, boundary } = setup({ telemetryEnabled: false });
+
+    await runStartupErrorHook(module, new Error("boom"), "start");
+
+    expect(boundary.$.capturedEvents).toHaveLength(0);
+    expect(boundary.$.shutdownCalled).toBe(false);
   });
 });

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -13,6 +13,12 @@
  *     uncaughtException  → log; report + flush (if telemetry on, with timeout);
  *       ALWAYS exit(1). Logging + exit are unconditional (crash behavior is
  *       preserved with telemetry off); only the telemetry report is gated.
+ * - app:start / error: a fatal startup failure (any app:start hook rejected, e.g.
+ *     code-server health check timed out) ran the app:start "error" hook. Report
+ *     (if telemetry on) with crash_source: "startup" + the failing phase, then
+ *     flush. The operation awaits this hook, so the report lands before the
+ *     composition root shows the native "Startup Failed" box and quits — the
+ *     rejection is caught there, so it never surfaces as an uncaughtException.
  * - app:start / init (after "ui-ready"): subscribe the UI renderer crash guard
  *     on the UI view. An uncaught exception in the UI renderer (e.g. a Svelte
  *     effect loop killing the effect runtime) bricks the UI silently, so:
@@ -49,8 +55,12 @@ import type { DialogBoundary } from "../boundaries/shell/dialog";
 import type { ViewBoundary, UncaughtExceptionDetails } from "../boundaries/shell/view";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
 import { ANY_VALUE } from "../intents/lib/operation";
-import type { HookOutput } from "../intents/lib/operation";
-import { APP_START_OPERATION_ID } from "../intents/app-start";
+import type { HookOutput, HookContext } from "../intents/lib/operation";
+import {
+  APP_START_OPERATION_ID,
+  APP_START_ERROR_HOOK,
+  type AppStartErrorHookContext,
+} from "../intents/app-start";
 import { INTENT_APP_SHUTDOWN, type AppShutdownIntent } from "../intents/app-shutdown";
 import { EVENT_SHORTCUT_KEY_PRESSED, type ShortcutKeyPressedEvent } from "../intents/shortcut-key";
 import { INTENT_SUBMIT_BUG_REPORT, type SubmitBugReportIntent } from "../intents/submit-bug-report";
@@ -428,6 +438,24 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
           requires: { "ui-ready": ANY_VALUE },
           handler: async (): Promise<HookOutput<Record<string, never>>> => {
             subscribeUiCrashGuard();
+            return { result: {} };
+          },
+        },
+        // A fatal startup failure. The operation runs this hook (awaited) in its
+        // catch before re-throwing, so we can capture + flush the report before the
+        // composition root shows the native box and quits. Gated on telemetry, like
+        // the other automatic crash reports; the manual bug-report path is separate.
+        [APP_START_ERROR_HOOK]: {
+          handler: async (ctx: HookContext): Promise<HookOutput<Record<string, never>>> => {
+            const { error, phase } = ctx as AppStartErrorHookContext;
+            if (deps.telemetryEnabled.get()) {
+              try {
+                await captureCrash(error, { crash_source: "startup", phase });
+                await flushWithTimeout();
+              } catch {
+                // Best-effort: reporting must never block or alter the fatal path.
+              }
+            }
             return { result: {} };
           },
         },


### PR DESCRIPTION
- Add an `error` hook point to the `app:start` operation, run inside its catch (awaited, so the report captures + flushes before the rejection unwinds) carrying the live `Error` + failing phase (`before-ready`/`init`/`show-ui`/`check-deps`/`setup`/`start`).
- `error-report-module` handles it: telemetry-gated `captureCrash({ crash_source: "startup", phase })` + bounded flush — consistent with the existing automatic crash reports (uncaughtException / renderer crash). Real `Error` → real stack, no reconstruction.
- Composition root's native "Startup Failed" box now notes a report was sent when telemetry is on.
- Closes the hole where a caught `app:start` rejection (code-server health-check timeout, mcp/port allocation, window creation, state/logging init, …) never reached PostHog and carried no logs/config/state.
- Tests: app-start operation fires the error hook with correct error + phase and still rejects (and doesn't fire on success); error-report-module reports with `crash_source:"startup"` + phase + logs/config and flushes when telemetry on, sends nothing when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)