### PR TITLE
fix(build): install electron binary during postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "validate": "pnpm format:check && pnpm lint && pnpm check && pnpm test && pnpm build && pnpm site:check && pnpm site:build",
     "validate:fix": "pnpm format && pnpm lint:fix && pnpm check && pnpm test && pnpm build && pnpm site:check && pnpm site:build",
     "validate:quick": "pnpm format && pnpm lint:fix && pnpm check",
-    "postinstall": "tsx scripts/download-binaries.ts",
+    "postinstall": "node node_modules/electron/install.js && tsx scripts/download-binaries.ts",
     "dist": "pnpm build && pnpm dist:linux && pnpm dist:win && pnpm dist:mac",
     "dist:win": "pnpm dist:win:installer && pnpm dist:win:portable",
     "dist:win:installer": "electron-builder --win nsis",


### PR DESCRIPTION
Electron 43 (upgraded from 41 in `818c8b85`) dropped the `postinstall` script that older versions used to download the platform binary during install. Package managers only run install hooks a dependency declares, so `pnpm install` no longer fetched the Electron binary — it was instead downloaded lazily on the first `require("electron")`, an unretried per-Vitest-worker network fetch that intermittently failed CI on Windows with *"Electron failed to install correctly"* (Linux hit the same lazy download but reliably succeeded).

- Run Electron's own installer (`node node_modules/electron/install.js`) in `postinstall`, before `download-binaries.ts`
- Binary now lands deterministically at install time (once), instead of lazily at validate time
- Idempotent: `install.js` exits 0 when the binary is already present
- Fail-loud: `&&` short-circuits so a download failure fails `pnpm install` rather than surfacing mid-`validate`