### PR TITLE
fix: workspace status switches to busy when agent continues after bash command

### DIFF
--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -568,7 +568,7 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChanges).toEqual(["idle"]);
     });
 
-    it("PreToolUse does not change status without prior PermissionRequest", async () => {
+    it("PreToolUse while busy does not change status", async () => {
       const port = await serverManager.startServer("/workspace/feature-a");
       const statusChanges: AgentStatus[] = [];
       serverManager.onStatusChange("/workspace/feature-a", (status) => {
@@ -579,13 +579,37 @@ describe("ClaudeCodeServerManager integration", () => {
       await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
       await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
 
-      // PreToolUse without PermissionRequest should not change status
+      // PreToolUse mid-turn (already busy) should not change status
       await sendHook(port, "PreToolUse", {
         workspacePath: "/workspace/feature-a",
         tool_name: "bash",
       });
 
       // Status should remain busy
+      expect(statusChanges).toEqual(["idle", "busy"]);
+    });
+
+    it("PreToolUse transitions to busy when idle without UserPromptSubmit (bash-mode turn)", async () => {
+      // Claude Code's bash-mode ("!cmd") commands run a user-typed shell command
+      // without emitting UserPromptSubmit, so the ensuing agent turn never flips
+      // to busy. The first tool call the agent makes is our signal that it's
+      // working — it must transition the idle workspace to busy.
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      // Session is idle, waiting for the user; no UserPromptSubmit is sent.
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      // Agent runs a tool as part of a bash-mode-triggered turn.
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "bash",
+      });
+
       expect(statusChanges).toEqual(["idle", "busy"]);
     });
 
@@ -605,6 +629,41 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(lastStatus(statusChanges)).toBe("idle");
 
       // PreToolUse after PermissionRequest should transition to busy
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "bash",
+      });
+
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy"]);
+    });
+
+    it("permission dialog: real hook ordering stays idle while pending, busy on approve", async () => {
+      // Mirrors the real Claude Code ordering observed in the bridge logs, which
+      // differs from the simplified test above:
+      //   PreToolUse (busy, pre-dialog) → no change
+      //   PermissionRequest             → idle  (dialog shown)
+      //   PreToolUse (idle, on approve) → busy  (tool runs)
+      const port = await serverManager.startServer("/workspace/feature-a");
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange("/workspace/feature-a", (status) => {
+        statusChanges.push(status);
+      });
+
+      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
+
+      // Tool wants to run — PreToolUse fires first, while still busy (no change).
+      await sendHook(port, "PreToolUse", {
+        workspacePath: "/workspace/feature-a",
+        tool_name: "bash",
+      });
+      expect(lastStatus(statusChanges)).toBe("busy");
+
+      // Dialog appears → idle while it waits for the user.
+      await sendHook(port, "PermissionRequest", { workspacePath: "/workspace/feature-a" });
+      expect(lastStatus(statusChanges)).toBe("idle");
+
+      // User approves → the tool runs, PreToolUse fires again → busy.
       await sendHook(port, "PreToolUse", {
         workspacePath: "/workspace/feature-a",
         tool_name: "bash",

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -48,8 +48,6 @@ export interface WorkspaceState {
   sessionId?: string;
   /** Callbacks for status changes */
   statusCallbacks: Set<(status: AgentStatus) => void>;
-  /** Flag set after PermissionRequest, cleared on PreToolUse */
-  awaitingPermissionResolution?: boolean;
   /** Flag set when PreCompact arrives while busy, cleared on SessionStart */
   ignoreNextSessionStart?: boolean;
   /** Path to the initial prompt file (for getInitialPromptPath) */
@@ -667,12 +665,17 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       }
     }
 
-    // Special handling for permission resolution flow:
-    // PermissionRequest sets flag, PreToolUse clears it and transitions to busy
-    if (hookName === "PermissionRequest") {
-      state.awaitingPermissionResolution = true;
-    } else if (hookName === "PreToolUse" && state.awaitingPermissionResolution) {
-      state.awaitingPermissionResolution = false;
+    // A tool starting while the workspace reads idle means the agent is
+    // actually working — flip to busy. Two paths reach here:
+    //  1. Permission resolution: PermissionRequest transitioned us to idle
+    //     (waiting for the user); once approved, the tool runs.
+    //  2. Bash-mode ("!cmd") turns: Claude Code runs a user-typed shell command
+    //     without emitting UserPromptSubmit, so the ensuing agent turn never
+    //     flipped to busy. The first tool call is the earliest reliable signal
+    //     that the agent is working. (A text-only reply has no hook and can't
+    //     be caught here.)
+    // PreToolUse while already busy (normal mid-turn tool use) is a no-op.
+    if (hookName === "PreToolUse" && state.status === "idle") {
       newStatus = "busy";
     }
 

--- a/src/modules/agent-module/claude/types.ts
+++ b/src/modules/agent-module/claude/types.ts
@@ -95,8 +95,9 @@ export type HookStatusChange = AgentStatus | null;
  * - idle: Waiting for user (submit prompt, answer permission, etc.)
  * - busy: Agent is working, no action needed
  *
- * Note: PreToolUse is handled specially in server-manager.ts
- * to only transition to busy after a PermissionRequest (flag-based).
+ * Note: PreToolUse is handled specially in server-manager.ts — a tool starting
+ * while the workspace reads idle transitions it to busy (covers permission
+ * resolution and bash-mode "!cmd" turns that never emit UserPromptSubmit).
  */
 const HOOK_STATUS_MAP: Readonly<Record<ClaudeCodeHookName, HookStatusChange>> = {
   // Wrapper started, Claude about to be spawned
@@ -117,7 +118,7 @@ const HOOK_STATUS_MAP: Readonly<Record<ClaudeCodeHookName, HookStatusChange>> = 
   StopFailure: "idle",
   // Subagent done, main agent continues (no change)
   SubagentStop: null,
-  // Tool starting - handled specially with flag (see server-manager.ts)
+  // Tool starting - handled specially: busy if workspace was idle (see server-manager.ts)
   PreToolUse: null,
   // Tool done, back to busy (handles return from PermissionRequest idle state)
   PostToolUse: "busy",


### PR DESCRIPTION
Claude Code's bash-mode (`!cmd`) commands run a user-typed shell command without emitting `UserPromptSubmit`, so the agent turn they trigger never flipped the workspace to busy. A long-running follow-up tool (e.g. a `ship-wait`) then ran while the pill showed idle.

- Generalize the `PreToolUse` rule: a tool starting while the workspace reads **idle** now transitions it to **busy**. This subsumes the prior permission-resolution special case (after `PermissionRequest` the status is already idle) and additionally covers bash-mode turns.
- Remove the now-vestigial `awaitingPermissionResolution` flag.
- Add a test for the bash-mode turn, and one pinning the real permission-dialog hook ordering (`PreToolUse` busy → `PermissionRequest` idle → `PreToolUse` busy) so the permission flow can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRa87Ni9k42VNRfNXSF3av