### PR TITLE
feat: bug reports can be filed via MCP

### DIFF
--- a/src/intents/submit-bug-report.ts
+++ b/src/intents/submit-bug-report.ts
@@ -14,9 +14,6 @@ import type { Operation, OperationContext } from "./lib/operation";
 
 export interface SubmitBugReportPayload {
   readonly description: string;
-  readonly logs: string;
-  /** Chromium/Electron native log (--enable-logging=file output). */
-  readonly electronLogs: string;
 }
 
 export interface SubmitBugReportIntent extends Intent<void> {
@@ -32,9 +29,6 @@ export const INTENT_SUBMIT_BUG_REPORT = "bug-report:submit" as const;
 
 export interface BugReportSubmittedPayload {
   readonly description: string;
-  readonly logs: string;
-  /** Chromium/Electron native log (--enable-logging=file output). */
-  readonly electronLogs: string;
 }
 
 export interface BugReportSubmittedEvent extends DomainEvent {
@@ -48,7 +42,7 @@ export const EVENT_BUG_REPORT_SUBMITTED = "bug-report:submitted" as const;
 // Operation
 // =============================================================================
 
-const SUBMIT_BUG_REPORT_OPERATION_ID = "submit-bug-report";
+export const SUBMIT_BUG_REPORT_OPERATION_ID = "submit-bug-report";
 
 export class SubmitBugReportOperation implements Operation<SubmitBugReportIntent, void> {
   readonly id = SUBMIT_BUG_REPORT_OPERATION_ID;
@@ -58,10 +52,12 @@ export class SubmitBugReportOperation implements Operation<SubmitBugReportIntent
       type: EVENT_BUG_REPORT_SUBMITTED,
       payload: {
         description: ctx.intent.payload.description,
-        logs: ctx.intent.payload.logs,
-        electronLogs: ctx.intent.payload.electronLogs,
       },
     };
-    ctx.emit(event);
+    // Awaited so dispatch() resolves only after the subscriber (error-report
+    // module) has read logs, captured the exception, and flushed. The MCP
+    // report_bug tool relies on this to confirm delivery; the dialog path
+    // fire-and-forgets its dispatch, so it is unaffected.
+    await ctx.emit(event);
   }
 }

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -4,11 +4,12 @@
  * report dialog AND the automatic crash handlers.
  *
  * Covers three surfaces:
- *  - the "b" shortcut dialog (reads logs, dispatches bug-report:submit)
- *  - the bug-report:submitted capture (logs + redacted config/state, unconditional)
+ *  - the "b" shortcut dialog (dispatches bug-report:submit with the description)
+ *  - the bug-report:submitted capture (reads logs + redacted config/state, unconditional)
  *  - the process error handlers (log always; report gated on telemetry; flush+exit)
  */
 
+import { gunzipSync } from "node:zlib";
 import { describe, it, expect, vi } from "vitest";
 import { createErrorReportModule, type ErrorReportModuleDeps } from "./error-report-module";
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
@@ -115,6 +116,11 @@ async function emitBugReport(
   await module.events![EVENT_BUG_REPORT_SUBMITTED]!.handler(event);
 }
 
+/** Decompress a gzip+base64 log blob back to its raw string. */
+function decompressLog(blob: unknown): string {
+  return typeof blob === "string" && blob ? gunzipSync(Buffer.from(blob, "base64")).toString() : "";
+}
+
 /** Stub process.on, dispatch app:start to register the crash handlers, return them. */
 async function registerCrashHandlers(
   module: ReturnType<typeof setup>["module"]
@@ -186,7 +192,7 @@ describe("ErrorReportModule — bug report dialog", () => {
     expect(deps.ui.dialog).toHaveBeenCalledOnce();
   });
 
-  it("reads logs and dispatches bug-report:submit on 'send'", async () => {
+  it("dispatches bug-report:submit with only the description on 'send'", async () => {
     const { module, deps, handle } = setup();
     await emitKey(module, "b");
     handle.emitEvent({
@@ -195,40 +201,12 @@ describe("ErrorReportModule — bug report dialog", () => {
       data: { description: "It broke" },
     });
 
-    await vi.waitFor(() => {
-      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: {
-            description: "It broke",
-            logs: "test log content\nline 2",
-            electronLogs: "electron log content",
-          },
-        })
-      );
-    });
-    expect(handle.handle.close).toHaveBeenCalled();
-  });
-
-  it("marks the Send button busy before the dialog closes", async () => {
-    const { module, handle } = setup();
-    await emitKey(module, "b");
-    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
-
-    // A busy config is pushed synchronously on click (before the async log
-    // reads resolve and close the dialog), so the primary button shows its
-    // in-flight state until the window hides.
-    const busyConfig = handle.configs.find((c) =>
-      c.sections.some(
-        (s) =>
-          s.type === "group" &&
-          s.items.some((i) => i.type === "button" && i.id === "send" && i.busy === true)
-      )
+    expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { description: "It broke" } })
     );
-    expect(busyConfig).toBeDefined();
-    expect(handle.handle.update).toHaveBeenCalled();
-    expect(handle.handle.close).not.toHaveBeenCalled();
-
-    await vi.waitFor(() => expect(handle.handle.close).toHaveBeenCalled());
+    // Log-gathering now lives in the submitted handler, not the dialog.
+    expect(deps.fileSystem.readFile).not.toHaveBeenCalled();
+    expect(handle.handle.close).toHaveBeenCalled();
   });
 
   it("ignores a second 'send' while the first is in flight", async () => {
@@ -262,36 +240,6 @@ describe("ErrorReportModule — bug report dialog", () => {
     await emitKey(module, "b");
     expect(deps.ui.dialog).toHaveBeenCalledTimes(2);
   });
-
-  it("includes rotated archive log alongside the current log", async () => {
-    const { module, deps, handle } = setup();
-    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
-      if (path === "/logs/test-session.log") return Promise.resolve("CURRENT");
-      if (path === "/logs/test-session.old.log") return Promise.resolve("ARCHIVE\n");
-      return Promise.reject(new Error("ENOENT"));
-    });
-    await emitKey(module, "b");
-    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
-
-    await vi.waitFor(() => {
-      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: expect.objectContaining({ logs: "ARCHIVE\nCURRENT" }) })
-      );
-    });
-  });
-
-  it("tolerates a log read failure", async () => {
-    const { module, deps, handle } = setup();
-    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("ENOENT"));
-    await emitKey(module, "b");
-    handle.emitEvent({ dialogId: "dlg-test", actionId: "send", data: { description: "x" } });
-
-    await vi.waitFor(() => {
-      expect(deps.dispatcher.dispatch).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: expect.objectContaining({ logs: "" }) })
-      );
-    });
-  });
 });
 
 // =============================================================================
@@ -299,38 +247,64 @@ describe("ErrorReportModule — bug report dialog", () => {
 // =============================================================================
 
 describe("ErrorReportModule — bug-report:submitted capture", () => {
-  it("captures a BugReport $exception with compressed logs + redacted config/state", async () => {
+  it("reads logs itself and captures a BugReport $exception with redacted config/state", async () => {
     const { module, boundary } = setup({
       configOverrides: { agent: "claude", "log.level": "debug" },
       stateOverrides: { "auto-workspaces": { "github/1": { workspaceName: "pr-1" } } },
     });
 
-    await emitBugReport(module, {
-      description: "It crashed",
-      logs: "app logs here",
-      electronLogs: "electron logs here",
-    });
+    // The handler gathers logs from the filesystem; the event carries only the
+    // description (defaultReadFile supplies the log/electron-log content).
+    await emitBugReport(module, { description: "It crashed" });
 
     const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
     expect(captured).toBeDefined();
     const props = captured!.properties;
     expect(props["$exception_list"]).toEqual([{ type: "BugReport", value: "It crashed" }]);
     expect(props["logs_format"]).toBe("gzip+base64");
+    expect(decompressLog(props["logs"])).toBe("test log content\nline 2");
+    expect(decompressLog(props["electron_logs"])).toBe("electron log content");
     expect(props["config"]).toEqual({ agent: "claude", "log.level": "debug" });
     expect(props["state"]).toEqual({
       "auto-workspaces": { "github/1": { workspaceName: "pr-1" } },
     });
   });
 
+  it("includes the rotated archive log alongside the current log", async () => {
+    const { module, boundary, deps } = setup();
+    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+      if (path === "/logs/test-session.log") return Promise.resolve("CURRENT");
+      if (path === "/logs/test-session.old.log") return Promise.resolve("ARCHIVE\n");
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    await emitBugReport(module, { description: "x" });
+
+    const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
+    expect(decompressLog(captured!.properties["logs"])).toBe("ARCHIVE\nCURRENT");
+  });
+
+  it("tolerates a log read failure", async () => {
+    const { module, boundary, deps } = setup();
+    (deps.fileSystem.readFile as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("ENOENT"));
+
+    await emitBugReport(module, { description: "x" });
+
+    const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
+    expect(captured).toBeDefined();
+    expect(captured!.properties["logs_format"]).toBe("none");
+    expect(decompressLog(captured!.properties["logs"])).toBe("");
+  });
+
   it("flushes after a manual report for prompt delivery", async () => {
     const { module, boundary } = setup();
-    await emitBugReport(module, { description: "x", logs: "l", electronLogs: "e" });
+    await emitBugReport(module, { description: "x" });
     expect(boundary.$.flushCount).toBe(1);
   });
 
   it("sends the manual report even when telemetry is disabled (explicit consent)", async () => {
     const { module, boundary } = setup({ telemetryEnabled: false });
-    await emitBugReport(module, { description: "still sends", logs: "l", electronLogs: "" });
+    await emitBugReport(module, { description: "still sends" });
     expect(boundary).toHaveCapturedError();
   });
 });

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -116,14 +116,7 @@ function compressAndTrim(raw: string): { compressed: string; rawBytesKept: numbe
   return { compressed, rawBytesKept: kept.length };
 }
 
-/**
- * Build the bug-report dialog config. When `busy` is set (after the user hits
- * Send / Ctrl+Enter), the primary button shows a spinner label and the form is
- * frozen — the report can't hide instantly because it first reads the log files
- * off disk, so the button carries that in-flight state until the dialog closes.
- */
-function buildDialogConfig(options?: { busy?: boolean }): DialogConfig {
-  const busy = options?.busy ?? false;
+function buildDialogConfig(): DialogConfig {
   return {
     sections: [
       { type: "text", content: "Report a Bug", style: "heading", icon: "bug" },
@@ -134,7 +127,6 @@ function buildDialogConfig(options?: { busy?: boolean }): DialogConfig {
         multiline: true,
         initialValue: DESCRIPTION_INITIAL,
         selectInitialValue: true,
-        disabled: busy,
       },
       {
         type: "text",
@@ -144,22 +136,8 @@ function buildDialogConfig(options?: { busy?: boolean }): DialogConfig {
       {
         type: "group",
         items: [
-          {
-            type: "button",
-            id: "send",
-            label: "Send",
-            variant: "primary",
-            busy,
-            busyLabel: "Sending...",
-          },
-          {
-            type: "button",
-            id: "cancel",
-            label: "Cancel",
-            variant: "secondary",
-            role: "cancel",
-            disabled: busy,
-          },
+          { type: "button", id: "send", label: "Send", variant: "primary" },
+          { type: "button", id: "cancel", label: "Cancel", variant: "secondary", role: "cancel" },
         ],
       },
     ],
@@ -423,34 +401,26 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
     const handle = deps.ui.dialog(buildDialogConfig());
     activeHandle = handle;
 
-    // Guards against a second Send firing while the first is in flight (e.g. a
-    // double Ctrl+Enter before the busy config reaches the renderer).
+    // Guards against a second Send being processed if two "send" events are
+    // queued (e.g. a double Ctrl+Enter) before the dialog closes below.
     let sending = false;
 
     handle.onEvent((event) => {
       if (event.actionId === "send") {
         if (sending) return;
         sending = true;
-        // Reflect the in-flight send on the primary button (spinner label) and
-        // freeze the form until the dialog closes — the log reads below can take
-        // a perceptible moment, so the button must not look unresponsive.
-        handle.update(buildDialogConfig({ busy: true }));
+        const description = event.data?.["description"] ?? "";
 
-        void (async () => {
-          const [logs, electronLogs] = await Promise.all([
-            readLogContent(),
-            readElectronLogContent(),
-          ]);
-          const description = event.data?.["description"] ?? "";
+        // Log-gathering lives in the bug-report:submitted handler, so the
+        // dialog only forwards the description. Fire-and-forget: the dialog
+        // closes immediately (the awaited flush happens in the subscriber).
+        void deps.dispatcher.dispatch({
+          type: INTENT_SUBMIT_BUG_REPORT,
+          payload: { description },
+        } as SubmitBugReportIntent);
 
-          void deps.dispatcher.dispatch({
-            type: INTENT_SUBMIT_BUG_REPORT,
-            payload: { description, logs, electronLogs },
-          } as SubmitBugReportIntent);
-
-          handle.close();
-          activeHandle = null;
-        })();
+        handle.close();
+        activeHandle = null;
       } else if (event.actionId === "cancel") {
         handle.close();
         activeHandle = null;
@@ -515,7 +485,15 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
       },
       [EVENT_BUG_REPORT_SUBMITTED]: {
         handler: async (event: DomainEvent): Promise<void> => {
-          const { description, logs, electronLogs } = (event as BugReportSubmittedEvent).payload;
+          const { description } = (event as BugReportSubmittedEvent).payload;
+
+          // The module owns log-gathering for every bug report, so both the
+          // dialog and the MCP report_bug tool only need to supply a
+          // description. Read both streams here, then capture + flush.
+          const [logs, electronLogs] = await Promise.all([
+            readLogContent(),
+            readElectronLogContent(),
+          ]);
 
           // Synthetic error so the SDK formats it as $exception_list. Manual
           // reports always send (explicit consent), even with telemetry off.

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -68,6 +68,8 @@ import { INTENT_VSCODE_SHOW_MESSAGE } from "../intents/vscode-show-message";
 import type { VscodeShowMessageIntent } from "../intents/vscode-show-message";
 import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import type { VscodeCommandIntent } from "../intents/vscode-command";
+import { INTENT_SUBMIT_BUG_REPORT } from "../intents/submit-bug-report";
+import type { SubmitBugReportIntent } from "../intents/submit-bug-report";
 
 /**
  * Optional target workspace path for tools that can act on a workspace other
@@ -157,6 +159,8 @@ export const SERVER_INSTRUCTIONS = [
   '- "info", "warning", "error" — show a notification. Add options for action buttons.',
   '- "status" — update the status bar (single entry per workspace). Set message to null to clear it. hint is the tooltip.',
   '- "select" — show a selection dialog. With options: quick pick list. Without options: free text input. hint is the placeholder.',
+  "",
+  "report_bug files a bug report about CodeHydra itself with the maintainers. Use it only when the user explicitly asks to report a CodeHydra bug or send feedback — never proactively. It attaches CodeHydra's current logs and redacted config and sends even if telemetry is off.",
 ].join("\n");
 
 export function createDefaultMcpServer(): McpServerSdk {
@@ -977,7 +981,39 @@ export class McpServer {
       }
     );
 
-    this.logger.debug("Registered tools", { count: 11 });
+    // report_bug - files a bug report through the same pipeline as the in-app
+    // "Report a Bug" dialog. Non-workspace: reports are app-global and the
+    // module attaches the current logs + redacted config/state itself.
+    mcpServer.registerTool(
+      "report_bug",
+      {
+        description:
+          "File a bug report for CodeHydra itself (not the user's project). " +
+          "Only use this when the user explicitly asks to report a bug or send feedback about CodeHydra — do not file reports proactively. " +
+          "The report sends the given description together with CodeHydra's current application logs and redacted configuration to CodeHydra's maintainers, and is sent even if telemetry is disabled. " +
+          "Returns { submitted: true } once the report has been sent.",
+        inputSchema: z.object({
+          description: z
+            .string()
+            .trim()
+            .min(1)
+            .describe("Description of the bug or feedback. Must be non-empty."),
+        }),
+      },
+      async (args: { description: string }) => {
+        try {
+          await this.dispatcher.dispatch({
+            type: INTENT_SUBMIT_BUG_REPORT,
+            payload: { description: args.description },
+          } as SubmitBugReportIntent);
+          return this.successResult({ submitted: true });
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    this.logger.debug("Registered tools", { count: 12 });
   }
 
   /**

--- a/src/modules/mcp-server.test-utils.ts
+++ b/src/modules/mcp-server.test-utils.ts
@@ -47,6 +47,10 @@ import {
   INTENT_VSCODE_SHOW_MESSAGE,
   VSCODE_SHOW_MESSAGE_OPERATION_ID,
 } from "../intents/vscode-show-message";
+import {
+  INTENT_SUBMIT_BUG_REPORT,
+  SUBMIT_BUG_REPORT_OPERATION_ID,
+} from "../intents/submit-bug-report";
 
 /**
  * Find a free port for testing.
@@ -149,6 +153,11 @@ const TOOL_OPERATIONS = {
       metadata: { base: "main" },
       projectId: "test-12345678" as ProjectId,
     } as unknown,
+  },
+  submitBugReport: {
+    intent: INTENT_SUBMIT_BUG_REPORT,
+    operationId: SUBMIT_BUG_REPORT_OPERATION_ID,
+    result: undefined as unknown,
   },
 } as const;
 

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -17,6 +17,7 @@ import type { Intent } from "../intents/lib/types";
 import { INTENT_HIBERNATE_WORKSPACE } from "../intents/hibernate-workspace";
 import { INTENT_WAKE_WORKSPACE } from "../intents/wake-workspace";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import { INTENT_SUBMIT_BUG_REPORT } from "../intents/submit-bug-report";
 import {
   createMockToolOperations,
   findFreePort,
@@ -159,7 +160,8 @@ describe("McpServer", () => {
       expect(toolNames).toContain("workspace_create");
       expect(toolNames).toContain("ui_show_message");
       expect(toolNames).toContain("log");
-      expect(tools.length).toBe(13);
+      expect(toolNames).toContain("report_bug");
+      expect(tools.length).toBe(14);
     });
 
     it("workspace_hibernate tool dispatches the hibernate intent", async () => {
@@ -371,6 +373,28 @@ describe("McpServer", () => {
       // Verify result contains the port number
       expect(result).toEqual({
         content: [{ type: "text", text: "14001" }],
+      });
+    });
+
+    it("report_bug dispatches the submit-bug-report intent and returns submitted:true", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const reportTool = tools.find((t) => t.name === "report_bug");
+      expect(reportTool).toBeDefined();
+
+      // Non-workspace tool: no auth extra needed.
+      const result = await reportTool!.handler({ description: "Sidebar crashes on resize" }, {});
+
+      expect(mockDispatcher.operations.submitBugReport).toHaveBeenCalled();
+      const intent = mockDispatcher.operations.submitBugReport!.mock.calls[0]![0].intent as Intent;
+      expect(intent.type).toBe(INTENT_SUBMIT_BUG_REPORT);
+      expect((intent.payload as { description: string }).description).toBe(
+        "Sidebar crashes on resize"
+      );
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ submitted: true }) }],
       });
     });
   });


### PR DESCRIPTION
Adds a `report_bug` MCP tool so an agent can file a CodeHydra bug report on the user's behalf, implementing the "filing bug reports should be possible via MCP" feature request.

- New `report_bug` MCP tool: takes a non-empty `description`, dispatches the existing `bug-report:submit` intent, and returns `{ submitted: true }` once the report is captured and flushed
- Always sends (even with telemetry off, matching the in-app "Report a Bug" path); tool instructions steer the agent to file only on explicit user request and disclose that logs + redacted config are attached
- Log-gathering moved out of the callers into the `bug-report:submitted` handler, so the intent payload carries only the description — one path for both the dialog and MCP
- `SubmitBugReportOperation` now awaits its emit so `dispatch()` resolves after the flush, letting the tool confirm delivery
- Tests: behavioral coverage for the new tool and the relocated log-gathering (dialog dispatches description-only; the module reads logs on submit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)