### PR TITLE
fix: on windows git integration did not update on file changes

### DIFF
--- a/src/boundaries/platform/simple-git-client.boundary.test.ts
+++ b/src/boundaries/platform/simple-git-client.boundary.test.ts
@@ -286,6 +286,33 @@ describe("SimpleGitClient", () => {
       expect(status.stagedCount).toBe(1);
       expect(status.isDirty).toBe(true);
     });
+
+    it("does not take optional index locks, unlike a plain git status", async () => {
+      // Bump the working file's mtime clearly past the index's cached stat so git
+      // wants to refresh the index. Optional-lock refresh rewrites .git/index;
+      // GIT_OPTIONAL_LOCKS=0 suppresses it. Comparing the index bytes before/after
+      // is a deterministic signal of whether the optional lock was taken.
+      const future = new Date("2035-01-01T00:00:00Z");
+
+      // Control (optional locks ON): a plain simple-git status rewrites the index.
+      const controlRepo = await createTestGitRepo();
+      try {
+        const controlIndex = nodePath.join(controlRepo.path, ".git", "index");
+        await fs.utimes(nodePath.join(controlRepo.path, "README.md"), future, future);
+        const before = await fs.readFile(controlIndex);
+        await simpleGit(controlRepo.path).status();
+        expect((await fs.readFile(controlIndex)).equals(before)).toBe(false);
+      } finally {
+        await controlRepo.cleanup();
+      }
+
+      // Client (optional locks OFF): getStatus leaves .git/index untouched.
+      const indexPath = nodePath.join(repoPath.toNative(), ".git", "index");
+      await fs.utimes(nodePath.join(repoPath.toNative(), "README.md"), future, future);
+      const before = await fs.readFile(indexPath);
+      await client.getStatus(repoPath);
+      expect((await fs.readFile(indexPath)).equals(before)).toBe(true);
+    });
   });
 
   describe("fetch", () => {

--- a/src/boundaries/platform/simple-git-client.ts
+++ b/src/boundaries/platform/simple-git-client.ts
@@ -31,7 +31,18 @@ export class SimpleGitClient implements IGitClient {
       trimmed: true,
       config: process.platform === "win32" ? ["core.longpaths=true"] : [],
     };
-    return simpleGit(options);
+    // GIT_OPTIONAL_LOCKS=0 suppresses only *optional* locks — the ones git takes
+    // as a side-effect optimization, e.g. `git status` grabbing index.lock to
+    // rewrite the index it didn't need to. Write operations (add/commit/branch/
+    // worktree) still take their *required* locks and behave normally, so this is
+    // safe to apply uniformly here. The win is that our status checks stop
+    // contending with the embedded editor's watcher/refresh for index.lock while
+    // an agent is writing. This mirrors VS Code's own git extension.
+    //
+    // process.env must be spread in: simple-git passes `env` straight to
+    // child_process.spawn, which *replaces* (not merges) the child environment,
+    // so a bare { GIT_OPTIONAL_LOCKS } would drop PATH/HOME and break git.
+    return simpleGit(options).env({ ...process.env, GIT_OPTIONAL_LOCKS: "0" });
   }
 
   /**

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -9,6 +9,10 @@
 
 import { createMockDispatcher } from "../../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The watcher shim's own behavior is covered in watcher-shim.integration.test.ts;
+// here we only assert the download step wires it in (and gates it to Windows).
+vi.mock("./watcher-shim", () => ({ applyWatcherShim: vi.fn().mockResolvedValue(1) }));
 import { delimiter, join } from "node:path";
 
 import type { Operation, OperationContext } from "../../intents/lib/operation";
@@ -45,6 +49,7 @@ import type {
   DeleteHookResult,
 } from "../../intents/delete-workspace";
 import { createIdeServerModule, type IdeServerModuleDeps } from "./ide-server-module";
+import { applyWatcherShim } from "./watcher-shim";
 import { createMockConfig } from "../../boundaries/platform/config.test-utils";
 import type { ExtensionRequirement, ExtensionInstallEntry } from "../../intents/app-start";
 import type { DirEntry } from "../../boundaries/platform/filesystem";
@@ -761,6 +766,37 @@ describe("CodeServerModule", () => {
           error: expect.stringContaining("Failed to download code-server"),
         })
       );
+    });
+
+    it("applies the watcher shim to the downloaded bundle on Windows", async () => {
+      vi.mocked(applyWatcherShim).mockClear();
+      const deps = createDownloadDeps({
+        platform: "win32",
+        arch: "x64",
+        archiveExtractor: createArchiveExtractorMock(),
+      });
+      const { dispatcher } = createTestSetup(deps);
+      const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
+      dispatcher.registerOperation("setup", op);
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(applyWatcherShim).toHaveBeenCalledWith(
+        expect.objectContaining({ fileSystemLayer: deps.fileSystemLayer }),
+        expect.stringContaining("code-server")
+      );
+    });
+
+    it("does not apply the watcher shim on non-Windows platforms", async () => {
+      vi.mocked(applyWatcherShim).mockClear();
+      const deps = createDownloadDeps({ archiveExtractor: createArchiveExtractorMock() });
+      const { dispatcher } = createTestSetup(deps);
+      const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
+      dispatcher.registerOperation("setup", op);
+
+      await dispatcher.dispatch({ type: "setup", payload: {} });
+
+      expect(applyWatcherShim).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -65,6 +65,7 @@ import { IdeServerError, SetupError, getErrorMessage } from "../../shared/errors
 import { waitForHealthy } from "../../utils/health-check";
 import { createCodeServerIdeServer, CODE_SERVER_VERSION } from "./code-server";
 import { createVscodiumIdeServer, VSCODIUM_VERSION } from "./vscodium";
+import { applyWatcherShim } from "./watcher-shim";
 import type { IdeServer } from "./types";
 
 // =============================================================================
@@ -572,6 +573,22 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
     } catch (error) {
       const message = getErrorMessage(error);
       throw new IdeServerError(`Failed to download code-server: ${message}`);
+    }
+
+    // Windows-only: patch the freshly extracted bundle's native file watcher so
+    // absolute backslash ignore globs don't crash it (see watcher-shim.ts). A
+    // re-download overwrites the shim, so it must run after every download.
+    // Best-effort — a shim failure must not fail an otherwise-good download.
+    if (deps.platform === "win32") {
+      try {
+        const applied = await applyWatcherShim(
+          { fileSystemLayer: deps.fileSystemLayer, logger },
+          request.destDir
+        );
+        logger.debug("Watcher shim pass complete", { applied });
+      } catch (error) {
+        logger.warn("Watcher shim pass failed", { error: getErrorMessage(error) });
+      }
     }
   }
 

--- a/src/modules/ide-server-module/watcher-shim.integration.test.ts
+++ b/src/modules/ide-server-module/watcher-shim.integration.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+/**
+ * Tests for the watcher forward-slash shim.
+ *
+ * - Behavioral-mock tests cover discovery, application, idempotency, and the
+ *   layouts of both supported distributions (reh-web `@parcel/watcher` at the
+ *   bundle root; code-server `@vscode/watcher` under `lib/vscode`).
+ * - A real-filesystem test loads the generated shim and proves it rewrites
+ *   backslash `ignore` globs to forward slashes (the actual crash fix).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+
+import {
+  createFileSystemMock,
+  file,
+  type MockFileSystemBoundary,
+} from "../../boundaries/platform/filesystem.state-mock";
+import { DefaultFileSystemBoundary } from "../../boundaries/platform/filesystem";
+import { SILENT_LOGGER } from "../../boundaries/platform/logging";
+import { applyWatcherShim } from "./watcher-shim";
+
+const ORIGINAL = "module.exports = { __original: true };\n";
+
+function deps(fsLayer: MockFileSystemBoundary) {
+  return { fileSystemLayer: fsLayer, logger: SILENT_LOGGER };
+}
+
+/**
+ * Create a mock bundle with a watcher package. The `entries` factory option does
+ * not build the directory tree, so seed via `setEntry`, which auto-creates the
+ * parent directories the discovery walk relies on.
+ */
+function bundleWithWatcher(
+  nodeModulesDir: string,
+  scope: "@parcel" | "@vscode",
+  main = "index.js"
+): MockFileSystemBoundary {
+  const fsLayer = createFileSystemMock();
+  const pkgDir = `${nodeModulesDir}/${scope}/watcher`;
+  fsLayer.$.setEntry(`${pkgDir}/package.json`, file(JSON.stringify({ name: "watcher", main })));
+  fsLayer.$.setEntry(`${pkgDir}/${main}`, file(ORIGINAL));
+  return fsLayer;
+}
+
+describe("applyWatcherShim (behavioral)", () => {
+  it("shims the reh-web @parcel/watcher at the bundle root", async () => {
+    const fsLayer = bundleWithWatcher("/bundle/node_modules", "@parcel");
+
+    const applied = await applyWatcherShim(deps(fsLayer), "/bundle");
+
+    expect(applied).toBe(1);
+    const pkg = "/bundle/node_modules/@parcel/watcher";
+    expect(fsLayer).toHaveFile(`${pkg}/index.orig.js`, ORIGINAL);
+    expect(fsLayer).toHaveFileContaining(`${pkg}/index.js`, 'require("./index.orig.js")');
+    expect(fsLayer).toHaveFileContaining(`${pkg}/index.js`, "fixIgnore");
+  });
+
+  it("shims the code-server @vscode/watcher nested under lib/vscode", async () => {
+    const fsLayer = bundleWithWatcher("/bundle/lib/vscode/node_modules", "@vscode");
+
+    const applied = await applyWatcherShim(deps(fsLayer), "/bundle");
+
+    expect(applied).toBe(1);
+    const pkg = "/bundle/lib/vscode/node_modules/@vscode/watcher";
+    expect(fsLayer).toHaveFile(`${pkg}/index.orig.js`, ORIGINAL);
+    expect(fsLayer).toHaveFileContaining(`${pkg}/index.js`, "fixIgnore");
+  });
+
+  it("honors a non-default package.json main entry", async () => {
+    const fsLayer = bundleWithWatcher("/bundle/node_modules", "@parcel", "lib/watcher.js");
+
+    const applied = await applyWatcherShim(deps(fsLayer), "/bundle");
+
+    expect(applied).toBe(1);
+    const pkg = "/bundle/node_modules/@parcel/watcher";
+    expect(fsLayer).toHaveFile(`${pkg}/lib/watcher.orig.js`, ORIGINAL);
+    expect(fsLayer).toHaveFileContaining(`${pkg}/lib/watcher.js`, 'require("./watcher.orig.js")');
+  });
+
+  it("is idempotent: a second pass applies nothing and preserves the original", async () => {
+    const fsLayer = bundleWithWatcher("/bundle/node_modules", "@parcel");
+
+    expect(await applyWatcherShim(deps(fsLayer), "/bundle")).toBe(1);
+    const pkg = "/bundle/node_modules/@parcel/watcher";
+    const shimmed = await fsLayer.readFile(`${pkg}/index.js`);
+
+    expect(await applyWatcherShim(deps(fsLayer), "/bundle")).toBe(0);
+    // Original untouched (not double-wrapped) and shim unchanged.
+    expect(fsLayer).toHaveFile(`${pkg}/index.orig.js`, ORIGINAL);
+    expect(await fsLayer.readFile(`${pkg}/index.js`)).toBe(shimmed);
+  });
+
+  it("returns 0 and does not throw when no watcher is present", async () => {
+    const fsLayer = createFileSystemMock();
+    fsLayer.$.setEntry("/bundle/bin/code-server", file("#!/bin/sh\n"));
+
+    expect(await applyWatcherShim(deps(fsLayer), "/bundle")).toBe(0);
+  });
+
+  it("ignores an @parcel scope that has no watcher package", async () => {
+    const fsLayer = createFileSystemMock();
+    fsLayer.$.setEntry("/bundle/node_modules/@parcel/core/index.js", file("x"));
+
+    expect(await applyWatcherShim(deps(fsLayer), "/bundle")).toBe(0);
+  });
+});
+
+describe("applyWatcherShim (real filesystem)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(nodePath.join(os.tmpdir(), "watcher-shim-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it("rewrites backslash ignore globs to forward slashes at runtime", async () => {
+    // A fake watcher whose subscribe echoes back the opts it received, so we can
+    // observe what the shim passed through.
+    const pkgDir = nodePath.join(tmp, "node_modules", "@parcel", "watcher");
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(nodePath.join(pkgDir, "package.json"), JSON.stringify({ main: "index.js" }));
+    await fs.writeFile(
+      nodePath.join(pkgDir, "index.js"),
+      "module.exports = { subscribe: (dir, fn, opts) => opts, unsubscribe: () => {}," +
+        " writeSnapshot: () => {}, getEventsSince: () => {} };\n"
+    );
+
+    const fsLayer = new DefaultFileSystemBoundary(SILENT_LOGGER);
+    const applied = await applyWatcherShim(
+      { fileSystemLayer: fsLayer, logger: SILENT_LOGGER },
+      tmp
+    );
+    expect(applied).toBe(1);
+
+    const require = createRequire(import.meta.url);
+    const watcher = require(pkgDir) as {
+      subscribe: (
+        dir: string,
+        fn: () => void,
+        opts: { ignore: unknown[] }
+      ) => { ignore: unknown[] };
+    };
+
+    const result = watcher.subscribe("C:/ws", () => {}, {
+      ignore: ["c:\\users\\stefan\\worktrees\\git-reload\\**", "**\\node_modules\\**", 42],
+    });
+
+    // Backslashes normalized to forward slashes; non-string entries untouched.
+    expect(result.ignore).toEqual([
+      "c:/users/stefan/worktrees/git-reload/**",
+      "**/node_modules/**",
+      42,
+    ]);
+  });
+});

--- a/src/modules/ide-server-module/watcher-shim.ts
+++ b/src/modules/ide-server-module/watcher-shim.ts
@@ -1,0 +1,225 @@
+/**
+ * Forward-slash-normalizing shim for the embedded IDE server's native file
+ * watcher (`@parcel/watcher` in VSCodium reh-web, the API-identical
+ * `@vscode/watcher` fork in code-server).
+ *
+ * ## Why
+ *
+ * On Windows the watcher compiles each glob `ignore` pattern into a C++
+ * `std::regex` via picomatch's regex source. VS Code passes absolute *backslash*
+ * paths as ignore globs to exclude a bare-repo worktree's external `.git` dir,
+ * and the watcher lowercases them — so `C:\Users\…` becomes `c:\users\…`. The
+ * `\u` in `\users` is an invalid escape in `std::regex`'s ECMAScript grammar and
+ * throws `regex_error(error_escape)`, aborting `subscribe()`. Recursive watching
+ * is then disabled for every workspace, so saving a file no longer refreshes the
+ * Source Control view (upstream: parcel-bundler/watcher#194).
+ *
+ * Forward-slash globs match identically on Windows (picomatch runs with
+ * `windows: true` either way, and VS Code's own built-in excludes are already
+ * forward-slash), so rewriting the separators only prevents the crash — it does
+ * not change matching behavior.
+ *
+ * ## How
+ *
+ * A tiny post-download shim wraps the watcher package's entry module: the
+ * original is renamed to `<name>.orig.js` and a new entry re-exports the API,
+ * rewriting `opts.ignore` string entries `\` → `/` before they reach
+ * picomatch/`std::regex`. Idempotent (skips if the `.orig.js` already exists) and
+ * re-applied after every download, since a bundle re-download restores the
+ * originals.
+ */
+
+import { basename, dirname, join } from "node:path";
+
+import type { FileSystemBoundary } from "../../boundaries/platform/filesystem";
+import type { Logger } from "../../boundaries/platform/logging-types";
+import { getErrorMessage } from "../../shared/errors/service-errors";
+
+/** Scoped package names of the watchers shipped by the supported distributions. */
+const WATCHER_SCOPES = ["@parcel", "@vscode"] as const;
+
+/** Guard rails for the bundle directory walk (a runaway tree never hangs setup). */
+const MAX_WALK_DEPTH = 12;
+const MAX_WALK_DIRS = 10_000;
+
+/** FileSystem surface the shim needs — a narrow slice of the boundary. */
+export type WatcherShimFs = Pick<
+  FileSystemBoundary,
+  "readdir" | "readFile" | "writeFile" | "rename"
+>;
+
+export interface WatcherShimDeps {
+  readonly fileSystemLayer: WatcherShimFs;
+  readonly logger: Logger;
+}
+
+/**
+ * Build the shim entry module source. `origRequire` is the relative specifier of
+ * the renamed original (e.g. `./index.orig.js`), resolved from the shim's own
+ * directory.
+ */
+function buildShimSource(origRequire: string): string {
+  return `// Injected by CodeHydra: forward-slash-normalize watcher ignore globs on
+// Windows so absolute backslash paths (e.g. c:\\users\\...) don't compile to an
+// invalid std::regex and crash subscribe(). See watcher-shim.ts for details.
+const orig = require(${JSON.stringify(origRequire)});
+const fixIgnore = (opts) =>
+  opts && Array.isArray(opts.ignore)
+    ? {
+        ...opts,
+        ignore: opts.ignore.map((v) => (typeof v === "string" ? v.replace(/\\\\/g, "/") : v)),
+      }
+    : opts;
+module.exports = {
+  ...orig,
+  subscribe: (dir, fn, opts) => orig.subscribe(dir, fn, fixIgnore(opts)),
+  unsubscribe: (dir, fn, opts) => orig.unsubscribe(dir, fn, fixIgnore(opts)),
+  writeSnapshot: (dir, snapshot, opts) => orig.writeSnapshot(dir, snapshot, fixIgnore(opts)),
+  getEventsSince: (dir, snapshot, opts) => orig.getEventsSince(dir, snapshot, fixIgnore(opts)),
+};
+`;
+}
+
+/** Insert `.orig` before the file extension (index.js → index.orig.js). */
+function toOrigName(fileName: string): string {
+  return fileName.endsWith(".js")
+    ? `${fileName.slice(0, -".js".length)}.orig.js`
+    : `${fileName}.orig.js`;
+}
+
+/**
+ * Resolve a watcher package's entry file from its package.json `main`
+ * (defaulting to `index.js`), or `null` if the directory isn't a watcher
+ * package (missing/unreadable — a bare `@parcel` scope with no `watcher`, etc).
+ */
+async function resolveEntryFile(fs: WatcherShimFs, packageDir: string): Promise<string | null> {
+  let names: readonly string[];
+  try {
+    names = (await fs.readdir(packageDir)).map((e) => e.name);
+  } catch {
+    return null; // directory doesn't exist
+  }
+
+  let main = "index.js";
+  if (names.includes("package.json")) {
+    try {
+      const pkg = JSON.parse(await fs.readFile(join(packageDir, "package.json"))) as {
+        main?: unknown;
+      };
+      if (typeof pkg.main === "string" && pkg.main.trim() !== "") {
+        // Strip a leading "./" so join() treats it as relative to the package dir.
+        main = pkg.main.replace(/^\.\//, "");
+      }
+    } catch {
+      // Malformed package.json — fall back to index.js.
+    }
+  }
+  return join(packageDir, main);
+}
+
+/**
+ * Apply the shim to a single watcher package. Returns true if it was newly
+ * shimmed, false if it was already shimmed (idempotent skip) or not applicable.
+ */
+async function shimPackage(
+  deps: WatcherShimDeps,
+  packageDir: string
+): Promise<"applied" | "skipped"> {
+  const { fileSystemLayer: fs, logger } = deps;
+
+  const entryPath = await resolveEntryFile(fs, packageDir);
+  if (entryPath === null) return "skipped";
+
+  const entryDir = dirname(entryPath);
+  const origName = toOrigName(basename(entryPath));
+  const origPath = join(entryDir, origName);
+
+  // Idempotency: presence of the renamed original means we've already shimmed.
+  try {
+    await fs.readFile(origPath);
+    logger.debug("Watcher shim already applied", { packageDir });
+    return "skipped";
+  } catch {
+    // Not yet shimmed — proceed.
+  }
+
+  await fs.rename(entryPath, origPath);
+  try {
+    await fs.writeFile(entryPath, buildShimSource(`./${origName}`));
+  } catch (error) {
+    // Never leave the package without an entry module: restore the original.
+    await fs.rename(origPath, entryPath).catch(() => {});
+    throw error;
+  }
+  logger.info("Applied watcher forward-slash shim", { packageDir });
+  return "applied";
+}
+
+/**
+ * Recursively locate watcher package directories under `bundleDir`. Descends the
+ * bundle skeleton and, at each `node_modules`, checks the known watcher scopes
+ * without recursing into sibling packages (the watcher is a hoisted top-level
+ * dependency in both distributions).
+ */
+async function findWatcherPackages(fs: WatcherShimFs, bundleDir: string): Promise<string[]> {
+  const found: string[] = [];
+  let visited = 0;
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > MAX_WALK_DEPTH || visited >= MAX_WALK_DIRS) return;
+    visited++;
+
+    let entries;
+    try {
+      entries = await fs.readdir(dir);
+    } catch {
+      return; // unreadable / not a directory
+    }
+
+    if (basename(dir) === "node_modules") {
+      const scopes = new Set(entries.filter((e) => e.isDirectory).map((e) => e.name));
+      for (const scope of WATCHER_SCOPES) {
+        if (scopes.has(scope)) found.push(join(dir, scope, "watcher"));
+      }
+      return; // don't recurse into individual packages
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory && !entry.isSymbolicLink) {
+        await walk(join(dir, entry.name), depth + 1);
+      }
+    }
+  }
+
+  await walk(bundleDir, 0);
+  return found;
+}
+
+/**
+ * Locate every watcher package under `bundleDir` and apply the forward-slash
+ * shim to each. Best-effort and idempotent: individual package failures are
+ * logged and skipped rather than propagated, so a shim problem never fails the
+ * IDE server download. Returns the number of packages newly shimmed.
+ */
+export async function applyWatcherShim(deps: WatcherShimDeps, bundleDir: string): Promise<number> {
+  const { logger } = deps;
+  const packages = await findWatcherPackages(deps.fileSystemLayer, bundleDir);
+
+  if (packages.length === 0) {
+    logger.debug("No watcher package found to shim", { bundleDir });
+    return 0;
+  }
+
+  let applied = 0;
+  for (const packageDir of packages) {
+    try {
+      if ((await shimPackage(deps, packageDir)) === "applied") applied++;
+    } catch (error) {
+      logger.warn("Failed to apply watcher shim", {
+        packageDir,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+  return applied;
+}


### PR DESCRIPTION
On Windows the embedded IDE server's native file watcher crashed at startup with `regex_error(error_escape)`, disabling recursive watching so saving a file no longer refreshed the Source Control view.

- **Root cause**: `@parcel/watcher` (and the API-identical `@vscode/watcher` fork in code-server) compiles each glob `ignore` into a C++ `std::regex`. VS Code passes absolute backslash paths as ignore globs (the external `.git` dir of a bare-repo worktree, lowercased to `c:\users\...`); the `\u` escape is invalid in `std::regex`, so `subscribe()` throws and recursive watching is disabled (upstream: parcel-bundler/watcher#194).
- **Fix (primary)**: post-download shim (Windows only) that forward-slash-normalizes the watcher's `ignore` globs before they reach picomatch/`std::regex`. Matching is identical on Windows, so this only prevents the crash. Idempotent, best-effort, discovers the watcher package by walking the bundle, and re-runs after every download.
- **Fix (secondary)**: run CodeHydra's git operations with `GIT_OPTIONAL_LOCKS=0` (mirroring VS Code's git extension) so status checks stop contending with the editor's watcher/refresh for `index.lock` while an agent is writing. Only optional locks are suppressed; writes keep their required locks.
- Covers both IDE distributions (`code-server` and `vscodium`).

Tests: watcher-shim unit/behavioral + real-`require` end-to-end proving backslash→forward-slash rewrite; a boundary test proving `getStatus` no longer rewrites `.git/index`; and module wiring tests gating the shim to Windows.