### PR TITLE
refactor(agent): unify background-task busy detection via Stop payload

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -256,19 +256,46 @@ For agents like OpenCode, sessions waiting for user permission are displayed as 
 - `session.deleted`: Clears pending permissions for that session
 - Disconnect: Clears all pending permissions (reconnection safety)
 
-### Background Shell Handling (Claude Code)
+### Background Tasks: Sub-agents and Shells (Claude Code)
 
-With `experimental.busy-during-background-shell` enabled, the workspace stays busy while
-the agent has a qualifying background shell running (Bash with `run_in_background`),
-instead of going idle when the turn ends. The Stop/StopFailure hook payload carries
-`background_tasks` — the live list of still-running background tasks — which the bridge
-evaluates on every Stop: `true` keeps the workspace busy for any running shell task;
-an array of regexes (config.json only) keeps it busy only for shells whose command
-matches (e.g. `["ship-wait"]` for a CI-wait script), so dev servers don't pin the
-workspace busy. The decision is stashed to also suppress the `idle_prompt` notification
-that fires ~60s after Stop, and cleared when the agent is re-invoked (`UserPromptSubmit`,
-which happens automatically when a background shell exits) or the session ends.
-`PermissionRequest` → idle is never suppressed. Default: disabled.
+The `Stop` hook payload carries `background_tasks` — the live snapshot of still-running
+background work, each entry tagged `type: "shell"` or `type: "subagent"`. On every `Stop`
+the bridge evaluates it (`taskKeepsBusy`) and, when any qualifies, keeps the workspace
+busy instead of going idle:
+
+- A running **sub-agent** (`type: "subagent"`, from an `Agent` tool call with
+  `run_in_background`) always keeps the workspace busy — it is unambiguous agent work,
+  independent of config.
+- A running **shell** (`type: "shell"`, Bash with `run_in_background`) keeps it busy only
+  when `experimental.busy-during-background-shell` selects it: `true` for any shell, or an
+  array of regexes (config.json only) for shells whose command matches (e.g. `["ship-wait"]`
+  for a CI-wait script), so dev servers don't pin the workspace busy.
+
+The decision is stashed to also suppress the `idle_prompt` notification that fires ~60s
+after Stop, and cleared when the agent is re-invoked (`UserPromptSubmit`, which fires
+automatically when a task finishes) or the session ends. Because the snapshot is re-read
+from ground truth on every Stop, no per-sub-agent bookkeeping is needed —
+`SubagentStart`/`SubagentStop` are subscribed for logging only and don't drive status,
+and a sub-agent that crashes without reporting completion can't leak (the next empty Stop
+is authoritative). `StopFailure` carries no `background_tasks` (it's an API error — rate
+limit, auth, max-tokens), so it always transitions to idle to surface the stuck main agent
+regardless of background work. `PermissionRequest` → idle is never suppressed.
+
+A `Stop`/`StopFailure` that carries an `agent_id` is a **sub-agent's** turn end (the main
+agent's `Stop` has none) and is ignored for the workspace status entirely.
+
+### Busy→Idle Edge for Untracked Turns (Claude Code)
+
+Bash-mode turns (`!cmd`) emit **only** a `Stop` — no `UserPromptSubmit` and no
+`PreToolUse` — so a text-only reply never flips the workspace to busy, and the closing
+`Stop` lands on an already-idle workspace with no transition (so the "agent finished"
+signal/chime never fires). To surface that a turn happened, a main-agent `Stop` that
+arrives while the workspace is already `idle` emits a **synthetic busy→idle edge**: it
+sets busy then immediately idle. The status-cache dedup (`module-provider`) treats each
+emission as a distinct edge, so both propagate and the finished-signal fires — no timer or
+dwell time; the transition is what matters, not how long it stays red. Final status is
+idle, so a following real turn proceeds normally. A tool-using bash-mode turn still flips
+to busy for real via the `PreToolUse`-while-idle rule.
 
 ---
 
@@ -389,7 +416,7 @@ Content-Type: application/json
 
 ### Status Derivation
 
-Status is driven by the Claude CLI's hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PermissionRequest`, ...) routed through a per-workspace state machine in the server manager (see `claude/types.ts` for the hook → status mapping). It also handles compaction, sub-agent tracking, and permission-resolution edge cases. `WrapperStart`/`WrapperEnd` are not accepted over HTTP — they are driven by the sidekick via the `agent:lifecycle` intent (`triggerWrapperLifecycle`).
+Status is driven by the Claude CLI's hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `PermissionRequest`, ...) routed through a per-workspace state machine in the server manager (see `claude/types.ts` for the hook → status mapping). It also handles compaction, background tasks (sub-agents and shells via the `Stop` payload's `background_tasks`), AskUserQuestion parking, and permission-resolution edge cases. `WrapperStart`/`WrapperEnd` are not accepted over HTTP — they are driven by the sidekick via the `agent:lifecycle` intent (`triggerWrapperLifecycle`).
 
 ### Session Resumption
 

--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -1184,25 +1184,53 @@ describe("ClaudeCodeServerManager integration", () => {
     });
   });
 
-  describe("sub-agent tracking", () => {
-    it("StopFailure suppressed when sub-agents are active", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
+  describe("background sub-agents (via Stop.background_tasks)", () => {
+    const WS = "/workspace/feature-a";
+
+    /** Background sub-agent entry as carried by the Stop payload (Claude Code 2.1.202). */
+    function subagentTask(id = "sub-1"): Record<string, unknown> {
+      return {
+        id,
+        type: "subagent",
+        status: "running",
+        description: "work",
+        agent_type: "general-purpose",
+      };
+    }
+    /** Stop payload carrying the given still-running background tasks. */
+    function stopWith(tasks: Record<string, unknown>[]): Record<string, unknown> {
+      return { workspacePath: WS, background_tasks: tasks };
+    }
+    async function start(): Promise<{ port: number; statusChanges: AgentStatus[] }> {
+      const port = await serverManager.startServer(WS);
       const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
+      serverManager.onStatusChange(WS, (status) => statusChanges.push(status));
+      await sendHook(port, "SessionStart", { workspacePath: WS });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS });
+      return { port, statusChanges };
+    }
 
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Main agent hits API error, but sub-agent is still running
-      await sendHook(port, "StopFailure", { workspacePath: "/workspace/feature-a" });
-
-      // Should stay busy — StopFailure suppressed
+    it("Stop with a running background sub-agent stays busy", async () => {
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()]));
       expect(statusChanges).toEqual(["idle", "busy"]);
+    });
+
+    it("a background sub-agent keeps busy even when busy-during-background-shell is off", async () => {
+      // The default manager leaves the shell toggle at its false fallback;
+      // sub-agents are unconditional, proving they don't consult that config.
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()]));
+      expect(lastStatus(statusChanges)).toBe("busy");
+    });
+
+    it("StopFailure surfaces idle even with a sub-agent running (main agent errored)", async () => {
+      // StopFailure carries no background_tasks; the main agent hit an API error
+      // and needs the user, so surface idle regardless of background work.
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()]));
+      await sendHook(port, "StopFailure", { workspacePath: WS });
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
     it("StopFailure without sub-agents transitions to idle", async () => {
@@ -1219,65 +1247,16 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
-    it("Stop suppressed to busy when sub-agents are active", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      // Sub-agent spawned
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Main agent stops, but sub-agent is still running
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // Should stay busy — Stop suppressed
+    it("SubagentStart/SubagentStop do not drive status (kept for logging only)", async () => {
+      const { port, statusChanges } = await start();
+      // The sub-agent lifecycle hooks no longer move status; busy-ness is derived
+      // from the Stop payload instead.
+      await sendHook(port, "SubagentStart", { workspacePath: WS, agent_id: "sub-1" });
+      await sendHook(port, "SubagentStop", { workspacePath: WS, agent_id: "sub-1" });
       expect(statusChanges).toEqual(["idle", "busy"]);
-    });
 
-    it("last SubagentStop stays busy, subsequent Stop goes idle", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-2",
-      });
-      // Main agent stops
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // First sub-agent stops — still one active
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // Last sub-agent stops — stays busy (main agent will resume to process result)
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-2",
-      });
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // Main agent resumes, processes result, then stops → real idle
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
+      // A subsequent empty Stop goes idle normally.
+      await sendHook(port, "Stop", stopWith([]));
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
@@ -1319,230 +1298,90 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
-    it("sub-agent result processing: full cycle stays busy until final Stop", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
+    it("full cycle: Stop(sub-agent running) → resume → Stop([]) → single idle", async () => {
+      // Matches the real trace: the first Stop carries the still-running sub-agent
+      // (suppressed → busy); once it finishes, the agent resumes (UserPromptSubmit)
+      // and the next Stop carries no tasks → the one true idle.
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()]));
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS });
+      await sendHook(port, "Stop", stopWith([]));
 
-      // Matches real log trace: SubagentStart → Stop(suppressed) → SubagentStop → UserPromptSubmit → Stop(idle)
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Main agent resumes to process sub-agent result
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      // Main agent finishes processing → real idle
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // Only one idle transition — no false idle blip after SubagentStop
+      // Only one idle transition — no false idle blip while the sub-agent ran.
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
-    it("WrapperEnd clears sub-agent tracking", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
+    it("WrapperEnd clears the background-task stash", async () => {
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()])); // suppressed → busy
 
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Main agent stops (suppressed)
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // WrapperEnd — clears all tracking
-      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
-
+      // WrapperEnd — clears background-task state
+      serverManager.triggerWrapperLifecycle(WS, "WrapperEnd");
       expect(statusChanges).toEqual(["idle", "busy", "none"]);
 
-      // New session: Stop should go idle normally (sub-agent tracking was cleared)
-      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperStart");
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+      // New session: an empty Stop goes idle normally (stash was cleared).
+      serverManager.triggerWrapperLifecycle(WS, "WrapperStart");
+      await sendHook(port, "SessionStart", { workspacePath: WS });
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS });
+      await sendHook(port, "Stop", stopWith([]));
 
       expect(statusChanges).toEqual(["idle", "busy", "none", "idle", "busy", "idle"]);
     });
 
-    it("SessionEnd clears sub-agent tracking", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Main agent stops (suppressed)
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // SessionEnd — clears all tracking
-      await sendHook(port, "SessionEnd", { workspacePath: "/workspace/feature-a" });
+    it("SessionEnd clears the background-task stash", async () => {
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()])); // suppressed → busy
+      await sendHook(port, "SessionEnd", { workspacePath: WS });
 
       expect(statusChanges).toEqual(["idle", "busy", "none"]);
     });
 
-    it("orphaned sub-agent (SubagentStop never fires) stays busy until a terminal hook clears it", async () => {
-      // Deliberate trade-off: UserPromptSubmit no longer clears sub-agent tracking
-      // (that dropped still-running background sub-agents). Claude Code pairs
-      // SubagentStart/SubagentStop reliably, so a missing SubagentStop is a crash —
-      // rare — and is cleared by the terminal hooks rather than a timeout reaper.
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      // Sub-agent spawned but SubagentStop never fires (e.g., sub-agent crashes).
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-orphan",
-      });
-
-      // The orphan keeps the workspace busy — Stop is suppressed and a new prompt
-      // no longer clears it.
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // A terminal hook (workspace close) clears the orphan.
-      serverManager.triggerWrapperLifecycle("/workspace/feature-a", "WrapperEnd");
-      expect(lastStatus(statusChanges)).toBe("none");
-    });
-
-    it("concurrent sub-agents: UserPromptSubmit mid-run does not drop still-running sub-agents", async () => {
-      // Reproduces the real 2026-07-07 trace: 3 background sub-agents spawned, one
-      // finishes and the main agent resumes (UserPromptSubmit) then Stops while the
-      // other two are still running. The workspace must stay busy until the last
-      // SubagentStop, not blip to idle when the resume-prompt arrives.
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      for (const id of ["sub-1", "sub-2", "sub-3"]) {
-        await sendHook(port, "SubagentStart", {
-          workspacePath: "/workspace/feature-a",
-          agent_id: id,
-        });
-      }
-      // Main agent goes quiet with 3 sub-agents running (Stop suppressed).
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // First sub-agent finishes; main agent resumes to consume its result, then Stops.
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      // Two sub-agents still running — must NOT go idle here (the reported bug).
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // Remaining sub-agents finish; main agent resumes and finishes → real idle.
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-2",
-      });
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-3",
-      });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // Single clean idle transition — no premature blip while sub-agents ran.
-      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
-    });
-
-    it("single sub-agent: UserPromptSubmit between start and stop keeps workspace busy", async () => {
-      // A UserPromptSubmit landing while one sub-agent is still running (the main
-      // agent resumed) must not drop it and let the following Stop go idle.
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
-
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      // Interleaved resume-prompt while the sub-agent is still running.
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      expect(lastStatus(statusChanges)).toBe("busy");
-
-      // Sub-agent finishes, main agent resumes and finishes → idle.
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
+    it("no leak: a later empty Stop goes idle even without a SubagentStop", async () => {
+      // The old ID-set model needed defensive cleanup for a sub-agent that crashed
+      // without emitting SubagentStop. The Stop snapshot can't leak: the next
+      // empty Stop is ground truth, so no orphan can pin the workspace busy.
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()])); // busy
+      // No SubagentStop ever arrives; the agent resumes and stops with no tasks.
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS });
+      await sendHook(port, "Stop", stopWith([]));
 
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
-    it("idle_prompt Notification stays busy while a sub-agent is active", async () => {
-      const port = await serverManager.startServer("/workspace/feature-a");
-      const statusChanges: AgentStatus[] = [];
-      serverManager.onStatusChange("/workspace/feature-a", (status) => {
-        statusChanges.push(status);
-      });
+    it("mixed tasks: a shell (config off) is ignored but a co-running sub-agent keeps busy", async () => {
+      // Default manager has the shell toggle off, so the shell alone wouldn't
+      // suppress — but the sub-agent is unconditional, so the workspace stays busy.
+      const { port, statusChanges } = await start();
+      await sendHook(
+        port,
+        "Stop",
+        stopWith([
+          {
+            id: "sh",
+            type: "shell",
+            status: "running",
+            description: "dev",
+            command: "npm run dev",
+          },
+          subagentTask(),
+        ])
+      );
+      expect(statusChanges).toEqual(["idle", "busy"]);
+    });
 
-      // Matches real log trace: main agent dispatches a sub-agent then goes quiet;
-      // Claude Code fires idle_prompt ~60s later while the sub-agent still runs.
-      await sendHook(port, "SessionStart", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "SubagentStart", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-      // idle_prompt must NOT blip to idle — the sub-agent is still working
-      await sendHook(port, "Notification", {
-        workspacePath: "/workspace/feature-a",
-        notification_type: "idle_prompt",
-      });
-
+    it("idle_prompt after a suppressed Stop (sub-agent running) stays busy", async () => {
+      // Claude Code fires idle_prompt ~60s after the main thread goes quiet; while
+      // a background sub-agent runs it's just the lagging echo of the suppressed
+      // Stop and must not blip to idle.
+      const { port, statusChanges } = await start();
+      await sendHook(port, "Stop", stopWith([subagentTask()]));
+      await sendHook(port, "Notification", { workspacePath: WS, notification_type: "idle_prompt" });
       expect(lastStatus(statusChanges)).toBe("busy");
 
-      // Sub-agent finishes, main agent resumes and finishes → single idle transition
-      await sendHook(port, "SubagentStop", {
-        workspacePath: "/workspace/feature-a",
-        agent_id: "sub-1",
-      });
-      await sendHook(port, "UserPromptSubmit", { workspacePath: "/workspace/feature-a" });
-      await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
-
-      // No false idle blip across the whole sub-agent run
+      // Sub-agent finishes, main agent resumes and finishes → single idle transition.
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS });
+      await sendHook(port, "Stop", stopWith([]));
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
 
@@ -1672,6 +1511,45 @@ describe("ClaudeCodeServerManager integration", () => {
       await sendHook(port, "Stop", { workspacePath: "/workspace/feature-a" });
 
       // Normal flow — no sub-agents, Stop goes idle
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+    });
+  });
+
+  describe("busy→idle edge for untracked (bash-mode) turns", () => {
+    const WS = "/workspace/feature-a";
+    async function startIdle(): Promise<{ port: number; statusChanges: AgentStatus[] }> {
+      const port = await serverManager.startServer(WS);
+      const statusChanges: AgentStatus[] = [];
+      serverManager.onStatusChange(WS, (status) => statusChanges.push(status));
+      await sendHook(port, "SessionStart", { workspacePath: WS }); // → idle
+      return { port, statusChanges };
+    }
+
+    it("main-agent Stop while idle emits a synthetic busy→idle edge", async () => {
+      const { port, statusChanges } = await startIdle();
+      // Bash-mode turn: only a Stop fires, and the workspace is already idle.
+      await sendHook(port, "Stop", { workspacePath: WS });
+      // Synchronous edge — the busy→idle transition (which fires the done signal).
+      expect(statusChanges).toEqual(["idle", "busy", "idle"]);
+    });
+
+    it("two bash-mode turns emit two edges", async () => {
+      const { port, statusChanges } = await startIdle();
+      await sendHook(port, "Stop", { workspacePath: WS });
+      await sendHook(port, "Stop", { workspacePath: WS });
+      expect(statusChanges).toEqual(["idle", "busy", "idle", "busy", "idle"]);
+    });
+
+    it("a sub-agent Stop (carries agent_id) while idle is ignored (no edge)", async () => {
+      const { port, statusChanges } = await startIdle();
+      await sendHook(port, "Stop", { workspacePath: WS, agent_id: "sub-1" });
+      expect(statusChanges).toEqual(["idle"]);
+    });
+
+    it("a normal turn (UserPromptSubmit → Stop) emits a single edge, not a synthetic one", async () => {
+      const { port, statusChanges } = await startIdle();
+      await sendHook(port, "UserPromptSubmit", { workspacePath: WS }); // busy
+      await sendHook(port, "Stop", { workspacePath: WS }); // busy → idle (real)
       expect(statusChanges).toEqual(["idle", "busy", "idle"]);
     });
   });
@@ -1840,13 +1718,16 @@ describe("ClaudeCodeServerManager integration", () => {
       expect(lastStatus(statusChanges)).toBe("idle");
     });
 
-    it("StopFailure is suppressed like Stop", async () => {
+    it("StopFailure goes idle even with a running background shell (API error needs the user)", async () => {
+      // StopFailure is an API error and carries no background_tasks in practice;
+      // even if one is present it must not suppress — the stuck main agent needs
+      // the user, so we surface idle regardless of background work.
       serverManager = createManager(true);
       const { port, statusChanges } = await startBusyWorkspace(serverManager);
 
       await sendHook(port, "StopFailure", stopWithTasks([shellTask("npx tsx ship-wait.ts 512")]));
 
-      expect(lastStatus(statusChanges)).toBe("busy");
+      expect(lastStatus(statusChanges)).toBe("idle");
     });
 
     it("flag disabled: Stop goes idle even with a running background shell", async () => {

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -65,16 +65,11 @@ export interface WorkspaceState {
   /** Flag: first WrapperStart should set status to busy (a non-empty initial prompt) */
   busyOnWrapperStart?: boolean;
   /**
-   * Active sub-agent IDs (tracked via SubagentStart/SubagentStop). Claude Code
-   * pairs these reliably by agent_id, so an entry is added on SubagentStart and
-   * removed on its matching SubagentStop. A sub-agent that never reports
-   * SubagentStop (a crash) is cleared by the terminal hooks (WrapperEnd/SessionEnd).
+   * True when the last Stop was suppressed because background tasks keep the
+   * workspace busy — running shells and/or background sub-agents, read from the
+   * Stop payload's background_tasks. Also suppresses the ~60s-lagging idle_prompt.
    */
-  activeSubagents: Set<string>;
-  /** True when main agent has stopped but sub-agents are still running */
-  mainAgentStopped?: boolean;
-  /** True when the last Stop was suppressed because background shells keep the workspace busy */
-  busyForBackgroundShells?: boolean;
+  busyForBackgroundTasks?: boolean;
 }
 
 /**
@@ -186,7 +181,6 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     this.workspaces.set(normalizedPath, {
       status: "none",
       statusCallbacks: new Set(),
-      activeSubagents: new Set(),
     });
 
     // Generate config files for this workspace
@@ -267,7 +261,6 @@ export class ClaudeCodeServerManager implements AgentServerManager {
     this.workspaces.set(normalizedPath, {
       status: "none",
       statusCallbacks: savedCallbacks,
-      activeSubagents: new Set(),
     });
 
     // Regenerate config files
@@ -666,6 +659,20 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       state.sessionId = session_id;
     }
 
+    // A Stop/StopFailure carrying an agent_id is a *sub-agent's* turn end, not the
+    // main agent's (the main agent's Stop has no agent_id). Sub-agent turn-ends
+    // must not drive the workspace status — the main agent's own Stop does that,
+    // and background sub-agents are already reflected in that Stop's
+    // background_tasks. Ignore it entirely.
+    if ((hookName === "Stop" || hookName === "StopFailure") && payload.agent_id) {
+      this.logger.silly("Ignoring sub-agent Stop for main status", {
+        hookName,
+        workspacePath: normalizedPath,
+        agentId: payload.agent_id,
+      });
+      return;
+    }
+
     // Determine status change for this hook
     let newStatus = getStatusChangeForHook(hookName);
 
@@ -752,16 +759,16 @@ export class ClaudeCodeServerManager implements AgentServerManager {
         payload.notification_type === "permission_prompt" ||
         payload.notification_type === "elicitation_dialog")
     ) {
-      // idle_prompt fires ~60s after the main thread goes quiet, which is exactly
-      // what happens while the main agent waits on active sub-agents. Suppress it
-      // while sub-agents are still tracked so the workspace stays busy instead of
-      // blipping to idle — mirrors the background-shell guard below. The other two
-      // types genuinely need the user, so they still transition to idle.
-      if (payload.notification_type === "idle_prompt" && state.activeSubagents.size > 0) {
+      // idle_prompt fires ~60s after the main thread goes quiet — which also
+      // happens while the main agent waits on background tasks (a running shell
+      // or a background sub-agent). When the preceding Stop was suppressed for
+      // that reason (busyForBackgroundTasks), this idle_prompt is just its
+      // lagging echo, so suppress it too and stay busy. The other two types
+      // genuinely need the user, so they still transition to idle.
+      if (payload.notification_type === "idle_prompt" && state.busyForBackgroundTasks) {
         newStatus = null;
-        this.logger.debug("Idle suppressed for active sub-agents", {
+        this.logger.debug("Idle suppressed for background tasks", {
           workspacePath: normalizedPath,
-          activeSubagents: state.activeSubagents.size,
         });
       } else {
         newStatus = "idle";
@@ -769,77 +776,50 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       }
     }
 
-    // Sub-agent lifecycle tracking:
-    // SubagentStart adds to active set, SubagentStop removes.
-    // When Stop fires with active sub-agents, suppress idle transition.
-    // When last sub-agent stops and main agent has stopped, transition to idle.
-    if (hookName === "SubagentStart" && payload.agent_id) {
-      state.activeSubagents.add(payload.agent_id);
-    } else if (hookName === "SubagentStop" && payload.agent_id) {
-      state.activeSubagents.delete(payload.agent_id);
-      if (state.activeSubagents.size === 0 && state.mainAgentStopped) {
-        // Don't go idle here — the main agent will resume via UserPromptSubmit
-        // to process the sub-agent result, then Stop will transition to idle.
-        state.mainAgentStopped = false;
-      }
-    } else if (
-      (hookName === "Stop" || hookName === "StopFailure") &&
-      state.activeSubagents.size > 0
-    ) {
-      state.mainAgentStopped = true;
-      newStatus = null;
-    } else if (hookName === "UserPromptSubmit") {
-      // New user activity — the main agent is running again. Do NOT clear
-      // activeSubagents here: background sub-agents from the previous prompt may
-      // still be running, and UserPromptSubmit also fires when the main agent
-      // resumes to consume a background sub-agent result. Clearing on every
-      // prompt dropped still-live sub-agents and let a following Stop go idle
-      // prematurely. A sub-agent that never reports SubagentStop (a crash) is
-      // cleared by the terminal hooks (WrapperEnd/SessionEnd) instead.
-      state.mainAgentStopped = false;
-    }
+    // Sub-agent status is derived from the Stop payload's background_tasks below
+    // (background sub-agents surface there as type "subagent"), so SubagentStart/
+    // SubagentStop no longer drive status — they stay subscribed for logging only.
+    // A synchronous sub-agent runs nested inside its parent Agent tool call, so
+    // no Stop fires while it runs and the workspace stays busy from the tool.
 
-    // Background shell handling (experimental.busy-during-background-shell):
-    // The Stop/StopFailure payload carries background_tasks — the live list of
-    // still-running background tasks. When any running shell task qualifies
-    // under the config value (true = all, string[] = command regexes), the
-    // idle transition is suppressed and the decision is stashed so the later
-    // idle_prompt Notification (~60s after Stop) stays suppressed too. When a
-    // shell exits, Claude Code re-invokes the agent (UserPromptSubmit), which
-    // clears the stash — the next Stop re-evaluates from fresh ground truth.
-    // PermissionRequest is deliberately NOT suppressed: a pending permission
-    // needs the user regardless.
+    // Background task handling: the Stop payload carries background_tasks — the
+    // live list of still-running background work (shells and background
+    // sub-agents). taskKeepsBusy() decides which keep the workspace busy:
+    // sub-agents always do; shells only when experimental.busy-during-background-
+    // shell selects them (true = all, string[] = command regexes). When any
+    // qualifies, the idle transition is suppressed and the decision is stashed so
+    // the ~60s-later idle_prompt Notification (handled above) stays suppressed
+    // too. When a task finishes, Claude Code re-invokes the agent
+    // (UserPromptSubmit), which clears the stash — the next Stop re-evaluates from
+    // fresh ground truth. PermissionRequest is deliberately NOT suppressed.
+    //
+    // StopFailure carries no background_tasks (it's an API error — rate limit,
+    // auth, max-tokens — and the payload omits the field), so it always goes idle
+    // to surface the stuck main agent regardless of background work; clear the
+    // stash there.
     const busyConfig: BusyDuringBackgroundShell = this.busyDuringBackgroundShell?.get() ?? false;
-    if (busyConfig !== false) {
-      if (hookName === "Stop" || hookName === "StopFailure") {
-        const tasks = Array.isArray(payload.background_tasks) ? payload.background_tasks : [];
-        const busyTasks = tasks.filter((task) => taskKeepsBusy(busyConfig, task));
-        state.busyForBackgroundShells = busyTasks.length > 0;
-        if (busyTasks.length > 0) {
-          newStatus = null;
-          this.logger.debug("Idle suppressed for background shells", {
-            workspacePath: normalizedPath,
-            commands: busyTasks.map((task) => task.command).join(", "),
-          });
-        }
-      } else if (
-        hookName === "Notification" &&
-        payload.notification_type === "idle_prompt" &&
-        state.busyForBackgroundShells
-      ) {
+    if (hookName === "Stop") {
+      const tasks = Array.isArray(payload.background_tasks) ? payload.background_tasks : [];
+      const busyTasks = tasks.filter((task) => taskKeepsBusy(busyConfig, task));
+      state.busyForBackgroundTasks = busyTasks.length > 0;
+      if (busyTasks.length > 0) {
         newStatus = null;
+        this.logger.debug("Idle suppressed for background tasks", {
+          workspacePath: normalizedPath,
+          tasks: busyTasks.map((task) => task.command ?? task.agent_type ?? task.type).join(", "),
+        });
       }
+    } else if (hookName === "StopFailure") {
+      state.busyForBackgroundTasks = false;
     }
     if (hookName === "UserPromptSubmit") {
-      state.busyForBackgroundShells = false;
+      state.busyForBackgroundTasks = false;
       state.awaitingUserInputResolution = false;
     }
 
-    // Terminal hooks clear sub-agent and background shell state as defensive cleanup
+    // Terminal hooks clear background-task state as defensive cleanup
     if (hookName === "WrapperEnd" || hookName === "SessionEnd") {
-      state.activeSubagents.clear();
-      state.mainAgentStopped = false;
-      state.busyForBackgroundShells = false;
+      state.busyForBackgroundTasks = false;
       state.awaitingUserInputResolution = false;
     }
 
@@ -885,7 +865,41 @@ export class ClaudeCodeServerManager implements AgentServerManager {
       if (hookName === "WrapperStart" || newStatus === "idle") {
         this.markActiveHandler?.(normalizedPath);
       }
+    } else if (
+      hookName === "Stop" &&
+      newStatus === "idle" &&
+      state.status === "idle" &&
+      !state.awaitingUserInputResolution
+    ) {
+      // The main agent's Stop landed on an already-idle workspace — a turn ran
+      // that we never saw start. Bash-mode ("!cmd") turns emit only a Stop (no
+      // UserPromptSubmit, no PreToolUse), so a text-only reply never flipped the
+      // workspace to busy. Emit a synthetic busy→idle edge so the "agent
+      // finished" signal (badge/chime) still fires — the transition is what
+      // matters, not the dwell time, so this is a plain synchronous edge rather
+      // than a timed flash.
+      this.emitBusyIdleEdge(normalizedPath, state);
     }
+  }
+
+  /**
+   * Emit a synthetic busy→idle status edge (the workspace ends back at idle).
+   * Used when a main-agent turn completes that we never saw start, so the
+   * status-change consumers still see the "finished" edge. The status-cache
+   * dedup layer treats each emission as a distinct edge, so no dwell time is
+   * needed. Final status is idle, so a following real turn proceeds normally.
+   */
+  private emitBusyIdleEdge(workspacePath: string, state: WorkspaceState): void {
+    this.logger.info("Emitting busy→idle edge for untracked turn", { workspacePath });
+    state.status = "busy";
+    for (const callback of state.statusCallbacks) {
+      callback("busy");
+    }
+    state.status = "idle";
+    for (const callback of state.statusCallbacks) {
+      callback("idle");
+    }
+    this.markActiveHandler?.(workspacePath);
   }
 
   /**

--- a/src/modules/agent-module/claude/types.ts
+++ b/src/modules/agent-module/claude/types.ts
@@ -59,9 +59,11 @@ export interface ClaudeCodeHookPayload {
 }
 
 /**
- * A background task entry from the Stop/StopFailure payload's background_tasks
- * array. Shape verified against Claude Code 2.1.170:
- * `{id, type: "shell", status: "running", description, command}`.
+ * A background task entry from the Stop payload's background_tasks array.
+ * (StopFailure omits background_tasks entirely.) Shape verified against Claude
+ * Code 2.1.202:
+ * - shell:    `{id, type: "shell", status: "running", description, command}`
+ * - subagent: `{id, type: "subagent", status: "running", description, agent_type}`
  * All fields optional — the payload is external input.
  */
 export interface ClaudeCodeBackgroundTask {
@@ -70,6 +72,7 @@ export interface ClaudeCodeBackgroundTask {
   readonly status?: string;
   readonly description?: string;
   readonly command?: string;
+  readonly agent_type?: string;
 }
 
 /**
@@ -209,17 +212,26 @@ export function configBusyDuringBackgroundShell(): PersistedTypeBuilder<BusyDuri
 }
 
 /**
- * Decide whether a background task keeps the workspace busy under the given
- * config value. Only running shell tasks qualify (background agents are
- * covered by sub-agent tracking). true keeps every qualifying shell busy;
- * a pattern array keeps a shell busy if any regex tests true against its
- * command (partial, case-sensitive). false never matches.
+ * Decide whether a running background task keeps the workspace busy.
+ *
+ * A background sub-agent (type "subagent") is unambiguous agent work and always
+ * keeps the workspace busy, independent of config. A background shell (type
+ * "shell") keeps it busy only when the experimental.busy-during-background-shell
+ * config selects it: true keeps every shell busy; a pattern array keeps a shell
+ * busy if any regex tests true against its command (partial, case-sensitive);
+ * false never matches. Non-running tasks and other types never qualify.
  */
 export function taskKeepsBusy(
   config: BusyDuringBackgroundShell,
   task: ClaudeCodeBackgroundTask
 ): boolean {
-  if (task.type !== "shell" || (task.status !== undefined && task.status !== "running")) {
+  if (task.status !== undefined && task.status !== "running") {
+    return false;
+  }
+  if (task.type === "subagent") {
+    return true;
+  }
+  if (task.type !== "shell") {
     return false;
   }
   if (typeof config === "boolean") {


### PR DESCRIPTION
Derive "keep busy while background work runs" from the main-agent `Stop` payload's `background_tasks` (tagged `type: "shell"` or `"subagent"` in Claude Code 2.1.202) instead of a separate sub-agent id set. Verified empirically against Claude Code 2.1.202.

- **`taskKeepsBusy()`**: a running sub-agent always keeps the workspace busy; shells stay gated by `experimental.busy-during-background-shell`.
- **Removed** the `activeSubagents` / `mainAgentStopped` tracking and its crash-cleanup — the `Stop` snapshot is ground truth and can't leak. `SubagentStart`/`SubagentStop` stay subscribed for logging only.
- **`StopFailure`** carries no `background_tasks` (it's an API-error payload), so it always goes idle to surface the stuck main agent.
- A `Stop`/`StopFailure` carrying an `agent_id` is a sub-agent's turn end and is ignored for the main workspace status.
- **Bash-mode (`!cmd`) turns** emit only a `Stop`; a main-agent `Stop` landing on an already-idle workspace emits a synthetic `busy→idle` edge so the "agent finished" signal still fires (no timer — the edge is what matters, not the dwell time).

Net −66 lines. Docs updated in `docs/AGENTS.md`.