### PR TITLE
fix: Alt+F4 was not working on Linux under Wayland

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -769,6 +769,7 @@ const shortcutModule = createShortcutModule({
   windowManager,
   ui: presentationModule,
   dispatcher,
+  platform: platformInfo.platform,
   logger: loggingService.createLogger("shortcut"),
 });
 

--- a/src/modules/shortcut-module.integration.test.ts
+++ b/src/modules/shortcut-module.integration.test.ts
@@ -151,7 +151,10 @@ interface TestHarness {
   emitSwitched: () => Promise<void>;
 }
 
-async function createHarness(modalOpen = false): Promise<TestHarness> {
+async function createHarness(
+  modalOpen = false,
+  platform: NodeJS.Platform = "linux"
+): Promise<TestHarness> {
   const dispatcher = createMockDispatcher();
   const uiHandle = createViewHandle("ui-view");
   const callbacks = createMockCallbacks();
@@ -181,6 +184,7 @@ async function createHarness(modalOpen = false): Promise<TestHarness> {
     windowManager: { getWindowHandle: () => createWindowHandle() },
     ui: dialogManager as unknown as ShortcutModuleDeps["ui"],
     dispatcher: { dispatch: dispatchSpy } as unknown as ShortcutModuleDeps["dispatcher"],
+    platform,
     logger: SILENT_LOGGER,
   });
 
@@ -584,6 +588,64 @@ describe("ShortcutModule integration", () => {
       expect(callbacks.inputUnsubscribes.get("ui-view")).toHaveBeenCalled();
       expect(callbacks.destroyedUnsubscribes.get("ui-view")).toHaveBeenCalled();
       expect(callbacks.blurUnsubscribe).toHaveBeenCalled();
+    });
+  });
+
+  describe("Alt+F4 quit", () => {
+    const shutdownCount = (dispatchSpy: ReturnType<typeof vi.fn>): number =>
+      dispatchSpy.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { type: string }).type === INTENT_APP_SHUTDOWN
+      ).length;
+
+    it("dispatches app:shutdown on Alt+F4 (linux)", async () => {
+      const { callbacks, dispatchSpy } = await createHarness();
+      simulateInput(callbacks, "ui-view", createKeyboardInput("F4", "keyDown", { alt: true }));
+      expect(shutdownCount(dispatchSpy)).toBe(1);
+    });
+
+    it("quits even while shortcut mode is active", async () => {
+      const { callbacks, dispatchSpy } = await createHarness();
+      activate(callbacks);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("F4", "keyDown", { alt: true }));
+      expect(shutdownCount(dispatchSpy)).toBe(1);
+    });
+
+    it("does not preventDefault the Alt+F4 key (Electron #37336)", async () => {
+      const { callbacks } = await createHarness();
+      const { preventDefault } = simulateInput(
+        callbacks,
+        "ui-view",
+        createKeyboardInput("F4", "keyDown", { alt: true })
+      );
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("ignores F4 without Alt", async () => {
+      const { callbacks, dispatchSpy } = await createHarness();
+      simulateInput(callbacks, "ui-view", createKeyboardInput("F4", "keyDown", { alt: false }));
+      expect(shutdownCount(dispatchSpy)).toBe(0);
+    });
+
+    it("ignores the Alt+F4 keyUp (acts only on keydown)", async () => {
+      const { callbacks, dispatchSpy } = await createHarness();
+      simulateInput(callbacks, "ui-view", createKeyboardInput("F4", "keyUp", { alt: true }));
+      expect(shutdownCount(dispatchSpy)).toBe(0);
+    });
+
+    it("ignores auto-repeat Alt+F4 (does not re-dispatch while held)", async () => {
+      const { callbacks, dispatchSpy } = await createHarness();
+      simulateInput(
+        callbacks,
+        "ui-view",
+        createKeyboardInput("F4", "keyDown", { alt: true, isAutoRepeat: true })
+      );
+      expect(shutdownCount(dispatchSpy)).toBe(0);
+    });
+
+    it.each(["darwin", "win32"] as const)("does not quit on Alt+F4 on %s", async (platform) => {
+      const { callbacks, dispatchSpy } = await createHarness(false, platform);
+      simulateInput(callbacks, "ui-view", createKeyboardInput("F4", "keyDown", { alt: true }));
+      expect(shutdownCount(dispatchSpy)).toBe(0);
     });
   });
 });

--- a/src/modules/shortcut-module.ts
+++ b/src/modules/shortcut-module.ts
@@ -43,7 +43,11 @@ import type { WindowManager } from "../boundaries/shell/window-manager";
 import type { IDispatcher } from "../intents/lib/dispatcher";
 import type { UiPresenter } from "./presentation/presentation-module";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
+import {
+  APP_SHUTDOWN_OPERATION_ID,
+  INTENT_APP_SHUTDOWN,
+  type AppShutdownIntent,
+} from "../intents/app-shutdown";
 import {
   INTENT_SET_SHORTCUT_ACTIVE,
   type SetShortcutActiveIntent,
@@ -55,6 +59,22 @@ type ShortcutActivationState = "NORMAL" | "ALT_WAITING";
 
 const SHORTCUT_MODIFIER_KEY = "Alt";
 const SHORTCUT_ACTIVATION_KEY = "x";
+
+/**
+ * Alt+<QUIT_KEY> quits the app. This shares ShortcutModule's before-input stream
+ * rather than living in its own module, since both are UI-view accelerators read
+ * off the same subscription. It is NOT part of the Alt+X shortcut-mode state
+ * machine — it fires directly, in any state.
+ *
+ * Why the app handles Alt+F4 at all: normally the window manager owns it and
+ * sends a window close. Under native Wayland (Linux, Electron 43+) Chromium uses
+ * the keyboard-shortcuts-inhibit protocol so the focused code-server surface
+ * receives ALL keys — the compositor stops acting on Alt+F4 and forwards it here
+ * instead. Owning it restores quit. Linux-only (see `deps.platform` guard):
+ * Windows closes via the OS (SC_CLOSE) and macOS uses Cmd+Q, so Alt+F4 must not
+ * quit there.
+ */
+const QUIT_KEY = "F4";
 
 /**
  * The only shortcut honored while a modal is open (restricted mode): opens the
@@ -104,6 +124,8 @@ export interface ShortcutModuleDeps {
   readonly windowManager: Pick<WindowManager, "getWindowHandle">;
   readonly ui: Pick<UiPresenter, "isModalOpen">;
   readonly dispatcher: Pick<IDispatcher, "dispatch">;
+  /** Host platform; Alt+F4-to-quit is honored only on `"linux"`. */
+  readonly platform: NodeJS.Platform;
   readonly logger: Logger;
 }
 
@@ -215,6 +237,17 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
 
     // Ignore auto-repeat events (fires dozens per second on key hold)
     if (input.isAutoRepeat) return;
+
+    // Alt+F4 quits the app (Linux only — see QUIT_KEY). Handled here, ahead of
+    // the Alt+X state machine, so it fires in any state (including shortcut mode).
+    if (deps.platform === "linux" && input.key === QUIT_KEY && input.alt) {
+      deps.logger.info("Alt+F4 pressed — dispatching app:shutdown");
+      void deps.dispatcher.dispatch({
+        type: INTENT_APP_SHUTDOWN,
+        payload: {},
+      } as AppShutdownIntent);
+      return;
+    }
 
     const isActivationKey = input.key.toLowerCase() === SHORTCUT_ACTIVATION_KEY;
 


### PR DESCRIPTION
Alt+F4 stopped quitting the app on Linux after the Electron 43 upgrade.

**Root cause:** Electron 43 defaults to native Wayland (previously XWayland). Under native Wayland, Chromium uses the keyboard-shortcuts-inhibit protocol so the focused code-server surface receives all keys — the compositor no longer acts on its own Alt+F4 close shortcut and forwards the key to the app instead. With no app-side handler, Alt+F4 was silently dropped.

**Fix:**
- Handle Alt+F4 in `ShortcutModule`'s existing `before-input` stream (shared with the Alt+X accelerator — no extra subscription) and dispatch `app:shutdown`, the same graceful path `window-all-closed` takes.
- Fired ahead of the Alt+X state machine, so it quits in any state (including shortcut mode).
- Linux-only (`deps.platform` guard): Windows closes via the OS (SC_CLOSE) and macOS uses Cmd+Q, so Alt+F4 must not quit there.
- Added integration coverage: quits on Alt+F4 (Linux), quits during shortcut mode, no `preventDefault`, ignores bare F4 / keyUp / auto-repeat, and does not quit on darwin/win32.