### PR TITLE
feat(bug-report): show loading on Send until the dialog hides

### DIFF
--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -209,6 +209,38 @@ describe("ErrorReportModule — bug report dialog", () => {
     expect(handle.handle.close).toHaveBeenCalled();
   });
 
+  it("marks the Send button busy before the dialog closes", async () => {
+    const { module, handle } = setup();
+    await emitKey(module, "b");
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
+
+    // A busy config is pushed synchronously on click (before the async log
+    // reads resolve and close the dialog), so the primary button shows its
+    // in-flight state until the window hides.
+    const busyConfig = handle.configs.find((c) =>
+      c.sections.some(
+        (s) =>
+          s.type === "group" &&
+          s.items.some((i) => i.type === "button" && i.id === "send" && i.busy === true)
+      )
+    );
+    expect(busyConfig).toBeDefined();
+    expect(handle.handle.update).toHaveBeenCalled();
+    expect(handle.handle.close).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(handle.handle.close).toHaveBeenCalled());
+  });
+
+  it("ignores a second 'send' while the first is in flight", async () => {
+    const { module, deps, handle } = setup();
+    await emitKey(module, "b");
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
+    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
+
+    await vi.waitFor(() => expect(handle.handle.close).toHaveBeenCalled());
+    expect(deps.dispatcher.dispatch).toHaveBeenCalledOnce();
+  });
+
   it("closes without dispatching on 'cancel'", async () => {
     const { module, deps, handle } = setup();
     await emitKey(module, "b");

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -116,7 +116,14 @@ function compressAndTrim(raw: string): { compressed: string; rawBytesKept: numbe
   return { compressed, rawBytesKept: kept.length };
 }
 
-function buildDialogConfig(): DialogConfig {
+/**
+ * Build the bug-report dialog config. When `busy` is set (after the user hits
+ * Send / Ctrl+Enter), the primary button shows a spinner label and the form is
+ * frozen — the report can't hide instantly because it first reads the log files
+ * off disk, so the button carries that in-flight state until the dialog closes.
+ */
+function buildDialogConfig(options?: { busy?: boolean }): DialogConfig {
+  const busy = options?.busy ?? false;
   return {
     sections: [
       { type: "text", content: "Report a Bug", style: "heading", icon: "bug" },
@@ -127,6 +134,7 @@ function buildDialogConfig(): DialogConfig {
         multiline: true,
         initialValue: DESCRIPTION_INITIAL,
         selectInitialValue: true,
+        disabled: busy,
       },
       {
         type: "text",
@@ -136,8 +144,22 @@ function buildDialogConfig(): DialogConfig {
       {
         type: "group",
         items: [
-          { type: "button", id: "send", label: "Send", variant: "primary" },
-          { type: "button", id: "cancel", label: "Cancel", variant: "secondary", role: "cancel" },
+          {
+            type: "button",
+            id: "send",
+            label: "Send",
+            variant: "primary",
+            busy,
+            busyLabel: "Sending...",
+          },
+          {
+            type: "button",
+            id: "cancel",
+            label: "Cancel",
+            variant: "secondary",
+            role: "cancel",
+            disabled: busy,
+          },
         ],
       },
     ],
@@ -401,8 +423,19 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
     const handle = deps.ui.dialog(buildDialogConfig());
     activeHandle = handle;
 
+    // Guards against a second Send firing while the first is in flight (e.g. a
+    // double Ctrl+Enter before the busy config reaches the renderer).
+    let sending = false;
+
     handle.onEvent((event) => {
       if (event.actionId === "send") {
+        if (sending) return;
+        sending = true;
+        // Reflect the in-flight send on the primary button (spinner label) and
+        // freeze the form until the dialog closes — the log reads below can take
+        // a perceptible moment, so the button must not look unresponsive.
+        handle.update(buildDialogConfig({ busy: true }));
+
         void (async () => {
           const [logs, electronLogs] = await Promise.all([
             readLogContent(),


### PR DESCRIPTION
- The bug-report dialog's primary **Send** button gave no feedback between click (or Ctrl+Enter) and the window hiding, even though the send first reads the log files off disk — so it could look unresponsive.
- On send, synchronously push a busy config: the Send button spins with a `Sending...` label and the form freezes, until `handle.close()` hides the dialog.
- Added a `sending` guard so a double Ctrl+Enter can't submit the report twice.
- No shared-type / IPC changes — drives the existing `DialogButton.busy` capability from the backend module.
- Tests: busy config is pushed before close; second in-flight `send` is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrXkeQiwSejmiC2kLUnj7p