### PR TITLE
fix: reverted code-server to 4.117.0

### DIFF
--- a/src/modules/code-server-module.ts
+++ b/src/modules/code-server-module.ts
@@ -64,7 +64,7 @@ import { waitForHealthy } from "../utils/health-check";
 /**
  * Current version of code-server to download.
  */
-export const CODE_SERVER_VERSION = "4.127.0";
+export const CODE_SERVER_VERSION = "4.117.0";
 
 /**
  * GitHub repository for Windows code-server builds.


### PR DESCRIPTION
- Reverted `CODE_SERVER_VERSION` from `4.127.0` to `4.117.0`
- Today's code-server 4.118–4.127 releases were broken; drop back to the latest known-good version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKroCxqCPGZdce4jnMyeVc