### PR TITLE
fix: workspace goes to idle when AskUserTool is used despite running background agents

### DIFF
--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -531,6 +531,32 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
+    it("AskUserQuestion parks the workspace on idle until answered", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+
+      // AskUserQuestion surfaces as a tool: PreToolUse parks on the user (idle),
+      // PostToolUse (the answer) returns to busy.
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy"]);
+    });
+
     it("Notification(auth_success) does not change status", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
@@ -1437,6 +1463,120 @@ describe("ClaudeCodeServerManager integration", () => {
 
       // No false idle blip across the whole sub-agent run
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+    });
+
+    it("AskUserQuestion idle survives concurrent sub-agent tool activity", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Real trace: the main agent dispatches background sub-agents, then asks the
+      // user a question. While the question is open, the sub-agents' own tool
+      // calls emit PostToolUse (→busy) on this same workspace bridge — which used
+      // to stomp the ask-user idle. They must now be suppressed so the workspace
+      // stays idle until the user actually answers.
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SubagentStart", {
+        workspacePath: "/workspace/feature-a",
+        agent_id: "sub-1",
+      });
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      // Concurrent sub-agent tool traffic — none of this may flip us to busy.
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "Agent",
+      });
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "WebSearch",
+      });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      // The user answers → PostToolUse(AskUserQuestion) returns to busy.
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy"]);
+    });
+
+    it("AskUserQuestion idle is not resolved by a concurrent sub-agent PreToolUse", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // AskUserQuestion also fires its own PermissionRequest. The generic
+      // permission flow would let the *next* PreToolUse (here a sub-agent's)
+      // resolve it back to busy — that must not happen while parked.
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "SubagentStart", {
+        workspacePath: "/workspace/feature-a",
+        agent_id: "sub-1",
+      });
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      await sendHook(port, "PermissionRequest", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      // A sub-agent starts a tool while the question is open.
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "Bash",
+      });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy"]);
+    });
+
+    it("AskUserQuestion unparks (→busy) on PostToolUseFailure so the flag can't stick", async () => {
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      // The question is cancelled/errors → PostToolUseFailure must clear the park.
+      await sendHook(port, "PostToolUseFailure", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "AskUserQuestion",
+      });
+      expect(lastStatus(statusChanges)).toBe("busy");
+
+      // Subsequent normal work is no longer suppressed to idle.
+      await sendHook(port, "PostToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "Bash",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy"]);
     });
 
     it("Stop without sub-agents still transitions to idle normally", async () => {

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -48,6 +48,14 @@ export interface WorkspaceState {
   sessionId?: string;
   /** Callbacks for status changes */
   statusCallbacks: Set<(status: AgentStatus) => void>;
+  /**
+   * Flag set while the workspace is parked on an AskUserQuestion (the main agent
+   * is blocked on the user). Set by PreToolUse(AskUserQuestion), cleared by
+   * PostToolUse(AskUserQuestion). While set, busy transitions from concurrent
+   * sub-agent tool activity on this shared workspace bridge are suppressed so the
+   * workspace stays idle until the user answers.
+   */
+  awaitingUserInputResolution?: boolean;
   /** Flag set when PreCompact arrives while busy, cleared on SessionStart */
   ignoreNextSessionStart?: boolean;
   /** Path to the initial prompt file (for getInitialPromptPath) */
@@ -679,6 +687,32 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       newStatus = "busy";
     }
 
+    // AskUserQuestion parks the workspace on the user: the main agent is blocked
+    // until the user answers. It surfaces as a normal tool
+    // (PreToolUse → PermissionRequest → PostToolUse, all tool_name
+    // "AskUserQuestion"), but the generic handling above can't cope when
+    // sub-agents run concurrently:
+    //  - the "PreToolUse while idle → busy" rule would un-park us the moment a
+    //    *sub-agent's* tool call fires, not the user's answer;
+    //  - concurrent sub-agent tool calls emit PostToolUse (→busy) on this same
+    //    workspace bridge, which would immediately overwrite the idle.
+    // So we bracket it explicitly: PreToolUse(AskUserQuestion) parks (→idle),
+    // PostToolUse(AskUserQuestion) unparks (→busy); while parked, every busy
+    // transition is suppressed (guard near the end of this method). This block
+    // runs after the generalized PreToolUse rule so the park wins.
+    if (hookName === "PreToolUse" && payload.tool_name === "AskUserQuestion") {
+      state.awaitingUserInputResolution = true;
+      newStatus = "idle";
+    } else if (
+      (hookName === "PostToolUse" || hookName === "PostToolUseFailure") &&
+      payload.tool_name === "AskUserQuestion"
+    ) {
+      // Unpark on either outcome (answered or cancelled/errored) so the flag can
+      // never get stuck and keep the workspace suppressed to idle.
+      state.awaitingUserInputResolution = false;
+      newStatus = "busy";
+    }
+
     // Special handling for compaction flow:
     // PreCompact while busy sets flag (automatic compaction mid-turn).
     // Stop/StopFailure between PreCompact and SessionStart is suppressed so the
@@ -790,6 +824,7 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     }
     if (hookName === "UserPromptSubmit") {
       state.busyForBackgroundShells = false;
+      state.awaitingUserInputResolution = false;
     }
 
     // Terminal hooks clear sub-agent and background shell state as defensive cleanup
@@ -797,6 +832,20 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       state.activeSubagents.clear();
       state.mainAgentStopped = false;
       state.busyForBackgroundShells = false;
+      state.awaitingUserInputResolution = false;
+    }
+
+    // While parked on an AskUserQuestion the main agent is blocked on the user;
+    // any "busy" computed above comes from concurrent sub-agent tool activity on
+    // this shared workspace bridge, not real main-agent progress. Suppress it so
+    // the workspace stays idle. The AskUserQuestion PostToolUse clears the flag
+    // above before reaching here, so the user's answer still returns us to busy.
+    if (state.awaitingUserInputResolution && newStatus === "busy") {
+      newStatus = null;
+      this.logger.debug("Busy suppressed while parked on AskUserQuestion", {
+        workspacePath: normalizedPath,
+        hookName,
+      });
     }
 
     this.logger.debug("Hook received", {


### PR DESCRIPTION
When the main agent blocks on an `AskUserQuestion` while background sub-agents are still running, the workspace stayed **busy** — hiding that it actually needs the user's answer.

- Root cause (verified via silly-level hook capture): `AskUserQuestion` surfaces as a normal tool (`PreToolUse → PermissionRequest → PostToolUse`, `tool_name: "AskUserQuestion"`). Its `PermissionRequest` does flip to idle, but concurrent sub-agent tool calls emit `PostToolUse` (→busy) on the **same** workspace bridge and immediately overwrite it; the `PermissionRequest` is also prematurely "resolved" by the next (sub-agent) `PreToolUse`.
- Fix: bracket `AskUserQuestion` explicitly. `PreToolUse(AskUserQuestion)` parks the workspace on the user (idle); `PostToolUse`/`PostToolUseFailure(AskUserQuestion)` unparks (busy). While parked, busy transitions from concurrent sub-agent tool activity are suppressed so the workspace stays idle until the user answers.
- The `idle_prompt` sub-agent-suppression guard is unchanged.
- Adds 5 integration tests covering the park/answer cycle, survival of concurrent sub-agent tool activity, the premature-resolution trap, and the `PostToolUseFailure` safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLYPpEWGULtV7v4kvXzpPH