### PR TITLE
fix(renderer): stop dialog-teardown crash and force-quit on UI errors

### DIFF
--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -408,15 +408,15 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
     expect(module.hooks![APP_START_OPERATION_ID]!["init"]!.requires).toHaveProperty("ui-ready");
   });
 
-  it("uncaught exception: logs, reports with crash_source + logs/config, shows the quit dialog", async () => {
+  it("uncaught exception: logs + reports with crash_source + logs/config, but does NOT show a dialog or quit", async () => {
     const s = setup({ telemetryEnabled: true, configOverrides: { "log.level": "debug" } });
     await subscribeUiCrashGuard(s.module);
 
     s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
 
     expect(s.logger.error).toHaveBeenCalledWith(
-      "UI renderer crashed",
-      { source: "ui-renderer-exception" },
+      "Uncaught exception in UI renderer",
+      {},
       expect.any(Error)
     );
     await vi.waitFor(() => {
@@ -427,19 +427,17 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
       expect(captured!.properties["config"]).toEqual({ "log.level": "debug" });
     });
 
-    const state = s.dialogBoundary._getState();
-    expect(state.messageBoxCount).toBe(1);
-    const options = state.calls[0]!.options as DialogMessageBoxOptions;
-    expect(options.type).toBe("error");
-    expect(options.buttons).toEqual(["Quit CodeHydra"]);
-    expect(options.detail).toContain("effect_update_depth_exceeded");
+    // The renderer process is still alive — a single mid-session throw must NOT
+    // force-quit the app (only render-process-gone does).
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(0);
+    expect(s.deps.dispatcher.dispatch).not.toHaveBeenCalled();
   });
 
-  it("dispatches app:shutdown once the quit dialog is dismissed", async () => {
+  it("dispatches app:shutdown once the quit dialog is dismissed (render-process-gone)", async () => {
     const s = setup();
     await subscribeUiCrashGuard(s.module);
 
-    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+    s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "crashed", exitCode: 1 });
 
     await vi.waitFor(() => {
       expect(s.deps.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -448,15 +446,16 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
     });
   });
 
-  it("still shows the dialog but does NOT report when telemetry is off", async () => {
+  it("uncaught exception: logs but does NOT report when telemetry is off, and never quits", async () => {
     const s = setup({ telemetryEnabled: false });
     await subscribeUiCrashGuard(s.module);
 
     s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
 
-    expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
     await Promise.resolve();
     expect(s.boundary.$.capturedEvents).toHaveLength(0);
+    expect(s.dialogBoundary._getState().messageBoxCount).toBe(0);
+    expect(s.deps.dispatcher.dispatch).not.toHaveBeenCalled();
   });
 
   it("unhandled rejection: reports without a dialog", async () => {
@@ -484,7 +483,12 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
 
     s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "oom", exitCode: 137 });
 
-    expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);
+    const state = s.dialogBoundary._getState();
+    expect(state.messageBoxCount).toBe(1);
+    const options = state.calls[0]!.options as DialogMessageBoxOptions;
+    expect(options.type).toBe("error");
+    expect(options.buttons).toEqual(["Quit CodeHydra"]);
+    expect(options.detail).toContain("UI renderer process gone: oom (exit code 137)");
     await vi.waitFor(() => {
       const captured = s.boundary.$.capturedEvents.find((e) => e.event === "$exception");
       expect(captured).toBeDefined();
@@ -499,8 +503,10 @@ describe("ErrorReportModule — UI renderer crash guard", () => {
     const s = setup();
     await subscribeUiCrashGuard(s.module);
 
+    // Uncaught exceptions never open a dialog; repeated render-process-gone
+    // signals must not stack a second quit dialog on top of the first.
     s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
-    s.viewLayer.$.triggerUncaughtException(s.uiViewHandle, UI_EXCEPTION);
+    s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "crashed", exitCode: 1 });
     s.viewLayer.$.triggerRenderProcessGone(s.uiViewHandle, { reason: "crashed", exitCode: 1 });
 
     expect(s.dialogBoundary._getState().messageBoxCount).toBe(1);

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -20,11 +20,16 @@
  *     composition root shows the native "Startup Failed" box and quits — the
  *     rejection is caught there, so it never surfaces as an uncaughtException.
  * - app:start / init (after "ui-ready"): subscribe the UI renderer crash guard
- *     on the UI view. An uncaught exception in the UI renderer (e.g. a Svelte
- *     effect loop killing the effect runtime) bricks the UI silently, so:
- *     uncaught exception / render-process-gone → log; report (if telemetry on);
- *       show a quit-only native dialog (the UI itself can't be trusted to
- *       render anything), then dispatch app:shutdown.
+ *     on the UI view.
+ *     render-process-gone → log; report (if telemetry on); show a quit-only
+ *       native dialog, then dispatch app:shutdown. The renderer PROCESS is dead
+ *       and can't re-bootstrap mid-session — the only truly unrecoverable
+ *       signal, so a restart is the only recovery.
+ *     uncaught exception → log; report (if telemetry on); NO dialog. Unlike
+ *       render-process-gone the renderer process is still alive and the DOM is
+ *       intact, so a single mid-session throw (e.g. a transient reactive
+ *       teardown error) usually recovers — force-quitting the whole app is a
+ *       worse outcome than surviving it. Treated like a rejection.
  *     unhandled rejection → log; report (if telemetry on); no dialog —
  *       rejections rarely brick the UI and may even be handled later.
  *     unresponsive → log only.
@@ -361,12 +366,17 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
 
     deps.viewLayer.onUncaughtException(uiViewHandle, (details) => {
       const error = toUiError(details);
+      // Neither an uncaught exception nor a rejection is fatal: the renderer
+      // process is still alive (unlike render-process-gone) and a single throw
+      // typically doesn't brick the UI. Log + report both, never force-quit.
+      // Only render-process-gone routes to handleUiCrash (below).
       if (details.isPromiseRejection) {
         deps.logger.error("Unhandled promise rejection in UI renderer", {}, error);
         reportUiError(error, "ui-renderer-rejection");
         return;
       }
-      handleUiCrash(error, "ui-renderer-exception");
+      deps.logger.error("Uncaught exception in UI renderer", {}, error);
+      reportUiError(error, "ui-renderer-exception");
     });
 
     deps.viewLayer.onRenderProcessGone(uiViewHandle, ({ reason, exitCode }) => {

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -32,6 +32,7 @@
   import { getFocusables } from "$lib/utils/focus-trap";
   import MainView from "$lib/components/MainView.svelte";
   import DialogHost from "$lib/components/DialogHost.svelte";
+  import ErrorBoundary from "$lib/components/ErrorBoundary.svelte";
 
   const logger = createLogger("ui");
 
@@ -142,7 +143,11 @@
     <div class="initializing-container" aria-busy="true"></div>
   {:else if ui !== null}
     <div class="main-view-container">
-      <MainView {ui} />
+      <!-- Wall off the main workspace UI: a render/effect throw here degrades to
+           a fallback + telemetry instead of escaping to the crash guard. -->
+      <ErrorBoundary label="main-view">
+        <MainView {ui} />
+      </ErrorBoundary>
     </div>
   {/if}
 

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -8,6 +8,7 @@
 <script lang="ts">
   import type { UiDialog } from "@shared/ui-state";
   import DialogView from "./DialogView.svelte";
+  import ErrorBoundary from "./ErrorBoundary.svelte";
 
   interface Props {
     /** Open dialog sessions from the snapshot (modal + panel). */
@@ -18,5 +19,9 @@
 </script>
 
 {#each dialogs.filter((d) => d.kind === "modal") as entry (entry.id)}
-  <DialogView dialogId={entry.id} config={entry.config} />
+  <!-- Per-dialog wall: a render error in one modal shows a fallback for that
+       modal only, leaving the rest of the UI live and navigable. -->
+  <ErrorBoundary label="dialog:{entry.id}">
+    <DialogView dialogId={entry.id} config={entry.config} />
+  </ErrorBoundary>
 {/each}

--- a/src/renderer/lib/components/ErrorBoundary.svelte
+++ b/src/renderer/lib/components/ErrorBoundary.svelte
@@ -1,0 +1,94 @@
+<!--
+  ErrorBoundary.svelte
+
+  A reusable wall around a UI subtree. Wraps Svelte's <svelte:boundary> so a
+  throw during rendering / effects / $derived recomputation is CONTAINED to this
+  region — the boundary swaps its content for a fallback instead of letting the
+  error propagate to window and reach the main-process crash guard (which would
+  otherwise report + surface a quit-only dialog).
+
+  Two reporting hops, both over existing channels (no new IPC):
+  - logger.error → the renderer `log` event, so it lands in the log file that is
+    attached to bug / crash reports.
+  - a deferred re-throw → the main-process uncaught-exception path (CDP
+    Runtime.exceptionThrown), which reports it to telemetry. That path is
+    non-fatal for uncaught exceptions (see error-report-module), so the app
+    keeps running while this boundary shows its fallback.
+
+  IMPORTANT: <svelte:boundary> only catches errors thrown DURING rendering /
+  effects. Errors from event handlers or async work (setTimeout, promises) are
+  NOT caught here — those must be handled at their source (e.g. cancel timers on
+  destroy) and, as a last resort, by the main-process crash guard.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { createLogger } from "$lib/logging";
+
+  interface Props {
+    /** Names the walled-off region in logs / telemetry (e.g. "dialog:abc"). */
+    label: string;
+    /** The subtree to protect. */
+    children: Snippet;
+    /**
+     * Optional custom fallback, rendered in place of the subtree after a catch.
+     * Receives the error and a `reset` that re-creates the subtree. A minimal
+     * default is used when omitted.
+     */
+    fallback?: Snippet<[unknown, () => void]>;
+  }
+
+  const { label, children, fallback }: Props = $props();
+
+  const logger = createLogger("ui");
+
+  function onerror(error: unknown): void {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error(`UI boundary "${label}" caught an error`, {
+      message: err.message,
+      stack: err.stack ?? null,
+    });
+    // Re-surface asynchronously so the main-process crash guard reports it to
+    // telemetry via the existing uncaught-exception path — non-fatal there, so
+    // the app survives while this boundary shows its fallback. Deferred so it
+    // does not re-enter the boundary while it is still handling the error.
+    setTimeout(() => {
+      throw err;
+    }, 0);
+  }
+</script>
+
+<svelte:boundary {onerror}>
+  {@render children()}
+
+  {#snippet failed(error, reset)}
+    {#if fallback}
+      {@render fallback(error, reset)}
+    {:else}
+      <div class="ch-boundary-fallback" role="alert">
+        <p>Something went wrong here.</p>
+        <button type="button" onclick={reset}>Try again</button>
+      </div>
+    {/if}
+  {/snippet}
+</svelte:boundary>
+
+<style>
+  .ch-boundary-fallback {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    color: var(--ch-foreground);
+  }
+
+  .ch-boundary-fallback button {
+    padding: 4px 12px;
+    color: var(--ch-button-foreground, var(--vscode-button-foreground, #ffffff));
+    background: var(--ch-button-background, var(--vscode-button-background, #0e639c));
+    border: none;
+    border-radius: var(--ch-radius-sm, 4px);
+    cursor: pointer;
+  }
+</style>

--- a/src/renderer/lib/components/ErrorBoundary.test.ts
+++ b/src/renderer/lib/components/ErrorBoundary.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for ErrorBoundary: it contains a render-time throw in its subtree,
+ * swaps in a fallback instead of letting the error propagate, and reports the
+ * error over the renderer log channel.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+
+// Capture logger.error calls.
+const { mockError } = vi.hoisted(() => ({ mockError: vi.fn() }));
+
+vi.mock("$lib/logging", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockError,
+  }),
+}));
+
+// Import after the mock is set up.
+import ErrorBoundary from "./ErrorBoundary.svelte";
+
+const okChildren = createRawSnippet(() => ({
+  render: () => `<p data-testid="ok">content</p>`,
+}));
+
+const throwingChildren = createRawSnippet(() => ({
+  render: () => {
+    throw new Error("boom from child");
+  },
+}));
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("renders its children when nothing throws", () => {
+    render(ErrorBoundary, { props: { label: "test", children: okChildren } });
+
+    expect(screen.getByTestId("ok")).toHaveTextContent("content");
+  });
+
+  it("contains a render-time throw, showing the fallback and reporting it", () => {
+    // Fake timers so the deferred telemetry re-throw never fires during the
+    // test — here we only assert containment + logging.
+    vi.useFakeTimers();
+
+    expect(() =>
+      render(ErrorBoundary, { props: { label: "panel:test", children: throwingChildren } })
+    ).not.toThrow();
+
+    // The fallback replaced the subtree; the throwing child is gone.
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryByTestId("ok")).not.toBeInTheDocument();
+
+    // Reported over the log channel, tagged with the region label.
+    expect(mockError).toHaveBeenCalledWith(
+      'UI boundary "panel:test" caught an error',
+      expect.objectContaining({ message: "boom from child" })
+    );
+
+    vi.clearAllTimers();
+  });
+});

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -220,8 +220,8 @@
        view is "creation" (the ground state when no workspace is active). -->
   {#if creationShown && creationDialog}
     <PanelView
-      dialogId={creationDialog.id}
-      config={creationDialog.config}
+      dialogId={creationDialog?.id}
+      config={creationDialog?.config}
       kind="modeless"
       {modalAbove}
     />
@@ -234,7 +234,7 @@
        workspace and are mutually exclusive, so they never coexist with the
        creation ground state or each other. -->
   {#if main?.kind === "workspace" && panelDialog}
-    <PanelView dialogId={panelDialog.id} config={panelDialog.config} kind="panel" {modalAbove} />
+    <PanelView dialogId={panelDialog?.id} config={panelDialog?.config} kind="panel" {modalAbove} />
   {/if}
 
   {#if main?.kind === "hibernated"}

--- a/src/renderer/lib/components/PanelView.svelte
+++ b/src/renderer/lib/components/PanelView.svelte
@@ -28,8 +28,13 @@
   import Form from "./form/Form.svelte";
 
   interface Props {
-    dialogId: string;
-    config: DialogConfig;
+    // dialogId/config are optional to survive the teardown flush: when the
+    // owning dialog leaves the ui:state snapshot, MainView's `xDialog?.config`
+    // getter yields `undefined` for the frame between the dialog disappearing
+    // and this component being destroyed. Rendering nothing that frame beats
+    // dereferencing undefined and throwing (which the crash guard would report).
+    dialogId: string | undefined;
+    config: DialogConfig | undefined;
     /** "modeless" (creation, above sidebar) or "panel" (deletion, below sidebar). */
     kind: Extract<DialogKind, "modeless" | "panel">;
     /** Whether a blocking modal is open above (drives refocus on close). */
@@ -42,7 +47,7 @@
 
   /** Derive heading text from sections for the accessible name. */
   const heading = $derived.by(() => {
-    const headingSection = config.sections.find((s) => s.type === "text" && s.style === "heading");
+    const headingSection = config?.sections.find((s) => s.type === "text" && s.style === "heading");
     return headingSection?.type === "text" ? headingSection.content : "Panel";
   });
 
@@ -62,9 +67,11 @@
   aria-label={heading}
 >
   <div class="panel-card">
-    {#key dialogId}
-      <Form bind:this={formRef} {dialogId} {config} {kind} />
-    {/key}
+    {#if config && dialogId}
+      {#key dialogId}
+        <Form bind:this={formRef} {dialogId} {config} {kind} />
+      {/key}
+    {/if}
   </div>
 </section>
 

--- a/src/renderer/lib/components/PanelView.svelte
+++ b/src/renderer/lib/components/PanelView.svelte
@@ -26,6 +26,7 @@
 <script lang="ts">
   import type { DialogConfig, DialogKind } from "@shared/dialog-types";
   import Form from "./form/Form.svelte";
+  import ErrorBoundary from "./ErrorBoundary.svelte";
 
   interface Props {
     // dialogId/config are optional to survive the teardown flush: when the
@@ -68,9 +69,13 @@
 >
   <div class="panel-card">
     {#if config && dialogId}
-      {#key dialogId}
-        <Form bind:this={formRef} {dialogId} {config} {kind} />
-      {/key}
+      <!-- Wall off the form: a render error in the panel's form degrades to a
+           fallback instead of escaping to the crash guard. -->
+      <ErrorBoundary label="panel:{kind}">
+        {#key dialogId}
+          <Form bind:this={formRef} {dialogId} {config} {kind} />
+        {/key}
+      </ErrorBoundary>
     {/if}
   </div>
 </section>

--- a/src/renderer/lib/components/PanelView.test.ts
+++ b/src/renderer/lib/components/PanelView.test.ts
@@ -154,4 +154,39 @@ describe("PanelView component (panel surface)", () => {
       );
     });
   });
+
+  // When the owning dialog leaves the ui:state snapshot, MainView's
+  // `xDialog?.config` getter yields `undefined` for the frame between the
+  // dialog disappearing and this component being destroyed. Dereferencing it
+  // (the old `config.sections` / non-null props) threw a TypeError that the
+  // main-process crash guard reported and — until fixed — force-quit the app.
+  describe("teardown tolerance (dialog leaves the snapshot mid-flush)", () => {
+    it("renders only the shell, no Form, when config/dialogId are undefined", () => {
+      expect(() =>
+        render(PanelView, {
+          props: { dialogId: undefined, config: undefined, kind: "modeless", modalAbove: false },
+        })
+      ).not.toThrow();
+
+      expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+      expect(document.querySelector("textarea")).toBeNull();
+      // Heading derivation short-circuits to the default accessible name.
+      expect(screen.getByRole("region", { name: "Panel" })).toBeInTheDocument();
+    });
+
+    it("survives config/dialogId going undefined on the teardown flush", async () => {
+      const { rerender } = renderPanel(createConfig(), "panel-1");
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("New Workspace");
+
+      // The teardown frame: no throw, and the Form is torn down.
+      await rerender({
+        dialogId: undefined,
+        config: undefined,
+        kind: "modeless",
+        modalAbove: false,
+      });
+
+      expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -261,6 +261,13 @@
   // effect above — so backend-driven config updates never re-emit (no loop).
   const changeTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 
+  // The deferred focus timer (mount auto-focus / refocus, both a setTimeout(0)).
+  // Tracked so it can be canceled on unmount: its callback reads reactive state
+  // (`layout` → `config.layout`), and a config-less teardown flush leaves the
+  // prop getter dereferencing an undefined dialog — firing this after destroy
+  // threw the "reading 'config'" crash. At most one is pending at a time.
+  let focusTimer: ReturnType<typeof setTimeout> | undefined;
+
   /**
    * Effective debounce (ms) for a field's change-event opt-in, or null when the
    * field does not opt in. Default debounce per field type: continuous editing
@@ -328,14 +335,28 @@
 
   onDestroy(() => {
     cancelChangeTimers();
+    if (focusTimer !== undefined) clearTimeout(focusTimer);
   });
+
+  /**
+   * Defer `run` to the next tick, tracking the handle so unmount can cancel it.
+   * Focus placement always waits a tick (for mount / DOM settle); a pending one
+   * must not fire after the component is torn down (see `focusTimer`).
+   */
+  function scheduleFocus(run: () => void): void {
+    if (focusTimer !== undefined) clearTimeout(focusTimer);
+    focusTimer = setTimeout(() => {
+      focusTimer = undefined;
+      run();
+    }, 0);
+  }
 
   /** Focus the control marked data-autofocus (after a tick for mounting). */
   function focusAutofocusTarget(): void {
-    setTimeout(() => {
+    scheduleFocus(() => {
       const target = formRef?.querySelector<HTMLElement>("[data-autofocus]");
       target?.focus();
-    }, 0);
+    });
   }
 
   /**
@@ -391,7 +412,7 @@
   // first field would open its dropdown list, so we leave focus unset unless a
   // control opts in with an explicit autofocus flag.
   onMount(() => {
-    setTimeout(() => {
+    scheduleFocus(() => {
       const explicit = formRef?.querySelector<HTMLElement>("[data-autofocus]");
       if (explicit) {
         explicit.focus();
@@ -399,7 +420,7 @@
       }
       if (layout === "form") return;
       defaultFocusTarget()?.focus();
-    }, 0);
+    });
   });
 
   // Focus follows when a config update MOVES the autofocus flag to a


### PR DESCRIPTION
Resolves the PostHog `UIRendererError` crash (Cannot read properties of undefined reading 'config') and hardens the UI against renderer errors.

- **fix(dialog):** cancel Form's deferred focus `setTimeout` on destroy — it fired one tick after a dialog closed and dereferenced the undefined dialog through the forwarded `config` getter chain. Plus defense-in-depth: PanelView tolerates a transient undefined config/dialogId, and MainView uses optional chaining on the panel getters.
- **fix(error-report):** an uncaught renderer exception is now reported but no longer force-quits the app; the quit-only dialog + `app:shutdown` is reserved for `render-process-gone`, the only unrecoverable signal.
- **feat(renderer):** reusable `ErrorBoundary` (`<svelte:boundary>`) at the App root, per modal dialog, and around the panel form — contains render/effect throws to a fallback and reports them via the existing log + crash-guard paths (no new IPC).

Note: boundaries only catch render/effect errors, not async/event-handler throws — those stay handled at the source (timer cancel-on-destroy) and by the crash guard.