### PR TITLE
fix: base branch loads faster in creation dialog

### DIFF
--- a/src/boundaries/platform/git-worktree-provider.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.test.ts
@@ -481,6 +481,36 @@ describe("GitWorktreeProvider error injection", () => {
 
       expect(result).toBeUndefined();
     });
+
+    it("reuses pre-fetched bases instead of enumerating branches again", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "origin/main"],
+            currentBranch: "main",
+            remotes: ["origin"],
+          },
+        },
+      });
+
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        mockLogger
+      );
+
+      const listBranchesSpy = vi.spyOn(mockClient, "listBranches");
+      const bases = await provider.listBases(PROJECT_ROOT);
+      const callsAfterListBases = listBranchesSpy.mock.calls.length;
+
+      const result = await provider.defaultBase(PROJECT_ROOT, bases);
+
+      // Passing bases must not trigger another branch enumeration.
+      expect(listBranchesSpy.mock.calls.length).toBe(callsAfterListBases);
+      expect(result).toBe("origin/main");
+    });
   });
 
   describe("cleanupOrphanedWorkspaces", () => {

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -709,12 +709,15 @@ export class GitWorktreeProvider {
    * over local ones to ensure proper tracking. Purely local: never hits the network.
    *
    * @param projectRoot Root of the git repository
+   * @param bases Pre-fetched bases to reuse; when omitted, listBases() is called.
+   *   Callers that already enumerated bases (e.g. the get-project-bases list
+   *   hook) pass them to avoid a second full branch enumeration.
    * @returns Promise resolving to the default base branch, or undefined if none found
    */
-  async defaultBase(projectRoot: Path): Promise<string | undefined> {
+  async defaultBase(projectRoot: Path, bases?: readonly BaseInfo[]): Promise<string | undefined> {
     try {
-      const bases = await this.listBases(projectRoot);
-      const branchNames = new Set(bases.map((b) => b.name));
+      const resolvedBases = bases ?? (await this.listBases(projectRoot));
+      const branchNames = new Set(resolvedBases.map((b) => b.name));
 
       // Resolve a detected branch name to a selectable base, preferring remote-tracking
       const pick = (branchName: string | null, remote?: string): string | undefined => {

--- a/src/intents/list-projects.integration.test.ts
+++ b/src/intents/list-projects.integration.test.ts
@@ -197,6 +197,46 @@ describe("ListProjects Operation", () => {
     });
   });
 
+  describe("default base branch", () => {
+    it("carries defaultBaseBranch from the workspace entry onto the project", async () => {
+      const setup = createTestSetup(
+        async () => ({
+          result: {
+            projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          },
+        }),
+        async () => ({
+          result: {
+            entries: [
+              { projectPath: PROJECT_A_PATH, workspaces: [], defaultBaseBranch: "origin/main" },
+            ],
+          },
+        })
+      );
+
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result[0]!.defaultBaseBranch).toBe("origin/main");
+    });
+
+    it("omits defaultBaseBranch when the workspace entry has none", async () => {
+      const setup = createTestSetup(
+        async () => ({
+          result: {
+            projects: [{ projectId: PROJECT_A_ID, name: "project-a", path: PROJECT_A_PATH }],
+          },
+        }),
+        async () => ({
+          result: { entries: [{ projectPath: PROJECT_A_PATH, workspaces: [] }] },
+        })
+      );
+
+      const result = (await setup.dispatcher.dispatch(listProjectsIntent())) as Project[];
+
+      expect(result[0]!.defaultBaseBranch).toBeUndefined();
+    });
+  });
+
   describe("project with no matching workspaces", () => {
     let setup: TestSetup;
 

--- a/src/intents/list-projects.ts
+++ b/src/intents/list-projects.ts
@@ -47,6 +47,12 @@ export interface ListProjectsHookResult {
 export interface ListWorkspacesHookEntry {
   readonly projectPath: string;
   readonly workspaces: readonly InternalWorkspace[];
+  /**
+   * Per-project default base branch, computed once at project:open and cached
+   * by the contributing module. Carried here so the creation form can seed the
+   * base field synchronously on first paint instead of awaiting a git round-trip.
+   */
+  readonly defaultBaseBranch?: string;
 }
 
 export interface ListWorkspacesHookResult {
@@ -81,14 +87,18 @@ export class ListProjectsOperation implements Operation<ListProjectsIntent, Proj
     );
     throwHookErrors(workspacesResult.errors, "Multiple errors listing workspaces");
 
-    // Build workspace lookup by projectPath
+    // Build workspace + default-base lookups by projectPath
     const workspaceMap = new Map<string, InternalWorkspace[]>();
+    const defaultBaseMap = new Map<string, string>();
     for (const result of workspacesResult.results) {
       if (result.entries) {
         for (const entry of result.entries) {
           const existing = workspaceMap.get(entry.projectPath) ?? [];
           existing.push(...entry.workspaces);
           workspaceMap.set(entry.projectPath, existing);
+          if (entry.defaultBaseBranch !== undefined) {
+            defaultBaseMap.set(entry.projectPath, entry.defaultBaseBranch);
+          }
         }
       }
     }
@@ -99,11 +109,13 @@ export class ListProjectsOperation implements Operation<ListProjectsIntent, Proj
       if (result.projects) {
         for (const entry of result.projects) {
           const internalWorkspaces = workspaceMap.get(entry.path) ?? [];
+          const defaultBaseBranch = defaultBaseMap.get(entry.path);
           projects.push({
             id: entry.projectId,
             name: entry.name,
             path: entry.path,
             workspaces: toIpcWorkspaces(internalWorkspaces, entry.projectId),
+            ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
           });
         }
       }

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -412,6 +412,29 @@ describe("CreationModule", () => {
       expect(field(panel.config, "base")["loading"]).toBe(false);
     });
 
+    it("seeds the base field from the project's defaultBaseBranch before bases load", async () => {
+      const seeded: Project = { ...PROJECT_A, defaultBaseBranch: "origin/seeded" };
+      const s = setup({ projects: [seeded] });
+      // Hang the bases fetch so only the synchronous first-paint seed is visible.
+      s.dispatcher.results.set(INTENT_GET_PROJECT_BASES, () => new Promise(() => {}));
+
+      const panel = await s.start();
+
+      const base = field(panel.config, "base");
+      // Value painted from the project list, not from the (pending) git round-trip.
+      expect(base["value"]).toBe("origin/seeded");
+      expect(base["loading"]).toBe(true);
+    });
+
+    it("leaves the base field empty when the project has no known default", async () => {
+      const s = setup({ projects: [PROJECT_A] });
+      s.dispatcher.results.set(INTENT_GET_PROJECT_BASES, () => new Promise(() => {}));
+
+      const panel = await s.start();
+
+      expect(field(panel.config, "base")["value"]).toBe("");
+    });
+
     it("name suggestions are derivable branches (value = ref, label = derives)", async () => {
       const s = setup();
       const panel = await s.start();

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -527,7 +527,11 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     branches = [];
     branchesLoading = true;
     branchesError = null;
-    baseValue = "";
+    // Seed the base field from the project's known default (computed at
+    // project:open, carried on the project list) so it paints on the first
+    // frame instead of after the git round-trip. The async list/refresh below
+    // validates and, if needed, re-defaults it.
+    baseValue = projects.find((p) => p.path === projectPath)?.defaultBaseBranch ?? "";
     formError = null;
     const epoch = ++selectionEpoch;
     if (options?.refocusName) {

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -553,6 +553,19 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       expect(provider.cleanupOrphanedWorkspaces).toHaveBeenCalledWith(new Path("/projects/my-app"));
     });
+
+    it("caches the default base from discover and surfaces it via list-workspaces", async () => {
+      const { dispatcher, provider } = setup;
+      const projectPath = "/projects/my-app";
+      provider.discover.mockResolvedValue([]);
+      provider.defaultBase.mockResolvedValue("origin/main");
+
+      await dispatchOpenProject(dispatcher, projectPath);
+      const listed = await dispatchListWorkspaces(dispatcher);
+
+      const entry = listed.entries!.find((e) => e.projectPath === new Path(projectPath).toString());
+      expect(entry?.defaultBaseBranch).toBe("origin/main");
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -1007,16 +1020,18 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const { dispatcher, provider } = setup;
       const projectPath = "/projects/my-app";
 
-      provider.listBases.mockResolvedValue([
+      const bases = [
         { name: "origin/main", isRemote: true, base: "origin/main" },
         { name: "main", isRemote: false, base: "origin/main" },
-      ]);
+      ];
+      provider.listBases.mockResolvedValue(bases);
       provider.defaultBase.mockResolvedValue("origin/main");
 
       const result = await dispatchListBases(dispatcher, projectPath);
 
       expect(provider.listBases).toHaveBeenCalledWith(new Path(projectPath));
-      expect(provider.defaultBase).toHaveBeenCalledWith(new Path(projectPath));
+      // defaultBase reuses the already-enumerated bases (no second listBases).
+      expect(provider.defaultBase).toHaveBeenCalledWith(new Path(projectPath), bases);
       expect(result.bases).toHaveLength(2);
       expect(result.defaultBaseBranch).toBe("origin/main");
     });

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -93,6 +93,10 @@ export function createGitWorktreeWorkspaceModule(
   // Internal state
   const workspaces = new Map<string, Workspace[]>();
   const deletionPending = new Map<string, { projectPath: string; workspace: Workspace }>();
+  // Per-project default base branch, computed at project:open (discover) and
+  // refreshed by the get-project-bases list hook. Surfaced via list-workspaces
+  // so the creation form can seed the base field without a git round-trip.
+  const projectDefaults = new Map<string, string>();
 
   // ---------------------------------------------------------------------------
   // Private Helpers
@@ -222,6 +226,9 @@ export function createGitWorktreeWorkspaceModule(
               });
 
             const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj);
+            if (defaultBaseBranch !== undefined) {
+              projectDefaults.set(key, defaultBaseBranch);
+            }
 
             return {
               result: {
@@ -259,6 +266,7 @@ export function createGitWorktreeWorkspaceModule(
             gitWorktreeProvider.unregisterProject(projectPathObj);
             const key = projectPathObj.toString();
             workspaces.delete(key);
+            projectDefaults.delete(key);
 
             // Clear deletion-pending entries for this project
             for (const [wsPath, entry] of deletionPending) {
@@ -374,8 +382,13 @@ export function createGitWorktreeWorkspaceModule(
             const { projectPath } = ctx as ListBasesHookInput;
             const projectPathObj = new Path(projectPath);
 
+            // Enumerate once and reuse for the default (avoids a second full
+            // branch enumeration inside defaultBase).
             const bases = await gitWorktreeProvider.listBases(projectPathObj);
-            const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj);
+            const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj, bases);
+            if (defaultBaseBranch !== undefined) {
+              projectDefaults.set(projectPathObj.toString(), defaultBaseBranch);
+            }
 
             return {
               result: {
@@ -496,9 +509,11 @@ export function createGitWorktreeWorkspaceModule(
           handler: async (): Promise<HookOutput<ListWorkspacesHookResult>> => {
             const entries: ListWorkspacesHookEntry[] = [];
             for (const [key, wsList] of getMergedWorkspaces()) {
+              const defaultBaseBranch = projectDefaults.get(key);
               entries.push({
                 projectPath: key,
                 workspaces: wsList,
+                ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
               });
             }
             return { result: { entries } };


### PR DESCRIPTION
The workspace creation dialog's **Base Branch** field was briefly empty on load (reported via PostHog bug report). The per-project default base was resolved asynchronously via git even though `project:open` already computes it — then discards it.

- Thread the computed default through `project:list` (cached per project in the git-worktree module, surfaced via `list-workspaces`) so the creation form seeds the base field synchronously on the first frame.
- The async list/refresh still validates and re-defaults the value; cold start falls back to the previous async load (no regression).
- Reuse the already-enumerated bases inside `defaultBase()` to avoid a redundant second branch enumeration per load, shrinking the latency window itself.
- Added integration/provider tests for the threaded default, the synchronous first-paint seed, and the bases reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)