### PR TITLE
feat(intents): validation as a first-class intent-system feature

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,33 @@ export default tseslint.config(
       ],
     },
   },
+  // zod confinement: zod is the intent system's dependency (src/intents/contract, item 2).
+  // Renderer, preload, and shared consume contract *types* (type-only, erased at build) — they
+  // must not import zod directly, so contract types never pull zod into those bundles. Two
+  // pre-existing shared IPC/plugin message validators (ui-event, plugin-protocol) are exempted.
+  {
+    files: [
+      "src/renderer/**/*.ts",
+      "src/renderer/**/*.svelte",
+      "src/preload/**/*.ts",
+      "src/shared/**/*.ts",
+    ],
+    ignores: ["src/shared/ui-event.ts", "src/shared/plugin-protocol.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["zod", "zod/*"],
+              message:
+                "zod is confined to the intent system (src/intents/contract). Import contract types (type-only) or a re-exported schema value; do not import zod in renderer/preload/shared. (Legacy exceptions: src/shared/ui-event.ts, src/shared/plugin-protocol.ts.)",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // markdown-review-editor CommentEditor.svelte - specific overrides
   {
     files: ["extensions/markdown-review-editor/src/lib/components/CommentEditor.svelte"],

--- a/planning/REMOTE_WORKSPACES_FEDERATION.md
+++ b/planning/REMOTE_WORKSPACES_FEDERATION.md
@@ -216,9 +216,11 @@ Remote workspaces run their agent + code-server on the box, so failures originat
 The value surface (intent payloads, hook results, capability values, event payloads) is
 overwhelmingly plain serializable data — no structural blockers, given the **data-only
 contract invariant** (item 2a) that forbids the few remaining function fields. What remains
-is a bounded, sequenced list. Sequencing rationale unchanged: the handler/capability
-**contract** first, then the **wire schemas** against the final shape, then the leaky-module
-**splits**.
+is a bounded list. The original sequencing was contract → wire schemas → splits; in practice
+the handler/capability **contract** (item 1) and the leaky-module **splits** (item 3) both
+**landed first** — item 3 because it is a self-contained local refactor needing no transport —
+leaving **validation** (item 2, reframed below from "wire schemas" to a first-class
+intent-system feature) as the next code step, ahead of the transport items 4/5.
 
 **1. Reshape the capability contract — ✅ DONE** (commit `d871aea6`, pre-session).
 Handlers return a `HookOutput { result?, provides? }`; the merge loop is wire-ready. Rule
@@ -226,48 +228,87 @@ recorded in `docs/INTENTS.md` (_a value is a capability iff a sibling handler `r
 it; everything else consumed is a `result`_). `workspaceUrl`/`agentType` migrated from
 capabilities to results. `requires` stays host-evaluated; `ANY_VALUE` never crosses the wire.
 
-**2. Wire codecs + zod validation (decided design).** The seam is **asymmetric**, and
-the untrusted direction is **remote→host**, which carries **three** independently-defined
-type families — not just intents: **intent payloads** (a remote handler dispatches),
-**hook results** (`HookOutput.result`, which _ride the invocation response_ back — 6+ per
-op, e.g. `delete-workspace`), and **provided data** (`HookOutput.provides`). Event payloads
-travel host→remote (trusted). Today the dispatcher does **zero** validation
-(`dispatcher.ts:397`): intent payloads are `unknown`, hook results are merged via an
-unchecked `output.result as T` cast (`dispatcher.ts:290`), and capability values are read
-via `as number` casts (`code-server-module.ts:706`, `agent-module.ts:211`). So "just
-schematize intents" under-scopes the actual attack surface.
+**2. Validation as a first-class intent-system feature (decided design).** Reframed from
+"wire codecs": the contract surface is **already plain serializable data** — every path in an
+intent payload / hook result is a **branded string** (`WorkspacePath = string & brand`,
+`ProjectId`, `WorkspaceName`), not a `Path` instance (`Path` lives _inside_ modules and is
+stringified before it reaches `collect`/`dispatch`), and the only non-serializable carrier is
+`AppStartErrorHookContext.error: Error`, a **host-only** hook that never crosses a wire. So the
+`Path↔string` / `Error↔object` transform machinery the earlier revision leaned on is largely
+theoretical, and **codecs are deferred until a wire actually exists**. What is real and durable
+_now_ is **runtime validation**: the dispatcher does **zero** today (`dispatcher.ts`), so intent
+payloads are `unknown`, hook results merge via an unchecked `output.result as T` cast
+(`dispatcher.ts:300`), the operation return value is cast `as IntentResult<I>` (`:478`), and
+capability values are read via `as number` casts. Item 2 replaces all of these with
+`schema.parse` — a first-class intent-system feature, applied on **every dispatch whether or not
+a wire is ever built** (aligned with CLAUDE.md's no-assertions rule). Wire-readiness falls out as
+a byproduct; it is not the driver.
 
 Resolved design:
 
-- **Schemas live on the Operation.** Each operation declares zod schemas for its intent
-  payload, its per-hook-point results, its provided-data, and its events — colocated with
-  the `*_OPERATION_ID` / hook-point / `EVENT_*` definitions it already owns. TS types
-  become `z.infer<schema>`, so the schema is the single source of truth (no separate
-  hand-synced registry like today's `plugin-protocol.ts`).
-- **Data-only contract (global invariant — see item 2a).** With no functions anywhere in
-  the contract, the _entire_ operation surface is schematizable; scope is not bounded by
-  serializability.
-- **Validate + transform anywhere.** Every dispatch runs `schema.parse` — validation _and_
-  `Path↔string` / `Error↔object` transforms — whether or not the message crosses the wire.
-  **One code path, no local-vs-wire branch**, so the wire path is exercised on every local
-  dispatch and a remote-only serialization bug cannot hide. This is safe because `Path` is a
-  value object compared via `.equals()` / `.toString()` (never by reference) and
-  `HookResult.errors` are data-only reports — a `Path` round-tripped through `string` back to
-  a fresh `new Path()`, or an `Error` through `{message,stack}`, is _equivalent_; instance
-  identity never mattered. _(Doc note for implementers: don't rely on `Path`/`Error`
-  instance identity or live `Error` prototypes across a dispatch — reconstructed instances
-  are equivalent by value only.)_
-- **The dispatcher is the validation home** — "the intent system handles validation,"
-  literally. This replaces the unsafe `as` casts everywhere (aligned with CLAUDE.md's
-  no-assertions rule), not only at the wire.
-- **`requires` stays host-evaluated** with the `ANY_VALUE` sentinel — it never needs a value
-  schema and never crosses the wire; only `provides` _data_ is schematized.
+- **zod is the single source of truth.** Schemas are what you write; types are `z.infer<schema>`
+  (no hand-synced registry like today's `plugin-protocol.ts`). Branded ids become
+  `z.string().brand<…>()`. The generic **envelopes** (`Intent<R>`, `DomainEvent`, `HookContext`)
+  stay hand-written — zod can't model the phantom result-type param — while everything they
+  _carry_ (payloads, results, provides, contexts) is zod-derived. `readonly` is preserved via
+  `.readonly()` so inferred types match today's deeply-`readonly` contracts.
+- **zod is confined to the intent system.** The shared contract vocabulary (branded ids,
+  `agentSpecSchema`, `Workspace`, metadata) is _defined inside_ `src/intents/` (a `contract/`
+  module; per-operation schemas stay colocated on their operations). `shared/api/types.ts` and
+  `shared/ipc.ts` become **type-only re-export façades** (`export type { … } from "…/intents/…"`),
+  so renderer / preload / services keep their import paths **unchanged** — those imports are
+  already `import type` and thus erased at build. (This is already why zod stays out of the
+  renderer bundle today despite `shared/api/types.ts:5` importing `zod/v4`: `renderer/lib/api`
+  imports these names type-only.) A **boundary lint forbids `zod` imports under `src/renderer`,
+  `src/preload`, `src/shared`**, making the confinement structural, not a tree-shaking accident.
+  The one runtime zod consumer in `shared/` today — `plugin-protocol.ts`'s `agentSpecSchema.safeParse`
+  (main-only) — value-imports the schema from the intents `contract/` module (an accepted, main-only
+  `shared→intents` runtime edge; alternatively that guard relocates into the contract module).
+- **Schemas hung on the Operation.** A `schemas` field —
+  `{ payload, result, hooks: { <point>: { input, result, provides } }, events: { <type> } }` —
+  colocated with the op's `*_OPERATION_ID` / hook-point / `EVENT_*` defs. The dispatcher indexes
+  it at `registerOperation` (payload/hook/result reachable via the operations map; event schemas
+  folded into an event→schema lookup for `emitEvent`). Modules registering a handler import the
+  point's schema to conform.
+- **Five validated carriers** — everything crossing the intent-system boundary, in **both**
+  directions:
 
-Cost: a `schema.parse` per dispatch, including the hot path (`project:resolve`) — mitigated
-by the item-4 host-cached projections; zod v4 (already imported for `agentSpecSchema`) is
-fast. Still do the full sweep for other non-JSON leaks (Maps/Sets/Buffers/class instances)
-so every carrier has a transform.
-→ research workspace `research-wire-codecs`.
+  | Carrier                                                       | Where                                 | On failure                                                         |
+  | ------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+  | Intent payload                                                | `dispatch()` entry                    | reject the dispatch                                                |
+  | Hook input context (whole ctx)                                | into each handler                     | throw (operation built a bad ctx — a framework bug)                |
+  | Hook result                                                   | `collectHookResults:300`, per handler | push to `collect`'s `errors[]` (isolated, like a throwing handler) |
+  | Provides — a **scalar bag** (`string\|number\|boolean\|null`) | merge at `:305`                       | push to `errors[]`                                                 |
+  | Event payload                                                 | `emit()`                              | throw                                                              |
+  | Operation return value                                        | before `handle.resolve` (`:478`)      | reject the dispatch                                                |
+
+- **`.strip()`, not strict.** Unknown keys are silently dropped and the dispatcher **forwards the
+  parsed (stripped) value** so normalization takes effect and a future wire can't leak stray
+  fields; known keys are still fully type-checked (so the `as number` capability reads are
+  protected — only extra-key _detection_ is traded away).
+- **Whole-context validation** at every hook point: the enrichment fields are validated strictly,
+  the `intent` portion re-affirmed against the op's own payload schema, and `capabilities` is a
+  **shape check** (`z.record` of scalars) — each capability value was already validated against its
+  `provides` schema at merge time, so its values aren't re-parsed. All current capability values
+  are already scalar (ports=number, `app-ready`/`ui-ready`=boolean, `agent`=`AgentType` string), so
+  the scalar constraint holds against the whole codebase without a provider refactor.
+- **`requires` stays host-evaluated** with the `ANY_VALUE` sentinel — it tests key _presence_, never
+  needs a value schema, and never crosses a wire; only `provides` _data_ is schematized.
+
+**Rollout: one atomic big-bang PR.** All ~30 operations get schemas + the shared branded-type
+rewrite (`shared/api/types.ts`, `ipc.ts`) + mandatory validation from day one; CI proves the whole
+surface at once (no half-validated window). Shared value schemas (`AgentSpec` — reuse the existing
+`agentSpecSchema` — `Workspace`, metadata) live in a shared `schemas.ts` that operation schemas
+compose; each event type has exactly one owning operation file and registration rejects a duplicate
+event-schema.
+
+Cost: a `schema.parse` per dispatch **and** per hook point, including the hot paths
+(`project:resolve`, `switch`, `get-active-workspace`) — and the item-4 host-cached projections that
+would mitigate it don't exist yet (they need the transport work). Posture: **accept it, measure,
+optimize only on a real regression** — zod v4 (already imported for `agentSpecSchema`) is fast and
+payloads are small; add a `project:resolve`/`switch` benchmark to the PR so the cost is visible.
+Implementation residue (no decision): a per-brand constructor helper for building branded values at
+runtime, and integration tests that lean on extra/invalid fields (mostly absorbed by `.strip()`).
 
 **2a. Enforce the data-only handler contract.** _Both a handler's `HookContext` (in) and its
 `HookOutput` (result + provides) — and every event payload — must be pure data: no
@@ -385,11 +426,30 @@ Separable, buildable/de-riskable independently.
 
 ## 10. Next steps
 
-- **Recommended spike:** prove the reverse channel by hand — run code-server + one agent
-  on a remote box with `ssh -L`/`-R`, confirm the Claude bridge callback and the OpenCode
-  MCP round-trip both work through the tunnel — before committing.
-- **Then:** fold `research-wire-codecs` + `research-leaky-*` findings into a phased
-  implementation plan (2 → 3, then 4/5), with the data-plane spike alongside.
+Progress: **item 1 done** (capability contract), **item 3 done** (single-tier handlers +
+streaming framework), and **item 2 done** (validation as a first-class intent-system feature —
+implemented and green). `research-wire-codecs`, `research-leaky-*`, and
+`research-provides-closures` are all **moot**.
+
+Item 2 as landed: the contract vocabulary (branded ids, AgentSpec, domain value objects) lives
+in `src/intents/contract.ts` (zod = single source of truth), with `shared/api/types.ts` +
+`shared/ipc.ts` as **type-only re-export façades** and an eslint boundary rule confining zod to
+the intent system (legacy exceptions: `ui-event.ts`, `plugin-protocol.ts`). The dispatcher
+validates all five carriers (intent payload, hook input ctx, hook result, provides, event, +
+operation result) via schemas hung on each `Operation`. **`Operation` is parameterized by its
+schema bundle** — `Operation<S extends OperationSchemas>` with required `schemas: S` and
+`execute(ctx: OperationContext<IntentOf<S>>): Promise<ResultOf<S>>` — so a production op is just
+`implements Operation<typeof schemas>` and its Intent/result derive from the bundle (`IntentOf` /
+`ResultOf`), never restated. `registerOperation(op)` is single-arg (key = `op.schemas.type`). Test
+mocks were consolidated onto a single generic helper (`createMinimalOperation(id, intentType,
+hookPoint, opts)` → `Operation<S>` with a permissive `z.unknown()` payload + `z.custom<R>()` result
+that keeps dispatched results typed); a few genuinely-custom mocks stay bespoke `Operation<typeof
+schemas>` objects. **Deferred polish** (not blocking): tightening the few `z.custom<T>()` escapes
+(AgentInfo / BinaryType / Path-carrying internal types) to structural schemas.
+
+- **Next code step:** the transport work (items 4/5) + the §10 reverse-channel spike.
+- **Recommended spike (in parallel):** prove the reverse channel by hand — run code-server + one
+  agent on a remote box with `ssh -L`/`-R`, confirm the Claude bridge callback and the OpenCode
+  MCP round-trip both work through the tunnel — before committing to the transport (items 4/5).
 - **Open details not yet drilled:** the exact config-injection key list (§5), the
-  connection/registration lifecycle mechanics (§8 item 5), and the data-plane tunnel choice
-  (§9). `research-provides-closures` is **moot** (item 1 done) and can be discarded.
+  connection/registration lifecycle mechanics (§8 item 5), and the data-plane tunnel choice (§9).

--- a/src/intents/agent-launch-options.ts
+++ b/src/intents/agent-launch-options.ts
@@ -7,65 +7,100 @@
  * whose provider type matches the requested backend contributes. Detection is
  * best-effort: a provider that fails to report contributes nothing, so the form
  * falls back to offering only the default.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { LifecycleAgentType } from "../shared/ipc";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetLaunchOptionsPayload {
-  /** Backend the form currently targets. */
-  readonly backend: LifecycleAgentType;
-}
-
-/**
- * Launch options for a backend.
- * - permissionModes: selectable Claude permission modes (empty for OpenCode,
- *   or when detection fails — the form then offers only the default).
- */
-export interface LaunchOptionsResult {
-  readonly permissionModes: readonly string[];
-}
-
-export interface GetLaunchOptionsIntent extends Intent<LaunchOptionsResult> {
-  readonly type: "agent:get-launch-options";
-  readonly payload: GetLaunchOptionsPayload;
-}
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { hookCtxSchema } from "./contract";
 
 export const INTENT_GET_LAUNCH_OPTIONS = "agent:get-launch-options" as const;
 
 export const GET_LAUNCH_OPTIONS_OPERATION_ID = "get-launch-options";
 
 // =============================================================================
-// Hook Result & Input Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-/** Input context for the "launch-options" hook point. */
-export interface LaunchOptionsHookInput extends HookContext {
-  readonly backend: LifecycleAgentType;
-}
+/**
+ * Local schema for `LifecycleAgentType` (`"opencode" | "claude"`, from shared/ipc).
+ * That shared type is not part of the intent `contract` vocabulary, so it is defined
+ * here; its inferred type is structurally identical to `LifecycleAgentType`.
+ */
+const lifecycleAgentTypeSchema = z.enum(["opencode", "claude"]);
+
+export const getLaunchOptionsPayloadSchema = z
+  .object({
+    /** Backend the form currently targets. */
+    backend: lifecycleAgentTypeSchema,
+  })
+  .readonly();
+
+/**
+ * Launch options for a backend.
+ * - permissionModes: selectable Claude permission modes (empty for OpenCode,
+ *   or when detection fails — the form then offers only the default).
+ */
+export const launchOptionsResultSchema = z
+  .object({
+    permissionModes: z.array(z.string()).readonly(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "launch-options" hook point. Each agent module
  * contributes only when the requested backend matches its provider type.
  */
-export interface LaunchOptionsHookResult {
-  readonly permissionModes?: readonly string[];
-}
+export const launchOptionsHookResultSchema = z
+  .object({
+    permissionModes: z.array(z.string()).readonly().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "launch-options" hook point (beyond the base HookContext). */
+const launchOptionsEnrichmentSchema = z.object({ backend: lifecycleAgentTypeSchema });
+
+/** Runtime whole-context validation schema for "launch-options". */
+export const launchOptionsHookInputSchema = hookCtxSchema(
+  getLaunchOptionsPayloadSchema,
+  launchOptionsEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_GET_LAUNCH_OPTIONS,
+  payload: getLaunchOptionsPayloadSchema,
+  result: launchOptionsResultSchema,
+  hooks: {
+    "launch-options": {
+      input: launchOptionsHookInputSchema,
+      result: launchOptionsHookResultSchema,
+    },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetLaunchOptionsPayload = z.infer<typeof getLaunchOptionsPayloadSchema>;
+export type LaunchOptionsResult = z.infer<typeof launchOptionsResultSchema>;
+export type GetLaunchOptionsIntent = IntentOf<typeof schemas>;
+export type LaunchOptionsHookResult = z.infer<typeof launchOptionsHookResultSchema>;
+
+/** Input context for the "launch-options" hook point: base envelope + inferred enrichment. */
+export type LaunchOptionsHookInput = HookContext & z.infer<typeof launchOptionsEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class AgentLaunchOptionsOperation implements Operation<
-  GetLaunchOptionsIntent,
-  LaunchOptionsResult
-> {
+export class AgentLaunchOptionsOperation implements Operation<typeof schemas> {
   readonly id = GET_LAUNCH_OPTIONS_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<GetLaunchOptionsIntent>): Promise<LaunchOptionsResult> {
     const hookCtx: LaunchOptionsHookInput = {

--- a/src/intents/agent-lifecycle.ts
+++ b/src/intents/agent-lifecycle.ts
@@ -11,47 +11,77 @@
  * event is emitted here — the provider's own status change propagates via
  * agent:update-status. The "lifecycle" hook is resolved per-workspace agent by
  * the workspace-agent resolver, then handled by the matching agent module.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/hook input
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` type is
+ * **derived** from that bundle via `IntentOf` — never restated. The result is void.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { AgentLifecycleEvent } from "../shared/plugin-protocol";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { hookCtxSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface AgentLifecyclePayload {
-  readonly workspacePath: string;
-  readonly event: AgentLifecycleEvent;
-}
-
-export interface AgentLifecycleIntent extends Intent<void> {
-  readonly type: "agent:lifecycle";
-  readonly payload: AgentLifecyclePayload;
-}
 
 export const INTENT_AGENT_LIFECYCLE = "agent:lifecycle" as const;
 
-// =============================================================================
-// Hook Input Types
-// =============================================================================
-
 export const AGENT_LIFECYCLE_OPERATION_ID = "agent-lifecycle";
 
-/** Input context for the "lifecycle" hook point. */
-export interface AgentLifecycleHookInput extends HookContext {
-  readonly workspacePath: string;
-  readonly event: AgentLifecycleEvent;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+/**
+ * Local schema for `AgentLifecycleEvent` (`"open" | "close"`, from shared/plugin-protocol).
+ * That shared type is not part of the intent `contract` vocabulary, so it is defined here;
+ * its inferred type is structurally identical to `AgentLifecycleEvent`.
+ */
+const agentLifecycleEventSchema = z.enum(["open", "close"]);
+
+export const agentLifecyclePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    event: agentLifecycleEventSchema,
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "lifecycle" hook point (beyond the base HookContext). */
+const lifecycleEnrichmentSchema = z.object({
+  workspacePath: z.string(),
+  event: agentLifecycleEventSchema,
+});
+
+/** Runtime whole-context validation schema for "lifecycle". */
+export const lifecycleHookInputSchema = hookCtxSchema(
+  agentLifecyclePayloadSchema,
+  lifecycleEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_AGENT_LIFECYCLE,
+  payload: agentLifecyclePayloadSchema,
+  hooks: {
+    lifecycle: { input: lifecycleHookInputSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type AgentLifecyclePayload = z.infer<typeof agentLifecyclePayloadSchema>;
+export type AgentLifecycleIntent = IntentOf<typeof schemas>;
+
+/** Input context for the "lifecycle" hook point: base envelope + inferred enrichment. */
+export type AgentLifecycleHookInput = HookContext & z.infer<typeof lifecycleEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class AgentLifecycleOperation implements Operation<AgentLifecycleIntent, void> {
+export class AgentLifecycleOperation implements Operation<typeof schemas> {
   readonly id = AGENT_LIFECYCLE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<AgentLifecycleIntent>): Promise<void> {
     const { payload } = ctx.intent;

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -21,7 +21,8 @@ import type { AppReadyIntent, LoadProjectsResult } from "./app-ready";
 import { INTENT_OPEN_PROJECT } from "./open-project";
 import type { OpenProjectIntent } from "./open-project";
 import type { IntentModule } from "./lib/module";
-import type { HookOutput, Operation, OperationContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { HookOutput, Operation, OperationSchemas } from "./lib/operation";
 import type { Project } from "../shared/api/types";
 import { createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { ConfigAgentType } from "../boundaries/platform/config";
@@ -57,14 +58,22 @@ function createProjectModule(projectPaths: readonly string[]): IntentModule {
   };
 }
 
+const openProjectStubSchemas = {
+  type: INTENT_OPEN_PROJECT,
+  payload: z.unknown(),
+  result: z.custom<Project>(),
+} satisfies OperationSchemas;
+
 function createProjectOpenStub(
   state: TestState,
   options?: { failForPath?: string }
-): Operation<OpenProjectIntent, Project> {
+): Operation<typeof openProjectStubSchemas> {
   return {
     id: "open-project",
-    async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project> {
-      const pathStr = ctx.intent.payload.path?.toString() ?? "";
+    schemas: openProjectStubSchemas,
+    async execute(ctx): Promise<Project> {
+      const payload = ctx.intent.payload as OpenProjectIntent["payload"];
+      const pathStr = payload.path?.toString() ?? "";
       if (options?.failForPath === pathStr) {
         throw new Error(`Project not found: ${pathStr}`);
       }
@@ -82,15 +91,14 @@ function createProjectOpenStub(
 
 function createTestSetup(
   modules: IntentModule[],
-  stub: Operation<OpenProjectIntent, Project>
+  stub: Operation<typeof openProjectStubSchemas>
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(
-    INTENT_APP_READY,
     new AppReadyOperation(createMockAccessor<ConfigAgentType>("agent", "claude"))
   );
-  dispatcher.registerOperation(INTENT_OPEN_PROJECT, stub);
+  dispatcher.registerOperation(stub);
 
   for (const m of modules) dispatcher.registerModule(m);
 
@@ -178,10 +186,12 @@ describe("AppReady Operation", () => {
       const latch = new Promise<void>((r) => {
         resolveLatch = r;
       });
-      const stub: Operation<OpenProjectIntent, Project> = {
+      const stub: Operation<typeof openProjectStubSchemas> = {
         id: "open-project",
-        async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project> {
-          const p = ctx.intent.payload.path?.toString() ?? "";
+        schemas: openProjectStubSchemas,
+        async execute(ctx): Promise<Project> {
+          const payload = ctx.intent.payload as OpenProjectIntent["payload"];
+          const p = payload.path?.toString() ?? "";
           started.push(p);
           if (started.length === paths.length) resolveLatch();
           await latch;

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -11,41 +11,22 @@
  * After collecting paths, dispatches project:open for each saved project
  * (best-effort, skips invalid projects). Once all dispatches complete,
  * emits an `app:started` domain event so the renderer knows startup is done.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook/
+ * event schemas are declared once and hung on the operation's `schemas` field; the `Intent`
+ * and result types are **derived** via `IntentOf`/`z.infer`. `AgentInfo`/`LifecycleAgentType`
+ * are shared IPC types modeled with `z.custom` so their exact named types flow through.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
 import { Path } from "../utils/path/path";
 import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
 import type { ConfigAgentType } from "../boundaries/platform/config";
 import { throwHookErrors } from "./lib/hook-helpers";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface AppReadyPayload {
-  /** No payload needed. */
-  readonly [key: string]: never;
-}
-
-/**
- * Result of app:ready. No longer sent to the renderer (the ui-connected
- * handshake is fire-and-forget); retained as the operation's typed result.
- */
-export interface AppReadyResult {
-  /** Global default agent (config.agent). Null when not yet chosen (first-run pending). */
-  readonly defaultAgent: LifecycleAgentType | null;
-  /** Agents whose binaries are currently present on disk. */
-  readonly availableAgents: readonly AgentInfo[];
-}
-
-export interface AppReadyIntent extends Intent<AppReadyResult> {
-  readonly type: "app:ready";
-  readonly payload: AppReadyPayload;
-}
 
 export const INTENT_APP_READY = "app:ready" as const;
 
@@ -62,28 +43,78 @@ export const EVENT_APP_STARTED = "app:started" as const;
 
 export const APP_READY_OPERATION_ID = "app-ready";
 
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const appReadyPayloadSchema = z.object({}).readonly();
+
+/**
+ * Result of app:ready. No longer sent to the renderer (the ui-connected
+ * handshake is fire-and-forget); retained as the operation's typed result.
+ */
+export const appReadyResultSchema = z
+  .object({
+    /** Global default agent (config.agent). Null when not yet chosen (first-run pending). */
+    defaultAgent: z.custom<LifecycleAgentType>().nullable(),
+    /** Agents whose binaries are currently present on disk. */
+    availableAgents: z.array(z.custom<AgentInfo>()).readonly(),
+  })
+  .readonly();
+
 /**
  * Per-handler result for "load-projects" hook point.
  * Modules return paths to saved projects that should be opened on startup.
  */
-export interface LoadProjectsResult {
-  readonly projectPaths?: readonly string[];
-}
+export const loadProjectsResultSchema = z
+  .object({
+    projectPaths: z.array(z.string()).readonly().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "available-agents" hook point.
  * Each agent module returns its `AgentInfo` only if its binary is present.
  */
-export interface AvailableAgentsResult {
-  readonly agent?: AgentInfo;
-}
+export const availableAgentsResultSchema = z
+  .object({
+    agent: z.custom<AgentInfo>().optional(),
+  })
+  .readonly();
+
+/** Payload emitted by `app:started`. */
+export const appStartedPayloadSchema = z.object({}).readonly();
+
+const schemas = {
+  type: INTENT_APP_READY,
+  payload: appReadyPayloadSchema,
+  result: appReadyResultSchema,
+  hooks: {
+    "load-projects": { result: loadProjectsResultSchema },
+    "available-agents": { result: availableAgentsResultSchema },
+  },
+  events: {
+    [EVENT_APP_STARTED]: appStartedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type AppReadyPayload = z.infer<typeof appReadyPayloadSchema>;
+export type AppReadyResult = z.infer<typeof appReadyResultSchema>;
+export type AppReadyIntent = IntentOf<typeof schemas>;
+export type LoadProjectsResult = z.infer<typeof loadProjectsResultSchema>;
+export type AvailableAgentsResult = z.infer<typeof availableAgentsResultSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class AppReadyOperation implements Operation<AppReadyIntent, AppReadyResult> {
+export class AppReadyOperation implements Operation<typeof schemas> {
   readonly id = APP_READY_OPERATION_ID;
+  readonly schemas = schemas;
 
   constructor(private readonly agentConfig: PersistedAccessor<ConfigAgentType>) {}
 

--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -12,19 +12,18 @@
  *
  * After hooks complete, emits `app:resumed` for telemetry subscribers
  * (telemetry-module) that don't depend on server state.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload, hook-result,
+ * and event schemas are declared once and hung on the operation's `schemas` field; the
+ * `Intent` and payload types are **derived** via `IntentOf`/`z.infer`. The event
+ * interfaces (`AppResumeFailedEvent`, `IdeServerRestartedEvent`) are consumed by other
+ * modules, so they stay exported — their `payload` types are derived from the schemas.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface AppResumeIntent extends Intent<void> {
-  readonly type: "app:resume";
-  readonly payload: Record<string, never>;
-}
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 
 export const INTENT_APP_RESUME = "app:resume" as const;
 
@@ -35,23 +34,65 @@ export const INTENT_APP_RESUME = "app:resume" as const;
 export const APP_RESUME_OPERATION_ID = "app-resume";
 export const APP_RESUME_HOOK_RESUME = "resume";
 
-/**
- * Per-handler result for the "resume" hook point (data only).
- * A handler reports the outcome of its recovery attempt; the operation maps it to
- * domain events. Omit both fields (return void) when there was nothing to recover.
- */
-export interface ResumeHookResult {
-  /** A stale server was killed and a fresh one is now listening (→ ide-server:restarted). */
-  readonly restarted?: boolean;
-  /** Recovery failed; human-readable error for display (→ app:resume-failed). */
-  readonly failed?: { readonly error: string };
-}
-
 // =============================================================================
 // Event Types
 // =============================================================================
 
 export const EVENT_APP_RESUMED = "app:resumed" as const;
+
+export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
+
+export const EVENT_IDE_SERVER_RESTARTED = "ide-server:restarted" as const;
+
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const appResumePayloadSchema = z.object({}).readonly();
+
+/**
+ * Per-handler result for the "resume" hook point (data only).
+ * A handler reports the outcome of its recovery attempt; the operation maps it to
+ * domain events. Omit both fields (return void) when there was nothing to recover.
+ */
+export const resumeHookResultSchema = z
+  .object({
+    /** A stale server was killed and a fresh one is now listening (→ ide-server:restarted). */
+    restarted: z.boolean().optional(),
+    /** Recovery failed; human-readable error for display (→ app:resume-failed). */
+    failed: z.object({ error: z.string() }).readonly().optional(),
+  })
+  .readonly();
+
+/** Payload emitted by `app:resumed` (telemetry). */
+export const appResumedPayloadSchema = z.object({}).readonly();
+
+/** Payload emitted by `app:resume-failed` — a human-readable error for display. */
+export const appResumeFailedPayloadSchema = z.object({ error: z.string() }).readonly();
+
+/** Payload emitted by `ide-server:restarted`. */
+export const ideServerRestartedPayloadSchema = z.object({}).readonly();
+
+const schemas = {
+  type: INTENT_APP_RESUME,
+  payload: appResumePayloadSchema,
+  hooks: {
+    [APP_RESUME_HOOK_RESUME]: { result: resumeHookResultSchema },
+  },
+  events: {
+    [EVENT_APP_RESUMED]: appResumedPayloadSchema,
+    [EVENT_APP_RESUME_FAILED]: appResumeFailedPayloadSchema,
+    [EVENT_IDE_SERVER_RESTARTED]: ideServerRestartedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type AppResumePayload = z.infer<typeof appResumePayloadSchema>;
+export type AppResumeIntent = IntentOf<typeof schemas>;
+export type ResumeHookResult = z.infer<typeof resumeHookResultSchema>;
 
 /**
  * Emitted by any handler on the `resume` hook point when recovery fails.
@@ -60,10 +101,8 @@ export const EVENT_APP_RESUMED = "app:resumed" as const;
  */
 export interface AppResumeFailedEvent extends DomainEvent {
   readonly type: typeof EVENT_APP_RESUME_FAILED;
-  readonly payload: { readonly error: string };
+  readonly payload: z.infer<typeof appResumeFailedPayloadSchema>;
 }
-
-export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
 
 /**
  * Emitted by ide-server-module after it kills and restarts the IDE server on
@@ -74,17 +113,16 @@ export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
  */
 export interface IdeServerRestartedEvent extends DomainEvent {
   readonly type: typeof EVENT_IDE_SERVER_RESTARTED;
-  readonly payload: Record<string, never>;
+  readonly payload: z.infer<typeof ideServerRestartedPayloadSchema>;
 }
-
-export const EVENT_IDE_SERVER_RESTARTED = "ide-server:restarted" as const;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class AppResumeOperation implements Operation<AppResumeIntent, void> {
+export class AppResumeOperation implements Operation<typeof schemas> {
   readonly id = APP_RESUME_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<AppResumeIntent>): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };

--- a/src/intents/app-shutdown.integration.test.ts
+++ b/src/intents/app-shutdown.integration.test.ts
@@ -203,7 +203,7 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+  dispatcher.registerOperation(new AppShutdownOperation());
 
   if (options?.withIdempotency) {
     const idempotencyModule = createIdempotencyModule([{ intentType: INTENT_APP_SHUTDOWN }]);

--- a/src/intents/app-shutdown.ts
+++ b/src/intents/app-shutdown.ts
@@ -13,24 +13,16 @@
  * and do not prevent other modules from disposing.
  *
  * No provider dependencies - hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload schema is
+ * declared once and hung on the operation's `schemas` field; the `Intent` and payload
+ * types are **derived** from that bundle via `IntentOf`/`z.infer`. Both hook points
+ * ("stop", "quit") return void, so no per-hook-point schema is declared.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface AppShutdownPayload {
-  /** If true, install a downloaded update after shutdown cleanup. */
-  readonly installUpdate?: boolean;
-}
-
-export interface AppShutdownIntent extends Intent<void> {
-  readonly type: "app:shutdown";
-  readonly payload: AppShutdownPayload;
-}
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 
 export const INTENT_APP_SHUTDOWN = "app:shutdown" as const;
 
@@ -41,11 +33,35 @@ export const INTENT_APP_SHUTDOWN = "app:shutdown" as const;
 export const APP_SHUTDOWN_OPERATION_ID = "app-shutdown";
 
 // =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const appShutdownPayloadSchema = z
+  .object({
+    /** If true, install a downloaded update after shutdown cleanup. */
+    installUpdate: z.boolean().optional(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_APP_SHUTDOWN,
+  payload: appShutdownPayloadSchema,
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type AppShutdownPayload = z.infer<typeof appShutdownPayloadSchema>;
+export type AppShutdownIntent = IntentOf<typeof schemas>;
+
+// =============================================================================
 // Operation
 // =============================================================================
 
-export class AppShutdownOperation implements Operation<AppShutdownIntent, void> {
+export class AppShutdownOperation implements Operation<typeof schemas> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<AppShutdownIntent>): Promise<void> {
     const hookCtx: HookContext = {

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -47,19 +47,25 @@ import type {
   InitResult,
 } from "./app-start";
 import { INTENT_SETUP } from "./setup";
-import type { SetupIntent } from "./setup";
 import type { IntentModule } from "./lib/module";
+import { z } from "zod/v4";
 import {
   ANY_VALUE,
   type HookContext,
   type HookOutput,
   type Operation,
-  type OperationContext,
+  type OperationSchemas,
 } from "./lib/operation";
 import type { ConfigAgentType } from "../shared/api/types";
 import type { BinaryType } from "./app-start";
 import { createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
+
+/** Permissive schemas for the stub setup operation (app:setup dispatched during checks). */
+const setupStubSchemas = {
+  type: INTENT_SETUP,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
 /** Mock accessor that seeds the configured agent. Pass null to leave it unset. */
 function createMockAgentAccessor(
@@ -234,10 +240,7 @@ function createTestSetup(
 ): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(
-    INTENT_APP_START,
-    new AppStartOperation(createMockAgentAccessor(), () => true)
-  );
+  dispatcher.registerOperation(new AppStartOperation(createMockAgentAccessor(), () => true));
 
   const allModules = options?.skipDefaultChecks ? modules : [...defaultCheckModules(), ...modules];
   for (const m of allModules) dispatcher.registerModule(m);
@@ -434,10 +437,11 @@ describe("AppStart Operation", () => {
     }
 
     /** Stub setup operation that records dispatch and succeeds. */
-    function createSetupStub(state: TestState): Operation<SetupIntent, void> {
+    function createSetupStub(state: TestState): Operation<typeof setupStubSchemas> {
       return {
         id: "setup",
-        async execute(ctx: OperationContext<SetupIntent>): Promise<void> {
+        schemas: setupStubSchemas,
+        async execute(ctx): Promise<void> {
           state.executionOrder.push("setup");
           void ctx;
         },
@@ -447,7 +451,7 @@ describe("AppStart Operation", () => {
     function createCheckTestSetup(
       modules: IntentModule[],
       options?: {
-        setupStub?: Operation<SetupIntent, void>;
+        setupStub?: Operation<typeof setupStubSchemas>;
         configuredAgent?: ConfigAgentType | null;
       }
     ): { dispatcher: Dispatcher } {
@@ -460,11 +464,10 @@ describe("AppStart Operation", () => {
       const wasConfigured = configured !== null;
       const agent: ConfigAgentType = configured && configured !== null ? configured : "opencode";
       dispatcher.registerOperation(
-        INTENT_APP_START,
         new AppStartOperation(createMockAgentAccessor(agent), () => wasConfigured)
       );
       if (options?.setupStub) {
-        dispatcher.registerOperation(INTENT_SETUP, options.setupStub);
+        dispatcher.registerOperation(options.setupStub);
       }
       for (const m of modules) dispatcher.registerModule(m);
 

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -30,51 +30,27 @@
  * Aborts on error in any hook. Services that are optional must handle
  * their own errors internally (e.g., PluginServer graceful degradation in
  * CodeServerModule).
+ *
+ * Contract schemas (item 2): zod is the single source of truth. Payload, per-hook-point
+ * (result/input) schemas are declared once and hung on the operation's `schemas` field; the
+ * `Intent`, result, and hook-input-context types are **derived** via `IntentOf`/`z.infer`.
+ * The "start" and "await-retry" hook points return void (no schema). `BinaryType` is a shared
+ * binary-resolution type modeled with `z.custom` so its exact named type flows through.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { configAgentTypeSchema, hookCtxSchema } from "./contract";
 import type { ConfigAgentType } from "../shared/api/types";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
 import type { BinaryType } from "../utils/binary-resolution/types";
-
-/** Re-exported for use by operation integration tests (avoids direct service import). */
-export type { BinaryType } from "../utils/binary-resolution/types";
-
-// =============================================================================
-// Extension Types (operation contract types for check-deps and setup hooks)
-// =============================================================================
-
-/** What the manifest declares — produced by extension-module, consumed by ide-server-module. */
-export interface ExtensionRequirement {
-  readonly id: string;
-  readonly version: string;
-  /** Native path to the .vsix file. */
-  readonly vsixPath: string;
-}
-
-/** What needs to be installed — produced by ide-server-module check-deps, consumed by setup. */
-export interface ExtensionInstallEntry {
-  readonly id: string;
-  readonly vsixPath: string;
-}
 import { INTENT_SETUP } from "./setup";
 import { INTENT_APP_READY, type AppReadyIntent } from "./app-ready";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface AppStartPayload {
-  /** No payload needed - startup configuration comes from module closures. */
-  readonly [key: string]: never;
-}
-
-export interface AppStartIntent extends Intent<void> {
-  readonly type: "app:start";
-  readonly payload: AppStartPayload;
-}
+/** Re-exported for use by operation integration tests (avoids direct service import). */
+export type { BinaryType } from "../utils/binary-resolution/types";
 
 export const INTENT_APP_START = "app:start" as const;
 
@@ -84,38 +60,66 @@ export const INTENT_APP_START = "app:start" as const;
 
 export const APP_START_OPERATION_ID = "app-start";
 
-/** Input context for "check-deps". Agent modules use their own isActive flag. */
-export interface CheckDepsHookContext extends HookContext {
-  readonly configuredAgent: ConfigAgentType | null;
-  readonly extensionRequirements: readonly ExtensionRequirement[];
-}
+/** The app:start hook point that runs when startup fails fatally. */
+export const APP_START_ERROR_HOOK = "error" as const;
 
-/** Per-handler result for "check-deps" hook point. Arrays only -- booleans derived by operation. */
-export interface CheckDepsResult {
-  readonly missingBinaries?: readonly BinaryType[];
-  readonly extensionInstallPlan?: readonly ExtensionInstallEntry[];
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const appStartPayloadSchema = z.object({}).readonly();
+
+/** What the manifest declares — produced by extension-module, consumed by ide-server-module. */
+export const extensionRequirementSchema = z
+  .object({
+    id: z.string(),
+    version: z.string(),
+    /** Native path to the .vsix file. */
+    vsixPath: z.string(),
+  })
+  .readonly();
+
+/** What needs to be installed — produced by ide-server-module check-deps, consumed by setup. */
+export const extensionInstallEntrySchema = z
+  .object({
+    id: z.string(),
+    vsixPath: z.string(),
+  })
+  .readonly();
+
+/**
+ * The startup phase in which a fatal error occurred. Mirrors the hook-point
+ * sequence, plus "setup" for the app:setup sub-operation region. Attached to the
+ * startup failure report so a crash can be attributed to a phase.
+ */
+export const appStartPhaseSchema = z.enum([
+  "before-ready",
+  "init",
+  "show-ui",
+  "check-deps",
+  "setup",
+  "start",
+]);
 
 /**
  * Per-handler result for "before-ready" hook point.
  * Returns optional script declarations to be copied to bin directory.
  */
-export interface ConfigureResult {
-  readonly scripts?: readonly string[];
-}
-
-/** Input context for "init" -- carries requiredScripts collected from before-ready results. */
-export interface InitHookContext extends HookContext {
-  readonly requiredScripts: readonly string[];
-}
+export const configureResultSchema = z
+  .object({
+    scripts: z.array(z.string()).readonly().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for "init" hook point.
  * Extension module returns extensionRequirements. Other init handlers return `{}`.
  */
-export interface InitResult {
-  readonly extensionRequirements?: readonly ExtensionRequirement[];
-}
+export const initResultSchema = z
+  .object({
+    extensionRequirements: z.array(extensionRequirementSchema).readonly().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for "show-ui" hook point.
@@ -124,19 +128,82 @@ export interface InitResult {
  * is a separate `await-retry` hook point (the handler blocks internally and returns data),
  * not a closure handed back to the operation.
  */
-export interface ShowUIHookResult {
-  readonly retrySupported?: boolean;
-}
+export const showUIHookResultSchema = z
+  .object({
+    retrySupported: z.boolean().optional(),
+  })
+  .readonly();
 
-/** The app:start hook point that runs when startup fails fatally. */
-export const APP_START_ERROR_HOOK = "error" as const;
+/** Per-handler result for "check-deps" hook point. Arrays only -- booleans derived by operation. */
+export const checkDepsResultSchema = z
+  .object({
+    missingBinaries: z.array(z.custom<BinaryType>()).readonly().optional(),
+    extensionInstallPlan: z.array(extensionInstallEntrySchema).readonly().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for "init" -- carries requiredScripts from before-ready results. */
+const initEnrichmentSchema = z.object({
+  requiredScripts: z.array(z.string()).readonly(),
+});
+const initHookInputSchema = hookCtxSchema(appStartPayloadSchema, initEnrichmentSchema.shape);
+
+/** Operation-added enrichment for "check-deps". Agent modules use their own isActive flag. */
+const checkDepsEnrichmentSchema = z.object({
+  configuredAgent: configAgentTypeSchema.nullable(),
+  extensionRequirements: z.array(extensionRequirementSchema).readonly(),
+});
+const checkDepsHookInputSchema = hookCtxSchema(
+  appStartPayloadSchema,
+  checkDepsEnrichmentSchema.shape
+);
 
 /**
- * The startup phase in which a fatal error occurred. Mirrors the hook-point
- * sequence, plus "setup" for the app:setup sub-operation region. Attached to the
- * startup failure report so a crash can be attributed to a phase.
+ * Operation-added enrichment for the "error" hook point. Carries the live fatal error
+ * (a real Error instance — host-only) and the phase it occurred in.
  */
-export type AppStartPhase = "before-ready" | "init" | "show-ui" | "check-deps" | "setup" | "start";
+const appStartErrorEnrichmentSchema = z.object({
+  error: z.instanceof(Error),
+  phase: appStartPhaseSchema,
+});
+const appStartErrorHookInputSchema = hookCtxSchema(
+  appStartPayloadSchema,
+  appStartErrorEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_APP_START,
+  payload: appStartPayloadSchema,
+  hooks: {
+    "before-ready": { result: configureResultSchema },
+    init: { input: initHookInputSchema, result: initResultSchema },
+    "show-ui": { result: showUIHookResultSchema },
+    "check-deps": { input: checkDepsHookInputSchema, result: checkDepsResultSchema },
+    [APP_START_ERROR_HOOK]: { input: appStartErrorHookInputSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type AppStartPayload = z.infer<typeof appStartPayloadSchema>;
+export type AppStartIntent = IntentOf<typeof schemas>;
+
+export type ExtensionRequirement = z.infer<typeof extensionRequirementSchema>;
+export type ExtensionInstallEntry = z.infer<typeof extensionInstallEntrySchema>;
+export type AppStartPhase = z.infer<typeof appStartPhaseSchema>;
+
+export type ConfigureResult = z.infer<typeof configureResultSchema>;
+export type InitResult = z.infer<typeof initResultSchema>;
+export type ShowUIHookResult = z.infer<typeof showUIHookResultSchema>;
+export type CheckDepsResult = z.infer<typeof checkDepsResultSchema>;
+
+/** Input context for "init" -- carries requiredScripts collected from before-ready results. */
+export type InitHookContext = HookContext & z.infer<typeof initEnrichmentSchema>;
+
+/** Input context for "check-deps". Agent modules use their own isActive flag. */
+export type CheckDepsHookContext = HookContext & z.infer<typeof checkDepsEnrichmentSchema>;
 
 /**
  * Input context for the "error" hook point. Carries the fatal error and the
@@ -144,10 +211,7 @@ export type AppStartPhase = "before-ready" | "init" | "show-ui" | "check-deps" |
  * report + flush — before the operation re-throws to the composition root, which
  * shows the native failure box and quits.
  */
-export interface AppStartErrorHookContext extends HookContext {
-  readonly error: Error;
-  readonly phase: AppStartPhase;
-}
+export type AppStartErrorHookContext = HookContext & z.infer<typeof appStartErrorEnrichmentSchema>;
 
 // ActivateHookContext removed — ports are now read from capabilities within the "start" hook point.
 
@@ -166,8 +230,9 @@ interface CheckResult {
 // Operation
 // =============================================================================
 
-export class AppStartOperation implements Operation<AppStartIntent, void> {
+export class AppStartOperation implements Operation<typeof schemas> {
   readonly id = APP_START_OPERATION_ID;
+  readonly schemas = schemas;
 
   constructor(
     private readonly agentConfig: PersistedAccessor<ConfigAgentType>,

--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -43,7 +43,6 @@ import type {
 import {
   DeleteWorkspaceOperation,
   DELETE_WORKSPACE_OPERATION_ID,
-  INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETED,
 } from "./delete-workspace";
 import type {
@@ -194,8 +193,8 @@ function createTestHarness(options?: {
   };
 
   // Register operations
-  dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
+  dispatcher.registerOperation(new CloseProjectOperation());
+  dispatcher.registerOperation(new DeleteWorkspaceOperation());
 
   // Shared workspace:resolve (reverse lookup over the project) and project:resolve
   registerTestInfrastructure(dispatcher, {

--- a/src/intents/close-project.ts
+++ b/src/intents/close-project.ts
@@ -16,51 +16,24 @@
  * without closing") so the per-key idempotency guard resets.
  *
  * No provider dependencies - hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/hook/event
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, hookCtxSchema } from "./contract";
 import { INTENT_DELETE_WORKSPACE, type DeleteWorkspaceIntent } from "./delete-workspace";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface CloseProjectPayload {
-  readonly projectPath: string;
-  readonly removeLocalRepo?: boolean;
-  /**
-   * The dispatch is user-interactive: the "confirm" hook point runs after
-   * resolve, parking the dispatch on a confirmation dialog that contributes
-   * removeAll/removeLocalRepo or cancels. Programmatic callers omit it and
-   * never see a dialog.
-   */
-  readonly interactive?: boolean;
-}
-
-export interface CloseProjectIntent extends Intent<void> {
-  readonly type: "project:close";
-  readonly payload: CloseProjectPayload;
-}
-
 export const INTENT_CLOSE_PROJECT = "project:close" as const;
-
-// =============================================================================
-// Event Types
-// =============================================================================
-
-export interface ProjectClosedPayload {
-  readonly projectId: ProjectId;
-}
-
-export interface ProjectClosedEvent extends DomainEvent {
-  readonly type: "project:closed";
-  readonly payload: ProjectClosedPayload;
-}
+export const CLOSE_PROJECT_OPERATION_ID = "close-project";
 
 export const EVENT_PROJECT_CLOSED = "project:closed" as const;
 
@@ -72,8 +45,152 @@ export const EVENT_PROJECT_CLOSED = "project:closed" as const;
  */
 export const EVENT_PROJECT_CLOSE_FAILED = "project:close-failed" as const;
 
-export interface ProjectCloseFailedPayload {
-  readonly projectPath: string;
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const closeProjectPayloadSchema = z
+  .object({
+    projectPath: z.string(),
+    removeLocalRepo: z.boolean().optional(),
+    /**
+     * The dispatch is user-interactive: the "confirm" hook point runs after
+     * resolve, parking the dispatch on a confirmation dialog that contributes
+     * removeAll/removeLocalRepo or cancels. Programmatic callers omit it and
+     * never see a dialog.
+     */
+    interactive: z.boolean().optional(),
+  })
+  .readonly();
+
+// -----------------------------------------------------------------------------
+// Event payload schemas (events this file owns)
+// -----------------------------------------------------------------------------
+
+export const projectClosedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+  })
+  .readonly();
+
+export const projectCloseFailedPayloadSchema = z
+  .object({
+    projectPath: z.string(),
+  })
+  .readonly();
+
+// -----------------------------------------------------------------------------
+// Hook result schemas
+// -----------------------------------------------------------------------------
+
+/** Per-handler result contract for the "resolve" hook point. */
+export const closeResolveHookResultSchema = z
+  .object({
+    remoteUrl: z.string().optional(),
+    workspaces: z
+      .array(z.object({ path: z.string() }))
+      .readonly()
+      .optional(),
+  })
+  .readonly();
+
+/**
+ * Per-handler result for the "confirm" hook point. canceled aborts the
+ * dispatch (project:close-failed is emitted so the idempotency guard resets);
+ * otherwise removeAll upgrades the per-workspace teardown to full deletion
+ * and removeLocalRepo overrides the payload.
+ */
+export const closeConfirmHookResultSchema = z
+  .object({
+    canceled: z.boolean().optional(),
+    removeAll: z.boolean().optional(),
+    removeLocalRepo: z.boolean().optional(),
+  })
+  .readonly();
+
+/**
+ * Per-handler result contract for the "close" hook point.
+ * Side-effect handlers return `{}`.
+ */
+export const closeHookResultSchema = z
+  .object({
+    otherProjectsExist: z.boolean().optional(),
+  })
+  .readonly();
+
+// -----------------------------------------------------------------------------
+// Hook input enrichment + whole-context schemas
+// -----------------------------------------------------------------------------
+
+/** Operation-added enrichment for the "confirm" hook point (interactive dispatches only). */
+const closeConfirmEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  remoteUrl: z.string().optional(),
+  workspaces: z.array(z.object({ path: z.string() })).readonly(),
+});
+
+/** Runtime whole-context validation schema for "confirm". */
+export const closeConfirmHookInputSchema = hookCtxSchema(
+  closeProjectPayloadSchema,
+  closeConfirmEnrichmentSchema.shape
+);
+
+/** Operation-added enrichment for the "close" hook point. */
+const closeEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  remoteUrl: z.string().optional(),
+  removeLocalRepo: z.boolean(),
+});
+
+/** Runtime whole-context validation schema for "close". */
+export const closeHookInputSchema = hookCtxSchema(
+  closeProjectPayloadSchema,
+  closeEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_CLOSE_PROJECT,
+  payload: closeProjectPayloadSchema,
+  hooks: {
+    resolve: { result: closeResolveHookResultSchema },
+    confirm: { input: closeConfirmHookInputSchema, result: closeConfirmHookResultSchema },
+    close: { input: closeHookInputSchema, result: closeHookResultSchema },
+  },
+  events: {
+    [EVENT_PROJECT_CLOSED]: projectClosedPayloadSchema,
+    [EVENT_PROJECT_CLOSE_FAILED]: projectCloseFailedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type CloseProjectPayload = z.infer<typeof closeProjectPayloadSchema>;
+export type CloseProjectIntent = IntentOf<typeof schemas>;
+
+export type ProjectClosedPayload = z.infer<typeof projectClosedPayloadSchema>;
+export type ProjectCloseFailedPayload = z.infer<typeof projectCloseFailedPayloadSchema>;
+
+export type CloseResolveHookResult = z.infer<typeof closeResolveHookResultSchema>;
+export type CloseConfirmHookResult = z.infer<typeof closeConfirmHookResultSchema>;
+export type CloseHookResult = z.infer<typeof closeHookResultSchema>;
+
+/**
+ * Input context for the "confirm" hook handler (interactive dispatches only)
+ * — built by the operation from resolve results, carrying what the
+ * confirmation dialog renders.
+ */
+export type CloseConfirmHookInput = HookContext & z.infer<typeof closeConfirmEnrichmentSchema>;
+
+/**
+ * Input context for "close" hook handlers — built by the operation from resolve results.
+ */
+export type CloseHookInput = HookContext & z.infer<typeof closeEnrichmentSchema>;
+
+export interface ProjectClosedEvent extends DomainEvent {
+  readonly type: typeof EVENT_PROJECT_CLOSED;
+  readonly payload: ProjectClosedPayload;
 }
 
 export interface ProjectCloseFailedEvent extends DomainEvent {
@@ -82,65 +199,12 @@ export interface ProjectCloseFailedEvent extends DomainEvent {
 }
 
 // =============================================================================
-// Hook Context
-// =============================================================================
-
-export const CLOSE_PROJECT_OPERATION_ID = "close-project";
-
-/**
- * Per-handler result contract for the "resolve" hook point.
- */
-export interface CloseResolveHookResult {
-  readonly remoteUrl?: string;
-  readonly workspaces?: ReadonlyArray<{ path: string }>;
-}
-
-/**
- * Input context for the "confirm" hook handler (interactive dispatches only)
- * — built by the operation from resolve results, carrying what the
- * confirmation dialog renders.
- */
-export interface CloseConfirmHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly remoteUrl?: string;
-  readonly workspaces: ReadonlyArray<{ path: string }>;
-}
-
-/**
- * Per-handler result for the "confirm" hook point. canceled aborts the
- * dispatch (project:close-failed is emitted so the idempotency guard resets);
- * otherwise removeAll upgrades the per-workspace teardown to full deletion
- * and removeLocalRepo overrides the payload.
- */
-export interface CloseConfirmHookResult {
-  readonly canceled?: boolean;
-  readonly removeAll?: boolean;
-  readonly removeLocalRepo?: boolean;
-}
-
-/**
- * Input context for "close" hook handlers — built by the operation from resolve results.
- */
-export interface CloseHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly remoteUrl?: string;
-  readonly removeLocalRepo: boolean;
-}
-
-/**
- * Per-handler result contract for the "close" hook point.
- * Side-effect handlers return `{}`.
- */
-export interface CloseHookResult {
-  readonly otherProjectsExist?: boolean;
-}
-
-// =============================================================================
 // Operation
 // =============================================================================
 
-export class CloseProjectOperation implements Operation<CloseProjectIntent, void> {
+export class CloseProjectOperation implements Operation<typeof schemas> {
   readonly id = CLOSE_PROJECT_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<CloseProjectIntent>): Promise<void> {
     const { payload } = ctx.intent;

--- a/src/intents/contract.ts
+++ b/src/intents/contract.ts
@@ -1,0 +1,280 @@
+/**
+ * The intent contract vocabulary — shared primitive schemas + inferred types.
+ *
+ * zod is the single source of truth and stays confined to the intent system here.
+ * `shared/api/types.ts` and `shared/ipc.ts` re-export these types **type-only** (from
+ * `../intents/contract`), so renderer/preload keep their import paths while zod stays out of
+ * their bundles.
+ * Per-operation schemas (payloads, hook results, events) live on their operations.
+ */
+
+import { z } from "zod/v4";
+
+// =============================================================================
+// Branded identifiers
+// =============================================================================
+// Each id is a `z.string().brand<…>()` schema and its TS type is `z.infer<schema>`.
+
+/** Unique identifier for a project. Format: `<name>-<8-char-hex-hash>`. */
+export const projectIdSchema = z.string().brand<"ProjectId">();
+export type ProjectId = z.infer<typeof projectIdSchema>;
+
+/** Name of a workspace within a project (typically the git branch name). */
+export const workspaceNameSchema = z.string().brand<"WorkspaceName">();
+export type WorkspaceName = z.infer<typeof workspaceNameSchema>;
+
+/** Branded type for workspace paths (git worktree directories). */
+export const workspacePathSchema = z.string().brand<"WorkspacePath">();
+export type WorkspacePath = z.infer<typeof workspacePathSchema>;
+
+/** Branded type for project paths (git repository root directories). */
+export const projectPathSchema = z.string().brand<"ProjectPath">();
+export type ProjectPath = z.infer<typeof projectPathSchema>;
+
+// =============================================================================
+// Agent spec / session
+// =============================================================================
+// `agentSpecSchema` lives here (not in shared) so zod stays confined to the intent system.
+
+/** Model identifier (provider + model id) carried by an agent spec. */
+export const promptModelSchema = z
+  .object({
+    providerID: z.string().min(1),
+    modelID: z.string().min(1),
+  })
+  .readonly();
+export type PromptModel = z.infer<typeof promptModelSchema>;
+
+/**
+ * Agent specification for workspace creation — a discriminated union by backend.
+ * Discriminated on `type` so each backend only accepts the options it understands
+ * (e.g. permissionMode is Claude-only).
+ */
+export const agentSpecSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("default"),
+    prompt: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("claude"),
+    prompt: z.string().min(1).optional(),
+    model: promptModelSchema.optional(),
+    permissionMode: z.string().min(1).optional(),
+    agentName: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("opencode"),
+    prompt: z.string().min(1).optional(),
+    model: promptModelSchema.optional(),
+    agentName: z.string().min(1).optional(),
+  }),
+]);
+export type AgentSpec = z.infer<typeof agentSpecSchema>;
+
+/**
+ * Agent session information for a workspace — the primary session created/found
+ * when the agent server starts.
+ */
+export const agentSessionSchema = z
+  .object({
+    port: z.number(),
+    sessionId: z.string(),
+  })
+  .readonly();
+export type AgentSession = z.infer<typeof agentSessionSchema>;
+
+// =============================================================================
+// Domain value objects
+// =============================================================================
+
+/** A workspace within a project (represents a git worktree). */
+export const workspaceSchema = z
+  .object({
+    projectId: projectIdSchema,
+    name: workspaceNameSchema,
+    /** Current branch name, or null for detached HEAD state. */
+    branch: z.string().nullable(),
+    /** Workspace metadata stored in git config (always contains `base`). */
+    metadata: z.record(z.string(), z.string()).readonly(),
+    path: z.string(),
+    /** code-server URL for the iframe. Absent for hibernated workspaces until they wake. */
+    url: z.string().optional(),
+  })
+  .readonly();
+export type Workspace = z.infer<typeof workspaceSchema>;
+
+/** A project in CodeHydra (represents a git repository). */
+export const projectSchema = z
+  .object({
+    id: projectIdSchema,
+    name: z.string(),
+    path: z.string(),
+    workspaces: z.array(workspaceSchema).readonly(),
+    defaultBaseBranch: z.string().optional(),
+    /** Original git remote URL if the project was cloned from a URL. */
+    remoteUrl: z.string().optional(),
+  })
+  .readonly();
+export type Project = z.infer<typeof projectSchema>;
+
+/** Reference to a workspace (includes path for efficiency). Used in events. */
+export const workspaceRefSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    path: z.string(),
+  })
+  .readonly();
+export type WorkspaceRef = z.infer<typeof workspaceRefSchema>;
+
+/** Agent status counts for a workspace. */
+export const agentStatusCountsSchema = z
+  .object({
+    idle: z.number(),
+    busy: z.number(),
+    total: z.number(),
+  })
+  .readonly();
+export type AgentStatusCounts = z.infer<typeof agentStatusCountsSchema>;
+
+/** Agent status for a workspace (discriminated union by `type`). */
+export const agentStatusSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("none") }),
+  z.object({ type: z.literal("idle"), counts: agentStatusCountsSchema }),
+  z.object({ type: z.literal("busy"), counts: agentStatusCountsSchema }),
+  z.object({ type: z.literal("mixed"), counts: agentStatusCountsSchema }),
+]);
+export type AgentStatus = z.infer<typeof agentStatusSchema>;
+
+/** Combined status of a workspace. */
+export const workspaceStatusSchema = z
+  .object({
+    isDirty: z.boolean(),
+    unmergedCommits: z.number(),
+    agent: agentStatusSchema,
+  })
+  .readonly();
+export type WorkspaceStatus = z.infer<typeof workspaceStatusSchema>;
+
+/** Information about a base branch. */
+export const baseInfoSchema = z
+  .object({
+    /** Full branch reference (e.g., "main" or "origin/main"). */
+    name: z.string(),
+    /** Whether this is a remote-tracking branch. */
+    isRemote: z.boolean(),
+    /** Suggested base branch for creating a workspace from this branch. */
+    base: z.string().optional(),
+    /** Derivable workspace name if a workspace can be created from this branch. */
+    derives: z.string().optional(),
+  })
+  .readonly();
+export type BaseInfo = z.infer<typeof baseInfoSchema>;
+
+/** Agent types that can be selected by the user. */
+export const configAgentTypeSchema = z.enum(["claude", "opencode"]);
+export type ConfigAgentType = z.infer<typeof configAgentTypeSchema>;
+
+// =============================================================================
+// Setup screen progress
+// =============================================================================
+
+/** Identifiers for setup screen rows. */
+export const setupRowIdSchema = z.enum(["vscode", "agent", "setup"]);
+export type SetupRowId = z.infer<typeof setupRowIdSchema>;
+
+/** Status of a setup row. */
+export const setupRowStatusSchema = z.enum(["pending", "running", "done", "failed"]);
+export type SetupRowStatus = z.infer<typeof setupRowStatusSchema>;
+
+// =============================================================================
+// Deletion progress
+// =============================================================================
+
+/** Information about a process blocking workspace deletion (Windows). */
+export const blockingProcessSchema = z
+  .object({
+    pid: z.number(),
+    name: z.string(),
+    commandLine: z.string(),
+    /** Files locked by this process, relative to workspace (max 20). */
+    files: z.array(z.string()).readonly(),
+    /** CWD relative to workspace, or null if outside the workspace. */
+    cwd: z.string().nullable(),
+  })
+  .readonly();
+export type BlockingProcess = z.infer<typeof blockingProcessSchema>;
+
+/** Identifiers for deletion operations. */
+export const deletionOperationIdSchema = z.enum([
+  "killing-blockers",
+  "kill-terminals",
+  "stop-server",
+  "cleanup-vscode",
+  "detecting-blockers",
+  "cleanup-workspace",
+]);
+export type DeletionOperationId = z.infer<typeof deletionOperationIdSchema>;
+
+/** Status of a deletion operation. */
+export const deletionOperationStatusSchema = z.enum(["pending", "in-progress", "done", "error"]);
+export type DeletionOperationStatus = z.infer<typeof deletionOperationStatusSchema>;
+
+/** A single operation in the deletion process. */
+export const deletionOperationSchema = z
+  .object({
+    id: deletionOperationIdSchema,
+    label: z.string(),
+    status: deletionOperationStatusSchema,
+    error: z.string().optional(),
+  })
+  .readonly();
+export type DeletionOperation = z.infer<typeof deletionOperationSchema>;
+
+/** Progress state for workspace deletion (full state, emitted with each update). */
+export const deletionProgressSchema = z
+  .object({
+    workspacePath: workspacePathSchema,
+    workspaceName: workspaceNameSchema,
+    projectId: projectIdSchema,
+    keepBranch: z.boolean(),
+    operations: z.array(deletionOperationSchema).readonly(),
+    completed: z.boolean(),
+    hasErrors: z.boolean(),
+    /** Processes blocking deletion (Windows only), present when cleanup fails with EBUSY/EACCES/EPERM. */
+    blockingProcesses: z.array(blockingProcessSchema).readonly().optional(),
+  })
+  .readonly();
+export type DeletionProgress = z.infer<typeof deletionProgressSchema>;
+
+// =============================================================================
+// Hook input-context helpers
+// =============================================================================
+// Per the item-2 design, the dispatcher validates the whole hook input context at every
+// hook point: the `intent` re-affirmed against its payload schema, the accumulated
+// `capabilities` bag as a scalar-only shape check, and the operation-added enrichment fields.
+
+/**
+ * The accumulated capability bag: scalar primitives only (`string|number|boolean|null`).
+ * Values are already validated against their per-hook-point `provides` schema at merge time,
+ * so this is a shape check, not a re-validation of each value.
+ */
+export const capabilitiesSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean(), z.null()])
+);
+
+/**
+ * Build the whole-context schema for a hook input point: the base HookContext
+ * (`intent` + scalar `capabilities`) extended with the operation-added enrichment fields.
+ *
+ * @param payload the operation's intent payload schema (re-affirms `ctx.intent.payload`)
+ * @param enrichment the extra fields the operation puts on the context for this hook point
+ */
+export function hookCtxSchema<E extends z.ZodRawShape>(payload: z.ZodType, enrichment: E) {
+  return z.object({
+    intent: z.object({ type: z.string(), payload }),
+    capabilities: capabilitiesSchema.optional(),
+    ...enrichment,
+  });
+}

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -58,7 +58,6 @@ import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
 import {
   SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
   SWITCH_WORKSPACE_OPERATION_ID,
   EVENT_WORKSPACE_SWITCHED,
   selectNextWorkspace,
@@ -329,11 +328,11 @@ function createTestHarness(options?: {
   const workspaceFileService = createTestWorkspaceFileService();
 
   // Register operations
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
+  dispatcher.registerOperation(new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(new ResolveProjectOperation());
+  dispatcher.registerOperation(new DeleteWorkspaceOperation());
+  dispatcher.registerOperation(new SwitchWorkspaceOperation());
+  dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
   // Add interceptor via module (inline, matching bootstrap pattern)
   const inProgressDeletions = new Set<string>();

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -23,8 +23,10 @@
  * No provider dependencies - hook handlers do the actual work.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import type {
   ProjectId,
   WorkspaceName,
@@ -35,91 +37,57 @@ import type {
   BlockingProcess,
 } from "../shared/api/types";
 import type { WorkspacePath } from "../shared/ipc";
+import {
+  projectIdSchema,
+  workspaceNameSchema,
+  blockingProcessSchema,
+  deletionProgressSchema,
+  hookCtxSchema,
+} from "./contract";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { resolveWorkspaceIdentity } from "./lib/workspace-identity";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
 import { throwHookErrors, collectErrorMessages, lastDefined } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface DeleteWorkspacePayload {
-  readonly workspacePath: string;
-  readonly keepBranch: boolean;
-  readonly force: boolean;
-  /** Whether to remove the git worktree. true = full pipeline, false = shutdown only (runtime teardown). */
-  readonly removeWorktree: boolean;
-  readonly skipSwitch?: boolean;
-  /** If true, skip preflight checks for uncommitted changes and unmerged commits. */
-  readonly ignoreWarnings?: boolean;
-  /** PIDs from a previous failed attempt. When present, flush hook kills these before delete. */
-  readonly blockingPids?: readonly number[];
-  /**
-   * The dispatch is user-interactive: the "confirm" hook point runs before the
-   * pipeline, parking the dispatch on a confirmation dialog that contributes
-   * keepBranch or cancels. Programmatic callers (MCP, plugin, auto-workspace)
-   * omit it and never see a dialog. Only honored on the full-pipeline path
-   * (removeWorktree, not force).
-   */
-  readonly interactive?: boolean;
-}
-
-export interface DeleteWorkspaceIntent extends Intent<{ started: boolean }> {
-  readonly type: "workspace:delete";
-  readonly payload: DeleteWorkspacePayload;
-}
-
 export const INTENT_DELETE_WORKSPACE = "workspace:delete" as const;
-
-// =============================================================================
-// Event Types
-// =============================================================================
-
-export interface WorkspaceDeletedPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-  readonly projectPath: string;
-  /**
-   * True when the dispatch removed (or force-abandoned) the git worktree;
-   * false for runtime-only teardown (removeWorktree: false — e.g. the
-   * per-workspace teardown during project:close). Consumers that track real
-   * deletions (auto-workspace dismissal) must ignore teardown events.
-   */
-  readonly worktreeRemoved: boolean;
-}
-
-export interface WorkspaceDeletedEvent extends DomainEvent {
-  readonly type: "workspace:deleted";
-  readonly payload: WorkspaceDeletedPayload;
-}
+export const DELETE_WORKSPACE_OPERATION_ID = "delete-workspace";
 
 export const EVENT_WORKSPACE_DELETED = "workspace:deleted" as const;
-
 export const EVENT_WORKSPACE_DELETE_FAILED = "workspace:delete-failed" as const;
-
-export interface WorkspaceDeleteFailedPayload {
-  readonly workspacePath: string;
-}
-
-export interface WorkspaceDeleteFailedEvent extends DomainEvent {
-  readonly type: typeof EVENT_WORKSPACE_DELETE_FAILED;
-  readonly payload: WorkspaceDeleteFailedPayload;
-}
-
 export const EVENT_WORKSPACE_DELETION_PROGRESS = "workspace:deletion-progress" as const;
 
-export interface WorkspaceDeletionProgressEvent extends DomainEvent {
-  readonly type: typeof EVENT_WORKSPACE_DELETION_PROGRESS;
-  readonly payload: DeletionProgress;
-}
-
 // =============================================================================
-// Hook Result Types (returned by handlers via collect())
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export const DELETE_WORKSPACE_OPERATION_ID = "delete-workspace";
+export const deleteWorkspacePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    keepBranch: z.boolean(),
+    force: z.boolean(),
+    /** Whether to remove the git worktree. true = full pipeline, false = shutdown only (runtime teardown). */
+    removeWorktree: z.boolean(),
+    skipSwitch: z.boolean().optional(),
+    /** If true, skip preflight checks for uncommitted changes and unmerged commits. */
+    ignoreWarnings: z.boolean().optional(),
+    /** PIDs from a previous failed attempt. When present, flush hook kills these before delete. */
+    blockingPids: z.array(z.number()).readonly().optional(),
+    /**
+     * The dispatch is user-interactive: the "confirm" hook point runs before the
+     * pipeline, parking the dispatch on a confirmation dialog that contributes
+     * keepBranch or cancels. Programmatic callers (MCP, plugin, auto-workspace)
+     * omit it and never see a dialog. Only honored on the full-pipeline path
+     * (removeWorktree, not force).
+     */
+    interactive: z.boolean().optional(),
+  })
+  .readonly();
+
+export const deleteWorkspaceResultSchema = z.object({ started: z.boolean() }).readonly();
+
+// =============================================================================
+// Per-hook-point schemas
+// =============================================================================
 
 /**
  * Per-handler result for the "confirm" hook point (interactive dispatches
@@ -130,75 +98,161 @@ export const DELETE_WORKSPACE_OPERATION_ID = "delete-workspace";
  * the pipeline proceeds with ignoreWarnings semantics (the user just saw the
  * warnings).
  */
-export interface ConfirmHookResult {
-  readonly canceled?: boolean;
-  readonly keepBranch?: boolean;
-}
+export const confirmResultSchema = z
+  .object({
+    canceled: z.boolean().optional(),
+    keepBranch: z.boolean().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "preflight" hook point.
  * Checks workspace for uncommitted changes and unmerged commits before deletion.
  */
-export interface PreflightHookResult {
-  readonly isDirty?: boolean;
-  readonly unmergedCommits?: number;
-  readonly error?: string;
-}
+export const preflightResultSchema = z
+  .object({
+    isDirty: z.boolean().optional(),
+    unmergedCommits: z.number().optional(),
+    error: z.string().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "shutdown" hook point.
  * ViewModule provides wasActive; AgentModule may provide error.
  */
-export interface ShutdownHookResult {
-  readonly wasActive?: boolean;
-  readonly serverName?: string;
-  readonly error?: string;
-}
+export const shutdownResultSchema = z
+  .object({
+    wasActive: z.boolean().optional(),
+    serverName: z.string().optional(),
+    error: z.string().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "release" hook point.
  * CWD-only scan: finds and kills processes with CWD under workspace.
  */
-export interface ReleaseHookResult {
-  readonly error?: string;
-}
+export const releaseResultSchema = z.object({ error: z.string().optional() }).readonly();
 
-/**
- * Per-handler result for the "delete" hook point.
- */
-export interface DeleteHookResult {
-  readonly error?: string;
-}
+/** Per-handler result for the "delete" hook point. */
+export const deleteResultSchema = z.object({ error: z.string().optional() }).readonly();
 
 /**
  * Per-handler result for the "detect" hook point.
  * Full blocking process detection after delete failure.
  */
-export interface DetectHookResult {
-  readonly blockingProcesses?: readonly BlockingProcess[];
-  readonly error?: string;
-}
+export const detectResultSchema = z
+  .object({
+    blockingProcesses: z.array(blockingProcessSchema).readonly().optional(),
+    error: z.string().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "flush" hook point.
  * Kills blocking processes by PID.
  */
-export interface FlushHookResult {
-  readonly error?: string;
+export const flushResultSchema = z.object({ error: z.string().optional() }).readonly();
+
+/** Operation-added enrichment shared by shutdown/release/delete/detect/confirm/preflight hooks. */
+const deletePipelineEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  workspacePath: z.string(),
+  workspaceName: workspaceNameSchema,
+  active: z.boolean(),
+});
+const deletePipelineInputSchema = hookCtxSchema(
+  deleteWorkspacePayloadSchema,
+  deletePipelineEnrichmentSchema.shape
+);
+
+/** Operation-added enrichment for the "flush" hook point (adds PIDs to kill). */
+const flushEnrichmentSchema = deletePipelineEnrichmentSchema.extend({
+  blockingPids: z.array(z.number()).readonly(),
+});
+const flushInputSchema = hookCtxSchema(deleteWorkspacePayloadSchema, flushEnrichmentSchema.shape);
+
+// =============================================================================
+// Event payload schemas (events defined in this file)
+// =============================================================================
+
+const workspaceDeletedSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    workspacePath: z.string(),
+    projectPath: z.string(),
+    /**
+     * True when the dispatch removed (or force-abandoned) the git worktree;
+     * false for runtime-only teardown (removeWorktree: false — e.g. the
+     * per-workspace teardown during project:close). Consumers that track real
+     * deletions (auto-workspace dismissal) must ignore teardown events.
+     */
+    worktreeRemoved: z.boolean(),
+  })
+  .readonly();
+
+const workspaceDeleteFailedSchema = z.object({ workspacePath: z.string() }).readonly();
+
+const schemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: deleteWorkspacePayloadSchema,
+  result: deleteWorkspaceResultSchema,
+  hooks: {
+    confirm: { input: deletePipelineInputSchema, result: confirmResultSchema },
+    preflight: { input: deletePipelineInputSchema, result: preflightResultSchema },
+    shutdown: { input: deletePipelineInputSchema, result: shutdownResultSchema },
+    release: { input: deletePipelineInputSchema, result: releaseResultSchema },
+    delete: { input: deletePipelineInputSchema, result: deleteResultSchema },
+    detect: { input: deletePipelineInputSchema, result: detectResultSchema },
+    flush: { input: flushInputSchema, result: flushResultSchema },
+  },
+  events: {
+    [EVENT_WORKSPACE_DELETED]: workspaceDeletedSchema,
+    [EVENT_WORKSPACE_DELETE_FAILED]: workspaceDeleteFailedSchema,
+    [EVENT_WORKSPACE_DELETION_PROGRESS]: deletionProgressSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type DeleteWorkspacePayload = z.infer<typeof deleteWorkspacePayloadSchema>;
+export type DeleteWorkspaceIntent = IntentOf<typeof schemas>;
+
+export type WorkspaceDeletedPayload = z.infer<typeof workspaceDeletedSchema>;
+export type WorkspaceDeleteFailedPayload = z.infer<typeof workspaceDeleteFailedSchema>;
+
+export interface WorkspaceDeletedEvent extends DomainEvent {
+  readonly type: "workspace:deleted";
+  readonly payload: WorkspaceDeletedPayload;
 }
+
+export interface WorkspaceDeleteFailedEvent extends DomainEvent {
+  readonly type: typeof EVENT_WORKSPACE_DELETE_FAILED;
+  readonly payload: WorkspaceDeleteFailedPayload;
+}
+
+export interface WorkspaceDeletionProgressEvent extends DomainEvent {
+  readonly type: typeof EVENT_WORKSPACE_DELETION_PROGRESS;
+  readonly payload: DeletionProgress;
+}
+
+export type ConfirmHookResult = z.infer<typeof confirmResultSchema>;
+export type PreflightHookResult = z.infer<typeof preflightResultSchema>;
+export type ShutdownHookResult = z.infer<typeof shutdownResultSchema>;
+export type ReleaseHookResult = z.infer<typeof releaseResultSchema>;
+export type DeleteHookResult = z.infer<typeof deleteResultSchema>;
+export type DetectHookResult = z.infer<typeof detectResultSchema>;
+export type FlushHookResult = z.infer<typeof flushResultSchema>;
 
 /** Input for shutdown/release/delete/detect hooks (enriched with both resolved paths). */
-export interface DeletePipelineHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly workspacePath: string;
-  readonly workspaceName: WorkspaceName;
-  readonly active: boolean;
-}
+export type DeletePipelineHookInput = HookContext & z.infer<typeof deletePipelineEnrichmentSchema>;
 
 /** Input for flush hook (enriched with PIDs to kill). */
-export interface FlushHookInput extends DeletePipelineHookInput {
-  readonly blockingPids: readonly number[];
-}
+export type FlushHookInput = HookContext & z.infer<typeof flushEnrichmentSchema>;
 
 // =============================================================================
 // Merged Result Types (internal to operation)
@@ -224,6 +278,18 @@ interface MergedDetect {
 // Merge Functions
 // =============================================================================
 
+/**
+ * `collectErrorMessages` expects exact-optional `error?: string`, but zod infers `error?: string
+ * | undefined` for `.optional()` fields. The two are runtime-identical ("maybe an error string"),
+ * so bridge the exactOptionalPropertyTypes gap with a widening view at the single call boundary.
+ */
+type ErrorResult = { readonly error?: string | undefined };
+const errorMessages = (
+  results: readonly ErrorResult[],
+  collectErrors: readonly Error[]
+): string[] =>
+  collectErrorMessages(results as readonly { readonly error?: string }[], collectErrors);
+
 function mergeShutdown(
   results: readonly ShutdownHookResult[],
   collectErrors: readonly Error[]
@@ -234,14 +300,14 @@ function mergeShutdown(
     if (r.wasActive) wasActive = true;
     if (r.serverName && !serverName) serverName = r.serverName;
   }
-  return { wasActive, serverName, errors: collectErrorMessages(results, collectErrors) };
+  return { wasActive, serverName, errors: errorMessages(results, collectErrors) };
 }
 
 function mergeErrors(
-  results: readonly { readonly error?: string }[],
+  results: readonly ErrorResult[],
   collectErrors: readonly Error[]
 ): MergedErrors {
-  return { errors: collectErrorMessages(results, collectErrors) };
+  return { errors: errorMessages(results, collectErrors) };
 }
 
 function mergeDetect(
@@ -254,7 +320,7 @@ function mergeDetect(
   }
   return {
     ...(blockingProcesses !== undefined && { blockingProcesses }),
-    errors: collectErrorMessages(results, collectErrors),
+    errors: errorMessages(results, collectErrors),
   };
 }
 
@@ -295,11 +361,9 @@ interface PipelineResult {
   readonly canceled?: boolean;
 }
 
-export class DeleteWorkspaceOperation implements Operation<
-  DeleteWorkspaceIntent,
-  { started: boolean }
-> {
+export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: boolean }> {
     const { payload } = ctx.intent;

--- a/src/intents/get-active-workspace.integration.test.ts
+++ b/src/intents/get-active-workspace.integration.test.ts
@@ -50,7 +50,7 @@ interface TestSetup {
 function createTestSetup(cachedRef: WorkspaceRef | null): TestSetup {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
+  dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
   // Active workspace hook handler module (event-cache pattern)
   const activeWorkspaceModule: IntentModule = {

--- a/src/intents/get-active-workspace.ts
+++ b/src/intents/get-active-workspace.ts
@@ -6,46 +6,69 @@
  *
  * No provider dependencies - the hook handler does the actual work.
  * No domain events - this is a query operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer`.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { WorkspaceRef } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { workspaceRefSchema } from "./contract";
 import { throwHookErrors, lastDefined, requireResult } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetActiveWorkspaceIntent extends Intent<WorkspaceRef | null> {
-  readonly type: "ui:get-active-workspace";
-  readonly payload: Record<string, never>;
-}
-
 export const INTENT_GET_ACTIVE_WORKSPACE = "ui:get-active-workspace" as const;
-
-// =============================================================================
-// Operation
-// =============================================================================
-
 export const GET_ACTIVE_WORKSPACE_OPERATION_ID = "get-active-workspace";
+
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const getActiveWorkspacePayloadSchema = z.object({}).readonly();
+
+export const getActiveWorkspaceResultSchema = workspaceRefSchema.nullable();
 
 /**
  * Per-handler result contract for the "get" hook point.
  * Each handler returns its contribution — the operation merges them.
  * `null` is a valid result (no active workspace).
  */
-export interface GetActiveWorkspaceHookResult {
-  readonly workspaceRef: WorkspaceRef | null;
-}
+export const getActiveWorkspaceHookResultSchema = z
+  .object({
+    workspaceRef: workspaceRefSchema.nullable().optional(),
+  })
+  .readonly();
 
-export class GetActiveWorkspaceOperation implements Operation<
-  GetActiveWorkspaceIntent,
-  WorkspaceRef | null
-> {
+const schemas = {
+  type: INTENT_GET_ACTIVE_WORKSPACE,
+  payload: getActiveWorkspacePayloadSchema,
+  result: getActiveWorkspaceResultSchema,
+  hooks: {
+    get: { result: getActiveWorkspaceHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetActiveWorkspacePayload = z.infer<typeof getActiveWorkspacePayloadSchema>;
+export type GetActiveWorkspaceResult = z.infer<typeof getActiveWorkspaceResultSchema>;
+export type GetActiveWorkspaceIntent = IntentOf<typeof schemas>;
+export type GetActiveWorkspaceHookResult = z.infer<typeof getActiveWorkspaceHookResultSchema>;
+
+// =============================================================================
+// Operation
+// =============================================================================
+
+export class GetActiveWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = GET_ACTIVE_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<GetActiveWorkspaceIntent>): Promise<WorkspaceRef | null> {
+  async execute(
+    ctx: OperationContext<GetActiveWorkspaceIntent>
+  ): Promise<GetActiveWorkspaceResult> {
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };

--- a/src/intents/get-agent-session.integration.test.ts
+++ b/src/intents/get-agent-session.integration.test.ts
@@ -56,7 +56,7 @@ function createTestSetup(opts: { session?: AgentSessionInfo | null }): TestSetup
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
+  dispatcher.registerOperation(new GetAgentSessionOperation());
 
   registerTestInfrastructure(dispatcher, {
     workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },

--- a/src/intents/get-agent-session.ts
+++ b/src/intents/get-agent-session.ts
@@ -7,58 +7,85 @@
  *
  * No provider dependencies - the hook handlers do the actual work.
  * No domain events - this is a query operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth; the Intent and hook
+ * result/input types are derived from the `schemas` bundle.
  */
 
-import type { Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
-import type { AgentSession } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { HookContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { agentSessionSchema, hookCtxSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetAgentSessionPayload {
-  readonly workspacePath: string;
-}
-
-export interface GetAgentSessionIntent extends Intent<AgentSession | null> {
-  readonly type: "agent:get-session";
-  readonly payload: GetAgentSessionPayload;
-}
-
 export const INTENT_GET_AGENT_SESSION = "agent:get-session" as const;
-
-// =============================================================================
-// Hook Result & Input Types
-// =============================================================================
-
 export const GET_AGENT_SESSION_OPERATION_ID = "get-agent-session";
 
-/** Input context for the "get" hook point. */
-export interface GetAgentSessionHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const getAgentSessionPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+  })
+  .readonly();
+
+export const getAgentSessionResultSchema = agentSessionSchema.nullable();
 
 /**
  * Per-handler result contract for the "get" hook point.
  * Each handler returns its contribution — the operation merges them.
  * `null` is a valid result (no session exists).
  */
-export interface GetAgentSessionHookResult {
-  readonly session: AgentSession | null;
-}
+export const getAgentSessionHookResultSchema = z
+  .object({
+    session: agentSessionSchema.nullable().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
+const getAgentSessionEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "get". */
+export const getAgentSessionHookInputSchema = hookCtxSchema(
+  getAgentSessionPayloadSchema,
+  getAgentSessionEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_GET_AGENT_SESSION,
+  payload: getAgentSessionPayloadSchema,
+  result: getAgentSessionResultSchema,
+  hooks: {
+    get: { input: getAgentSessionHookInputSchema, result: getAgentSessionHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetAgentSessionPayload = z.infer<typeof getAgentSessionPayloadSchema>;
+export type GetAgentSessionResult = z.infer<typeof getAgentSessionResultSchema>;
+export type GetAgentSessionIntent = IntentOf<typeof schemas>;
+export type GetAgentSessionHookResult = z.infer<typeof getAgentSessionHookResultSchema>;
+
+/** Whole input context for "get" handlers: base envelope + inferred enrichment. */
+export type GetAgentSessionHookInput = HookContext &
+  z.infer<typeof getAgentSessionEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class GetAgentSessionOperation extends WorkspaceHookOperation<
-  GetAgentSessionIntent,
-  GetAgentSessionHookResult,
-  AgentSession | null
+  typeof schemas,
+  GetAgentSessionHookResult
 > {
+  readonly schemas = schemas;
+
   constructor() {
     super(GET_AGENT_SESSION_OPERATION_ID, {
       hookPoint: "get",

--- a/src/intents/get-metadata.integration.test.ts
+++ b/src/intents/get-metadata.integration.test.ts
@@ -64,8 +64,8 @@ function createTestSetup(): TestSetup {
   const dispatcher = createMockDispatcher();
 
   // Register set-metadata and get-metadata operations
-  dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-  dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
+  dispatcher.registerOperation(new SetMetadataOperation());
+  dispatcher.registerOperation(new GetMetadataOperation());
 
   // Register infrastructure operations (resolve-workspace, resolve-project, etc.)
   registerTestInfrastructure(dispatcher, {

--- a/src/intents/get-metadata.ts
+++ b/src/intents/get-metadata.ts
@@ -7,58 +7,83 @@
  *
  * No provider dependencies - hook handlers do the actual work.
  * No domain events - this is a query operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth; the Intent and hook
+ * result/input types are derived from the `schemas` bundle.
  */
 
-import type { Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { HookContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { hookCtxSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetMetadataPayload {
-  readonly workspacePath: string;
-}
-
-export interface GetMetadataIntent extends Intent<Readonly<Record<string, string>>> {
-  readonly type: "workspace:get-metadata";
-  readonly payload: GetMetadataPayload;
-}
-
 export const INTENT_GET_METADATA = "workspace:get-metadata" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const GET_METADATA_OPERATION_ID = "get-metadata";
 
-/**
- * Input context for "get" handlers — built from resolve results.
- */
-export interface GetHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const getMetadataPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+  })
+  .readonly();
+
+export const getMetadataResultSchema = z.record(z.string(), z.string()).readonly();
 
 /**
  * Per-handler result contract for the "get" hook point.
  * Each handler returns its contribution — the operation merges them.
  */
-export interface GetMetadataHookResult {
-  readonly metadata: Readonly<Record<string, string>>;
-}
+export const getMetadataHookResultSchema = z
+  .object({
+    metadata: z.record(z.string(), z.string()).readonly().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
+const getMetadataEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "get". */
+export const getMetadataHookInputSchema = hookCtxSchema(
+  getMetadataPayloadSchema,
+  getMetadataEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_GET_METADATA,
+  payload: getMetadataPayloadSchema,
+  result: getMetadataResultSchema,
+  hooks: {
+    get: { input: getMetadataHookInputSchema, result: getMetadataHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetMetadataPayload = z.infer<typeof getMetadataPayloadSchema>;
+export type GetMetadataResult = z.infer<typeof getMetadataResultSchema>;
+export type GetMetadataIntent = IntentOf<typeof schemas>;
+export type GetMetadataHookResult = z.infer<typeof getMetadataHookResultSchema>;
+
+/** Whole input context for "get" handlers: base envelope + inferred enrichment. */
+export type GetHookInput = HookContext & z.infer<typeof getMetadataEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class GetMetadataOperation extends WorkspaceHookOperation<
-  GetMetadataIntent,
-  GetMetadataHookResult,
-  Readonly<Record<string, string>>
+  typeof schemas,
+  GetMetadataHookResult
 > {
+  readonly schemas = schemas;
+
   constructor() {
     super(GET_METADATA_OPERATION_ID, {
       hookPoint: "get",

--- a/src/intents/get-project-bases.integration.test.ts
+++ b/src/intents/get-project-bases.integration.test.ts
@@ -28,11 +28,7 @@ import type {
   ListBasesHookResult,
   BasesUpdatedEvent,
 } from "./get-project-bases";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
+import { ResolveProjectOperation, RESOLVE_PROJECT_OPERATION_ID } from "./resolve-project";
 import type {
   ResolveHookResult as ResolveProjectHookResult,
   ResolveHookInput as ResolveProjectHookInput,
@@ -78,8 +74,8 @@ interface TestSetup {
 function createTestSetup(opts?: TestSetupOptions): TestSetup {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-  dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
+  dispatcher.registerOperation(new ResolveProjectOperation());
+  dispatcher.registerOperation(new GetProjectBasesOperation());
 
   // Shared project:resolve module
   const resolveProjectModule: IntentModule = {

--- a/src/intents/get-project-bases.ts
+++ b/src/intents/get-project-bases.ts
@@ -14,86 +14,115 @@
  * 4. Return cached bases (or fresh bases when wait=true)
  *
  * No provider dependencies — hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth; the Intent, result,
+ * hook, and event payload types are derived from the `schemas` bundle.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId, BaseInfo } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, baseInfoSchema, hookCtxSchema } from "./contract";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, mergeHookResults } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetProjectBasesPayload {
-  readonly projectPath: string;
-  readonly refresh?: boolean;
-  /** When true (and refresh is true), await the refresh and return fresh data. */
-  readonly wait?: boolean;
-}
-
-export interface GetProjectBasesResult {
-  readonly bases: readonly BaseInfo[];
-  readonly defaultBaseBranch?: string;
-  readonly projectPath: string;
-  readonly projectId: ProjectId;
-}
-
-export interface GetProjectBasesIntent extends Intent<GetProjectBasesResult> {
-  readonly type: "project:get-bases";
-  readonly payload: GetProjectBasesPayload;
-}
-
 export const INTENT_GET_PROJECT_BASES = "project:get-bases" as const;
+export const EVENT_BASES_UPDATED = "bases:updated" as const;
+export const GET_PROJECT_BASES_OPERATION_ID = "get-project-bases";
 
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface BasesUpdatedPayload {
-  readonly projectId: ProjectId;
-  readonly projectPath: string;
-  readonly bases: readonly BaseInfo[];
-  /** Fresh default base branch; absent when detection found none (authoritative). */
-  readonly defaultBaseBranch?: string;
-}
+export const getProjectBasesPayloadSchema = z
+  .object({
+    projectPath: z.string(),
+    refresh: z.boolean().optional(),
+    /** When true (and refresh is true), await the refresh and return fresh data. */
+    wait: z.boolean().optional(),
+  })
+  .readonly();
+
+export const getProjectBasesResultSchema = z
+  .object({
+    bases: z.array(baseInfoSchema).readonly(),
+    defaultBaseBranch: z.string().optional(),
+    projectPath: z.string(),
+    projectId: projectIdSchema,
+  })
+  .readonly();
+
+export const basesUpdatedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    projectPath: z.string(),
+    bases: z.array(baseInfoSchema).readonly(),
+    /** Fresh default base branch; absent when detection found none (authoritative). */
+    defaultBaseBranch: z.string().optional(),
+  })
+  .readonly();
+
+export const listBasesHookResultSchema = z
+  .object({
+    bases: z.array(baseInfoSchema).readonly().optional(),
+    defaultBaseBranch: z.string().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "list" / "refresh" hook points. */
+const listBasesEnrichmentSchema = z.object({ projectPath: z.string() });
+const refreshBasesEnrichmentSchema = z.object({ projectPath: z.string() });
+
+export const listBasesHookInputSchema = hookCtxSchema(
+  getProjectBasesPayloadSchema,
+  listBasesEnrichmentSchema.shape
+);
+export const refreshBasesHookInputSchema = hookCtxSchema(
+  getProjectBasesPayloadSchema,
+  refreshBasesEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_GET_PROJECT_BASES,
+  payload: getProjectBasesPayloadSchema,
+  result: getProjectBasesResultSchema,
+  hooks: {
+    list: { input: listBasesHookInputSchema, result: listBasesHookResultSchema },
+    refresh: { input: refreshBasesHookInputSchema },
+  },
+  events: {
+    [EVENT_BASES_UPDATED]: basesUpdatedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetProjectBasesPayload = z.infer<typeof getProjectBasesPayloadSchema>;
+export type GetProjectBasesResult = z.infer<typeof getProjectBasesResultSchema>;
+export type GetProjectBasesIntent = IntentOf<typeof schemas>;
+export type BasesUpdatedPayload = z.infer<typeof basesUpdatedPayloadSchema>;
+export type ListBasesHookResult = z.infer<typeof listBasesHookResultSchema>;
+
+/** Whole input context for "list" handlers: base envelope + inferred enrichment. */
+export type ListBasesHookInput = HookContext & z.infer<typeof listBasesEnrichmentSchema>;
+/** Whole input context for "refresh" handlers: base envelope + inferred enrichment. */
+export type RefreshBasesHookInput = HookContext & z.infer<typeof refreshBasesEnrichmentSchema>;
 
 export interface BasesUpdatedEvent extends DomainEvent {
   readonly type: "bases:updated";
   readonly payload: BasesUpdatedPayload;
 }
 
-export const EVENT_BASES_UPDATED = "bases:updated" as const;
-
-// =============================================================================
-// Hook Point Types
-// =============================================================================
-
-export interface ListBasesHookInput extends HookContext {
-  readonly projectPath: string;
-}
-
-export interface ListBasesHookResult {
-  readonly bases?: readonly BaseInfo[];
-  readonly defaultBaseBranch?: string;
-}
-
-export interface RefreshBasesHookInput extends HookContext {
-  readonly projectPath: string;
-}
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-export const GET_PROJECT_BASES_OPERATION_ID = "get-project-bases";
-
-export class GetProjectBasesOperation implements Operation<
-  GetProjectBasesIntent,
-  GetProjectBasesResult
-> {
+export class GetProjectBasesOperation implements Operation<typeof schemas> {
   readonly id = GET_PROJECT_BASES_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<GetProjectBasesIntent>): Promise<GetProjectBasesResult> {
     const { projectPath, refresh } = ctx.intent.payload;

--- a/src/intents/get-workspace-status.integration.test.ts
+++ b/src/intents/get-workspace-status.integration.test.ts
@@ -74,7 +74,7 @@ function createTestSetup(opts: {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
+  dispatcher.registerOperation(new GetWorkspaceStatusOperation());
 
   registerTestInfrastructure(dispatcher, {
     workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },
@@ -220,7 +220,7 @@ describe("GetWorkspaceStatus Operation", () => {
       const dispatcher = createMockDispatcher();
       const workspaceName = "feature-x" as WorkspaceName;
 
-      dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
+      dispatcher.registerOperation(new GetWorkspaceStatusOperation());
 
       registerTestInfrastructure(dispatcher, {
         workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },

--- a/src/intents/get-workspace-status.ts
+++ b/src/intents/get-workspace-status.ts
@@ -7,69 +7,100 @@
  *
  * No provider dependencies - hook handlers do the actual work.
  * No domain events - this is a query operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth; the Intent, result,
+ * and hook types are derived from the `schemas` bundle.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { workspaceStatusSchema, hookCtxSchema } from "./contract";
 import type { WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_GET_PROJECT_BASES, type GetProjectBasesIntent } from "./get-project-bases";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface GetWorkspaceStatusPayload {
-  readonly workspacePath: string;
-  /**
-   * If true, fetch remotes (via project:get-bases with refresh+wait) before
-   * reading status. Best-effort: fetch failures are swallowed and the status
-   * is read against possibly-stale local refs.
-   */
-  readonly refresh?: boolean;
-}
-
-export interface GetWorkspaceStatusIntent extends Intent<WorkspaceStatus> {
-  readonly type: "workspace:get-status";
-  readonly payload: GetWorkspaceStatusPayload;
-}
-
 export const INTENT_GET_WORKSPACE_STATUS = "workspace:get-status" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const GET_WORKSPACE_STATUS_OPERATION_ID = "get-workspace-status";
 
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const getWorkspaceStatusPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    /**
+     * If true, fetch remotes (via project:get-bases with refresh+wait) before
+     * reading status. Best-effort: fetch failures are swallowed and the status
+     * is read against possibly-stale local refs.
+     */
+    refresh: z.boolean().optional(),
+  })
+  .readonly();
+
 /**
- * Input context for "get" handlers — built from resolve results.
+ * Local schema for AggregatedAgentStatus (from shared/ipc) — not in contract.ts.
+ * The discriminated union of internal agent-status shapes with `{ idle, busy }` counts.
  */
-export interface GetStatusHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+const internalAgentCountsSchema = z.object({ idle: z.number(), busy: z.number() }).readonly();
+const aggregatedAgentStatusSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("none"), counts: internalAgentCountsSchema }),
+  z.object({ status: z.literal("idle"), counts: internalAgentCountsSchema }),
+  z.object({ status: z.literal("busy"), counts: internalAgentCountsSchema }),
+  z.object({ status: z.literal("mixed"), counts: internalAgentCountsSchema }),
+]);
 
 /**
  * Per-handler result contract for the "get" hook point.
  * Each handler returns its contribution — the operation merges them.
  */
-export interface GetStatusHookResult {
-  readonly isDirty?: boolean;
-  readonly unmergedCommits?: number;
-  readonly agentStatus?: AggregatedAgentStatus;
-}
+export const getStatusHookResultSchema = z
+  .object({
+    isDirty: z.boolean().optional(),
+    unmergedCommits: z.number().optional(),
+    agentStatus: aggregatedAgentStatusSchema.optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
+const getStatusEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "get". */
+export const getStatusHookInputSchema = hookCtxSchema(
+  getWorkspaceStatusPayloadSchema,
+  getStatusEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_GET_WORKSPACE_STATUS,
+  payload: getWorkspaceStatusPayloadSchema,
+  result: workspaceStatusSchema,
+  hooks: {
+    get: { input: getStatusHookInputSchema, result: getStatusHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type GetWorkspaceStatusPayload = z.infer<typeof getWorkspaceStatusPayloadSchema>;
+export type GetWorkspaceStatusIntent = IntentOf<typeof schemas>;
+export type GetStatusHookResult = z.infer<typeof getStatusHookResultSchema>;
+
+/** Whole input context for "get" handlers: base envelope + inferred enrichment. */
+export type GetStatusHookInput = HookContext & z.infer<typeof getStatusEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class GetWorkspaceStatusOperation implements Operation<
-  GetWorkspaceStatusIntent,
-  WorkspaceStatus
-> {
+export class GetWorkspaceStatusOperation implements Operation<typeof schemas> {
   readonly id = GET_WORKSPACE_STATUS_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<GetWorkspaceStatusIntent>): Promise<WorkspaceStatus> {
     const { payload } = ctx.intent;

--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -13,7 +13,8 @@ import { describe, it, expect } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 import type { IntentModule } from "./lib/module";
 import type { DomainEvent } from "./lib/types";
-import type { HookContext, HookOutput } from "./lib/operation";
+import { z } from "zod/v4";
+import type { HookContext, HookOutput, OperationSchemas } from "./lib/operation";
 import {
   HibernateWorkspaceOperation,
   HIBERNATE_WORKSPACE_OPERATION_ID,
@@ -41,7 +42,6 @@ import {
 import { registerTestInfrastructure } from "./operations.test-utils";
 import {
   SetMetadataOperation,
-  INTENT_SET_METADATA,
   SET_METADATA_OPERATION_ID,
   EVENT_METADATA_CHANGED,
   type MetadataChangedEvent,
@@ -68,6 +68,19 @@ const REOPENED_WORKSPACE: Workspace = {
   metadata: CLEAN_METADATA,
   path: WORKSPACE_PATH,
 };
+
+/** Permissive schemas for the stub get-metadata / open-workspace operations wake dispatches. */
+const getMetadataStubSchemas = {
+  type: INTENT_GET_METADATA,
+  payload: z.unknown(),
+  result: z.custom<Readonly<Record<string, string>>>(),
+} satisfies OperationSchemas;
+
+const openWorkspaceStubSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<Workspace>(),
+} satisfies OperationSchemas;
 
 interface Recorder {
   captureCalled: boolean;
@@ -250,19 +263,21 @@ function buildHarness(
   const recorder = createRecorder();
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-  dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, new WakeWorkspaceOperation());
+  dispatcher.registerOperation(new SetMetadataOperation());
+  dispatcher.registerOperation(new HibernateWorkspaceOperation());
+  dispatcher.registerOperation(new WakeWorkspaceOperation());
 
   // Mock the get-metadata + open-workspace operations that wake now dispatches
   // internally to bring the workspace back online. (Hibernate never dispatches
   // these, so registering them is harmless for those tests.)
-  dispatcher.registerOperation(INTENT_GET_METADATA, {
+  dispatcher.registerOperation({
     id: GET_METADATA_OPERATION_ID,
+    schemas: getMetadataStubSchemas,
     execute: async () => CLEAN_METADATA,
   });
-  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, {
+  dispatcher.registerOperation({
     id: OPEN_WORKSPACE_OPERATION_ID,
+    schemas: openWorkspaceStubSchemas,
     execute: async (ctx) => {
       recorder.openPayload = (ctx.intent as { payload: OpenWorkspacePayload }).payload;
       recorder.callOrder.push("open");

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -37,75 +37,121 @@
  * workspace from their state.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "./set-metadata";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { resolveWorkspaceIdentity, emitWorkspaceFailure } from "./lib/workspace-identity";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface HibernateWorkspacePayload {
-  readonly workspacePath: string;
-}
-
-export interface HibernateWorkspaceIntent extends Intent<{ started: true }> {
-  readonly type: "workspace:hibernate";
-  readonly payload: HibernateWorkspacePayload;
-}
-
 export const INTENT_HIBERNATE_WORKSPACE = "workspace:hibernate" as const;
-
 export const HIBERNATE_WORKSPACE_OPERATION_ID = "hibernate-workspace";
+export const EVENT_WORKSPACE_HIBERNATED = "workspace:hibernated" as const;
+export const EVENT_WORKSPACE_HIBERNATE_FAILED = "workspace:hibernate-failed" as const;
 
 /** Metadata key indicating a workspace is hibernated. */
 export const HIBERNATED_METADATA_KEY = "hibernated";
 
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface WorkspaceHibernatedPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-  readonly projectPath: string;
-}
+export const hibernateWorkspacePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+  })
+  .readonly();
+
+export const hibernateWorkspaceResultSchema = z.object({
+  started: z.literal(true),
+});
+
+export const workspaceHibernatedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    workspacePath: z.string(),
+    projectPath: z.string(),
+  })
+  .readonly();
+
+export const workspaceHibernateFailedPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    error: z.string(),
+  })
+  .readonly();
+
+/** Operation-added enrichment shared by every hibernate pipeline hook point. */
+const hibernatePipelineEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  workspacePath: z.string(),
+  projectId: projectIdSchema,
+  workspaceName: workspaceNameSchema,
+  active: z.boolean(),
+});
+
+/** Runtime whole-context validation schema for the hibernate pipeline hook points. */
+export const hibernatePipelineHookInputSchema = hookCtxSchema(
+  hibernateWorkspacePayloadSchema,
+  hibernatePipelineEnrichmentSchema.shape
+);
+
+/**
+ * Per-handler result for the "release" hook point.
+ * Best-effort CWD-rooted process kill.
+ */
+export const hibernateReleaseHookResultSchema = z
+  .object({
+    error: z.string().optional(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_HIBERNATE_WORKSPACE,
+  payload: hibernateWorkspacePayloadSchema,
+  result: hibernateWorkspaceResultSchema,
+  hooks: {
+    "prepare-capture": { input: hibernatePipelineHookInputSchema, result: z.object({}).readonly() },
+    capture: { input: hibernatePipelineHookInputSchema, result: z.object({}).readonly() },
+    "cleanup-capture": { input: hibernatePipelineHookInputSchema, result: z.object({}).readonly() },
+    shutdown: { input: hibernatePipelineHookInputSchema, result: z.object({}).readonly() },
+    release: { input: hibernatePipelineHookInputSchema, result: hibernateReleaseHookResultSchema },
+  },
+  events: {
+    [EVENT_WORKSPACE_HIBERNATED]: workspaceHibernatedPayloadSchema,
+    [EVENT_WORKSPACE_HIBERNATE_FAILED]: workspaceHibernateFailedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type HibernateWorkspacePayload = z.infer<typeof hibernateWorkspacePayloadSchema>;
+export type HibernateWorkspaceResult = z.infer<typeof hibernateWorkspaceResultSchema>;
+export type HibernateWorkspaceIntent = IntentOf<typeof schemas>;
+
+export type WorkspaceHibernatedPayload = z.infer<typeof workspaceHibernatedPayloadSchema>;
 
 export interface WorkspaceHibernatedEvent extends DomainEvent {
   readonly type: "workspace:hibernated";
   readonly payload: WorkspaceHibernatedPayload;
 }
 
-export const EVENT_WORKSPACE_HIBERNATED = "workspace:hibernated" as const;
-
-export interface WorkspaceHibernateFailedPayload {
-  readonly workspacePath: string;
-  readonly error: string;
-}
+export type WorkspaceHibernateFailedPayload = z.infer<typeof workspaceHibernateFailedPayloadSchema>;
 
 export interface WorkspaceHibernateFailedEvent extends DomainEvent {
   readonly type: "workspace:hibernate-failed";
   readonly payload: WorkspaceHibernateFailedPayload;
 }
 
-export const EVENT_WORKSPACE_HIBERNATE_FAILED = "workspace:hibernate-failed" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 /** Input for prepare-capture/capture/cleanup-capture/shutdown/release hook handlers. */
-export interface HibernatePipelineHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly workspacePath: string;
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly active: boolean;
-}
+export type HibernatePipelineHookInput = HookContext &
+  z.infer<typeof hibernatePipelineEnrichmentSchema>;
 
 /**
  * Per-handler result for the "prepare-capture" hook point. Runs before the
@@ -126,25 +172,20 @@ export type CleanupCaptureHookResult = Record<string, never>;
 /** Per-handler result for the "shutdown" hook point. */
 export type HibernateShutdownHookResult = Record<string, never>;
 
-/**
- * Per-handler result for the "release" hook point.
- * Best-effort CWD-rooted process kill.
- */
-export interface HibernateReleaseHookResult {
-  readonly error?: string;
-}
+/** Per-handler result for the "release" hook point. */
+export type HibernateReleaseHookResult = z.infer<typeof hibernateReleaseHookResultSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class HibernateWorkspaceOperation implements Operation<
-  HibernateWorkspaceIntent,
-  { started: true }
-> {
+export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = HIBERNATE_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<HibernateWorkspaceIntent>): Promise<{ started: true }> {
+  async execute(
+    ctx: OperationContext<HibernateWorkspaceIntent>
+  ): Promise<HibernateWorkspaceResult> {
     const { payload } = ctx.intent;
 
     let hookCtx: HibernatePipelineHookInput;

--- a/src/intents/lib/dispatcher.integration.test.ts
+++ b/src/intents/lib/dispatcher.integration.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import { z } from "zod/v4";
 import { Dispatcher, IntentHandle } from "./dispatcher";
 import type { IntentInterceptor } from "./dispatcher";
 import type { IntentModule } from "./module";
@@ -14,6 +15,7 @@ import type { Intent, DomainEvent } from "./types";
 import type {
   Operation,
   OperationContext,
+  OperationSchemas,
   HookContext,
   HookHandler,
   HookResult,
@@ -33,18 +35,36 @@ function createQueryIntent(): Intent {
   return { type: "test:query", payload: { question: "meaning" } };
 }
 
+/**
+ * Wrap an inline `{ id, execute }` spec into an Operation carrying a permissive
+ * schema whose `type` is the dispatcher registration key (the intent type it handles).
+ */
+function defineOp(
+  intentType: string,
+  spec: { id: string; execute: (ctx: OperationContext<Intent>) => Promise<unknown> }
+) {
+  const schemas = {
+    type: intentType,
+    payload: z.unknown(),
+    result: z.custom<unknown>(),
+  } satisfies OperationSchemas;
+  const op: Operation<typeof schemas> = { id: spec.id, schemas, execute: spec.execute };
+  return op;
+}
+
 function createTestOperation<R>(
   id: string,
   returnValue: R,
+  intentType = "test:action",
   sideEffect?: (ctx: OperationContext<Intent>) => void
-): Operation<Intent, R> {
-  return {
+) {
+  return defineOp(intentType, {
     id,
     execute: async (ctx) => {
       sideEffect?.(ctx);
       return returnValue;
     },
-  };
+  });
 }
 
 function createMockLogger(): Logger & {
@@ -86,8 +106,8 @@ describe("Dispatcher", () => {
     const dispatcher = createDispatcher();
 
     const result = { answer: 42 };
-    const operation = createTestOperation("query-op", result);
-    dispatcher.registerOperation("test:query", operation);
+    const operation = createTestOperation("query-op", result, "test:query");
+    dispatcher.registerOperation(operation);
 
     const actual = await dispatcher.dispatch(createQueryIntent());
 
@@ -106,9 +126,9 @@ describe("Dispatcher", () => {
     const dispatcher = createDispatcher();
 
     const operation = createTestOperation("op", undefined);
-    dispatcher.registerOperation("test:action", operation);
+    dispatcher.registerOperation(operation);
 
-    expect(() => dispatcher.registerOperation("test:action", operation)).toThrow(
+    expect(() => dispatcher.registerOperation(operation)).toThrow(
       "Operation already registered for intent type: test:action"
     );
   });
@@ -117,10 +137,12 @@ describe("Dispatcher", () => {
     const dispatcher = createDispatcher();
 
     const executeSpy = vi.fn().mockResolvedValue(undefined);
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: executeSpy,
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: executeSpy,
+      })
+    );
 
     const cancelInterceptor: IntentInterceptor = {
       id: "cancel-all",
@@ -140,12 +162,14 @@ describe("Dispatcher", () => {
     const dispatcher = createDispatcher();
 
     let capturedIntent: Intent | undefined;
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async (ctx) => {
-        capturedIntent = ctx.intent;
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          capturedIntent = ctx.intent;
+        },
+      })
+    );
 
     const modifyInterceptor: IntentInterceptor = {
       id: "modify-payload",
@@ -169,10 +193,12 @@ describe("Dispatcher", () => {
 
     const order: string[] = [];
 
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async () => undefined,
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async () => undefined,
+      })
+    );
 
     dispatcher.addInterceptor({
       id: "first",
@@ -203,12 +229,14 @@ describe("Dispatcher", () => {
       payload: { id: "123" },
     };
 
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async (ctx) => {
-        ctx.emit(testEvent);
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          ctx.emit(testEvent);
+        },
+      })
+    );
 
     const receivedEvents: DomainEvent[] = [];
     dispatcher.subscribe("test:completed", (event) => {
@@ -224,12 +252,14 @@ describe("Dispatcher", () => {
   it("unsubscribe removes event handler", async () => {
     const dispatcher = createDispatcher();
 
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async (ctx) => {
-        ctx.emit({ type: "test:completed", payload: {} });
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          ctx.emit({ type: "test:completed", payload: {} });
+        },
+      })
+    );
 
     const receivedEvents: DomainEvent[] = [];
     const unsubscribe = dispatcher.subscribe("test:completed", (event) => {
@@ -248,21 +278,25 @@ describe("Dispatcher", () => {
     const capturedCausations: (readonly string[])[] = [];
 
     // Register an action operation that triggers a query
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async (ctx) => {
-        capturedCausations.push(ctx.causation);
-        await ctx.dispatch(createQueryIntent());
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          capturedCausations.push(ctx.causation);
+          await ctx.dispatch(createQueryIntent());
+        },
+      })
+    );
 
-    dispatcher.registerOperation("test:query", {
-      id: "query-op",
-      execute: async (ctx) => {
-        capturedCausations.push(ctx.causation);
-        return { answer: 42 };
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:query", {
+        id: "query-op",
+        execute: async (ctx) => {
+          capturedCausations.push(ctx.causation);
+          return { answer: 42 };
+        },
+      })
+    );
 
     await dispatcher.dispatch(createActionIntent());
 
@@ -276,13 +310,15 @@ describe("Dispatcher", () => {
   it("events emitted inline even if operation later throws", async () => {
     const dispatcher = createDispatcher();
 
-    dispatcher.registerOperation("test:action", {
-      id: "action-op",
-      execute: async (ctx) => {
-        ctx.emit({ type: "test:completed", payload: {} });
-        throw new Error("operation failed");
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "action-op",
+        execute: async (ctx) => {
+          ctx.emit({ type: "test:completed", payload: {} });
+          throw new Error("operation failed");
+        },
+      })
+    );
 
     const receivedEvents: DomainEvent[] = [];
     dispatcher.subscribe("test:completed", (event) => {
@@ -314,14 +350,16 @@ describe("Dispatcher", () => {
       },
     });
 
-    dispatcher.registerOperation("test:query", {
-      id: "query-op",
-      execute: async (ctx) => {
-        const hookCtx: HookContext = { intent: ctx.intent };
-        await ctx.hooks.collect("get", hookCtx);
-        return { answer: 42 };
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:query", {
+        id: "query-op",
+        execute: async (ctx) => {
+          const hookCtx: HookContext = { intent: ctx.intent };
+          await ctx.hooks.collect("get", hookCtx);
+          return { answer: 42 };
+        },
+      })
+    );
 
     const result = await dispatcher.dispatch(createQueryIntent());
 
@@ -332,7 +370,7 @@ describe("Dispatcher", () => {
   it("dispatch returns IntentHandle", () => {
     const dispatcher = createDispatcher();
 
-    dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+    dispatcher.registerOperation(createTestOperation("op", undefined));
 
     const handle = dispatcher.dispatch(createActionIntent());
 
@@ -342,7 +380,7 @@ describe("Dispatcher", () => {
   it("accepted resolves to true when no interceptors cancel", async () => {
     const dispatcher = createDispatcher();
 
-    dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+    dispatcher.registerOperation(createTestOperation("op", undefined));
 
     const handle = dispatcher.dispatch(createActionIntent());
     const accepted = await handle.accepted;
@@ -353,7 +391,7 @@ describe("Dispatcher", () => {
   it("accepted resolves to false when interceptor cancels", async () => {
     const dispatcher = createDispatcher();
 
-    dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+    dispatcher.registerOperation(createTestOperation("op", undefined));
 
     dispatcher.addInterceptor({
       id: "cancel",
@@ -378,15 +416,17 @@ describe("Dispatcher", () => {
     });
     let operationFinished = false;
 
-    dispatcher.registerOperation("test:action", {
-      id: "slow-op",
-      execute: async () => {
-        resolveOperation();
-        // Wait for an extra microtask tick to simulate slow work
-        await new Promise<void>((r) => setTimeout(r, 10));
-        operationFinished = true;
-      },
-    });
+    dispatcher.registerOperation(
+      defineOp("test:action", {
+        id: "slow-op",
+        execute: async () => {
+          resolveOperation();
+          // Wait for an extra microtask tick to simulate slow work
+          await new Promise<void>((r) => setTimeout(r, 10));
+          operationFinished = true;
+        },
+      })
+    );
 
     const handle = dispatcher.dispatch(createActionIntent());
 
@@ -421,12 +461,14 @@ describe("Dispatcher", () => {
       };
 
       dispatcher.registerModule(testModule);
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("execute", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("execute", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -446,13 +488,13 @@ describe("Dispatcher", () => {
 
       dispatcher.registerModule(testModule);
 
-      const operation: Operation<Intent, void> = {
+      const operation = defineOp("test:action", {
         id: "action-op",
         execute: async (ctx: OperationContext<Intent>) => {
           ctx.emit({ type: "test:completed", payload: { id: "123" } });
         },
-      };
-      dispatcher.registerOperation("test:action", operation);
+      });
+      dispatcher.registerOperation(operation);
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -483,13 +525,13 @@ describe("Dispatcher", () => {
 
       dispatcher.registerModule(testModule);
 
-      const operation: Operation<Intent, void> = {
+      const operation = defineOp("test:action", {
         id: "action-op",
         execute: async () => {
           operationExecuted();
         },
-      };
-      dispatcher.registerOperation("test:action", operation);
+      });
+      dispatcher.registerOperation(operation);
 
       const result = await dispatcher.dispatch(createActionIntent());
 
@@ -536,12 +578,14 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -580,12 +624,14 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -625,12 +671,14 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -671,12 +719,14 @@ describe("Dispatcher", () => {
       dispatcher.registerModule(moduleA);
       dispatcher.registerModule(moduleB);
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("execute", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("execute", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -702,13 +752,15 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
-          collected = errors;
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            const { errors } = await ctx.hooks.collect("stop", { intent: ctx.intent });
+            collected = errors;
+          },
+        })
+      );
 
       await expect(dispatcher.dispatch(createActionIntent())).resolves.toBeUndefined();
       expect(collected).toHaveLength(1);
@@ -723,20 +775,24 @@ describe("Dispatcher", () => {
 
       // Child operation captures its causation
       const capturedCausation: (readonly string[])[] = [];
-      dispatcher.registerOperation("test:child", {
-        id: "child-op",
-        execute: async (ctx) => {
-          capturedCausation.push(ctx.causation);
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:child", {
+          id: "child-op",
+          execute: async (ctx) => {
+            capturedCausation.push(ctx.causation);
+          },
+        })
+      );
 
       // Parent operation with a hook point
-      dispatcher.registerOperation("test:parent", {
-        id: "parent-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:parent", {
+          id: "parent-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       // Hook handler dispatches directly on the dispatcher (not via ctx.dispatch)
       // — simulating what hook modules do in practice
@@ -775,19 +831,23 @@ describe("Dispatcher", () => {
       const dispatcher = createDispatcher();
 
       const capturedCausation: (readonly string[])[] = [];
-      dispatcher.registerOperation("test:child", {
-        id: "child-op",
-        execute: async (ctx) => {
-          capturedCausation.push(ctx.causation);
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:child", {
+          id: "child-op",
+          execute: async (ctx) => {
+            capturedCausation.push(ctx.causation);
+          },
+        })
+      );
 
-      dispatcher.registerOperation("test:parent", {
-        id: "parent-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:parent", {
+          id: "parent-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       // Hook handler passes explicit causation — should override ALS
       const hookModule: IntentModule = {
@@ -817,7 +877,7 @@ describe("Dispatcher", () => {
       const logger = createMockLogger();
       const dispatcher = createDispatcher({ logger });
 
-      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      dispatcher.registerOperation(createTestOperation("op", undefined));
       await dispatcher.dispatch(createActionIntent());
 
       const dispatchLog = logger.calls.find((c) => c.level === "info" && c.message === "dispatch");
@@ -831,7 +891,7 @@ describe("Dispatcher", () => {
       const logger = createMockLogger();
       const dispatcher = createDispatcher({ logger });
 
-      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      dispatcher.registerOperation(createTestOperation("op", undefined));
       await dispatcher.dispatch(createActionIntent());
 
       const completedLog = logger.calls.find(
@@ -847,12 +907,14 @@ describe("Dispatcher", () => {
       const logger = createMockLogger();
       const dispatcher = createDispatcher({ logger });
 
-      dispatcher.registerOperation("test:action", {
-        id: "op",
-        execute: async () => {
-          throw new Error("boom");
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "op",
+          execute: async () => {
+            throw new Error("boom");
+          },
+        })
+      );
 
       await expect(dispatcher.dispatch(createActionIntent())).rejects.toThrow("boom");
 
@@ -867,7 +929,7 @@ describe("Dispatcher", () => {
       const logger = createMockLogger();
       const dispatcher = createDispatcher({ logger });
 
-      dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+      dispatcher.registerOperation(createTestOperation("op", undefined));
       dispatcher.addInterceptor({
         id: "block-it",
         async before() {
@@ -900,12 +962,14 @@ describe("Dispatcher", () => {
       };
 
       dispatcher.registerModule(testModule);
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -951,12 +1015,14 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -982,12 +1048,14 @@ describe("Dispatcher", () => {
         },
       });
 
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -1022,12 +1090,14 @@ describe("Dispatcher", () => {
       };
 
       dispatcher.registerModule(testModule);
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          await ctx.hooks.collect("run", { intent: ctx.intent });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            await ctx.hooks.collect("run", { intent: ctx.intent });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -1056,12 +1126,14 @@ describe("Dispatcher", () => {
       };
 
       dispatcher.registerModule(testModule);
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => {
-          ctx.emit({ type: "test:completed", payload: {} });
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => {
+            ctx.emit({ type: "test:completed", payload: {} });
+          },
+        })
+      );
 
       await dispatcher.dispatch(createActionIntent());
 
@@ -1087,7 +1159,7 @@ describe("Dispatcher", () => {
         const logger = createMockLogger();
         const dispatcher = createDispatcher({ logger });
 
-        dispatcher.registerOperation("test:action", createTestOperation("op", undefined));
+        dispatcher.registerOperation(createTestOperation("op", undefined));
 
         const registerLog = logger.calls.find(
           (c) => c.level === "debug" && c.message === "register operation"
@@ -1249,23 +1321,27 @@ describe("Dispatcher", () => {
         })
       );
       let hookResult!: HookResult;
-      dispatcher.registerOperation("test:collect", {
-        id: "test-op",
-        execute: async (opCtx) => {
-          hookResult = await opCtx.hooks.collect("test-hook", ctx);
-          return hookResult;
-        },
-      });
+      dispatcher.registerOperation(
+        defineOp("test:collect", {
+          id: "test-op",
+          execute: async (opCtx) => {
+            hookResult = await opCtx.hooks.collect("test-hook", ctx);
+            return hookResult;
+          },
+        })
+      );
       await dispatcher.dispatch({ type: "test:collect", payload: {} });
       return hookResult;
     }
 
     it("empty hook point returns empty results and errors", async () => {
       const dispatcher = createDispatcher();
-      dispatcher.registerOperation("test:action", {
-        id: "action-op",
-        execute: async (ctx) => ctx.hooks.collect("nonexistent", { intent: ctx.intent }),
-      });
+      dispatcher.registerOperation(
+        defineOp("test:action", {
+          id: "action-op",
+          execute: async (ctx) => ctx.hooks.collect("nonexistent", { intent: ctx.intent }),
+        })
+      );
 
       const result = (await dispatcher.dispatch(createActionIntent())) as HookResult;
 
@@ -1668,10 +1744,12 @@ describe("Dispatcher", () => {
           },
         },
       });
-      dispatcher.registerOperation("test:collect", {
-        id: "test-op",
-        execute: async (ctx) => ctx.hooks.collect("test-hook", { intent: ctx.intent }),
-      });
+      dispatcher.registerOperation(
+        defineOp("test:collect", {
+          id: "test-op",
+          execute: async (ctx) => ctx.hooks.collect("test-hook", { intent: ctx.intent }),
+        })
+      );
 
       await dispatcher.dispatch({ type: "test:collect", payload: {} });
 

--- a/src/intents/lib/dispatcher.ts
+++ b/src/intents/lib/dispatcher.ts
@@ -15,10 +15,14 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { z } from "zod/v4";
 import type { Intent, IntentResult, DomainEvent } from "./types";
 import type {
   Operation,
   OperationContext,
+  OperationSchemas,
+  IntentOf,
+  HookPointSchemas,
   DispatchFn,
   ResolvedHooks,
   CollectOptions,
@@ -139,10 +143,14 @@ export interface IDispatcher {
 // =============================================================================
 
 export class Dispatcher implements IDispatcher {
-  private readonly operations = new Map<string, Operation<Intent, unknown>>();
+  private readonly operations = new Map<string, Operation>();
   private readonly interceptors: IntentInterceptor[] = [];
   private readonly causationContext = new AsyncLocalStorage<readonly string[]>();
   private readonly handlers = new Map<string, Map<string, HookHandler[]>>();
+  /** operationId → schemas (payload/result/hooks), indexed at registerOperation. */
+  private readonly operationSchemas = new Map<string, OperationSchemas>();
+  /** eventType → payload schema, folded from every operation's `schemas.events`. */
+  private readonly eventSchemas = new Map<string, z.ZodType>();
   private readonly initialCapabilities: Readonly<Record<string, unknown>>;
   private readonly logger: Logger;
 
@@ -161,11 +169,21 @@ export class Dispatcher implements IDispatcher {
    * Generic to accept operations with specific intent types. Type safety
    * is maintained by dispatch() matching intent.type to the correct operation.
    */
-  registerOperation<I extends Intent, R>(intentType: string, operation: Operation<I, R>): void {
+  registerOperation<S extends OperationSchemas>(operation: Operation<S>): void {
+    // The intent type is the operation's registration key — read from its schema bundle,
+    // so registration needs no separate intent-type argument.
+    const intentType = operation.schemas.type;
     if (this.operations.has(intentType)) {
       throw new Error(`Operation already registered for intent type: ${intentType}`);
     }
-    this.operations.set(intentType, operation as unknown as Operation<Intent, unknown>);
+    this.operations.set(intentType, operation as unknown as Operation);
+    this.operationSchemas.set(operation.id, operation.schemas);
+    for (const [eventType, schema] of Object.entries(operation.schemas.events ?? {})) {
+      if (this.eventSchemas.has(eventType)) {
+        throw new Error(`Event schema already registered for event type: ${eventType}`);
+      }
+      this.eventSchemas.set(eventType, schema);
+    }
     this.logger.debug("register operation", { intent: intentType });
   }
 
@@ -263,7 +281,8 @@ export class Dispatcher implements IDispatcher {
     hookHandlers: HookHandler[],
     inputCtx: HookContext,
     initialCaps: Readonly<Record<string, unknown>>,
-    onYield?: (frame: unknown) => void | Promise<void>
+    onYield?: (frame: unknown) => void | Promise<void>,
+    hookSchemas?: HookPointSchemas
   ): Promise<CollectResult<T>> {
     const capabilities: Record<string, unknown> = {
       ...initialCaps,
@@ -281,10 +300,15 @@ export class Dispatcher implements IDispatcher {
       for (const entry of pending) {
         const reqs = entry.requires ?? {};
         if (requirementsSatisfied(reqs, capabilities)) {
-          const frozenCtx = Object.freeze({
+          const frozenCtx: HookContext = Object.freeze({
             ...inputCtx,
             capabilities: Object.freeze({ ...capabilities }),
           });
+          // Whole-context validation (item 2): the input schema re-affirms the intent,
+          // shape-checks the scalar capability bag, and validates the enrichment. A failure
+          // here means the operation built a bad context — a framework bug — so it throws
+          // out of collect (not caught per-handler), aborting the operation → reject.
+          if (hookSchemas?.input) hookSchemas.input.parse(frozenCtx);
           try {
             // A handler returns a HookOutput (result and/or provided capabilities);
             // void is shorthand for an empty output. A streaming handler is an
@@ -297,13 +321,21 @@ export class Dispatcher implements IDispatcher {
                 ? await drainGenerator(invoked, onYield)
                 : await invoked) ?? {};
             if (output.result !== undefined && output.result !== null) {
-              results.push(output.result as T);
+              // Validate + normalize (strip) each handler's partial result. A failure is
+              // isolated to this handler (pushed to errors[]), like a throwing handler.
+              const validated = hookSchemas?.result
+                ? hookSchemas.result.parse(output.result)
+                : output.result;
+              results.push(validated as T);
             }
             // Merge provided capabilities from returned data (no host-side closure).
             // Skip undefined-valued keys: requires/ANY_VALUE test key *presence*, so a
             // key must only appear when it carries a defined value.
             if (output.provides) {
-              for (const [key, value] of Object.entries(output.provides)) {
+              const validated = hookSchemas?.provides
+                ? hookSchemas.provides.parse(output.provides)
+                : output.provides;
+              for (const [key, value] of Object.entries(validated)) {
                 if (value !== undefined) capabilities[key] = value;
               }
             }
@@ -346,6 +378,7 @@ export class Dispatcher implements IDispatcher {
 
   private resolveHooks(operationId: string): ResolvedHooks {
     const opMap = this.handlers.get(operationId);
+    const opHooks = this.operationSchemas.get(operationId)?.hooks;
     const initCaps = this.initialCapabilities;
     const logger = this.logger;
     return {
@@ -363,7 +396,8 @@ export class Dispatcher implements IDispatcher {
           hookHandlers,
           ctx,
           initCaps,
-          options?.onYield
+          options?.onYield,
+          opHooks?.[hookPointId]
         );
         const duration = Math.round(performance.now() - start);
 
@@ -404,9 +438,14 @@ export class Dispatcher implements IDispatcher {
   // ===========================================================================
 
   private async emitEvent(event: DomainEvent): Promise<void> {
+    // Validate + normalize the event payload (fail → throw at emit).
+    const schema = this.eventSchemas.get(event.type);
+    const validated: DomainEvent = schema
+      ? { ...event, payload: schema.parse(event.payload) }
+      : event;
     const eventOpId = `event:${event.type}`;
     const resolved = this.resolveHooks(eventOpId);
-    await resolved.collect("handle", { intent: event as unknown as Intent });
+    await resolved.collect("handle", { intent: validated as unknown as Intent });
   }
 
   private async runPipeline<I extends Intent>(
@@ -444,6 +483,13 @@ export class Dispatcher implements IDispatcher {
         throw new Error(`No operation registered for intent type: ${current.type}`);
       }
 
+      // Validate + normalize (strip) the intent payload; a failure rejects the dispatch
+      // via the outer catch. The parsed value is forwarded so downstream sees normalized data.
+      const opSchemas = this.operationSchemas.get(operation.id);
+      if (opSchemas?.payload) {
+        current = { ...current, payload: opSchemas.payload.parse(current.payload) };
+      }
+
       // Build causation chain using intent type
       const causationChain = [...(causation ?? []), current.type];
 
@@ -468,14 +514,23 @@ export class Dispatcher implements IDispatcher {
         causation: causationChain,
       };
 
-      // Execute operation within causation context so that any
-      // dispatcher.dispatch() calls from hooks inherit the chain.
-      const result = await this.causationContext.run(causationChain, () => operation.execute(ctx));
+      // Execute operation within causation context so that any dispatcher.dispatch() calls
+      // from hooks inherit the chain. The stored operation is erased to `Operation` (any
+      // schema); its `execute` is typed to its own IntentOf, so the generic `ctx` is bridged
+      // with a cast here (the intent's phantom result carrier never exists at runtime — the
+      // payload was already validated above). Call `execute` as a METHOD so `this` stays bound.
+      const opCtx = ctx as unknown as OperationContext<IntentOf<OperationSchemas>>;
+      const result = await this.causationContext.run(causationChain, () =>
+        operation.execute(opCtx)
+      );
+
+      // Validate + normalize the operation's return value (fail → reject via outer catch).
+      const validatedResult = opSchemas?.result ? opSchemas.result.parse(result) : result;
 
       const duration = Math.round(performance.now() - pipelineStart);
       this.logger.info("completed", { intent: current.type, ms: duration });
 
-      handle.resolve(result as IntentResult<I>);
+      handle.resolve(validatedResult as IntentResult<I>);
     } catch (e) {
       this.logger.error("failed", {
         intent: intent.type,

--- a/src/intents/lib/idempotency-module.integration.test.ts
+++ b/src/intents/lib/idempotency-module.integration.test.ts
@@ -7,20 +7,35 @@
 
 import { createMockDispatcher } from "./dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
 import { Dispatcher } from "./dispatcher";
 import { createIdempotencyModule } from "./idempotency-module";
 import type { Intent, DomainEvent } from "./types";
-import type { Operation, OperationContext } from "./operation";
+import type { Operation, OperationContext, OperationSchemas } from "./operation";
 
 // =============================================================================
 // Test Helpers
 // =============================================================================
 
-function noopOperation(id: string): Operation<Intent, void> {
-  return {
-    id,
-    execute: async () => {},
-  };
+/**
+ * Build a test operation with a permissive schema whose `type` is the dispatcher
+ * registration key (the intent type it handles).
+ */
+function opWithType(
+  intentType: string,
+  spec: { id: string; execute: (ctx: OperationContext<Intent>) => Promise<unknown> }
+) {
+  const schemas = {
+    type: intentType,
+    payload: z.unknown(),
+    result: z.custom<unknown>(),
+  } satisfies OperationSchemas;
+  const op: Operation<typeof schemas> = { id: spec.id, schemas, execute: spec.execute };
+  return op;
+}
+
+function noopOperation(id: string, intentType: string) {
+  return opWithType(intentType, { id, execute: async () => {} });
 }
 
 function setup(...args: Parameters<typeof createIdempotencyModule>): { dispatcher: Dispatcher } {
@@ -37,7 +52,7 @@ function setup(...args: Parameters<typeof createIdempotencyModule>): { dispatche
 describe("createIdempotencyModule", () => {
   it("singleton: blocks duplicate dispatch", async () => {
     const { dispatcher } = setup([{ intentType: "test:shutdown" }]);
-    dispatcher.registerOperation("test:shutdown", noopOperation("shutdown-op"));
+    dispatcher.registerOperation(noopOperation("shutdown-op", "test:shutdown"));
 
     // First dispatch succeeds
     const h1 = dispatcher.dispatch({ type: "test:shutdown", payload: {} });
@@ -51,8 +66,8 @@ describe("createIdempotencyModule", () => {
 
   it("singleton: passes through unrelated intents", async () => {
     const { dispatcher } = setup([{ intentType: "test:shutdown" }]);
-    dispatcher.registerOperation("test:shutdown", noopOperation("shutdown-op"));
-    dispatcher.registerOperation("test:other", noopOperation("other-op"));
+    dispatcher.registerOperation(noopOperation("shutdown-op", "test:shutdown"));
+    dispatcher.registerOperation(noopOperation("other-op", "test:other"));
 
     // Dispatch the guarded intent
     await dispatcher.dispatch({ type: "test:shutdown", payload: {} });
@@ -64,12 +79,14 @@ describe("createIdempotencyModule", () => {
 
   it("singleton with reset: blocks during active, unblocks after reset event", async () => {
     const { dispatcher } = setup([{ intentType: "test:setup", resetOn: "test:setup-error" }]);
-    dispatcher.registerOperation("test:setup", {
-      id: "setup-op",
-      execute: async (ctx: OperationContext<Intent>) => {
-        ctx.emit({ type: "test:setup-error", payload: {} });
-      },
-    } satisfies Operation<Intent, void>);
+    dispatcher.registerOperation(
+      opWithType("test:setup", {
+        id: "setup-op",
+        execute: async (ctx: OperationContext<Intent>) => {
+          ctx.emit({ type: "test:setup-error", payload: {} });
+        },
+      })
+    );
 
     // First dispatch succeeds and emits reset event
     await dispatcher.dispatch({ type: "test:setup", payload: {} });
@@ -86,7 +103,7 @@ describe("createIdempotencyModule", () => {
         getKey: (p) => (p as { path: string }).path,
       },
     ]);
-    dispatcher.registerOperation("test:delete", noopOperation("delete-op"));
+    dispatcher.registerOperation(noopOperation("delete-op", "test:delete"));
 
     // First dispatch for /a succeeds
     const h1 = dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } });
@@ -111,12 +128,14 @@ describe("createIdempotencyModule", () => {
     ]);
 
     let emitFn: ((event: DomainEvent) => Promise<void>) | undefined;
-    dispatcher.registerOperation("test:delete", {
-      id: "delete-op",
-      execute: async (ctx: OperationContext<Intent>) => {
-        emitFn = ctx.emit;
-      },
-    });
+    dispatcher.registerOperation(
+      opWithType("test:delete", {
+        id: "delete-op",
+        execute: async (ctx: OperationContext<Intent>) => {
+          emitFn = ctx.emit;
+        },
+      })
+    );
 
     // Dispatch /a and /b
     await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } });
@@ -150,7 +169,7 @@ describe("createIdempotencyModule", () => {
         isForced: (intent) => (intent.payload as { force: boolean }).force,
       },
     ]);
-    dispatcher.registerOperation("test:delete", noopOperation("delete-op"));
+    dispatcher.registerOperation(noopOperation("delete-op", "test:delete"));
 
     // First dispatch for /a
     await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a", force: false } });
@@ -171,7 +190,7 @@ describe("createIdempotencyModule", () => {
         getKey: (p) => (p as { path?: string }).path,
       },
     ]);
-    dispatcher.registerOperation("test:open", noopOperation("open-op"));
+    dispatcher.registerOperation(noopOperation("open-op", "test:open"));
 
     // Payload without path → getKey returns undefined → rule skipped
     const h1 = dispatcher.dispatch({ type: "test:open", payload: {} });
@@ -200,12 +219,14 @@ describe("createIdempotencyModule", () => {
     ]);
 
     let emitFn: ((event: DomainEvent) => Promise<void>) | undefined;
-    dispatcher.registerOperation("test:open", {
-      id: "open-op",
-      execute: async (ctx: OperationContext<Intent>) => {
-        emitFn = ctx.emit;
-      },
-    });
+    dispatcher.registerOperation(
+      opWithType("test:open", {
+        id: "open-op",
+        execute: async (ctx: OperationContext<Intent>) => {
+          emitFn = ctx.emit;
+        },
+      })
+    );
 
     // Dispatch /a → tracked
     await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
@@ -239,12 +260,14 @@ describe("createIdempotencyModule", () => {
     ]);
 
     let emitFn: ((event: DomainEvent) => Promise<void>) | undefined;
-    dispatcher.registerOperation("test:open", {
-      id: "open-op",
-      execute: async (ctx: OperationContext<Intent>) => {
-        emitFn = ctx.emit;
-      },
-    });
+    dispatcher.registerOperation(
+      opWithType("test:open", {
+        id: "open-op",
+        execute: async (ctx: OperationContext<Intent>) => {
+          emitFn = ctx.emit;
+        },
+      })
+    );
 
     // Track /a
     await dispatcher.dispatch({ type: "test:open", payload: { path: "/a" } });
@@ -266,8 +289,8 @@ describe("createIdempotencyModule", () => {
         getKey: (p) => (p as { path: string }).path,
       },
     ]);
-    dispatcher.registerOperation("test:shutdown", noopOperation("shutdown-op"));
-    dispatcher.registerOperation("test:delete", noopOperation("delete-op"));
+    dispatcher.registerOperation(noopOperation("shutdown-op", "test:shutdown"));
+    dispatcher.registerOperation(noopOperation("delete-op", "test:delete"));
 
     // Shutdown blocks on second call
     await dispatcher.dispatch({ type: "test:shutdown", payload: {} });
@@ -293,12 +316,14 @@ describe("createIdempotencyModule", () => {
     ]);
 
     let emitFn: ((event: DomainEvent) => Promise<void>) | undefined;
-    dispatcher.registerOperation("test:delete", {
-      id: "delete-op",
-      execute: async (ctx: OperationContext<Intent>) => {
-        emitFn = ctx.emit;
-      },
-    });
+    dispatcher.registerOperation(
+      opWithType("test:delete", {
+        id: "delete-op",
+        execute: async (ctx: OperationContext<Intent>) => {
+          emitFn = ctx.emit;
+        },
+      })
+    );
 
     // Dispatch /a (tracked)
     await dispatcher.dispatch({ type: "test:delete", payload: { path: "/a" } });

--- a/src/intents/lib/operation.test-utils.integration.test.ts
+++ b/src/intents/lib/operation.test-utils.integration.test.ts
@@ -45,11 +45,12 @@ describe("createMinimalOperation", () => {
       },
     });
 
-    const op = createMinimalOperation<Intent, { value: number }>(
+    const op = createMinimalOperation<{ value: number }>(
       TEST_OPERATION_ID,
+      TEST_INTENT_TYPE,
       TEST_HOOK_POINT
     );
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    dispatcher.registerOperation(op);
 
     const result = await dispatcher.dispatch(testIntent());
 
@@ -59,8 +60,8 @@ describe("createMinimalOperation", () => {
   it("returns undefined when no results (void operation)", async () => {
     const { dispatcher } = createTestSetup();
 
-    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_INTENT_TYPE, TEST_HOOK_POINT);
+    dispatcher.registerOperation(op);
 
     const result = await dispatcher.dispatch(testIntent());
 
@@ -82,8 +83,8 @@ describe("createMinimalOperation", () => {
       },
     });
 
-    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_INTENT_TYPE, TEST_HOOK_POINT);
+    dispatcher.registerOperation(op);
 
     await expect(dispatcher.dispatch(testIntent())).rejects.toThrow("hook failed");
   });
@@ -103,10 +104,10 @@ describe("createMinimalOperation", () => {
       },
     });
 
-    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT, {
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_INTENT_TYPE, TEST_HOOK_POINT, {
       throwOnError: false,
     });
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    dispatcher.registerOperation(op);
 
     await expect(dispatcher.dispatch(testIntent())).resolves.toBeUndefined();
   });
@@ -133,13 +134,18 @@ describe("createMinimalOperation", () => {
       readonly workspacePath: string;
     }
 
-    const op = createMinimalOperation<Intent, string>(TEST_OPERATION_ID, TEST_HOOK_POINT, {
-      hookContext: (ctx) => ({
-        intent: ctx.intent,
-        workspacePath: "/test/workspace",
-      }),
-    });
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    const op = createMinimalOperation<string>(
+      TEST_OPERATION_ID,
+      TEST_INTENT_TYPE,
+      TEST_HOOK_POINT,
+      {
+        hookContext: (ctx) => ({
+          intent: ctx.intent,
+          workspacePath: "/test/workspace",
+        }),
+      }
+    );
+    dispatcher.registerOperation(op);
 
     await dispatcher.dispatch(testIntent());
 
@@ -163,8 +169,8 @@ describe("createMinimalOperation", () => {
       },
     });
 
-    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_HOOK_POINT);
-    dispatcher.registerOperation(TEST_INTENT_TYPE, op);
+    const op = createMinimalOperation(TEST_OPERATION_ID, TEST_INTENT_TYPE, TEST_HOOK_POINT);
+    dispatcher.registerOperation(op);
 
     const intent = testIntent();
     await dispatcher.dispatch(intent);

--- a/src/intents/lib/operation.test-utils.ts
+++ b/src/intents/lib/operation.test-utils.ts
@@ -4,27 +4,37 @@
  * Replaces boilerplate Minimal*Operation classes in module integration tests.
  * Each created operation calls a single hook point via `ctx.hooks.collect()`,
  * optionally throws the first error, and returns the first result.
+ *
+ * Since operations are parameterized by their schema bundle (`Operation<S>`), a minimal
+ * operation carries a permissive schema (payload `z.unknown()`, result `z.custom<TResult>()`)
+ * so the dispatcher's validation is a no-op for it while the dispatched result stays typed.
+ * `intentType` becomes the operation's `schemas.type` — the dispatcher registration key.
  */
 
+import { z } from "zod/v4";
 import type { Intent } from "./types";
-import type { Operation, OperationContext, HookContext } from "./operation";
-import { DELETE_WORKSPACE_OPERATION_ID, EVENT_WORKSPACE_DELETED } from "../delete-workspace";
+import type { Operation, OperationContext, HookContext, OperationSchemas } from "./operation";
+import { DELETE_WORKSPACE_OPERATION_ID, INTENT_DELETE_WORKSPACE } from "../delete-workspace";
+import { EVENT_WORKSPACE_DELETED } from "../delete-workspace";
 import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../delete-workspace";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 
-/**
- * Options for `createMinimalOperation`.
- *
- * @template TIntent - The intent type the operation handles.
- */
-export interface MinimalOperationOptions<TIntent extends Intent, TResult = void> {
+/** Options for `createMinimalOperation`. */
+export interface MinimalOperationOptions<TResult = void> {
   /** Whether to throw `errors[0]` when the hook returns errors. Default: `true`. */
   throwOnError?: boolean;
   /** Custom hook context builder. Default: `{ intent: ctx.intent }`. */
-  hookContext?: (ctx: OperationContext<TIntent>) => HookContext;
+  hookContext?: (ctx: OperationContext<Intent>) => HookContext;
   /** Fallback returned when the hook produced no result (`results[0] ?? defaultResult`). */
   defaultResult?: TResult;
 }
+
+/** The permissive schema shape a minimal test operation carries. */
+type MinimalSchemas<TResult> = {
+  readonly type: string;
+  readonly payload: z.ZodUnknown;
+  readonly result: z.ZodType<TResult>;
+};
 
 /**
  * Create a minimal test operation that collects a single hook point.
@@ -32,32 +42,37 @@ export interface MinimalOperationOptions<TIntent extends Intent, TResult = void>
  * Behavior:
  * 1. Calls `ctx.hooks.collect<TResult>(hookPoint, hookContext)`
  * 2. If `throwOnError !== false` and `errors.length > 0`: throws `errors[0]`
- * 3. Returns `results[0] as TResult`
+ * 3. Returns `results[0] ?? defaultResult`
+ *
+ * @param operationId hook-point owner id (what modules register handlers against)
+ * @param intentType  intent type — the dispatcher registration key (`schemas.type`)
+ * @param hookPoint   the single hook point to collect
  *
  * @example
- * // Simple void operation
- * const op = createMinimalOperation(APP_START_OPERATION_ID, "start");
- *
- * // No-throw (shutdown/stop)
- * const op = createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false });
- *
- * // Custom hook context
- * const op = createMinimalOperation<Intent, GetStatusHookResult | undefined>(
- *   GET_WORKSPACE_STATUS_OPERATION_ID, "get",
+ * const op = createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start");
+ * const op = createMinimalOperation<GetStatusHookResult | undefined>(
+ *   GET_WORKSPACE_STATUS_OPERATION_ID, INTENT_GET_WORKSPACE_STATUS, "get",
  *   { hookContext: (ctx) => ({ intent: ctx.intent, workspacePath: "/test/workspace" }) },
  * );
  */
-export function createMinimalOperation<TIntent extends Intent = Intent, TResult = void>(
+export function createMinimalOperation<TResult = void>(
   operationId: string,
+  intentType: string,
   hookPoint: string,
-  options?: MinimalOperationOptions<TIntent, TResult>
-): Operation<TIntent, TResult> {
+  options?: MinimalOperationOptions<TResult>
+): Operation<MinimalSchemas<TResult>> {
+  const schemas = {
+    type: intentType,
+    payload: z.unknown(),
+    result: z.custom<TResult>(),
+  } satisfies OperationSchemas;
   const throwOnError = options?.throwOnError !== false;
   const buildHookContext = options?.hookContext;
 
-  return {
+  const op: Operation<typeof schemas> = {
     id: operationId,
-    async execute(ctx: OperationContext<TIntent>): Promise<TResult> {
+    schemas,
+    async execute(ctx) {
       const hookCtx = buildHookContext
         ? buildHookContext(ctx)
         : { intent: ctx.intent, capabilities: {} };
@@ -66,6 +81,7 @@ export function createMinimalOperation<TIntent extends Intent = Intent, TResult 
       return (results[0] ?? options?.defaultResult) as TResult;
     },
   };
+  return op;
 }
 
 /** Canned event fields for `createDeleteEventOperation`. */
@@ -75,25 +91,32 @@ export interface DeleteEventOperationFields {
   readonly projectPath?: string;
 }
 
+const deleteEventSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<{ started: true }>(),
+} satisfies OperationSchemas;
+
 /**
  * Minimal delete-workspace operation that only emits EVENT_WORKSPACE_DELETED,
  * so tests can trigger workspace:deleted through the public dispatcher API
- * without the full DeleteWorkspaceOperation pipeline. The workspacePath comes
- * from the intent; the remaining event fields are canned (overridable).
+ * without the full DeleteWorkspaceOperation pipeline.
  */
 export function createDeleteEventOperation(
   fields: DeleteEventOperationFields = {}
-): Operation<DeleteWorkspaceIntent, { started: true }> {
+): Operation<typeof deleteEventSchemas> {
   return {
     id: DELETE_WORKSPACE_OPERATION_ID,
-    async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+    schemas: deleteEventSchemas,
+    async execute(ctx): Promise<{ started: true }> {
+      const intent = ctx.intent as DeleteWorkspaceIntent;
       const event: WorkspaceDeletedEvent = {
         type: EVENT_WORKSPACE_DELETED,
         payload: {
           projectId: fields.projectId ?? ("test-12345678" as ProjectId),
           workspaceName: fields.workspaceName ?? ("ws" as WorkspaceName),
-          workspacePath: ctx.intent.payload.workspacePath,
-          worktreeRemoved: ctx.intent.payload.removeWorktree,
+          workspacePath: intent.payload.workspacePath,
+          worktreeRemoved: intent.payload.removeWorktree,
           projectPath: fields.projectPath ?? "/projects/test",
         },
       };

--- a/src/intents/lib/operation.ts
+++ b/src/intents/lib/operation.ts
@@ -5,6 +5,7 @@
  * They receive a context with hooks, dispatch, and emit capabilities.
  */
 
+import type { z } from "zod/v4";
 import type { Intent, IntentResult, DomainEvent } from "./types";
 
 // =============================================================================
@@ -156,7 +157,70 @@ export interface OperationContext<I extends Intent = Intent> {
  * Operations orchestrate hooks and emit domain events.
  * They never call providers directly — hook handlers do the actual work.
  */
-export interface Operation<I extends Intent = Intent, R = void> {
+export interface Operation<S extends OperationSchemas = OperationSchemas> {
   readonly id: string;
-  execute(ctx: OperationContext<I>): Promise<R>;
+  /**
+   * The operation's contract schemas (item 2) — the single source of truth for its Intent
+   * and result types. The dispatcher indexes them at registration (keyed by `schemas.type`)
+   * and validates every dispatch against them. The Intent/result the operation orchestrates
+   * are **derived** from this bundle via {@link IntentOf} / {@link ResultOf}.
+   */
+  readonly schemas: S;
+  execute(ctx: OperationContext<IntentOf<S>>): Promise<ResultOf<S>>;
 }
+
+/** Per-hook-point schemas: whole input context, each handler's partial result, provided data. */
+export interface HookPointSchemas {
+  /**
+   * Whole input context (intent + scalar capabilities + enrichment) — validated for its
+   * throw/normalization side effect only; the operation-built context (a `HookContext`) is
+   * what reaches the handler. Fail → throw (the operation built a bad context).
+   */
+  readonly input?: z.ZodType;
+  /** Each handler's partial result. Fail → collected error (isolated per handler). */
+  readonly result?: z.ZodType;
+  /** Provided capability data (scalar bag). Fail → collected error. */
+  readonly provides?: z.ZodType<Readonly<Record<string, unknown>>>;
+}
+
+/**
+ * The zod schemas an operation declares for its contract. Colocated with the op's
+ * `*_OPERATION_ID` / hook-point / `EVENT_*` definitions; the dispatcher reads them at
+ * `registerOperation` (payload/result/hooks via the operations map; `events` folded into
+ * an event→schema lookup for `emitEvent`).
+ */
+export interface OperationSchemas {
+  /** Intent type literal — the discriminator, and the dispatcher registration key. */
+  readonly type: string;
+  /** Intent payload — validated at dispatch entry (fail → reject the dispatch). */
+  readonly payload: z.ZodType;
+  /** Operation return value — validated before resolve (fail → reject). Omit for a void result. */
+  readonly result?: z.ZodType;
+  /** Per-hook-point schemas, keyed by hook point id. */
+  readonly hooks?: Readonly<Record<string, HookPointSchemas>>;
+  /** Event payload schemas, keyed by event type — validated at emit (fail → throw). */
+  readonly events?: Readonly<Record<string, z.ZodType>>;
+}
+
+/**
+ * The result type an operation's `schemas` describe — `z.infer` of the `result` schema,
+ * or `void` when none is declared. Derived so an operation never restates its result type.
+ */
+export type ResultOf<S extends OperationSchemas> = S extends {
+  readonly result: infer R extends z.ZodType;
+}
+  ? z.infer<R>
+  : void;
+
+/**
+ * The Intent type an operation's `schemas` describe: the declared `type` literal, the
+ * `z.infer` of the `payload` schema, and the derived result as the phantom carrier. Lets an
+ * operation derive its whole Intent from `typeof schemas` instead of hand-writing an interface:
+ *
+ *   const schemas = { type: INTENT_X, payload: xPayloadSchema, result: xResultSchema } satisfies OperationSchemas;
+ *   export type XIntent = IntentOf<typeof schemas>;
+ */
+export type IntentOf<S extends OperationSchemas> = Intent<ResultOf<S>> & {
+  readonly type: S["type"];
+  readonly payload: z.infer<S["payload"]>;
+};

--- a/src/intents/lib/workspace-operation.integration.test.ts
+++ b/src/intents/lib/workspace-operation.integration.test.ts
@@ -13,22 +13,15 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
 import { createMockDispatcher } from "./dispatcher.test-utils";
 import { WorkspaceHookOperation } from "./workspace-operation";
 import { lastDefined, requireResult } from "./hook-helpers";
 import type { Intent, DomainEvent } from "./types";
-import type { HookHandler, HookOutput } from "./operation";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "../resolve-workspace";
+import type { HookHandler, HookOutput, OperationSchemas } from "./operation";
+import { ResolveWorkspaceOperation, RESOLVE_WORKSPACE_OPERATION_ID } from "../resolve-workspace";
 import type { ResolveHookResult as ResolveWorkspaceHookResult } from "../resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "../resolve-project";
+import { ResolveProjectOperation, RESOLVE_PROJECT_OPERATION_ID } from "../resolve-project";
 import type { ResolveHookResult as ResolveProjectHookResult } from "../resolve-project";
 import type { IntentModule } from "./module";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
@@ -55,7 +48,15 @@ interface TestHookResult {
   readonly value?: string;
 }
 
-class TestOperation extends WorkspaceHookOperation<TestIntent, TestHookResult, string> {
+const testSchemas = {
+  type: INTENT_TEST,
+  payload: z.object({ workspacePath: z.string() }).readonly(),
+  result: z.string(),
+} satisfies OperationSchemas;
+
+class TestOperation extends WorkspaceHookOperation<typeof testSchemas, TestHookResult> {
+  readonly schemas = testSchemas;
+
   constructor(opts?: { resolveProject?: boolean; emitEvent?: boolean }) {
     super(TEST_OPERATION_ID, {
       hookPoint: "work",
@@ -91,10 +92,10 @@ function createSetup(opts: {
   registerProject?: boolean;
 }): { dispatcher: ReturnType<typeof createMockDispatcher>; hookRuns: () => number } {
   const dispatcher = createMockDispatcher();
-  dispatcher.registerOperation(INTENT_TEST, opts.operation);
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(opts.operation);
+  dispatcher.registerOperation(new ResolveWorkspaceOperation());
   if (opts.registerProject) {
-    dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+    dispatcher.registerOperation(new ResolveProjectOperation());
   }
 
   const resolveModule: IntentModule = {

--- a/src/intents/lib/workspace-operation.ts
+++ b/src/intents/lib/workspace-operation.ts
@@ -18,8 +18,16 @@
  * class names so registration in main.ts and tests is unchanged.
  */
 
+import type { z } from "zod/v4";
 import type { Intent, DomainEvent } from "./types";
-import type { Operation, OperationContext, HookContext } from "./operation";
+import type {
+  Operation,
+  OperationContext,
+  HookContext,
+  OperationSchemas,
+  IntentOf,
+  ResultOf,
+} from "./operation";
 import { throwHookErrors } from "./hook-helpers";
 import {
   INTENT_RESOLVE_WORKSPACE,
@@ -35,6 +43,11 @@ import {
 /** An intent whose payload carries the target workspace path. */
 export type WorkspaceScopedIntent<R> = Intent<R> & {
   readonly payload: { readonly workspacePath: string };
+};
+
+/** Operation schemas whose payload carries the target workspace path. */
+export type WorkspaceScopedSchemas = OperationSchemas & {
+  readonly payload: z.ZodType<{ readonly workspacePath: string }>;
 };
 
 /** Input context passed to the hook point — matches the per-op input interfaces. */
@@ -61,16 +74,17 @@ export interface WorkspaceHookSpec<I extends WorkspaceScopedIntent<R>, THook, R>
 }
 
 export abstract class WorkspaceHookOperation<
-  I extends WorkspaceScopedIntent<R>,
+  S extends WorkspaceScopedSchemas,
   THook,
-  R,
-> implements Operation<I, R> {
+> implements Operation<S> {
+  abstract readonly schemas: S;
+
   protected constructor(
     readonly id: string,
-    private readonly spec: WorkspaceHookSpec<I, THook, R>
+    private readonly spec: WorkspaceHookSpec<IntentOf<S>, THook, ResultOf<S>>
   ) {}
 
-  async execute(ctx: OperationContext<I>): Promise<R> {
+  async execute(ctx: OperationContext<IntentOf<S>>): Promise<ResultOf<S>> {
     const { workspacePath } = ctx.intent.payload;
 
     // 1. Dispatch shared workspace resolution

--- a/src/intents/list-projects.integration.test.ts
+++ b/src/intents/list-projects.integration.test.ts
@@ -58,7 +58,7 @@ function createTestSetup(
 ): TestSetup {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
+  dispatcher.registerOperation(new ListProjectsOperation());
 
   const projectModule: IntentModule = {
     name: "test-projects",

--- a/src/intents/list-projects.ts
+++ b/src/intents/list-projects.ts
@@ -7,66 +7,108 @@
  *
  * Joins results by projectPath and converts internal types to IPC types
  * using existing toIpcWorkspaces().
+ *
+ * Contract schemas (item 2): zod is the single source of truth; the Intent, result,
+ * and hook types are derived from the `schemas` bundle.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { Project, ProjectId } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import type { Project } from "../shared/api/types";
+import type { Path } from "../utils/path/path";
 import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
+import { projectIdSchema, projectSchema } from "./contract";
 import { toIpcWorkspaces } from "../utils/workspace-conversion";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 /** Re-exported for use by operation integration tests (avoids direct service import). */
 export type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface ListProjectsIntent extends Intent<Project[]> {
-  readonly type: "project:list";
-  readonly payload: Record<string, never>;
-}
-
 export const INTENT_LIST_PROJECTS = "project:list" as const;
+export const LIST_PROJECTS_OPERATION_ID = "list-projects";
 
 // =============================================================================
-// Hook Result Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface ListProjectsHookEntry {
-  readonly projectId: ProjectId;
-  readonly name: string;
-  readonly path: string;
-}
+export const listProjectsPayloadSchema = z.object({}).readonly();
 
-export interface ListProjectsHookResult {
-  readonly projects?: readonly ListProjectsHookEntry[];
-}
+export const listProjectsResultSchema = z.array(projectSchema);
 
-export interface ListWorkspacesHookEntry {
-  readonly projectPath: string;
-  readonly workspaces: readonly InternalWorkspace[];
-  /**
-   * Per-project default base branch, computed once at project:open and cached
-   * by the contributing module. Carried here so the creation form can seed the
-   * base field synchronously on first paint instead of awaiting a git round-trip.
-   */
-  readonly defaultBaseBranch?: string;
-}
+export const listProjectsHookEntrySchema = z
+  .object({
+    projectId: projectIdSchema,
+    name: z.string(),
+    path: z.string(),
+  })
+  .readonly();
 
-export interface ListWorkspacesHookResult {
-  readonly entries?: readonly ListWorkspacesHookEntry[];
-}
+export const listProjectsHookResultSchema = z
+  .object({
+    projects: z.array(listProjectsHookEntrySchema).readonly().optional(),
+  })
+  .readonly();
+
+/**
+ * Local schema for the internal Workspace shape (from boundaries/git-types) — not in
+ * contract.ts because it carries a `Path` instance (a class), not an IPC string.
+ */
+const internalWorkspaceSchema = z
+  .object({
+    name: z.string(),
+    path: z.custom<Path>(),
+    branch: z.string().nullable(),
+    metadata: z.record(z.string(), z.string()).readonly(),
+  })
+  .readonly();
+
+export const listWorkspacesHookEntrySchema = z
+  .object({
+    projectPath: z.string(),
+    workspaces: z.array(internalWorkspaceSchema).readonly(),
+    /**
+     * Per-project default base branch, computed once at project:open and cached
+     * by the contributing module. Carried here so the creation form can seed the
+     * base field synchronously on first paint instead of awaiting a git round-trip.
+     */
+    defaultBaseBranch: z.string().optional(),
+  })
+  .readonly();
+
+export const listWorkspacesHookResultSchema = z
+  .object({
+    entries: z.array(listWorkspacesHookEntrySchema).readonly().optional(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_LIST_PROJECTS,
+  payload: listProjectsPayloadSchema,
+  result: listProjectsResultSchema,
+  hooks: {
+    "list-projects": { result: listProjectsHookResultSchema },
+    "list-workspaces": { result: listWorkspacesHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type ListProjectsIntent = IntentOf<typeof schemas>;
+export type ListProjectsHookEntry = z.infer<typeof listProjectsHookEntrySchema>;
+export type ListProjectsHookResult = z.infer<typeof listProjectsHookResultSchema>;
+export type ListWorkspacesHookEntry = z.infer<typeof listWorkspacesHookEntrySchema>;
+export type ListWorkspacesHookResult = z.infer<typeof listWorkspacesHookResultSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export const LIST_PROJECTS_OPERATION_ID = "list-projects";
-
-export class ListProjectsOperation implements Operation<ListProjectsIntent, Project[]> {
+export class ListProjectsOperation implements Operation<typeof schemas> {
   readonly id = LIST_PROJECTS_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<ListProjectsIntent>): Promise<Project[]> {
     const hookCtx: HookContext = {

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -47,7 +47,6 @@ import type {
 import {
   OpenWorkspaceOperation,
   OPEN_WORKSPACE_OPERATION_ID,
-  INTENT_OPEN_WORKSPACE,
   EVENT_WORKSPACE_CREATED,
 } from "./open-workspace";
 import type {
@@ -58,7 +57,7 @@ import type {
 } from "./open-workspace";
 import type { Project, ProjectId, WorkspaceName } from "../shared/api/types";
 import { Path } from "../utils/path/path";
-import { SwitchWorkspaceOperation, INTENT_SWITCH_WORKSPACE } from "./switch-workspace";
+import { SwitchWorkspaceOperation } from "./switch-workspace";
 import {
   createTestViewManager,
   registerTestInfrastructure,
@@ -285,8 +284,8 @@ function createTestHarness(options?: {
   };
 
   // Register operations
-  dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
-  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
+  dispatcher.registerOperation(new OpenProjectOperation());
+  dispatcher.registerOperation(new OpenWorkspaceOperation());
 
   // Shared workspace:resolve (reverse lookup over registered projects),
   // project:resolve, switch-workspace activate, and infra operations.
@@ -724,9 +723,9 @@ describe("OpenProjectOperation", () => {
       lastBaseBranches: new Map(),
     };
 
-    dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
-    dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-    dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+    dispatcher.registerOperation(new OpenProjectOperation());
+    dispatcher.registerOperation(new OpenWorkspaceOperation());
+    dispatcher.registerOperation(new SwitchWorkspaceOperation());
 
     // Resolve module that always returns alreadyOpen: true
     const alreadyOpenResolveModule: IntentModule = {
@@ -927,7 +926,7 @@ describe("OpenProjectOperation", () => {
   it("test 10: returns null when select-folder hook returns null (canceled)", async () => {
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
+    dispatcher.registerOperation(new OpenProjectOperation());
 
     // Select-folder module that returns null (user canceled)
     const selectFolderModule: IntentModule = {
@@ -1025,9 +1024,9 @@ describe("OpenProjectOperation", () => {
     // Create harness where the resolve module signals alreadyOpen
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
-    dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-    dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+    dispatcher.registerOperation(new OpenProjectOperation());
+    dispatcher.registerOperation(new OpenWorkspaceOperation());
+    dispatcher.registerOperation(new SwitchWorkspaceOperation());
 
     // Resolve module that always returns alreadyOpen: true
     const alreadyOpenModule: IntentModule = {

--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -12,12 +12,19 @@
  * After hooks, dispatches workspace:open per discovered workspace (best-effort)
  * and emits project:opened. View activation is handled by the projectViewModule
  * event handler (registered in bootstrap).
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook/event
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import type { ProjectId, Project } from "../shared/api/types";
 import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
+import { projectSchema, projectIdSchema, hookCtxSchema } from "./contract";
 import {
   INTENT_OPEN_WORKSPACE,
   type OpenWorkspaceIntent,
@@ -30,104 +37,212 @@ import { toIpcWorkspaces } from "../utils/workspace-conversion";
 import { Path } from "../utils/path/path";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface OpenProjectPayload {
-  /** Absolute local filesystem path. Set by projects.open. */
-  readonly path?: Path;
-  /** Git URL or shorthand (e.g. "org/repo"). Set by the creation module's clone sub-dialog. */
-  readonly git?: string;
-}
-
-export interface OpenProjectIntent extends Intent<Project> {
-  readonly type: "project:open";
-  readonly payload: OpenProjectPayload;
-}
-
 export const INTENT_OPEN_PROJECT = "project:open" as const;
+export const OPEN_PROJECT_OPERATION_ID = "open-project";
+
+export const EVENT_PROJECT_OPENED = "project:opened" as const;
+export const EVENT_PROJECT_OPEN_FAILED = "project:open-failed" as const;
+export const EVENT_CLONE_PROGRESS = "clone:progress" as const;
 
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface ProjectOpenedPayload {
-  readonly project: Project;
-  /** Original intent path, for idempotency reset. */
-  readonly path?: Path;
-  /** Original intent git URL, for idempotency reset. */
-  readonly git?: string;
-}
+export const openProjectPayloadSchema = z
+  .object({
+    /** Absolute local filesystem path. Set by projects.open. */
+    path: z.instanceof(Path).optional(),
+    /** Git URL or shorthand (e.g. "org/repo"). Set by the creation module's clone sub-dialog. */
+    git: z.string().optional(),
+  })
+  .readonly();
+
+/** `null` result = user canceled the folder dialog (select-folder returned no path). */
+export const openProjectResultSchema = projectSchema.nullable();
+
+// -----------------------------------------------------------------------------
+// Internal (git-types) Workspace — local schema (no contract equivalent: the
+// contract's workspaceSchema is the IPC form with a string path; discover
+// results carry the internal form with a `Path` instance).
+// -----------------------------------------------------------------------------
+
+const internalWorkspaceSchema = z
+  .object({
+    name: z.string(),
+    path: z.instanceof(Path),
+    branch: z.string().nullable(),
+    metadata: z.record(z.string(), z.string()).readonly(),
+  })
+  .readonly();
+
+// -----------------------------------------------------------------------------
+// Hook result schemas
+// -----------------------------------------------------------------------------
+
+/** Result returned by handlers on the "select-folder" hook point. */
+export const selectFolderHookResultSchema = z
+  .object({
+    folderPath: z.string().nullable(),
+  })
+  .readonly();
+
+/** Result returned by handlers on the "prepare" hook point. */
+export const prepareHookResultSchema = z
+  .object({
+    /** If true, user canceled — abort the open operation. */
+    canceled: z.boolean().optional(),
+  })
+  .readonly();
+
+/** Result returned by handlers on the "resolve" hook point. */
+export const resolveHookResultSchema = z
+  .object({
+    /** Optional when using collect() — handler may skip via self-selection. */
+    projectPath: z.string().optional(),
+    remoteUrl: z.string().optional(),
+    /** If true, the project is already open — skip workspace:open and event emission. */
+    alreadyOpen: z.boolean().optional(),
+  })
+  .readonly();
+
+/** Result returned by handlers on the "discover" hook point. */
+export const discoverHookResultSchema = z
+  .object({
+    workspaces: z.array(internalWorkspaceSchema).readonly(),
+    defaultBaseBranch: z.string().optional(),
+  })
+  .readonly();
+
+/** Result returned by handlers on the "register" hook point. */
+export const registerHookResultSchema = z
+  .object({
+    /** Optional when using collect() — handler may skip via self-selection. */
+    projectId: projectIdSchema.optional(),
+    name: z.string().optional(),
+    /** If true, the project is already open — skip workspace:open and event emission. */
+    alreadyOpen: z.boolean().optional(),
+  })
+  .readonly();
+
+// -----------------------------------------------------------------------------
+// Hook input enrichment + whole-context schemas
+// -----------------------------------------------------------------------------
+
+/** Operation-added enrichment for the "discover" hook point. */
+const discoverEnrichmentSchema = z.object({ projectPath: z.string() });
+
+/** Runtime whole-context validation schema for "discover". */
+export const discoverHookInputSchema = hookCtxSchema(
+  openProjectPayloadSchema,
+  discoverEnrichmentSchema.shape
+);
+
+/** Operation-added enrichment for the "register" hook point. */
+const registerEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  remoteUrl: z.string().optional(),
+});
+
+/** Runtime whole-context validation schema for "register". */
+export const registerHookInputSchema = hookCtxSchema(
+  openProjectPayloadSchema,
+  registerEnrichmentSchema.shape
+);
+
+// -----------------------------------------------------------------------------
+// Event payload schemas (events this file owns)
+// -----------------------------------------------------------------------------
+
+export const projectOpenedPayloadSchema = z
+  .object({
+    project: projectSchema,
+    /** Original intent path, for idempotency reset. */
+    path: z.instanceof(Path).optional(),
+    /** Original intent git URL, for idempotency reset. */
+    git: z.string().optional(),
+  })
+  .readonly();
+
+export const projectOpenFailedPayloadSchema = z
+  .object({
+    /** Original intent path, for idempotency reset. */
+    path: z.instanceof(Path).optional(),
+    /** Original intent git URL, for idempotency reset. */
+    git: z.string().optional(),
+    /** Reason the open failed (error message or "already-open"). */
+    reason: z.string(),
+  })
+  .readonly();
+
+export const cloneProgressPayloadSchema = z
+  .object({
+    stage: z.string(),
+    progress: z.number(),
+    name: z.string(),
+    url: z.string(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_OPEN_PROJECT,
+  payload: openProjectPayloadSchema,
+  result: openProjectResultSchema,
+  hooks: {
+    "select-folder": { result: selectFolderHookResultSchema },
+    prepare: { result: prepareHookResultSchema },
+    resolve: { result: resolveHookResultSchema },
+    register: { input: registerHookInputSchema, result: registerHookResultSchema },
+    discover: { input: discoverHookInputSchema, result: discoverHookResultSchema },
+  },
+  events: {
+    [EVENT_PROJECT_OPENED]: projectOpenedPayloadSchema,
+    [EVENT_PROJECT_OPEN_FAILED]: projectOpenFailedPayloadSchema,
+    [EVENT_CLONE_PROGRESS]: cloneProgressPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type OpenProjectPayload = z.infer<typeof openProjectPayloadSchema>;
+export type OpenProjectIntent = IntentOf<typeof schemas>;
+
+export type SelectFolderHookResult = z.infer<typeof selectFolderHookResultSchema>;
+export type PrepareHookResult = z.infer<typeof prepareHookResultSchema>;
+export type ResolveHookResult = z.infer<typeof resolveHookResultSchema>;
+export type DiscoverHookResult = z.infer<typeof discoverHookResultSchema>;
+export type RegisterHookResult = z.infer<typeof registerHookResultSchema>;
+
+/** Input context for the "discover" hook point. */
+export type DiscoverHookInput = HookContext & z.infer<typeof discoverEnrichmentSchema>;
+
+/** Input context for the "register" hook point. */
+export type RegisterHookInput = HookContext & z.infer<typeof registerEnrichmentSchema>;
+
+export type ProjectOpenedPayload = z.infer<typeof projectOpenedPayloadSchema>;
+export type ProjectOpenFailedPayload = z.infer<typeof projectOpenFailedPayloadSchema>;
+export type CloneProgressPayload = z.infer<typeof cloneProgressPayloadSchema>;
 
 export interface ProjectOpenedEvent extends DomainEvent {
   readonly type: "project:opened";
   readonly payload: ProjectOpenedPayload;
 }
 
-export const EVENT_PROJECT_OPENED = "project:opened" as const;
-
-export interface ProjectOpenFailedPayload {
-  /** Original intent path, for idempotency reset. */
-  readonly path?: Path;
-  /** Original intent git URL, for idempotency reset. */
-  readonly git?: string;
-  /** Reason the open failed (error message or "already-open"). */
-  readonly reason: string;
-}
-
 export interface ProjectOpenFailedEvent extends DomainEvent {
-  readonly type: "project:open-failed";
+  readonly type: typeof EVENT_PROJECT_OPEN_FAILED;
   readonly payload: ProjectOpenFailedPayload;
 }
 
-export const EVENT_PROJECT_OPEN_FAILED = "project:open-failed" as const;
+export interface CloneProgressEvent extends DomainEvent {
+  readonly type: typeof EVENT_CLONE_PROGRESS;
+  readonly payload: CloneProgressPayload;
+}
 
 // =============================================================================
-// Hook Result & Input Types
+// Clone progress streaming frame (yielded by the "resolve" hook; not schematized —
+// yield frames are pure data forwarded to onYield, not validated at the boundary).
 // =============================================================================
-
-export const OPEN_PROJECT_OPERATION_ID = "open-project";
-
-/** Result returned by handlers on the "select-folder" hook point. */
-export interface SelectFolderHookResult {
-  readonly folderPath: string | null;
-}
-
-/** Result returned by handlers on the "prepare" hook point. */
-export interface PrepareHookResult {
-  /** If true, user canceled — abort the open operation. */
-  readonly canceled?: boolean;
-}
-
-/** Result returned by handlers on the "resolve" hook point. */
-export interface ResolveHookResult {
-  /** Optional when using collect() — handler may skip via self-selection. */
-  readonly projectPath?: string;
-  readonly remoteUrl?: string;
-  /** If true, the project is already open — skip workspace:open and event emission. */
-  readonly alreadyOpen?: boolean;
-}
-
-/** Result returned by handlers on the "discover" hook point. */
-export interface DiscoverHookResult {
-  readonly workspaces: readonly InternalWorkspace[];
-  readonly defaultBaseBranch?: string;
-}
-
-/** Result returned by handlers on the "register" hook point. */
-export interface RegisterHookResult {
-  /** Optional when using collect() — handler may skip via self-selection. */
-  readonly projectId?: ProjectId;
-  readonly name?: string;
-  /** If true, the project is already open — skip workspace:open and event emission. */
-  readonly alreadyOpen?: boolean;
-}
-
-/** Input context for the "discover" hook point. */
-export interface DiscoverHookInput extends HookContext {
-  readonly projectPath: string;
-}
 
 /**
  * Progress frame yielded by the "resolve" hook while cloning (data only, no closure).
@@ -154,35 +269,12 @@ export function isCloneProgressFrame(frame: unknown): frame is CloneProgressFram
 }
 
 // =============================================================================
-// Clone Progress Event Types
-// =============================================================================
-
-export const EVENT_CLONE_PROGRESS = "clone:progress" as const;
-
-export interface CloneProgressPayload {
-  readonly stage: string;
-  readonly progress: number;
-  readonly name: string;
-  readonly url: string;
-}
-
-export interface CloneProgressEvent extends DomainEvent {
-  readonly type: typeof EVENT_CLONE_PROGRESS;
-  readonly payload: CloneProgressPayload;
-}
-
-/** Input context for the "register" hook point. */
-export interface RegisterHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly remoteUrl?: string;
-}
-
-// =============================================================================
 // Operation
 // =============================================================================
 
-export class OpenProjectOperation implements Operation<OpenProjectIntent, Project | null> {
+export class OpenProjectOperation implements Operation<typeof schemas> {
   readonly id = OPEN_PROJECT_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project | null> {
     const { intent } = ctx;

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -185,7 +185,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
+  dispatcher.registerOperation(new OpenWorkspaceOperation());
 
   // Tracks known project paths for project:resolve resolution.
   // Only PROJECT_ROOT is known by default; tests can add more.
@@ -931,7 +931,7 @@ describe("OpenWorkspace Operation", () => {
       // Re-create setup with the extra module
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
+      dispatcher.registerOperation(new OpenWorkspaceOperation());
 
       registerTestInfrastructure(dispatcher, {
         workspaces: (wsPath) => ({

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -15,106 +15,227 @@
  * workspace:created domain event.
  *
  * No provider dependencies - hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook/event
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent`, result,
+ * hook, and event types are **derived** from that bundle — never restated.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName, Workspace, AgentSpec } from "../shared/api/types";
-import type { AgentType } from "../shared/plugin-protocol";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import type { WorkspaceName } from "./contract";
+import {
+  projectIdSchema,
+  workspaceNameSchema,
+  workspaceSchema,
+  agentSpecSchema,
+  hookCtxSchema,
+} from "./contract";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
 import { throwHookErrors, mergeHookResults } from "./lib/hook-helpers";
 
+export const INTENT_OPEN_WORKSPACE = "workspace:open" as const;
+export const OPEN_WORKSPACE_OPERATION_ID = "open-workspace";
+
+export const EVENT_WORKSPACE_CREATED = "workspace:created" as const;
+export const EVENT_WORKSPACE_LOADING = "workspace:loading" as const;
+export const EVENT_WORKSPACE_CREATE_FAILED = "workspace:create-failed" as const;
+
 // =============================================================================
-// Intent Types
+// Contract schemas (single source of truth)
 // =============================================================================
+
+/** Selected agent backend. Local schema (not in contract); mirrors plugin-protocol's AgentType. */
+const agentTypeSchema = z.enum(["opencode", "claude"]);
+type AgentType = z.infer<typeof agentTypeSchema>;
 
 /** Identifies which module dispatched a workspace:open intent. */
-export type WorkspaceOpenSource =
-  | "ui-ipc"
-  | "mcp"
-  | "plugin-server"
-  | "auto-workspace"
-  | "open-project"
-  | "creation";
+export const workspaceOpenSourceSchema = z.enum([
+  "ui-ipc",
+  "mcp",
+  "plugin-server",
+  "auto-workspace",
+  "open-project",
+  "creation",
+]);
+export type WorkspaceOpenSource = z.infer<typeof workspaceOpenSourceSchema>;
 
 /** Data for activating an existing (discovered) workspace via workspace:open */
-export interface ExistingWorkspaceData {
-  readonly path: string;
-  readonly name: string;
-  readonly branch: string | null;
-  readonly metadata: Readonly<Record<string, string>>;
-}
+export const existingWorkspaceDataSchema = z
+  .object({
+    path: z.string(),
+    name: z.string(),
+    branch: z.string().nullable(),
+    metadata: z.record(z.string(), z.string()).readonly(),
+  })
+  .readonly();
+export type ExistingWorkspaceData = z.infer<typeof existingWorkspaceDataSchema>;
 
-export interface OpenWorkspacePayload {
-  readonly workspaceName: string;
-  readonly base?: string;
-  /** Remote branch to check out (e.g., 'origin/feature-login'). When set, the local branch
-   *  is created at this ref with upstream configured, instead of forking from base. */
-  readonly tracking?: string;
-  /** If true, switch to the new workspace. If false, don't steal focus but still switch when
-   *  no workspace is active. Default behavior (undefined): switch. */
-  readonly stealFocus?: boolean;
-  /** When set, skip worktree creation and populate context from existing workspace data. */
-  readonly existingWorkspace?: ExistingWorkspaceData;
-  /** Authoritative project path. */
-  readonly projectPath: string;
-  /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
-  readonly source?: WorkspaceOpenSource;
-  /**
-   * Agent spec: prompt + backend-specific launch config. When the `type` is
-   * "claude"/"opencode" it also selects (and persists) the per-workspace
-   * backend; "default" or omitted falls back to git metadata / global config.
-   */
-  readonly agent?: AgentSpec;
-}
+export const openWorkspacePayloadSchema = z
+  .object({
+    workspaceName: z.string(),
+    base: z.string().optional(),
+    /** Remote branch to check out (e.g., 'origin/feature-login'). When set, the local branch
+     *  is created at this ref with upstream configured, instead of forking from base. */
+    tracking: z.string().optional(),
+    /** If true, switch to the new workspace. If false, don't steal focus but still switch when
+     *  no workspace is active. Default behavior (undefined): switch. */
+    stealFocus: z.boolean().optional(),
+    /** When set, skip worktree creation and populate context from existing workspace data. */
+    existingWorkspace: existingWorkspaceDataSchema.optional(),
+    /** Authoritative project path. */
+    projectPath: z.string(),
+    /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
+    source: workspaceOpenSourceSchema.optional(),
+    /**
+     * Agent spec: prompt + backend-specific launch config. When the `type` is
+     * "claude"/"opencode" it also selects (and persists) the per-workspace
+     * backend; "default" or omitted falls back to git metadata / global config.
+     */
+    agent: agentSpecSchema.optional(),
+  })
+  .readonly();
 
-export type OpenWorkspaceResult = Workspace;
-
-export interface OpenWorkspaceIntent extends Intent<OpenWorkspaceResult> {
-  readonly type: "workspace:open";
-  readonly payload: OpenWorkspacePayload;
-}
-
-export const INTENT_OPEN_WORKSPACE = "workspace:open" as const;
+export const openWorkspaceResultSchema = workspaceSchema;
 
 // =============================================================================
-// Event Types
+// Per-hook-point schemas
 // =============================================================================
 
-export interface WorkspaceCreatedPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-  readonly projectPath: string;
-  readonly branch: string;
-  readonly base?: string;
-  readonly tracking?: string;
-  readonly metadata: Readonly<Record<string, string>>;
-  readonly workspaceUrl: string;
-  readonly agent?: AgentSpec;
-  readonly stealFocus?: boolean;
-  /** True when re-activating a discovered workspace (not a fresh creation). */
-  readonly reopened?: boolean;
-  /** Which module dispatched the original intent. */
-  readonly source?: WorkspaceOpenSource;
-}
+/** Operation-added enrichment for the "create" hook point (resolved project path). */
+const createEnrichmentSchema = z.object({ projectPath: z.string() });
+const createInputSchema = hookCtxSchema(openWorkspacePayloadSchema, createEnrichmentSchema.shape);
+
+/** Result from the "create" hook point. Fields optional — multiple handlers may each contribute a subset. */
+export const createResultSchema = z
+  .object({
+    workspacePath: z.string().optional(),
+    branch: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).readonly().optional(),
+    /** The resolved base branch (explicit or auto-detected). Used in the event payload. */
+    resolvedBase: z.string().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "setup" hook point (merged create results). */
+const setupEnrichmentSchema = z.object({
+  workspacePath: z.string(),
+  projectPath: z.string(),
+});
+const setupInputSchema = hookCtxSchema(openWorkspacePayloadSchema, setupEnrichmentSchema.shape);
+
+/** Result from the "setup" hook point. */
+export const setupResultSchema = z
+  .object({
+    envVars: z.record(z.string(), z.string()).optional(),
+    /** Selected agent backend, contributed by the active agent module.
+     *  Operation-consumed (no sibling requires), so a result — not a capability. */
+    agentType: agentTypeSchema.nullable().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "finalize" hook point (create+setup results). */
+const finalizeEnrichmentSchema = z.object({
+  workspacePath: z.string(),
+  envVars: z.record(z.string(), z.string()),
+  agentType: agentTypeSchema.nullable(),
+});
+const finalizeInputSchema = hookCtxSchema(
+  openWorkspacePayloadSchema,
+  finalizeEnrichmentSchema.shape
+);
+
+/** The "finalize" hook produces the workspace URL string (only code-server contributes one). */
+const finalizeResultSchema = z.string();
+
+// =============================================================================
+// Event payload schemas (events defined in this file)
+// =============================================================================
+
+const workspaceCreatedSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    workspacePath: z.string(),
+    projectPath: z.string(),
+    branch: z.string(),
+    base: z.string().optional(),
+    tracking: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).readonly(),
+    workspaceUrl: z.string(),
+    agent: agentSpecSchema.optional(),
+    stealFocus: z.boolean().optional(),
+    /** True when re-activating a discovered workspace (not a fresh creation). */
+    reopened: z.boolean().optional(),
+    /** Which module dispatched the original intent. */
+    source: workspaceOpenSourceSchema.optional(),
+  })
+  .readonly();
+
+const workspaceLoadingSchema = z
+  .object({
+    workspaceName: z.string(),
+    projectPath: z.string(),
+    /** The requested base branch (absent when auto-detected later). */
+    base: z.string().optional(),
+  })
+  .readonly();
+
+const workspaceCreateFailedSchema = z
+  .object({
+    workspaceName: z.string(),
+    projectPath: z.string(),
+    error: z.string(),
+    /** Which module dispatched the original intent. */
+    source: workspaceOpenSourceSchema.optional(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: openWorkspacePayloadSchema,
+  result: openWorkspaceResultSchema,
+  hooks: {
+    create: { input: createInputSchema, result: createResultSchema },
+    setup: { input: setupInputSchema, result: setupResultSchema },
+    finalize: { input: finalizeInputSchema, result: finalizeResultSchema },
+  },
+  events: {
+    [EVENT_WORKSPACE_CREATED]: workspaceCreatedSchema,
+    [EVENT_WORKSPACE_LOADING]: workspaceLoadingSchema,
+    [EVENT_WORKSPACE_CREATE_FAILED]: workspaceCreateFailedSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type OpenWorkspacePayload = z.infer<typeof openWorkspacePayloadSchema>;
+export type OpenWorkspaceResult = z.infer<typeof openWorkspaceResultSchema>;
+export type OpenWorkspaceIntent = IntentOf<typeof schemas>;
+
+export type CreateHookResult = z.infer<typeof createResultSchema>;
+export type SetupHookResult = z.infer<typeof setupResultSchema>;
+
+/** Input context for the "create" hook point (enriched with resolved project path). */
+export type CreateHookInput = HookContext & z.infer<typeof createEnrichmentSchema>;
+/** Input context for the "setup" hook point (enriched with merged create results). */
+export type SetupHookInput = HookContext & z.infer<typeof setupEnrichmentSchema>;
+/** Input context for the "finalize" hook point (enriched with create+setup results). */
+export type FinalizeHookInput = HookContext & z.infer<typeof finalizeEnrichmentSchema>;
+
+export type WorkspaceCreatedPayload = z.infer<typeof workspaceCreatedSchema>;
+export type WorkspaceLoadingPayload = z.infer<typeof workspaceLoadingSchema>;
+export type WorkspaceCreateFailedPayload = z.infer<typeof workspaceCreateFailedSchema>;
 
 export interface WorkspaceCreatedEvent extends DomainEvent {
   readonly type: "workspace:created";
   readonly payload: WorkspaceCreatedPayload;
-}
-
-export const EVENT_WORKSPACE_CREATED = "workspace:created" as const;
-
-// -- workspace:loading (emitted before slow work begins) --
-
-export interface WorkspaceLoadingPayload {
-  readonly workspaceName: string;
-  readonly projectPath: string;
-  /** The requested base branch (absent when auto-detected later). */
-  readonly base?: string;
 }
 
 export interface WorkspaceLoadingEvent extends DomainEvent {
@@ -122,72 +243,18 @@ export interface WorkspaceLoadingEvent extends DomainEvent {
   readonly payload: WorkspaceLoadingPayload;
 }
 
-export const EVENT_WORKSPACE_LOADING = "workspace:loading" as const;
-
-// -- workspace:create-failed (emitted on operation error) --
-
-export interface WorkspaceCreateFailedPayload {
-  readonly workspaceName: string;
-  readonly projectPath: string;
-  readonly error: string;
-  /** Which module dispatched the original intent. */
-  readonly source?: WorkspaceOpenSource;
-}
-
 export interface WorkspaceCreateFailedEvent extends DomainEvent {
   readonly type: "workspace:create-failed";
   readonly payload: WorkspaceCreateFailedPayload;
 }
 
-export const EVENT_WORKSPACE_CREATE_FAILED = "workspace:create-failed" as const;
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-export const OPEN_WORKSPACE_OPERATION_ID = "open-workspace";
-
-// =============================================================================
-// Per-hook-point types
-// =============================================================================
-
-/** Input context for the "create" hook point (enriched with resolved project path). */
-export interface CreateHookInput extends HookContext {
-  readonly projectPath: string;
-}
-
-/** Result from the "create" hook point. Fields are optional — multiple handlers may each contribute a subset. */
-export interface CreateHookResult {
-  readonly workspacePath?: string;
-  readonly branch?: string;
-  readonly metadata?: Readonly<Record<string, string>>;
-  /** The resolved base branch (explicit or auto-detected). Used in the event payload. */
-  readonly resolvedBase?: string;
-}
-
-/** Input context for the "setup" hook point (enriched with merged create results). */
-export interface SetupHookInput extends HookContext {
-  readonly workspacePath: string;
-  readonly projectPath: string;
-}
-
-/** Result from the "setup" hook point. */
-export interface SetupHookResult {
-  readonly envVars?: Record<string, string>;
-  /** Selected agent backend, contributed by the active agent module.
-   *  Operation-consumed (no sibling requires), so a result — not a capability. */
-  readonly agentType?: AgentType | null;
-}
-
-/** Input context for the "finalize" hook point (enriched with create+setup results). */
-export interface FinalizeHookInput extends HookContext {
-  readonly workspacePath: string;
-  readonly envVars: Record<string, string>;
-  readonly agentType: AgentType | null;
-}
-
-export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, OpenWorkspaceResult> {
+export class OpenWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<OpenWorkspaceResult> {
     const { projectPath } = ctx.intent.payload;
@@ -302,7 +369,7 @@ export class OpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, Op
       ctx.intent.payload.workspaceName) as WorkspaceName;
     const projectId = resolvedProjectId;
 
-    const workspace: Workspace = {
+    const workspace: OpenWorkspaceResult = {
       projectId,
       name: resolvedWorkspaceName,
       branch,

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -22,17 +22,9 @@ import type { ProjectId, WorkspaceName, WorkspaceRef } from "../shared/api/types
 import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_UPDATE_AGENT_STATUS } from "./update-agent-status";
 import type { UpdateAgentStatusIntent } from "./update-agent-status";
-import {
-  ResolveWorkspaceOperation,
-  RESOLVE_WORKSPACE_OPERATION_ID,
-  INTENT_RESOLVE_WORKSPACE,
-} from "./resolve-workspace";
+import { ResolveWorkspaceOperation, RESOLVE_WORKSPACE_OPERATION_ID } from "./resolve-workspace";
 import type { ResolveHookResult as ResolveWorkspaceHookResult } from "./resolve-workspace";
-import {
-  ResolveProjectOperation,
-  RESOLVE_PROJECT_OPERATION_ID,
-  INTENT_RESOLVE_PROJECT,
-} from "./resolve-project";
+import { ResolveProjectOperation, RESOLVE_PROJECT_OPERATION_ID } from "./resolve-project";
 import type {
   ResolveHookResult as ResolveProjectHookResult,
   ResolveHookInput as ResolveProjectHookInput,
@@ -40,14 +32,9 @@ import type {
 import {
   GetActiveWorkspaceOperation,
   GET_ACTIVE_WORKSPACE_OPERATION_ID,
-  INTENT_GET_ACTIVE_WORKSPACE,
 } from "./get-active-workspace";
 import type { GetActiveWorkspaceHookResult } from "./get-active-workspace";
-import {
-  SwitchWorkspaceOperation,
-  SWITCH_WORKSPACE_OPERATION_ID,
-  INTENT_SWITCH_WORKSPACE,
-} from "./switch-workspace";
+import { SwitchWorkspaceOperation, SWITCH_WORKSPACE_OPERATION_ID } from "./switch-workspace";
 import type {
   SwitchWorkspaceIntent,
   SwitchWorkspaceHookResult,
@@ -319,10 +306,10 @@ export function registerTestInfrastructure(
   dispatcher: Dispatcher,
   config: TestMockConfig
 ): { mockModule: IntentModule } {
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-  dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
-  dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
+  dispatcher.registerOperation(new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(new ResolveProjectOperation());
+  dispatcher.registerOperation(new GetActiveWorkspaceOperation());
+  dispatcher.registerOperation(new SwitchWorkspaceOperation());
 
   const mockModule = createTestMockModule(config);
   dispatcher.registerModule(mockModule);

--- a/src/intents/resolve-project.integration.test.ts
+++ b/src/intents/resolve-project.integration.test.ts
@@ -44,7 +44,7 @@ function createTestSetup(
 } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
+  dispatcher.registerOperation(new ResolveProjectOperation());
 
   if (resolveHandler) {
     const module: IntentModule = {

--- a/src/intents/resolve-project.ts
+++ b/src/intents/resolve-project.ts
@@ -9,59 +9,83 @@
  * 1. "resolve" — collected from modules (e.g., localProjectModule)
  *
  * Throws if no handler returns projectId.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, hookCtxSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface ResolveProjectPayload {
-  readonly projectPath: string;
-}
-
-export interface ResolveProjectResult {
-  readonly projectId: ProjectId;
-  readonly projectName: string;
-}
-
-export interface ResolveProjectIntent extends Intent<ResolveProjectResult> {
-  readonly type: "project:resolve";
-  readonly payload: ResolveProjectPayload;
-}
-
 export const INTENT_RESOLVE_PROJECT = "project:resolve" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const RESOLVE_PROJECT_OPERATION_ID = "resolve-project";
 
-/** Input context for "resolve" handlers. */
-export interface ResolveHookInput extends HookContext {
-  readonly projectPath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
 
-/** Per-handler result for "resolve" hook point. */
-export interface ResolveHookResult {
-  readonly projectId?: ProjectId;
-  readonly projectName?: string;
-}
+export const resolveProjectPayloadSchema = z
+  .object({
+    projectPath: z.string(),
+  })
+  .readonly();
+
+export const resolveProjectResultSchema = z
+  .object({
+    projectId: projectIdSchema,
+    projectName: z.string(),
+  })
+  .readonly();
+
+/** Per-handler result for "resolve" (fields optional — each handler contributes a subset). */
+export const resolveHookResultSchema = z
+  .object({
+    projectId: projectIdSchema.optional(),
+    projectName: z.string().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "resolve" hook point (beyond the base HookContext). */
+const resolveEnrichmentSchema = z.object({ projectPath: z.string() });
+
+/** Runtime whole-context validation schema for "resolve" (its inferred type isn't the ctx type). */
+export const resolveHookInputSchema = hookCtxSchema(
+  resolveProjectPayloadSchema,
+  resolveEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_RESOLVE_PROJECT,
+  payload: resolveProjectPayloadSchema,
+  result: resolveProjectResultSchema,
+  hooks: {
+    resolve: { input: resolveHookInputSchema, result: resolveHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type ResolveProjectPayload = z.infer<typeof resolveProjectPayloadSchema>;
+export type ResolveProjectResult = z.infer<typeof resolveProjectResultSchema>;
+export type ResolveProjectIntent = IntentOf<typeof schemas>;
+export type ResolveHookResult = z.infer<typeof resolveHookResultSchema>;
+
+/** Whole input context for "resolve" handlers: base envelope + inferred enrichment. */
+export type ResolveHookInput = HookContext & z.infer<typeof resolveEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class ResolveProjectOperation implements Operation<
-  ResolveProjectIntent,
-  ResolveProjectResult
-> {
+export class ResolveProjectOperation implements Operation<typeof schemas> {
   readonly id = RESOLVE_PROJECT_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<ResolveProjectIntent>): Promise<ResolveProjectResult> {
     const { payload } = ctx.intent;
@@ -73,7 +97,7 @@ export class ResolveProjectOperation implements Operation<
     const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
     throwHookErrors(errors, "project:resolve hooks failed");
 
-    let projectId: ProjectId | undefined;
+    let projectId: ResolveProjectResult["projectId"] | undefined;
     let projectName: string | undefined;
     for (const r of results) {
       if (r.projectId !== undefined) projectId = r.projectId;

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -44,7 +44,7 @@ function createTestSetup(
 } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
+  dispatcher.registerOperation(new ResolveWorkspaceOperation());
 
   if (resolveHandler) {
     const module: IntentModule = {

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -9,64 +9,88 @@
  * 1. "resolve" — collected from modules (e.g., gitWorktreeWorkspaceModule)
  *
  * Throws if no handler returns projectPath or workspaceName.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { WorkspaceName } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { workspaceNameSchema, hookCtxSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface ResolveWorkspacePayload {
-  readonly workspacePath: string;
-}
-
-export interface ResolveWorkspaceResult {
-  readonly projectPath: string;
-  readonly workspaceName: WorkspaceName;
-  readonly active: boolean;
-  /** Current branch name, or null for detached HEAD. */
-  readonly branch: string | null;
-}
-
-export interface ResolveWorkspaceIntent extends Intent<ResolveWorkspaceResult> {
-  readonly type: "workspace:resolve";
-  readonly payload: ResolveWorkspacePayload;
-}
-
 export const INTENT_RESOLVE_WORKSPACE = "workspace:resolve" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const RESOLVE_WORKSPACE_OPERATION_ID = "resolve-workspace";
 
-/** Input context for "resolve" handlers. */
-export interface ResolveHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
 
-/** Per-handler result for "resolve" hook point. */
-export interface ResolveHookResult {
-  readonly projectPath?: string;
-  readonly workspaceName?: WorkspaceName;
-  readonly active?: boolean;
-  readonly branch?: string | null;
-}
+export const resolveWorkspacePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+  })
+  .readonly();
+
+export const resolveWorkspaceResultSchema = z
+  .object({
+    projectPath: z.string(),
+    workspaceName: workspaceNameSchema,
+    active: z.boolean(),
+    /** Current branch name, or null for detached HEAD. */
+    branch: z.string().nullable(),
+  })
+  .readonly();
+
+/** Per-handler result for "resolve" (fields optional — each handler contributes a subset). */
+export const resolveHookResultSchema = z
+  .object({
+    projectPath: z.string().optional(),
+    workspaceName: workspaceNameSchema.optional(),
+    active: z.boolean().optional(),
+    branch: z.string().nullable().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "resolve" hook point (beyond the base HookContext). */
+const resolveEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "resolve" (its inferred type isn't the ctx type). */
+export const resolveHookInputSchema = hookCtxSchema(
+  resolveWorkspacePayloadSchema,
+  resolveEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_RESOLVE_WORKSPACE,
+  payload: resolveWorkspacePayloadSchema,
+  result: resolveWorkspaceResultSchema,
+  hooks: {
+    resolve: { input: resolveHookInputSchema, result: resolveHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type ResolveWorkspacePayload = z.infer<typeof resolveWorkspacePayloadSchema>;
+export type ResolveWorkspaceResult = z.infer<typeof resolveWorkspaceResultSchema>;
+export type ResolveWorkspaceIntent = IntentOf<typeof schemas>;
+export type ResolveHookResult = z.infer<typeof resolveHookResultSchema>;
+
+/** Whole input context for "resolve" handlers: base envelope + inferred enrichment. */
+export type ResolveHookInput = HookContext & z.infer<typeof resolveEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class ResolveWorkspaceOperation implements Operation<
-  ResolveWorkspaceIntent,
-  ResolveWorkspaceResult
-> {
+export class ResolveWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = RESOLVE_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<ResolveWorkspaceIntent>): Promise<ResolveWorkspaceResult> {
     const { payload } = ctx.intent;
@@ -79,7 +103,7 @@ export class ResolveWorkspaceOperation implements Operation<
     throwHookErrors(errors, "workspace:resolve hooks failed");
 
     let projectPath: string | undefined;
-    let workspaceName: WorkspaceName | undefined;
+    let workspaceName: ResolveWorkspaceResult["workspaceName"] | undefined;
     let active = false;
     // branch can legitimately be null (detached HEAD), so track "provided"
     // separately from the null value.

--- a/src/intents/restart-agent.integration.test.ts
+++ b/src/intents/restart-agent.integration.test.ts
@@ -76,7 +76,7 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
+  dispatcher.registerOperation(new RestartAgentOperation());
 
   registerTestInfrastructure(dispatcher, {
     workspaces: { [WORKSPACE_PATH]: { projectPath: PROJECT_ROOT, workspaceName } },

--- a/src/intents/restart-agent.ts
+++ b/src/intents/restart-agent.ts
@@ -9,75 +9,106 @@
  * On success, emits an agent:restarted domain event.
  *
  * No provider dependencies - the hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook/event
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent`, result,
+ * and event-payload types are **derived** from that bundle via `IntentOf`/`z.infer`.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface RestartAgentPayload {
-  readonly workspacePath: string;
-}
-
-export interface RestartAgentIntent extends Intent<number> {
-  readonly type: "agent:restart";
-  readonly payload: RestartAgentPayload;
-}
-
 export const INTENT_RESTART_AGENT = "agent:restart" as const;
 
+export const RESTART_AGENT_OPERATION_ID = "restart-agent";
+
+const EVENT_AGENT_RESTARTED = "agent:restarted" as const;
+
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface AgentRestartedPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly path: string;
-  readonly port: number;
-}
+export const restartAgentPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+  })
+  .readonly();
+
+/** Operation return value — the port the restarted agent server listens on. */
+export const restartAgentResultSchema = z.number();
+
+export const agentRestartedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    path: z.string(),
+    port: z.number(),
+  })
+  .readonly();
+
+/**
+ * Per-handler result contract for the "restart" hook point.
+ * Each handler returns its contribution — the operation merges them.
+ */
+export const restartAgentHookResultSchema = z
+  .object({
+    port: z.number().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "restart" hook point (beyond the base HookContext). */
+const restartEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "restart". */
+export const restartAgentHookInputSchema = hookCtxSchema(
+  restartAgentPayloadSchema,
+  restartEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_RESTART_AGENT,
+  payload: restartAgentPayloadSchema,
+  result: restartAgentResultSchema,
+  hooks: {
+    restart: { input: restartAgentHookInputSchema, result: restartAgentHookResultSchema },
+  },
+  events: {
+    [EVENT_AGENT_RESTARTED]: agentRestartedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type RestartAgentPayload = z.infer<typeof restartAgentPayloadSchema>;
+export type RestartAgentIntent = IntentOf<typeof schemas>;
+export type RestartAgentHookResult = z.infer<typeof restartAgentHookResultSchema>;
+export type AgentRestartedPayload = z.infer<typeof agentRestartedPayloadSchema>;
 
 export interface AgentRestartedEvent extends DomainEvent {
   readonly type: "agent:restarted";
   readonly payload: AgentRestartedPayload;
 }
 
-const EVENT_AGENT_RESTARTED = "agent:restarted" as const;
-
-// =============================================================================
-// Hook Result & Input Types
-// =============================================================================
-
-export const RESTART_AGENT_OPERATION_ID = "restart-agent";
-
-/** Input context for the "restart" hook point. */
-export interface RestartAgentHookInput extends HookContext {
-  readonly workspacePath: string;
-}
-
-/**
- * Per-handler result contract for the "restart" hook point.
- * Each handler returns its contribution — the operation merges them.
- */
-export interface RestartAgentHookResult {
-  readonly port?: number;
-}
+/** Input context for the "restart" hook point: base envelope + inferred enrichment. */
+export type RestartAgentHookInput = HookContext & z.infer<typeof restartEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class RestartAgentOperation extends WorkspaceHookOperation<
-  RestartAgentIntent,
-  RestartAgentHookResult,
-  number
+  typeof schemas,
+  RestartAgentHookResult
 > {
+  readonly schemas = schemas;
+
   constructor() {
     super(RESTART_AGENT_OPERATION_ID, {
       hookPoint: "restart",

--- a/src/intents/set-metadata.integration.test.ts
+++ b/src/intents/set-metadata.integration.test.ts
@@ -25,11 +25,7 @@ import {
   EVENT_METADATA_CHANGED,
 } from "./set-metadata";
 import type { SetMetadataIntent, MetadataChangedEvent, SetHookInput } from "./set-metadata";
-import {
-  GetMetadataOperation,
-  GET_METADATA_OPERATION_ID,
-  INTENT_GET_METADATA,
-} from "./get-metadata";
+import { GetMetadataOperation, GET_METADATA_OPERATION_ID } from "./get-metadata";
 import type { GetMetadataHookResult, GetHookInput } from "./get-metadata";
 import { registerTestInfrastructure } from "./operations.test-utils";
 import { Path } from "../utils/path/path";
@@ -70,8 +66,8 @@ function createTestSetup(): TestSetup {
   const dispatcher = createMockDispatcher();
 
   // Register operations
-  dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-  dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
+  dispatcher.registerOperation(new SetMetadataOperation());
+  dispatcher.registerOperation(new GetMetadataOperation());
 
   // Register infrastructure operations (resolve-workspace, resolve-project, etc.)
   registerTestInfrastructure(dispatcher, {

--- a/src/intents/set-metadata.ts
+++ b/src/intents/set-metadata.ts
@@ -9,60 +9,82 @@
  * No provider dependencies - hook handlers do the actual work.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 
+export const INTENT_SET_METADATA = "workspace:set-metadata" as const;
+export const EVENT_METADATA_CHANGED = "workspace:metadata-changed" as const;
+export const SET_METADATA_OPERATION_ID = "set-metadata";
+
 // =============================================================================
-// Intent + Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface SetMetadataPayload {
-  readonly workspacePath: string;
-  readonly key: string;
-  readonly value: string | null;
-}
+export const setMetadataPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    key: z.string(),
+    value: z.string().nullable(),
+  })
+  .readonly();
 
-export interface SetMetadataIntent extends Intent<void> {
-  readonly type: "workspace:set-metadata";
-  readonly payload: SetMetadataPayload;
-}
+export const metadataChangedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    workspacePath: z.string(),
+    key: z.string(),
+    value: z.string().nullable(),
+  })
+  .readonly();
 
-export interface MetadataChangedPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-  readonly key: string;
-  readonly value: string | null;
-}
+/** Operation-added enrichment for the "set" hook point (beyond the base HookContext). */
+const setEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for the "set" hook point. */
+export const setHookInputSchema = hookCtxSchema(
+  setMetadataPayloadSchema,
+  setEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_SET_METADATA,
+  payload: setMetadataPayloadSchema,
+  hooks: {
+    set: { input: setHookInputSchema },
+  },
+  events: {
+    [EVENT_METADATA_CHANGED]: metadataChangedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type SetMetadataPayload = z.infer<typeof setMetadataPayloadSchema>;
+export type SetMetadataIntent = IntentOf<typeof schemas>;
+export type MetadataChangedPayload = z.infer<typeof metadataChangedPayloadSchema>;
 
 export interface MetadataChangedEvent extends DomainEvent {
   readonly type: "workspace:metadata-changed";
   readonly payload: MetadataChangedPayload;
 }
 
-export const INTENT_SET_METADATA = "workspace:set-metadata" as const;
-export const EVENT_METADATA_CHANGED = "workspace:metadata-changed" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
-export const SET_METADATA_OPERATION_ID = "set-metadata";
-
-/**
- * Input context for "set" handlers — built from resolve results.
- */
-export interface SetHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+/** Input context for "set" handlers — built from resolve results. */
+export type SetHookInput = HookContext & z.infer<typeof setEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
-export class SetMetadataOperation extends WorkspaceHookOperation<SetMetadataIntent, void, void> {
+export class SetMetadataOperation extends WorkspaceHookOperation<typeof schemas, void> {
+  readonly schemas = schemas;
+
   constructor() {
     super(SET_METADATA_OPERATION_ID, {
       hookPoint: "set",

--- a/src/intents/set-shortcut-active.ts
+++ b/src/intents/set-shortcut-active.ts
@@ -9,49 +9,67 @@
  * dialog/hover/workspace).
  *
  * No hooks — just emits the event. (Replaces the deleted ui:set-mode intent.)
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/event schemas are
+ * declared once and hung on the operation's `schemas` field; the `Intent` and event-payload
+ * types are **derived** from that bundle via `IntentOf`/`z.infer`. The result is void.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext } from "./lib/operation";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface SetShortcutActivePayload {
-  readonly active: boolean;
-}
-
-export interface SetShortcutActiveIntent extends Intent<void> {
-  readonly type: "ui:set-shortcut-active";
-  readonly payload: SetShortcutActivePayload;
-}
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 
 export const INTENT_SET_SHORTCUT_ACTIVE = "ui:set-shortcut-active" as const;
 
+export const EVENT_SHORTCUT_ACTIVE_CHANGED = "ui:shortcut-active-changed" as const;
+
+export const SET_SHORTCUT_ACTIVE_OPERATION_ID = "set-shortcut-active";
+
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface ShortcutActiveChangedPayload {
-  readonly active: boolean;
-}
+export const setShortcutActivePayloadSchema = z
+  .object({
+    active: z.boolean(),
+  })
+  .readonly();
+
+export const shortcutActiveChangedPayloadSchema = z
+  .object({
+    active: z.boolean(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_SET_SHORTCUT_ACTIVE,
+  payload: setShortcutActivePayloadSchema,
+  events: {
+    [EVENT_SHORTCUT_ACTIVE_CHANGED]: shortcutActiveChangedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type SetShortcutActivePayload = z.infer<typeof setShortcutActivePayloadSchema>;
+export type SetShortcutActiveIntent = IntentOf<typeof schemas>;
+export type ShortcutActiveChangedPayload = z.infer<typeof shortcutActiveChangedPayloadSchema>;
 
 export interface ShortcutActiveChangedEvent extends DomainEvent {
   readonly type: "ui:shortcut-active-changed";
   readonly payload: ShortcutActiveChangedPayload;
 }
 
-export const EVENT_SHORTCUT_ACTIVE_CHANGED = "ui:shortcut-active-changed" as const;
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-export const SET_SHORTCUT_ACTIVE_OPERATION_ID = "set-shortcut-active";
-
-export class SetShortcutActiveOperation implements Operation<SetShortcutActiveIntent, void> {
+export class SetShortcutActiveOperation implements Operation<typeof schemas> {
   readonly id = SET_SHORTCUT_ACTIVE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<SetShortcutActiveIntent>): Promise<void> {
     const event: ShortcutActiveChangedEvent = {

--- a/src/intents/setup.ts
+++ b/src/intents/setup.ts
@@ -14,119 +14,201 @@
  * On failure, emits setup:error domain event for renderer error UI.
  *
  * No provider dependencies - hook handlers do the actual work.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/hook/event
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent`, hook,
+ * and event types are **derived** from that bundle — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ConfigAgentType, SetupRowId, SetupRowStatus } from "../shared/api/types";
-import type { BinaryType } from "../utils/binary-resolution/types";
-import type { ExtensionInstallEntry } from "./app-start";
+import { z } from "zod/v4";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import type { ConfigAgentType } from "../shared/api/types";
+import {
+  configAgentTypeSchema,
+  setupRowIdSchema,
+  setupRowStatusSchema,
+  hookCtxSchema,
+} from "./contract";
 import type { LifecycleAgentType } from "../shared/ipc";
 import { throwHookErrors } from "./lib/hook-helpers";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface SetupPayload {
-  /** True if agent selection is needed */
-  readonly needsAgentSelection?: boolean;
-  /** True if binary download is needed */
-  readonly needsBinaryDownload?: boolean;
-  /** List of binaries that need download */
-  readonly missingBinaries?: readonly BinaryType[];
-  /** True if extensions need install */
-  readonly needsExtensions?: boolean;
-  /** Extensions to install (from check-deps install plan) */
-  readonly extensionInstallPlan?: readonly ExtensionInstallEntry[];
-  /** Currently configured agent (may be null) */
-  readonly configuredAgent?: ConfigAgentType | null;
-}
-
-export interface SetupIntent extends Intent<void> {
-  readonly type: "app:setup";
-  readonly payload: SetupPayload;
-}
-
 export const INTENT_SETUP = "app:setup" as const;
-
-// =============================================================================
-// Hook Context
-// =============================================================================
-
 export const SETUP_OPERATION_ID = "setup";
+
+export const EVENT_SETUP_PROGRESS = "setup:progress" as const;
+export const EVENT_SETUP_ERROR = "setup:error" as const;
+
+// =============================================================================
+// Local schemas (types missing from the shared contract)
+// =============================================================================
+
+/** Binaries the setup flow can download. Local schema; mirrors binary-resolution's BinaryType. */
+const binaryTypeSchema = z.enum(["code-server", "vscodium", "opencode", "claude"]);
+
+/** Selectable agent backend. Local schema; mirrors shared/ipc's LifecycleAgentType. */
+const lifecycleAgentTypeSchema = z.enum(["opencode", "claude"]);
+
+/** What needs to be installed. Local schema; mirrors app-start's ExtensionInstallEntry. */
+const extensionInstallEntrySchema = z
+  .object({
+    id: z.string(),
+    vsixPath: z.string(),
+  })
+  .readonly();
+
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const setupPayloadSchema = z
+  .object({
+    /** True if agent selection is needed */
+    needsAgentSelection: z.boolean().optional(),
+    /** True if binary download is needed */
+    needsBinaryDownload: z.boolean().optional(),
+    /** List of binaries that need download */
+    missingBinaries: z.array(binaryTypeSchema).readonly().optional(),
+    /** True if extensions need install */
+    needsExtensions: z.boolean().optional(),
+    /** Extensions to install (from check-deps install plan) */
+    extensionInstallPlan: z.array(extensionInstallEntrySchema).readonly().optional(),
+    /** Currently configured agent (may be null) */
+    configuredAgent: configAgentTypeSchema.nullable().optional(),
+  })
+  .readonly();
+
+// =============================================================================
+// Per-hook-point schemas
+// =============================================================================
 
 /**
  * Per-handler result contract for the "register-agents" hook point.
  * Each per-agent module returns its agent info for the selection UI.
  */
-export interface RegisterAgentResult {
-  readonly agent: LifecycleAgentType;
-  readonly label: string;
-  readonly icon: string;
-}
+export const registerAgentResultSchema = z
+  .object({
+    agent: lifecycleAgentTypeSchema,
+    label: z.string(),
+    icon: z.string(),
+  })
+  .readonly();
 
 // selectedAgent is the agent-selection hook *result* (operation-consumed, not a
 // capability — nothing in the hook point requires it).
 
+/** Operation-added enrichment for the "agent-selection" hook (available agents from register-agents). */
+const agentSelectionEnrichmentSchema = z.object({
+  availableAgents: z.array(registerAgentResultSchema).readonly(),
+});
+const agentSelectionInputSchema = hookCtxSchema(
+  setupPayloadSchema,
+  agentSelectionEnrichmentSchema.shape
+);
+
+/** Operation-added enrichment for the "save-agent" hook (selectedAgent from agent-selection). */
+const saveAgentEnrichmentSchema = z.object({ selectedAgent: configAgentTypeSchema });
+const saveAgentInputSchema = hookCtxSchema(setupPayloadSchema, saveAgentEnrichmentSchema.shape);
+
+/**
+ * Operation-added enrichment for the "binary" hook (agent + binary info from payload/selection).
+ * Progress is streamed by the handler (an async generator that yields `SetupProgressPayload`
+ * frames); the operation emits `setup:progress` for each — no `report` closure in the context.
+ */
+const binaryEnrichmentSchema = z.object({
+  selectedAgent: configAgentTypeSchema.optional(),
+  configuredAgent: configAgentTypeSchema.nullable().optional(),
+  missingBinaries: z.array(binaryTypeSchema).readonly().optional(),
+});
+const binaryInputSchema = hookCtxSchema(setupPayloadSchema, binaryEnrichmentSchema.shape);
+
+/**
+ * Operation-added enrichment for the "extensions" hook (install plan from payload).
+ * Progress streams the same way as the "binary" hook (yielded frames, not a closure).
+ */
+const extensionsEnrichmentSchema = z.object({
+  extensionInstallPlan: z.array(extensionInstallEntrySchema).readonly().optional(),
+});
+const extensionsInputSchema = hookCtxSchema(setupPayloadSchema, extensionsEnrichmentSchema.shape);
+
+// =============================================================================
+// Event payload schemas (events defined in this file)
+// =============================================================================
+
+const setupProgressSchema = z
+  .object({
+    id: setupRowIdSchema,
+    status: setupRowStatusSchema,
+    message: z.string().optional(),
+    error: z.string().optional(),
+    progress: z.number().optional(),
+  })
+  .readonly();
+
+const setupErrorSchema = z
+  .object({
+    message: z.string(),
+    code: z.string().optional(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_SETUP,
+  payload: setupPayloadSchema,
+  hooks: {
+    "register-agents": { result: registerAgentResultSchema },
+    "agent-selection": {
+      input: agentSelectionInputSchema,
+      result: lifecycleAgentTypeSchema,
+    },
+    "save-agent": { input: saveAgentInputSchema },
+    binary: { input: binaryInputSchema },
+    extensions: { input: extensionsInputSchema },
+  },
+  events: {
+    [EVENT_SETUP_PROGRESS]: setupProgressSchema,
+    [EVENT_SETUP_ERROR]: setupErrorSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type SetupPayload = z.infer<typeof setupPayloadSchema>;
+export type SetupIntent = IntentOf<typeof schemas>;
+
+export type RegisterAgentResult = z.infer<typeof registerAgentResultSchema>;
+
 /**
  * Input context for the "agent-selection" hook — carries available agents from register-agents.
  */
-export interface AgentSelectionHookContext extends HookContext {
-  readonly availableAgents: readonly RegisterAgentResult[];
-}
+export type AgentSelectionHookContext = HookContext &
+  z.infer<typeof agentSelectionEnrichmentSchema>;
 
 /**
  * Input context for the "save-agent" hook — carries selectedAgent from agent-selection.
  */
-export interface SaveAgentHookInput extends HookContext {
-  readonly selectedAgent: ConfigAgentType;
-}
+export type SaveAgentHookInput = HookContext & z.infer<typeof saveAgentEnrichmentSchema>;
 
 /**
  * Input context for the "binary" hook — carries agent and binary info from payload/selection.
- * Progress is streamed by the handler (an async generator that yields `SetupProgressPayload`
- * frames); the operation emits `setup:progress` for each — no `report` closure in the context.
  */
-export interface BinaryHookInput extends HookContext {
-  readonly selectedAgent?: ConfigAgentType;
-  readonly configuredAgent?: ConfigAgentType | null;
-  readonly missingBinaries?: readonly BinaryType[];
-}
+export type BinaryHookInput = HookContext & z.infer<typeof binaryEnrichmentSchema>;
 
 /**
  * Input context for the "extensions" hook — carries install plan from payload.
- * Progress streams the same way as the "binary" hook (yielded frames, not a closure).
  */
-export interface ExtensionsHookInput extends HookContext {
-  readonly extensionInstallPlan?: readonly ExtensionInstallEntry[];
-}
+export type ExtensionsHookInput = HookContext & z.infer<typeof extensionsEnrichmentSchema>;
 
-// =============================================================================
-// Domain Events
-// =============================================================================
-
-export const EVENT_SETUP_PROGRESS = "setup:progress" as const;
-
-export interface SetupProgressPayload {
-  readonly id: SetupRowId;
-  readonly status: SetupRowStatus;
-  readonly message?: string;
-  readonly error?: string;
-  readonly progress?: number;
-}
+export type SetupProgressPayload = z.infer<typeof setupProgressSchema>;
 
 export interface SetupProgressEvent {
   readonly type: typeof EVENT_SETUP_PROGRESS;
   readonly payload: SetupProgressPayload;
 }
 
-export const EVENT_SETUP_ERROR = "setup:error" as const;
-
-export interface SetupErrorPayload {
-  readonly message: string;
-  readonly code?: string;
-}
+export type SetupErrorPayload = z.infer<typeof setupErrorSchema>;
 
 export interface SetupErrorEvent {
   readonly type: typeof EVENT_SETUP_ERROR;
@@ -137,8 +219,9 @@ export interface SetupErrorEvent {
 // Operation
 // =============================================================================
 
-export class SetupOperation implements Operation<SetupIntent, void> {
+export class SetupOperation implements Operation<typeof schemas> {
   readonly id = SETUP_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<SetupIntent>): Promise<void> {
     const { payload } = ctx.intent;

--- a/src/intents/shortcut-key.ts
+++ b/src/intents/shortcut-key.ts
@@ -3,49 +3,67 @@
  *
  * No hooks needed — just emits a domain event for subscribers
  * (IPC bridge, DevTools module, etc.) to react to.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/event schemas are
+ * declared once and hung on the operation's `schemas` field; the `Intent` and event-payload
+ * types are **derived** from that bundle via `IntentOf`/`z.infer`. The result is void.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext } from "./lib/operation";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface ShortcutKeyPayload {
-  readonly key: string;
-}
-
-export interface ShortcutKeyIntent extends Intent<void> {
-  readonly type: "shortcut:key";
-  readonly payload: ShortcutKeyPayload;
-}
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 
 export const INTENT_SHORTCUT_KEY = "shortcut:key" as const;
 
+export const EVENT_SHORTCUT_KEY_PRESSED = "shortcut:key-pressed" as const;
+
+const SHORTCUT_KEY_OPERATION_ID = "shortcut-key";
+
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface ShortcutKeyPressedPayload {
-  readonly key: string;
-}
+export const shortcutKeyPayloadSchema = z
+  .object({
+    key: z.string(),
+  })
+  .readonly();
+
+export const shortcutKeyPressedPayloadSchema = z
+  .object({
+    key: z.string(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_SHORTCUT_KEY,
+  payload: shortcutKeyPayloadSchema,
+  events: {
+    [EVENT_SHORTCUT_KEY_PRESSED]: shortcutKeyPressedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type ShortcutKeyPayload = z.infer<typeof shortcutKeyPayloadSchema>;
+export type ShortcutKeyIntent = IntentOf<typeof schemas>;
+export type ShortcutKeyPressedPayload = z.infer<typeof shortcutKeyPressedPayloadSchema>;
 
 export interface ShortcutKeyPressedEvent extends DomainEvent {
   readonly type: "shortcut:key-pressed";
   readonly payload: ShortcutKeyPressedPayload;
 }
 
-export const EVENT_SHORTCUT_KEY_PRESSED = "shortcut:key-pressed" as const;
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-const SHORTCUT_KEY_OPERATION_ID = "shortcut-key";
-
-export class ShortcutKeyOperation implements Operation<ShortcutKeyIntent, void> {
+export class ShortcutKeyOperation implements Operation<typeof schemas> {
   readonly id = SHORTCUT_KEY_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<ShortcutKeyIntent>): Promise<void> {
     const event: ShortcutKeyPressedEvent = {

--- a/src/intents/submit-bug-report.ts
+++ b/src/intents/submit-bug-report.ts
@@ -3,49 +3,67 @@
  *
  * No hooks needed — just emits a domain event for subscribers
  * (PostHog module) to react to.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/event schemas are
+ * declared once and hung on the operation's `schemas` field; the `Intent` and event-payload
+ * types are **derived** from that bundle via `IntentOf`/`z.infer`. The result is void.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext } from "./lib/operation";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface SubmitBugReportPayload {
-  readonly description: string;
-}
-
-export interface SubmitBugReportIntent extends Intent<void> {
-  readonly type: "bug-report:submit";
-  readonly payload: SubmitBugReportPayload;
-}
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 
 export const INTENT_SUBMIT_BUG_REPORT = "bug-report:submit" as const;
 
+export const EVENT_BUG_REPORT_SUBMITTED = "bug-report:submitted" as const;
+
+export const SUBMIT_BUG_REPORT_OPERATION_ID = "submit-bug-report";
+
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface BugReportSubmittedPayload {
-  readonly description: string;
-}
+export const submitBugReportPayloadSchema = z
+  .object({
+    description: z.string(),
+  })
+  .readonly();
+
+export const bugReportSubmittedPayloadSchema = z
+  .object({
+    description: z.string(),
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_SUBMIT_BUG_REPORT,
+  payload: submitBugReportPayloadSchema,
+  events: {
+    [EVENT_BUG_REPORT_SUBMITTED]: bugReportSubmittedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type SubmitBugReportPayload = z.infer<typeof submitBugReportPayloadSchema>;
+export type SubmitBugReportIntent = IntentOf<typeof schemas>;
+export type BugReportSubmittedPayload = z.infer<typeof bugReportSubmittedPayloadSchema>;
 
 export interface BugReportSubmittedEvent extends DomainEvent {
   readonly type: "bug-report:submitted";
   readonly payload: BugReportSubmittedPayload;
 }
 
-export const EVENT_BUG_REPORT_SUBMITTED = "bug-report:submitted" as const;
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-export const SUBMIT_BUG_REPORT_OPERATION_ID = "submit-bug-report";
-
-export class SubmitBugReportOperation implements Operation<SubmitBugReportIntent, void> {
+export class SubmitBugReportOperation implements Operation<typeof schemas> {
   readonly id = SUBMIT_BUG_REPORT_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<SubmitBugReportIntent>): Promise<void> {
     const event: BugReportSubmittedEvent = {

--- a/src/intents/switch-workspace.ts
+++ b/src/intents/switch-workspace.ts
@@ -22,131 +22,184 @@
  * No provider dependencies - the hook handlers do the actual work.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import type { WorkspacePath } from "../shared/ipc";
+import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
+export const INTENT_SWITCH_WORKSPACE = "workspace:switch" as const;
+export const EVENT_WORKSPACE_SWITCHED = "workspace:switched" as const;
+export const SWITCH_WORKSPACE_OPERATION_ID = "switch-workspace";
+
 // =============================================================================
-// Intent Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
 /** Specific-target payload: switch to a known workspace, or deselect.
  *  `workspacePath: null` deselects the active workspace — no workspace is
  *  active afterwards and the creation panel becomes the main view (it is the
  *  ground state when nothing is selected). `focus` is ignored for null. */
-export interface SwitchWorkspaceTargetPayload {
-  readonly workspacePath: string | null;
-  readonly focus?: boolean;
-}
+export const switchWorkspaceTargetPayloadSchema = z
+  .object({
+    workspacePath: z.string().nullable(),
+    focus: z.boolean().optional(),
+  })
+  .readonly();
 
 /** Auto-select payload: find the best workspace after deletion. */
-export interface SwitchWorkspaceAutoPayload {
-  readonly auto: true;
-  readonly currentPath: string;
-  readonly focus?: boolean;
-  /** When true, if no other candidate is selectable, switch to currentPath
-   *  instead of emitting workspace:switched(null). Used by hibernate so the
-   *  user lands on the hibernation overlay rather than the empty backdrop
-   *  when the only workspace was just hibernated. */
-  readonly fallbackToCurrent?: boolean;
-}
+export const switchWorkspaceAutoPayloadSchema = z
+  .object({
+    auto: z.literal(true),
+    currentPath: z.string(),
+    focus: z.boolean().optional(),
+    /** When true, if no other candidate is selectable, switch to currentPath
+     *  instead of emitting workspace:switched(null). Used by hibernate so the
+     *  user lands on the hibernation overlay rather than the empty backdrop
+     *  when the only workspace was just hibernated. */
+    fallbackToCurrent: z.boolean().optional(),
+  })
+  .readonly();
 
-export type SwitchWorkspacePayload = SwitchWorkspaceTargetPayload | SwitchWorkspaceAutoPayload;
+export const switchWorkspacePayloadSchema = z.union([
+  switchWorkspaceTargetPayloadSchema,
+  switchWorkspaceAutoPayloadSchema,
+]);
 
-/** Type guard for auto-select mode. */
-function isAutoSwitch(payload: SwitchWorkspacePayload): payload is SwitchWorkspaceAutoPayload {
-  return "auto" in payload && payload.auto === true;
-}
+/** A workspace candidate returned by the "find-candidates" hook. */
+export const workspaceCandidateSchema = z
+  .object({
+    projectPath: z.string(),
+    projectName: z.string(),
+    workspacePath: z.string(),
+    /** Stored workspace name (original case) — used for alphabetical ordering. */
+    workspaceName: z.string(),
+    /** True when the candidate is hibernated. Hibernated candidates are excluded
+     *  from auto-switch — hibernation is always opt-in to wake. */
+    hibernated: z.boolean().optional(),
+  })
+  .readonly();
 
-export interface SwitchWorkspaceIntent extends Intent<void> {
-  readonly type: "workspace:switch";
-  readonly payload: SwitchWorkspacePayload;
-}
-
-export const INTENT_SWITCH_WORKSPACE = "workspace:switch" as const;
-
-// =============================================================================
-// Event Types
-// =============================================================================
-
-export interface WorkspaceSwitchedPayload {
-  readonly projectId: ProjectId;
-  readonly projectName: string;
-  readonly projectPath: string;
-  readonly workspaceName: WorkspaceName;
-  readonly path: string;
-}
-
-export interface WorkspaceSwitchedEvent extends DomainEvent {
-  readonly type: "workspace:switched";
-  readonly payload: WorkspaceSwitchedPayload | null;
-}
-
-export const EVENT_WORKSPACE_SWITCHED = "workspace:switched" as const;
-
-// =============================================================================
-// Hook Result & Input Types
-// =============================================================================
-
-export const SWITCH_WORKSPACE_OPERATION_ID = "switch-workspace";
-
-/** Input context for the "activate" hook point. `workspacePath: null` =
- *  deselect (clear the active workspace). */
-export interface ActivateHookInput extends HookContext {
-  readonly workspacePath: string | null;
-  readonly active: boolean;
-}
+export const workspaceSwitchedPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    projectName: z.string(),
+    projectPath: z.string(),
+    workspaceName: workspaceNameSchema,
+    path: z.string(),
+  })
+  .readonly();
 
 /**
  * Per-handler result contract for the "activate" hook point.
  * Each handler returns its contribution — the operation merges them.
  * Empty `{}` for no-op case (workspace already active).
  */
-export interface SwitchWorkspaceHookResult {
-  readonly resolvedPath?: string;
-}
-
-// =============================================================================
-// Auto-Select Types
-// =============================================================================
-
-/** A workspace candidate returned by the "find-candidates" hook. */
-export interface WorkspaceCandidate {
-  readonly projectPath: string;
-  readonly projectName: string;
-  readonly workspacePath: string;
-  /** Stored workspace name (original case) — used for alphabetical ordering. */
-  readonly workspaceName: string;
-  /** True when the candidate is hibernated. Hibernated candidates are excluded
-   *  from auto-switch — hibernation is always opt-in to wake. */
-  readonly hibernated?: boolean;
-}
+export const switchWorkspaceHookResultSchema = z
+  .object({
+    resolvedPath: z.string().optional(),
+  })
+  .readonly();
 
 /** Per-handler result for the "find-candidates" hook point. */
-export interface FindCandidatesHookResult {
-  readonly candidates?: readonly WorkspaceCandidate[];
-}
-
-/** Input context for the "select-next" hook point. */
-export interface SelectNextHookInput extends HookContext {
-  readonly currentPath: string;
-  readonly candidates: readonly WorkspaceCandidate[];
-}
+export const findCandidatesHookResultSchema = z
+  .object({
+    candidates: z.array(workspaceCandidateSchema).readonly().optional(),
+  })
+  .readonly();
 
 /** Per-handler result for the "select-next" hook point. */
-export interface SelectNextHookResult {
-  readonly selected?: WorkspaceCandidate;
+export const selectNextHookResultSchema = z
+  .object({
+    selected: workspaceCandidateSchema.optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "activate" hook point. `workspacePath: null`
+ *  = deselect (clear the active workspace). */
+const activateEnrichmentSchema = z.object({
+  workspacePath: z.string().nullable(),
+  active: z.boolean(),
+});
+
+/** Runtime whole-context validation schema for the "activate" hook point. */
+export const activateHookInputSchema = hookCtxSchema(
+  switchWorkspacePayloadSchema,
+  activateEnrichmentSchema.shape
+);
+
+/** Operation-added enrichment for the "select-next" hook point. */
+const selectNextEnrichmentSchema = z.object({
+  currentPath: z.string(),
+  candidates: z.array(workspaceCandidateSchema).readonly(),
+});
+
+/** Runtime whole-context validation schema for the "select-next" hook point. */
+export const selectNextHookInputSchema = hookCtxSchema(
+  switchWorkspacePayloadSchema,
+  selectNextEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_SWITCH_WORKSPACE,
+  payload: switchWorkspacePayloadSchema,
+  hooks: {
+    activate: { input: activateHookInputSchema, result: switchWorkspaceHookResultSchema },
+    "find-candidates": { result: findCandidatesHookResultSchema },
+    "select-next": { input: selectNextHookInputSchema, result: selectNextHookResultSchema },
+  },
+  events: {
+    [EVENT_WORKSPACE_SWITCHED]: workspaceSwitchedPayloadSchema.nullable(),
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type SwitchWorkspaceTargetPayload = z.infer<typeof switchWorkspaceTargetPayloadSchema>;
+export type SwitchWorkspaceAutoPayload = z.infer<typeof switchWorkspaceAutoPayloadSchema>;
+export type SwitchWorkspacePayload = z.infer<typeof switchWorkspacePayloadSchema>;
+export type SwitchWorkspaceIntent = IntentOf<typeof schemas>;
+
+export type WorkspaceSwitchedPayload = z.infer<typeof workspaceSwitchedPayloadSchema>;
+
+export interface WorkspaceSwitchedEvent extends DomainEvent {
+  readonly type: "workspace:switched";
+  readonly payload: WorkspaceSwitchedPayload | null;
 }
+
+/** A workspace candidate returned by the "find-candidates" hook. */
+export type WorkspaceCandidate = z.infer<typeof workspaceCandidateSchema>;
+
+/** Per-handler result for the "activate" hook point. */
+export type SwitchWorkspaceHookResult = z.infer<typeof switchWorkspaceHookResultSchema>;
+/** Per-handler result for the "find-candidates" hook point. */
+export type FindCandidatesHookResult = z.infer<typeof findCandidatesHookResultSchema>;
+/** Per-handler result for the "select-next" hook point. */
+export type SelectNextHookResult = z.infer<typeof selectNextHookResultSchema>;
+
+/** Input context for the "activate" hook point. `workspacePath: null` =
+ *  deselect (clear the active workspace). */
+export type ActivateHookInput = HookContext & z.infer<typeof activateEnrichmentSchema>;
+
+/** Input context for the "select-next" hook point. */
+export type SelectNextHookInput = HookContext & z.infer<typeof selectNextEnrichmentSchema>;
 
 /**
  * Agent status scorer function. Given a workspace path, returns a numeric score:
  * 0 = idle (preferred), 1 = busy, 2 = none/unknown.
  */
 export type AgentStatusScorer = (workspacePath: WorkspacePath) => number;
+
+/** Type guard for auto-select mode. */
+function isAutoSwitch(payload: SwitchWorkspacePayload): payload is SwitchWorkspaceAutoPayload {
+  return "auto" in payload && payload.auto === true;
+}
 
 // =============================================================================
 // Selection Algorithm
@@ -223,8 +276,9 @@ export function selectNextWorkspace(
 // Operation
 // =============================================================================
 
-export class SwitchWorkspaceOperation implements Operation<SwitchWorkspaceIntent, void> {
+export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = SWITCH_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<SwitchWorkspaceIntent>): Promise<void> {
     const { payload } = ctx.intent;

--- a/src/intents/update-agent-status.integration.test.ts
+++ b/src/intents/update-agent-status.integration.test.ts
@@ -12,11 +12,7 @@ import { createMockDispatcher } from "./lib/dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
 import { Dispatcher } from "./lib/dispatcher";
 
-import {
-  UpdateAgentStatusOperation,
-  INTENT_UPDATE_AGENT_STATUS,
-  EVENT_AGENT_STATUS_UPDATED,
-} from "./update-agent-status";
+import { UpdateAgentStatusOperation, EVENT_AGENT_STATUS_UPDATED } from "./update-agent-status";
 import type { AgentStatusUpdatedEvent } from "./update-agent-status";
 import { registerTestInfrastructure, updateStatusIntent } from "./operations.test-utils";
 import type { DomainEvent } from "./lib/types";
@@ -39,7 +35,7 @@ const TEST_WORKSPACE_ENTRY = {
 function createTestSetup(): { dispatcher: Dispatcher } {
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
+  dispatcher.registerOperation(new UpdateAgentStatusOperation());
 
   registerTestInfrastructure(dispatcher, {
     // Every workspace path used by the tests resolves to the same project.
@@ -124,7 +120,7 @@ describe("UpdateAgentStatus Operation", () => {
 
     it("silently returns when resolve hooks provide no projectPath", async () => {
       const dispatcher = createMockDispatcher();
-      dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
+      dispatcher.registerOperation(new UpdateAgentStatusOperation());
 
       // Empty lookups — resolve operations will throw, and update-agent-status
       // catches the error and silently returns.

--- a/src/intents/update-agent-status.ts
+++ b/src/intents/update-agent-status.ts
@@ -6,62 +6,106 @@
  * 2. project:resolve — projectId from projectPath
  *
  * If resolution is incomplete (unknown workspace), silently returns without emitting.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/event schemas are
+ * declared once and hung on the operation's `schemas` field; the `Intent` and event-payload
+ * types are **derived** from that bundle via `IntentOf`/`z.infer`. The result is void.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext } from "./lib/operation";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, workspaceNameSchema, workspacePathSchema } from "./contract";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface UpdateAgentStatusPayload {
-  readonly workspacePath: WorkspacePath;
-  readonly status: AggregatedAgentStatus;
-}
-
-export interface UpdateAgentStatusIntent extends Intent<void> {
-  readonly type: "agent:update-status";
-  readonly payload: UpdateAgentStatusPayload;
-}
-
 export const INTENT_UPDATE_AGENT_STATUS = "agent:update-status" as const;
 
+export const EVENT_AGENT_STATUS_UPDATED = "agent:status-updated" as const;
+
+const UPDATE_AGENT_STATUS_OPERATION_ID = "update-agent-status";
+
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface AgentStatusUpdatedWorkspaceRef {
-  readonly path: WorkspacePath;
-  readonly projectId: ProjectId;
-  readonly name: WorkspaceName;
-  readonly active: boolean;
-}
+/**
+ * Local schema for `InternalAgentCounts` (from shared/ipc). Not part of the intent
+ * `contract` vocabulary, so it is defined here; its inferred type is structurally identical.
+ */
+const internalAgentCountsSchema = z
+  .object({
+    idle: z.number(),
+    busy: z.number(),
+  })
+  .readonly();
 
-export interface AgentStatusUpdatedPayload {
-  readonly workspace: AgentStatusUpdatedWorkspaceRef;
-  readonly status: AggregatedAgentStatus;
-}
+/**
+ * Local schema for `AggregatedAgentStatus` (from shared/ipc) — a discriminated union by
+ * `status`. Not part of the intent `contract` vocabulary, so it is defined here; its inferred
+ * type is structurally identical to `AggregatedAgentStatus`.
+ */
+const aggregatedAgentStatusSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("none"), counts: internalAgentCountsSchema }).readonly(),
+  z.object({ status: z.literal("idle"), counts: internalAgentCountsSchema }).readonly(),
+  z.object({ status: z.literal("busy"), counts: internalAgentCountsSchema }).readonly(),
+  z.object({ status: z.literal("mixed"), counts: internalAgentCountsSchema }).readonly(),
+]);
+
+export const updateAgentStatusPayloadSchema = z
+  .object({
+    workspacePath: workspacePathSchema,
+    status: aggregatedAgentStatusSchema,
+  })
+  .readonly();
+
+const agentStatusUpdatedWorkspaceRefSchema = z
+  .object({
+    path: workspacePathSchema,
+    projectId: projectIdSchema,
+    name: workspaceNameSchema,
+    active: z.boolean(),
+  })
+  .readonly();
+
+export const agentStatusUpdatedPayloadSchema = z
+  .object({
+    workspace: agentStatusUpdatedWorkspaceRefSchema,
+    status: aggregatedAgentStatusSchema,
+  })
+  .readonly();
+
+const schemas = {
+  type: INTENT_UPDATE_AGENT_STATUS,
+  payload: updateAgentStatusPayloadSchema,
+  events: {
+    [EVENT_AGENT_STATUS_UPDATED]: agentStatusUpdatedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type UpdateAgentStatusPayload = z.infer<typeof updateAgentStatusPayloadSchema>;
+export type UpdateAgentStatusIntent = IntentOf<typeof schemas>;
+export type AgentStatusUpdatedWorkspaceRef = z.infer<typeof agentStatusUpdatedWorkspaceRefSchema>;
+export type AgentStatusUpdatedPayload = z.infer<typeof agentStatusUpdatedPayloadSchema>;
 
 export interface AgentStatusUpdatedEvent extends DomainEvent {
   readonly type: "agent:status-updated";
   readonly payload: AgentStatusUpdatedPayload;
 }
 
-export const EVENT_AGENT_STATUS_UPDATED = "agent:status-updated" as const;
-
 // =============================================================================
 // Operation
 // =============================================================================
 
-const UPDATE_AGENT_STATUS_OPERATION_ID = "update-agent-status";
-
-export class UpdateAgentStatusOperation implements Operation<UpdateAgentStatusIntent, void> {
+export class UpdateAgentStatusOperation implements Operation<typeof schemas> {
   readonly id = UPDATE_AGENT_STATUS_OPERATION_ID;
+  readonly schemas = schemas;
 
   async execute(ctx: OperationContext<UpdateAgentStatusIntent>): Promise<void> {
     const { payload } = ctx.intent;

--- a/src/intents/vscode-command.ts
+++ b/src/intents/vscode-command.ts
@@ -7,55 +7,83 @@
  *
  * No provider dependencies - hook handlers do the actual work.
  * No domain events - this is a command pass-through operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { HookContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined } from "./lib/hook-helpers";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface VscodeCommandPayload {
-  readonly workspacePath: string;
-  readonly command: string;
-  readonly args?: readonly unknown[] | undefined;
-}
-
-export interface VscodeCommandIntent extends Intent<unknown> {
-  readonly type: "vscode:command";
-  readonly payload: VscodeCommandPayload;
-}
+import { hookCtxSchema } from "./contract";
 
 export const INTENT_VSCODE_COMMAND = "vscode:command" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const VSCODE_COMMAND_OPERATION_ID = "vscode-command";
 
-/** Input context for "execute" handlers. */
-export interface ExecuteHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const vscodeCommandPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    command: z.string(),
+    args: z.array(z.unknown()).readonly().optional(),
+  })
+  .readonly();
+
+/** Command results are pass-through — a command may legitimately return anything (or nothing). */
+export const vscodeCommandResultSchema = z.unknown();
 
 /** Per-handler result for the "execute" hook point. */
-export interface ExecuteHookResult {
-  readonly result?: unknown;
-}
+export const executeHookResultSchema = z
+  .object({
+    result: z.unknown().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "execute" hook point (beyond the base HookContext). */
+const executeEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "execute". */
+export const executeHookInputSchema = hookCtxSchema(
+  vscodeCommandPayloadSchema,
+  executeEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_VSCODE_COMMAND,
+  payload: vscodeCommandPayloadSchema,
+  result: vscodeCommandResultSchema,
+  hooks: {
+    execute: { input: executeHookInputSchema, result: executeHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type VscodeCommandPayload = z.infer<typeof vscodeCommandPayloadSchema>;
+export type VscodeCommandIntent = IntentOf<typeof schemas>;
+export type ExecuteHookResult = z.infer<typeof executeHookResultSchema>;
+
+/** Whole input context for "execute" handlers: base envelope + inferred enrichment. */
+export type ExecuteHookInput = HookContext & z.infer<typeof executeEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class VscodeCommandOperation extends WorkspaceHookOperation<
-  VscodeCommandIntent,
-  ExecuteHookResult,
-  unknown
+  typeof schemas,
+  ExecuteHookResult
 > {
+  readonly schemas = schemas;
+
   constructor() {
     super(VSCODE_COMMAND_OPERATION_ID, {
       hookPoint: "execute",

--- a/src/intents/vscode-show-message.ts
+++ b/src/intents/vscode-show-message.ts
@@ -10,64 +10,92 @@
  *
  * No provider dependencies - hook handlers do the actual work.
  * No domain events - this is a UI pass-through operation.
+ *
+ * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook
+ * schemas are declared once and hung on the operation's `schemas` field; the `Intent` and
+ * result types are **derived** from that bundle via `IntentOf`/`z.infer` — never restated.
  */
 
-import type { Intent } from "./lib/types";
-import type { HookContext } from "./lib/operation";
+import { z } from "zod/v4";
+import type { HookContext, OperationSchemas } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined } from "./lib/hook-helpers";
-
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export type VscodeShowMessageType = "info" | "warning" | "error" | "status" | "select";
-
-export interface VscodeShowMessagePayload {
-  readonly workspacePath: string;
-  readonly type: VscodeShowMessageType;
-  /** Display text. null = dismiss (only valid for status). */
-  readonly message: string | null;
-  /** Secondary text: tooltip for status, placeholder for select. */
-  readonly hint?: string;
-  /** Action buttons (notification) or selection items (select). Omit for free text input. */
-  readonly options?: readonly string[];
-  /** Timeout in milliseconds for interactive operations. */
-  readonly timeoutMs?: number;
-}
-
-export interface VscodeShowMessageIntent extends Intent<string | null> {
-  readonly type: "vscode:show-message";
-  readonly payload: VscodeShowMessagePayload;
-}
+import { hookCtxSchema } from "./contract";
 
 export const INTENT_VSCODE_SHOW_MESSAGE = "vscode:show-message" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
 export const VSCODE_SHOW_MESSAGE_OPERATION_ID = "vscode-show-message";
 
-/** Input context for "show" handlers. */
-export interface ShowHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+// =============================================================================
+// Contract schemas (single source of truth)
+// =============================================================================
+
+export const vscodeShowMessageTypeSchema = z.enum(["info", "warning", "error", "status", "select"]);
+
+export const vscodeShowMessagePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    type: vscodeShowMessageTypeSchema,
+    /** Display text. null = dismiss (only valid for status). */
+    message: z.string().nullable(),
+    /** Secondary text: tooltip for status, placeholder for select. */
+    hint: z.string().optional(),
+    /** Action buttons (notification) or selection items (select). Omit for free text input. */
+    options: z.array(z.string()).readonly().optional(),
+    /** Timeout in milliseconds for interactive operations. */
+    timeoutMs: z.number().optional(),
+  })
+  .readonly();
+
+export const vscodeShowMessageResultSchema = z.string().nullable();
 
 /** Per-handler result for the "show" hook point. */
-export interface ShowHookResult {
-  readonly result?: string | null;
-}
+export const showHookResultSchema = z
+  .object({
+    result: z.string().nullable().optional(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "show" hook point (beyond the base HookContext). */
+const showEnrichmentSchema = z.object({ workspacePath: z.string() });
+
+/** Runtime whole-context validation schema for "show". */
+export const showHookInputSchema = hookCtxSchema(
+  vscodeShowMessagePayloadSchema,
+  showEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_VSCODE_SHOW_MESSAGE,
+  payload: vscodeShowMessagePayloadSchema,
+  result: vscodeShowMessageResultSchema,
+  hooks: {
+    show: { input: showHookInputSchema, result: showHookResultSchema },
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type VscodeShowMessageType = z.infer<typeof vscodeShowMessageTypeSchema>;
+export type VscodeShowMessagePayload = z.infer<typeof vscodeShowMessagePayloadSchema>;
+export type VscodeShowMessageIntent = IntentOf<typeof schemas>;
+export type ShowHookResult = z.infer<typeof showHookResultSchema>;
+
+/** Whole input context for "show" handlers: base envelope + inferred enrichment. */
+export type ShowHookInput = HookContext & z.infer<typeof showEnrichmentSchema>;
 
 // =============================================================================
 // Operation
 // =============================================================================
 
 export class VscodeShowMessageOperation extends WorkspaceHookOperation<
-  VscodeShowMessageIntent,
-  ShowHookResult,
-  string | null
+  typeof schemas,
+  ShowHookResult
 > {
+  readonly schemas = schemas;
+
   constructor() {
     super(VSCODE_SHOW_MESSAGE_OPERATION_ID, {
       hookPoint: "show",

--- a/src/intents/wake-workspace.ts
+++ b/src/intents/wake-workspace.ts
@@ -20,82 +20,119 @@
  * new view appears.
  */
 
-import type { Intent, DomainEvent } from "./lib/types";
-import type { Operation, OperationContext, HookContext } from "./lib/operation";
-import type { ProjectId, WorkspaceName, Workspace } from "../shared/api/types";
+import { z } from "zod/v4";
+import type { DomainEvent } from "./lib/types";
+import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
+import { type IntentOf } from "./lib/operation";
+import { projectIdSchema, workspaceNameSchema, workspaceSchema, hookCtxSchema } from "./contract";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "./set-metadata";
 import { INTENT_GET_METADATA, type GetMetadataIntent } from "./get-metadata";
-import {
-  INTENT_OPEN_WORKSPACE,
-  type OpenWorkspaceIntent,
-  type WorkspaceOpenSource,
-} from "./open-workspace";
+import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "./open-workspace";
 import { HIBERNATED_METADATA_KEY } from "./hibernate-workspace";
 import { resolveWorkspaceIdentity, emitWorkspaceFailure } from "./lib/workspace-identity";
 
-// =============================================================================
-// Intent Types
-// =============================================================================
-
-export interface WakeWorkspacePayload {
-  readonly workspacePath: string;
-  /** Forwarded to the internal workspace:open. If true, switch to the woken
-   *  workspace; if false, bring it online in the background. Default
-   *  (undefined): switch — matching the pre-fold renderer behavior. */
-  readonly stealFocus?: boolean;
-  /** Forwarded to the internal workspace:open. Identifies the originating
-   *  surface so error-notification can skip non-interactive sources (e.g. mcp). */
-  readonly source?: WorkspaceOpenSource;
-}
-
-export interface WakeWorkspaceIntent extends Intent<Workspace> {
-  readonly type: "workspace:wake";
-  readonly payload: WakeWorkspacePayload;
-}
-
 export const INTENT_WAKE_WORKSPACE = "workspace:wake" as const;
 export const WAKE_WORKSPACE_OPERATION_ID = "wake-workspace";
+export const EVENT_WORKSPACE_WOKEN = "workspace:woken" as const;
+export const EVENT_WORKSPACE_WAKE_FAILED = "workspace:wake-failed" as const;
 
 // =============================================================================
-// Event Types
+// Contract schemas (single source of truth)
 // =============================================================================
 
-export interface WorkspaceWokenPayload {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
-  readonly projectPath: string;
-}
+/**
+ * Which module dispatched a workspace:open intent. Local mirror of
+ * `WorkspaceOpenSource` from ./open-workspace (that module has no exported
+ * schema yet); kept in sync so wake can forward `source` to workspace:open.
+ */
+const workspaceOpenSourceSchema = z.enum([
+  "ui-ipc",
+  "mcp",
+  "plugin-server",
+  "auto-workspace",
+  "open-project",
+  "creation",
+]);
+
+export const wakeWorkspacePayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    /** Forwarded to the internal workspace:open. If true, switch to the woken
+     *  workspace; if false, bring it online in the background. Default
+     *  (undefined): switch — matching the pre-fold renderer behavior. */
+    stealFocus: z.boolean().optional(),
+    /** Forwarded to the internal workspace:open. Identifies the originating
+     *  surface so error-notification can skip non-interactive sources (e.g. mcp). */
+    source: workspaceOpenSourceSchema.optional(),
+  })
+  .readonly();
+
+export const workspaceWokenPayloadSchema = z
+  .object({
+    projectId: projectIdSchema,
+    workspaceName: workspaceNameSchema,
+    workspacePath: z.string(),
+    projectPath: z.string(),
+  })
+  .readonly();
+
+export const workspaceWakeFailedPayloadSchema = z
+  .object({
+    workspacePath: z.string(),
+    error: z.string(),
+  })
+  .readonly();
+
+/** Operation-added enrichment for the "cleanup" hook point. */
+const wakePipelineEnrichmentSchema = z.object({
+  projectPath: z.string(),
+  workspacePath: z.string(),
+  projectId: projectIdSchema,
+  workspaceName: workspaceNameSchema,
+});
+
+/** Runtime whole-context validation schema for the "cleanup" hook point. */
+export const wakePipelineHookInputSchema = hookCtxSchema(
+  wakeWorkspacePayloadSchema,
+  wakePipelineEnrichmentSchema.shape
+);
+
+const schemas = {
+  type: INTENT_WAKE_WORKSPACE,
+  payload: wakeWorkspacePayloadSchema,
+  result: workspaceSchema,
+  hooks: {
+    cleanup: { input: wakePipelineHookInputSchema, result: z.object({}).readonly() },
+  },
+  events: {
+    [EVENT_WORKSPACE_WOKEN]: workspaceWokenPayloadSchema,
+    [EVENT_WORKSPACE_WAKE_FAILED]: workspaceWakeFailedPayloadSchema,
+  },
+} satisfies OperationSchemas;
+
+// =============================================================================
+// Types derived from the schemas
+// =============================================================================
+
+export type WakeWorkspacePayload = z.infer<typeof wakeWorkspacePayloadSchema>;
+export type WakeWorkspaceIntent = IntentOf<typeof schemas>;
+
+export type WorkspaceWokenPayload = z.infer<typeof workspaceWokenPayloadSchema>;
 
 export interface WorkspaceWokenEvent extends DomainEvent {
   readonly type: "workspace:woken";
   readonly payload: WorkspaceWokenPayload;
 }
 
-export const EVENT_WORKSPACE_WOKEN = "workspace:woken" as const;
-
-export interface WorkspaceWakeFailedPayload {
-  readonly workspacePath: string;
-  readonly error: string;
-}
+export type WorkspaceWakeFailedPayload = z.infer<typeof workspaceWakeFailedPayloadSchema>;
 
 export interface WorkspaceWakeFailedEvent extends DomainEvent {
   readonly type: "workspace:wake-failed";
   readonly payload: WorkspaceWakeFailedPayload;
 }
 
-export const EVENT_WORKSPACE_WAKE_FAILED = "workspace:wake-failed" as const;
-
-// =============================================================================
-// Hook Types
-// =============================================================================
-
-export interface WakePipelineHookInput extends HookContext {
-  readonly projectPath: string;
-  readonly workspacePath: string;
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-}
+/** Input context for the "cleanup" hook point. */
+export type WakePipelineHookInput = HookContext & z.infer<typeof wakePipelineEnrichmentSchema>;
 
 export type CleanupHookResult = Record<string, never>;
 
@@ -103,10 +140,13 @@ export type CleanupHookResult = Record<string, never>;
 // Operation
 // =============================================================================
 
-export class WakeWorkspaceOperation implements Operation<WakeWorkspaceIntent, Workspace> {
+export class WakeWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = WAKE_WORKSPACE_OPERATION_ID;
+  readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<WakeWorkspaceIntent>): Promise<Workspace> {
+  async execute(
+    ctx: OperationContext<WakeWorkspaceIntent>
+  ): Promise<z.infer<typeof workspaceSchema>> {
     const { payload } = ctx.intent;
 
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,26 +78,20 @@ import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "./intents/app-shutdow
 import { AppResumeOperation, INTENT_APP_RESUME, EVENT_APP_RESUMED } from "./intents/app-resume";
 import type { AppShutdownIntent } from "./intents/app-shutdown";
 import { SetupOperation, INTENT_SETUP, EVENT_SETUP_ERROR } from "./intents/setup";
-import { SetMetadataOperation, INTENT_SET_METADATA } from "./intents/set-metadata";
-import { GetMetadataOperation, INTENT_GET_METADATA } from "./intents/get-metadata";
+import { SetMetadataOperation } from "./intents/set-metadata";
+import { GetMetadataOperation } from "./intents/get-metadata";
 import {
   GetWorkspaceStatusOperation,
   INTENT_GET_WORKSPACE_STATUS,
 } from "./intents/get-workspace-status";
-import { GetAgentSessionOperation, INTENT_GET_AGENT_SESSION } from "./intents/get-agent-session";
-import { RestartAgentOperation, INTENT_RESTART_AGENT } from "./intents/restart-agent";
-import { AgentLifecycleOperation, INTENT_AGENT_LIFECYCLE } from "./intents/agent-lifecycle";
-import {
-  GetActiveWorkspaceOperation,
-  INTENT_GET_ACTIVE_WORKSPACE,
-} from "./intents/get-active-workspace";
-import { ListProjectsOperation, INTENT_LIST_PROJECTS } from "./intents/list-projects";
-import { OpenWorkspaceOperation, INTENT_OPEN_WORKSPACE } from "./intents/open-workspace";
-import { GetProjectBasesOperation, INTENT_GET_PROJECT_BASES } from "./intents/get-project-bases";
-import {
-  AgentLaunchOptionsOperation,
-  INTENT_GET_LAUNCH_OPTIONS,
-} from "./intents/agent-launch-options";
+import { GetAgentSessionOperation } from "./intents/get-agent-session";
+import { RestartAgentOperation } from "./intents/restart-agent";
+import { AgentLifecycleOperation } from "./intents/agent-lifecycle";
+import { GetActiveWorkspaceOperation } from "./intents/get-active-workspace";
+import { ListProjectsOperation } from "./intents/list-projects";
+import { OpenWorkspaceOperation } from "./intents/open-workspace";
+import { GetProjectBasesOperation } from "./intents/get-project-bases";
+import { AgentLaunchOptionsOperation } from "./intents/agent-launch-options";
 import {
   DeleteWorkspaceOperation,
   INTENT_DELETE_WORKSPACE,
@@ -134,32 +128,21 @@ import {
   EVENT_PROJECT_CLOSE_FAILED,
   type CloseProjectPayload,
 } from "./intents/close-project";
-import {
-  SwitchWorkspaceOperation,
-  INTENT_SWITCH_WORKSPACE,
-  EVENT_WORKSPACE_SWITCHED,
-} from "./intents/switch-workspace";
+import { SwitchWorkspaceOperation, EVENT_WORKSPACE_SWITCHED } from "./intents/switch-workspace";
 import type { WorkspaceSwitchedEvent } from "./intents/switch-workspace";
 import type { GetWorkspaceStatusIntent } from "./intents/get-workspace-status";
 import {
   UpdateAgentStatusOperation,
-  INTENT_UPDATE_AGENT_STATUS,
   EVENT_AGENT_STATUS_UPDATED,
 } from "./intents/update-agent-status";
 import type { AgentStatusUpdatedEvent } from "./intents/update-agent-status";
-import { ShortcutKeyOperation, INTENT_SHORTCUT_KEY } from "./intents/shortcut-key";
-import {
-  SetShortcutActiveOperation,
-  INTENT_SET_SHORTCUT_ACTIVE,
-} from "./intents/set-shortcut-active";
-import { SubmitBugReportOperation, INTENT_SUBMIT_BUG_REPORT } from "./intents/submit-bug-report";
-import {
-  VscodeShowMessageOperation,
-  INTENT_VSCODE_SHOW_MESSAGE,
-} from "./intents/vscode-show-message";
+import { ShortcutKeyOperation } from "./intents/shortcut-key";
+import { SetShortcutActiveOperation } from "./intents/set-shortcut-active";
+import { SubmitBugReportOperation } from "./intents/submit-bug-report";
+import { VscodeShowMessageOperation } from "./intents/vscode-show-message";
 import { VscodeCommandOperation, INTENT_VSCODE_COMMAND } from "./intents/vscode-command";
-import { ResolveWorkspaceOperation, INTENT_RESOLVE_WORKSPACE } from "./intents/resolve-workspace";
-import { ResolveProjectOperation, INTENT_RESOLVE_PROJECT } from "./intents/resolve-project";
+import { ResolveWorkspaceOperation } from "./intents/resolve-workspace";
+import { ResolveProjectOperation } from "./intents/resolve-project";
 // Modules
 import { createExtensionModule } from "./modules/extension-module";
 import { createViewModule } from "./modules/view-module";
@@ -797,43 +780,42 @@ const errorReportModule = createErrorReportModule({
 
 // 8. Operation registration
 
-dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
-dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+dispatcher.registerOperation(new AppShutdownOperation());
+dispatcher.registerOperation(new AppResumeOperation());
 dispatcher.registerOperation(
-  INTENT_APP_START,
   new AppStartOperation(agentConfig, () => configService.wasConfigured())
 );
-dispatcher.registerOperation(INTENT_APP_READY, new AppReadyOperation(agentConfig));
+dispatcher.registerOperation(new AppReadyOperation(agentConfig));
 // config:set-values operation removed — config is now a plain service
-dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, new ResolveWorkspaceOperation());
-dispatcher.registerOperation(INTENT_RESOLVE_PROJECT, new ResolveProjectOperation());
-dispatcher.registerOperation(INTENT_SETUP, new SetupOperation());
-dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
-dispatcher.registerOperation(INTENT_GET_WORKSPACE_STATUS, new GetWorkspaceStatusOperation());
-dispatcher.registerOperation(INTENT_GET_AGENT_SESSION, new GetAgentSessionOperation());
-dispatcher.registerOperation(INTENT_RESTART_AGENT, new RestartAgentOperation());
-dispatcher.registerOperation(INTENT_AGENT_LIFECYCLE, new AgentLifecycleOperation());
-dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
-dispatcher.registerOperation(INTENT_LIST_PROJECTS, new ListProjectsOperation());
-dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, new OpenWorkspaceOperation());
-dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, new GetProjectBasesOperation());
-dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+dispatcher.registerOperation(new ResolveWorkspaceOperation());
+dispatcher.registerOperation(new ResolveProjectOperation());
+dispatcher.registerOperation(new SetupOperation());
+dispatcher.registerOperation(new SetMetadataOperation());
+dispatcher.registerOperation(new GetMetadataOperation());
+dispatcher.registerOperation(new GetWorkspaceStatusOperation());
+dispatcher.registerOperation(new GetAgentSessionOperation());
+dispatcher.registerOperation(new RestartAgentOperation());
+dispatcher.registerOperation(new AgentLifecycleOperation());
+dispatcher.registerOperation(new GetActiveWorkspaceOperation());
+dispatcher.registerOperation(new ListProjectsOperation());
+dispatcher.registerOperation(new OpenWorkspaceOperation());
+dispatcher.registerOperation(new GetProjectBasesOperation());
+dispatcher.registerOperation(new AgentLaunchOptionsOperation());
 
-dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new DeleteWorkspaceOperation());
-dispatcher.registerOperation(INTENT_HIBERNATE_WORKSPACE, new HibernateWorkspaceOperation());
-dispatcher.registerOperation(INTENT_WAKE_WORKSPACE, new WakeWorkspaceOperation());
+dispatcher.registerOperation(new DeleteWorkspaceOperation());
+dispatcher.registerOperation(new HibernateWorkspaceOperation());
+dispatcher.registerOperation(new WakeWorkspaceOperation());
 
-dispatcher.registerOperation(INTENT_OPEN_PROJECT, new OpenProjectOperation());
-dispatcher.registerOperation(INTENT_CLOSE_PROJECT, new CloseProjectOperation());
+dispatcher.registerOperation(new OpenProjectOperation());
+dispatcher.registerOperation(new CloseProjectOperation());
 
-dispatcher.registerOperation(INTENT_SWITCH_WORKSPACE, new SwitchWorkspaceOperation());
-dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-dispatcher.registerOperation(INTENT_SHORTCUT_KEY, new ShortcutKeyOperation());
-dispatcher.registerOperation(INTENT_SET_SHORTCUT_ACTIVE, new SetShortcutActiveOperation());
-dispatcher.registerOperation(INTENT_SUBMIT_BUG_REPORT, new SubmitBugReportOperation());
-dispatcher.registerOperation(INTENT_VSCODE_SHOW_MESSAGE, new VscodeShowMessageOperation());
-dispatcher.registerOperation(INTENT_VSCODE_COMMAND, new VscodeCommandOperation());
+dispatcher.registerOperation(new SwitchWorkspaceOperation());
+dispatcher.registerOperation(new UpdateAgentStatusOperation());
+dispatcher.registerOperation(new ShortcutKeyOperation());
+dispatcher.registerOperation(new SetShortcutActiveOperation());
+dispatcher.registerOperation(new SubmitBugReportOperation());
+dispatcher.registerOperation(new VscodeShowMessageOperation());
+dispatcher.registerOperation(new VscodeCommandOperation());
 
 // Initial terminal focus for a workspace, fired exactly once per session
 // per workspace (tracked in firstFocused). After the first focus, the

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -9,11 +9,16 @@
 
 import { createMockDispatcher } from "../../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod/v4";
 import { Dispatcher } from "../../intents/lib/dispatcher";
-import type { Operation, OperationContext, HookContext } from "../../intents/lib/operation";
-import type { Intent } from "../../intents/lib/types";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../../intents/lib/operation";
 import { createMinimalOperation } from "../../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID } from "../../intents/app-start";
+import { APP_START_OPERATION_ID, INTENT_APP_START } from "../../intents/app-start";
 import {
   AgentLaunchOptionsOperation,
   INTENT_GET_LAUNCH_OPTIONS,
@@ -23,7 +28,7 @@ import type {
   CheckDepsResult,
   CheckDepsHookContext,
 } from "../../intents/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
+import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../../intents/app-shutdown";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
 import type {
   RegisterAgentResult,
@@ -31,25 +36,37 @@ import type {
   BinaryHookInput,
   SetupProgressPayload,
 } from "../../intents/setup";
-import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
+import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../../intents/open-workspace";
 import type {
   SetupHookResult,
   SetupHookInput,
   OpenWorkspaceIntent,
 } from "../../intents/open-workspace";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
+} from "../../intents/delete-workspace";
 import type {
   ShutdownHookResult,
   DeletePipelineHookInput,
   DeleteWorkspaceIntent,
 } from "../../intents/delete-workspace";
-import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../../intents/get-workspace-status";
+import {
+  GET_WORKSPACE_STATUS_OPERATION_ID,
+  INTENT_GET_WORKSPACE_STATUS,
+} from "../../intents/get-workspace-status";
 import type { GetStatusHookResult } from "../../intents/get-workspace-status";
-import { GET_AGENT_SESSION_OPERATION_ID } from "../../intents/get-agent-session";
+import {
+  GET_AGENT_SESSION_OPERATION_ID,
+  INTENT_GET_AGENT_SESSION,
+} from "../../intents/get-agent-session";
 import type { GetAgentSessionHookResult } from "../../intents/get-agent-session";
-import { RESTART_AGENT_OPERATION_ID } from "../../intents/restart-agent";
+import { RESTART_AGENT_OPERATION_ID, INTENT_RESTART_AGENT } from "../../intents/restart-agent";
 import type { RestartAgentHookResult } from "../../intents/restart-agent";
-import { AGENT_LIFECYCLE_OPERATION_ID } from "../../intents/agent-lifecycle";
+import {
+  AGENT_LIFECYCLE_OPERATION_ID,
+  INTENT_AGENT_LIFECYCLE,
+} from "../../intents/agent-lifecycle";
 import { INTENT_UPDATE_AGENT_STATUS } from "../../intents/update-agent-status";
 import { createAgentModule, type AgentModuleDeps } from "./agent-module";
 import type { AgentModuleProvider, WorkspaceStartResult } from "./agent-module-provider";
@@ -112,10 +129,19 @@ function createMockProvider(overrides: Partial<AgentModuleProvider> = {}): Agent
 // Minimal Test Operations
 // =============================================================================
 
-class MinimalBeforeReadyOperation implements Operation<Intent, readonly ConfigureResult[]> {
-  readonly id = APP_START_OPERATION_ID;
+const beforeReadySchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<readonly ConfigureResult[]>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<readonly ConfigureResult[]> {
+class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = beforeReadySchemas;
+
+  async execute(
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+  ): Promise<readonly ConfigureResult[]> {
     const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
       intent: ctx.intent,
     });
@@ -124,70 +150,62 @@ class MinimalBeforeReadyOperation implements Operation<Intent, readonly Configur
   }
 }
 
-class MinimalCheckDepsOperation implements Operation<Intent, CheckDepsResult> {
-  readonly id = APP_START_OPERATION_ID;
-  private readonly configuredAgent: string | null;
+const checkDepsSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<CheckDepsResult>(),
+} satisfies OperationSchemas;
 
-  constructor(configuredAgent: string | null = "claude") {
-    this.configuredAgent = configuredAgent;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<CheckDepsResult> {
-    const hookCtx: CheckDepsHookContext = {
-      intent: ctx.intent,
-      configuredAgent: this.configuredAgent as CheckDepsHookContext["configuredAgent"],
-      extensionRequirements: [],
-    };
-    const { results } = await ctx.hooks.collect<CheckDepsResult>("check-deps", hookCtx);
-    const merged: CheckDepsResult = {};
-    for (const r of results) {
-      if (r.missingBinaries) {
-        (merged as Record<string, unknown>).missingBinaries = [
-          ...((merged.missingBinaries as string[]) ?? []),
-          ...r.missingBinaries,
-        ];
+function minimalCheckDeps(
+  configuredAgent: string | null = "claude"
+): Operation<typeof checkDepsSchemas> {
+  return {
+    id: APP_START_OPERATION_ID,
+    schemas: checkDepsSchemas,
+    async execute(ctx): Promise<CheckDepsResult> {
+      const hookCtx: CheckDepsHookContext = {
+        intent: ctx.intent,
+        configuredAgent: configuredAgent as CheckDepsHookContext["configuredAgent"],
+        extensionRequirements: [],
+      };
+      const { results } = await ctx.hooks.collect<CheckDepsResult>("check-deps", hookCtx);
+      const merged: CheckDepsResult = {};
+      for (const r of results) {
+        if (r.missingBinaries) {
+          (merged as Record<string, unknown>).missingBinaries = [
+            ...((merged.missingBinaries as string[]) ?? []),
+            ...r.missingBinaries,
+          ];
+        }
       }
-    }
-    return merged;
-  }
+      return merged;
+    },
+  };
 }
 
-class MinimalStartOperation implements Operation<Intent, void> {
-  readonly id = APP_START_OPERATION_ID;
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const hookCtx: HookContext = {
-      intent: ctx.intent,
-      capabilities: { mcpPort: null },
-    };
-    const { errors } = await ctx.hooks.collect<void>("start", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-  }
+/**
+ * Minimal app:start operation that runs the "start" hook point with `mcpPort` seeded as a
+ * capability (defaults to null). Replaces the old MinimalStart / MinimalStartWithMcpPort classes.
+ */
+function minimalStart(mcpPort: number | null = null): Operation<OperationSchemas> {
+  return createMinimalOperation<void>(APP_START_OPERATION_ID, INTENT_APP_START, "start", {
+    hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { mcpPort } }),
+  });
 }
 
-class MinimalStartWithMcpPortOperation implements Operation<Intent, void> {
-  readonly id = APP_START_OPERATION_ID;
-  private readonly mcpPort: number | null;
+const registerAgentsSchemas = {
+  type: "setup",
+  payload: z.unknown(),
+  result: z.custom<readonly RegisterAgentResult[]>(),
+} satisfies OperationSchemas;
 
-  constructor(mcpPort: number | null = null) {
-    this.mcpPort = mcpPort;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    // Run start with mcpPort as a pre-populated capability
-    const hookCtx: HookContext = {
-      intent: ctx.intent,
-      capabilities: { mcpPort: this.mcpPort },
-    };
-    const { errors } = await ctx.hooks.collect<void>("start", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-  }
-}
-
-class MinimalRegisterAgentsOperation implements Operation<Intent, readonly RegisterAgentResult[]> {
+class MinimalRegisterAgentsOperation implements Operation<typeof registerAgentsSchemas> {
   readonly id = SETUP_OPERATION_ID;
+  readonly schemas = registerAgentsSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<readonly RegisterAgentResult[]> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof registerAgentsSchemas>>
+  ): Promise<readonly RegisterAgentResult[]> {
     const { results, errors } = await ctx.hooks.collect<RegisterAgentResult>("register-agents", {
       intent: ctx.intent,
     });
@@ -196,49 +214,48 @@ class MinimalRegisterAgentsOperation implements Operation<Intent, readonly Regis
   }
 }
 
-class MinimalSaveAgentOperation implements Operation<Intent, void> {
-  readonly id = SETUP_OPERATION_ID;
-  private readonly selectedAgent: string;
-
-  constructor(selectedAgent: string) {
-    this.selectedAgent = selectedAgent;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const hookCtx: SaveAgentHookInput = {
+/** Minimal setup operation that runs the "save-agent" hook point with `selectedAgent` seeded. */
+function minimalSaveAgent(selectedAgent: string): Operation<OperationSchemas> {
+  return createMinimalOperation<void>(SETUP_OPERATION_ID, "setup", "save-agent", {
+    hookContext: (ctx): SaveAgentHookInput => ({
       intent: ctx.intent,
-      selectedAgent: this.selectedAgent as SaveAgentHookInput["selectedAgent"],
-    };
-    const { errors } = await ctx.hooks.collect("save-agent", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-  }
+      selectedAgent: selectedAgent as SaveAgentHookInput["selectedAgent"],
+    }),
+  });
 }
 
-class MinimalBinaryOperation implements Operation<Intent, void> {
-  readonly id = SETUP_OPERATION_ID;
-  private readonly hookInput: Partial<BinaryHookInput>;
-  /** Progress frames yielded by the streaming binary handler. */
-  readonly frames: SetupProgressPayload[] = [];
+const binarySchemas = {
+  type: "setup",
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  constructor(hookInput: Partial<BinaryHookInput> = {}) {
-    this.hookInput = hookInput;
-  }
+/** Bespoke binary operation exposing the streamed progress `frames` for assertions. */
+type MinimalBinaryOperation = Operation<typeof binarySchemas> & {
+  readonly frames: SetupProgressPayload[];
+};
 
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect(
-      "binary",
-      {
-        intent: ctx.intent,
-        ...this.hookInput,
-      },
-      {
-        onYield: (frame) => {
-          this.frames.push(frame as SetupProgressPayload);
+function minimalBinary(hookInput: Partial<BinaryHookInput> = {}): MinimalBinaryOperation {
+  const frames: SetupProgressPayload[] = [];
+  return {
+    id: SETUP_OPERATION_ID,
+    schemas: binarySchemas,
+    frames,
+    async execute(ctx): Promise<void> {
+      const { errors } = await ctx.hooks.collect(
+        "binary",
+        {
+          intent: ctx.intent,
+          ...hookInput,
         },
-      }
-    );
-    if (errors.length > 0) throw errors[0]!;
-  }
+        {
+          onYield: (frame) => {
+            frames.push(frame as SetupProgressPayload);
+          },
+        }
+      );
+      if (errors.length > 0) throw errors[0]!;
+    },
+  };
 }
 
 interface SetupOperationResult {
@@ -246,73 +263,65 @@ interface SetupOperationResult {
   agentType?: string;
 }
 
-class MinimalSetupOperation implements Operation<
-  OpenWorkspaceIntent,
-  SetupOperationResult | undefined
-> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-  private readonly hookInput: Partial<SetupHookInput>;
-  private readonly agentCapability: string | null;
+const setupSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<SetupOperationResult | undefined>(),
+} satisfies OperationSchemas;
 
-  constructor(hookInput: Partial<SetupHookInput> = {}, agentCapability: string | null = "claude") {
-    this.hookInput = hookInput;
-    this.agentCapability = agentCapability;
-  }
-
-  async execute(
-    ctx: OperationContext<OpenWorkspaceIntent>
-  ): Promise<SetupOperationResult | undefined> {
-    const { results, errors } = await ctx.hooks.collect<SetupHookResult | undefined>("setup", {
-      intent: ctx.intent,
-      workspacePath: "/test/workspace",
-      projectPath: "/test/project",
-      ...this.hookInput,
-      ...(this.agentCapability !== null && {
-        capabilities: { agent: this.agentCapability },
-      }),
-    });
-    if (errors.length > 0) throw errors[0]!;
-    const result = results[0];
-    if (result === undefined) return undefined;
-    return {
-      ...(result.envVars !== undefined && { envVars: result.envVars }),
-      ...(result.agentType != null && { agentType: result.agentType }),
-    };
-  }
+function minimalSetup(
+  hookInput: Partial<SetupHookInput> = {},
+  agentCapability: string | null = "claude"
+): Operation<typeof setupSchemas> {
+  return {
+    id: OPEN_WORKSPACE_OPERATION_ID,
+    schemas: setupSchemas,
+    async execute(ctx): Promise<SetupOperationResult | undefined> {
+      const { results, errors } = await ctx.hooks.collect<SetupHookResult | undefined>("setup", {
+        intent: ctx.intent,
+        workspacePath: "/test/workspace",
+        projectPath: "/test/project",
+        ...hookInput,
+        ...(agentCapability !== null && {
+          capabilities: { agent: agentCapability },
+        }),
+      });
+      if (errors.length > 0) throw errors[0]!;
+      const result = results[0];
+      if (result === undefined) return undefined;
+      return {
+        ...(result.envVars !== undefined && { envVars: result.envVars }),
+        ...(result.agentType != null && { agentType: result.agentType }),
+      };
+    },
+  };
 }
 
-class MinimalShutdownOperation implements Operation<
-  DeleteWorkspaceIntent,
-  ShutdownHookResult | undefined
-> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-  private readonly agentCapability: string | null;
-
-  constructor(agentCapability: string | null = "claude") {
-    this.agentCapability = agentCapability;
-  }
-
-  async execute(
-    ctx: OperationContext<DeleteWorkspaceIntent>
-  ): Promise<ShutdownHookResult | undefined> {
-    const { payload } = ctx.intent;
-    const hookCtx: DeletePipelineHookInput = {
-      intent: ctx.intent,
-      projectPath: "/test/project",
-      workspacePath: payload.workspacePath ?? "/test/workspace",
-      workspaceName: "test-workspace" as WorkspaceName,
-      active: false,
-      ...(this.agentCapability !== null && {
-        capabilities: { agent: this.agentCapability },
-      }),
-    };
-    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult | undefined>(
-      "shutdown",
-      hookCtx
-    );
-    if (errors.length > 0) throw errors[0]!;
-    return results[0];
-  }
+/**
+ * Minimal delete operation that runs the "shutdown" hook point, seeding the delete pipeline
+ * context (with `agentCapability` as the agent capability) and returning the first hook result.
+ */
+function minimalShutdown(agentCapability: string | null = "claude"): Operation<OperationSchemas> {
+  return createMinimalOperation<ShutdownHookResult | undefined>(
+    DELETE_WORKSPACE_OPERATION_ID,
+    INTENT_DELETE_WORKSPACE,
+    "shutdown",
+    {
+      hookContext: (ctx): DeletePipelineHookInput => {
+        const payload = ctx.intent.payload as { workspacePath?: string };
+        return {
+          intent: ctx.intent,
+          projectPath: "/test/project",
+          workspacePath: payload.workspacePath ?? "/test/workspace",
+          workspaceName: "test-workspace" as WorkspaceName,
+          active: false,
+          ...(agentCapability !== null && {
+            capabilities: { agent: agentCapability },
+          }),
+        };
+      },
+    }
+  );
 }
 
 // =============================================================================
@@ -349,7 +358,7 @@ async function activateModule(
   agentConfig: PersistedAccessor<ConfigAgentType>
 ): Promise<void> {
   await agentConfig.set("claude");
-  dispatcher.registerOperation("app:start", new MinimalStartOperation());
+  dispatcher.registerOperation(minimalStart());
   await dispatcher.dispatch({ type: "app:start", payload: {} });
 }
 
@@ -372,7 +381,7 @@ describe("createAgentModule", () => {
         type: "claude",
         getLaunchOptions: async () => ({ permissionModes: ["plan", "acceptEdits"] }),
       });
-      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+      dispatcher.registerOperation(new AgentLaunchOptionsOperation());
 
       const result = await dispatcher.dispatch({
         type: INTENT_GET_LAUNCH_OPTIONS,
@@ -387,7 +396,7 @@ describe("createAgentModule", () => {
         type: "claude",
         getLaunchOptions: async () => ({ permissionModes: ["plan"] }),
       });
-      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+      dispatcher.registerOperation(new AgentLaunchOptionsOperation());
 
       const result = await dispatcher.dispatch({
         type: INTENT_GET_LAUNCH_OPTIONS,
@@ -399,7 +408,7 @@ describe("createAgentModule", () => {
 
     it("returns empty when the provider exposes no launch options", async () => {
       const { dispatcher } = createTestSetup({ type: "claude" });
-      dispatcher.registerOperation(INTENT_GET_LAUNCH_OPTIONS, new AgentLaunchOptionsOperation());
+      dispatcher.registerOperation(new AgentLaunchOptionsOperation());
 
       const result = await dispatcher.dispatch({
         type: INTENT_GET_LAUNCH_OPTIONS,
@@ -433,7 +442,7 @@ describe("createAgentModule", () => {
   describe("before-ready", () => {
     it("returns provider scripts", async () => {
       const { dispatcher } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const results = (await dispatcher.dispatch({
         type: "app:start",
@@ -470,7 +479,7 @@ describe("createAgentModule", () => {
       const { dispatcher } = createTestSetup({
         preflight: vi.fn().mockResolvedValue({ success: true, needsDownload: true }),
       });
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation("claude"));
+      dispatcher.registerOperation(minimalCheckDeps("claude"));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -482,7 +491,7 @@ describe("createAgentModule", () => {
 
     it("returns empty when configuredAgent does not match", async () => {
       const { dispatcher } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation("opencode"));
+      dispatcher.registerOperation(minimalCheckDeps("opencode"));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -494,7 +503,7 @@ describe("createAgentModule", () => {
 
     it("returns empty missingBinaries when download not needed", async () => {
       const { dispatcher } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation("claude"));
+      dispatcher.registerOperation(minimalCheckDeps("claude"));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -512,7 +521,7 @@ describe("createAgentModule", () => {
   describe("start", () => {
     it("does not initialize provider during app:start (lazy init)", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -528,12 +537,11 @@ describe("createAgentModule", () => {
   describe("lazy init", () => {
     it("initializes provider with captured mcpPort on first workspace:open", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -554,12 +562,11 @@ describe("createAgentModule", () => {
 
     it("passes null mcpConfig when no mcpPort was captured", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(null));
+      dispatcher.registerOperation(minimalStart(null));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -579,12 +586,11 @@ describe("createAgentModule", () => {
 
     it("only initializes once across multiple workspace:open calls", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -604,12 +610,11 @@ describe("createAgentModule", () => {
 
     it("dispatches INTENT_UPDATE_AGENT_STATUS when onStatusChange fires", async () => {
       const { dispatcher, moduleDeps } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -636,12 +641,11 @@ describe("createAgentModule", () => {
 
     it("does not initialize when agent capability does not match provider type", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation(
+        minimalSetup(
           {
             workspacePath: "/test/workspace",
             projectPath: "/test/project",
@@ -666,7 +670,7 @@ describe("createAgentModule", () => {
   describe("register-agents", () => {
     it("returns provider agent info", async () => {
       const { dispatcher } = createTestSetup();
-      dispatcher.registerOperation("setup", new MinimalRegisterAgentsOperation());
+      dispatcher.registerOperation(new MinimalRegisterAgentsOperation());
 
       const results = (await dispatcher.dispatch({
         type: "setup",
@@ -690,7 +694,7 @@ describe("createAgentModule", () => {
     it("calls configService.set when selectedAgent matches provider type", async () => {
       const { dispatcher, agentConfig } = createTestSetup();
       const setSpy = vi.spyOn(agentConfig, "set");
-      dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("claude"));
+      dispatcher.registerOperation(minimalSaveAgent("claude"));
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -700,7 +704,7 @@ describe("createAgentModule", () => {
     it("skips when selectedAgent does not match provider type", async () => {
       const { dispatcher, agentConfig } = createTestSetup();
       const setSpy = vi.spyOn(agentConfig, "set");
-      dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("opencode"));
+      dispatcher.registerOperation(minimalSaveAgent("opencode"));
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -710,7 +714,7 @@ describe("createAgentModule", () => {
     it("throws SetupError on config save failure", async () => {
       const { dispatcher, agentConfig } = createTestSetup();
       vi.spyOn(agentConfig, "set").mockRejectedValue(new Error("disk full"));
-      dispatcher.registerOperation("setup", new MinimalSaveAgentOperation("claude"));
+      dispatcher.registerOperation(minimalSaveAgent("claude"));
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
     });
@@ -723,11 +727,11 @@ describe("createAgentModule", () => {
   describe("binary download", () => {
     it("downloads when agent type matches and binary is missing", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: ["claude"],
         selectedAgent: "claude",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -737,11 +741,11 @@ describe("createAgentModule", () => {
 
     it("reports done when agent matches but binary not missing", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: [],
         selectedAgent: "claude",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -751,11 +755,11 @@ describe("createAgentModule", () => {
 
     it("skips download and report when agent does not match", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: ["claude"],
         selectedAgent: "opencode",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -776,11 +780,11 @@ describe("createAgentModule", () => {
             }
           ),
       });
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: ["claude"],
         selectedAgent: "claude",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -802,11 +806,11 @@ describe("createAgentModule", () => {
       const { dispatcher } = createTestSetup({
         downloadBinary: vi.fn().mockRejectedValue(new Error("network error")),
       });
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: ["claude"],
         selectedAgent: "claude",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
       expect(op.frames).toContainEqual({ id: "agent", status: "failed", error: "network error" });
@@ -814,11 +818,11 @@ describe("createAgentModule", () => {
 
     it("uses configuredAgent when selectedAgent not provided", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      const op = new MinimalBinaryOperation({
+      const op = minimalBinary({
         missingBinaries: ["claude"],
         configuredAgent: "claude",
       });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
       await dispatcher.dispatch({ type: "setup", payload: {} });
 
@@ -836,8 +840,7 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -865,8 +868,7 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -893,8 +895,7 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -924,8 +925,7 @@ describe("createAgentModule", () => {
       const { dispatcher, mockProvider } = createTestSetup();
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation(
+        minimalSetup(
           {
             workspacePath: "/test/workspace",
             projectPath: "/test/project",
@@ -957,7 +957,7 @@ describe("createAgentModule", () => {
       const { dispatcher, agentConfig, mockProvider } = createTestSetup();
       await activateModule(dispatcher, agentConfig);
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
+      dispatcher.registerOperation(minimalShutdown());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -978,7 +978,7 @@ describe("createAgentModule", () => {
       const { dispatcher, agentConfig, mockProvider } = createTestSetup();
       await activateModule(dispatcher, agentConfig);
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
+      dispatcher.registerOperation(minimalShutdown());
 
       await dispatcher.dispatch({
         type: "workspace:delete",
@@ -999,7 +999,7 @@ describe("createAgentModule", () => {
       });
       await activateModule(dispatcher, agentConfig);
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
+      dispatcher.registerOperation(minimalShutdown());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -1021,7 +1021,7 @@ describe("createAgentModule", () => {
       });
       await activateModule(dispatcher, agentConfig);
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation());
+      dispatcher.registerOperation(minimalShutdown());
 
       await expect(
         dispatcher.dispatch({
@@ -1039,7 +1039,7 @@ describe("createAgentModule", () => {
     it("does not run when agent capability does not match provider type", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
 
-      dispatcher.registerOperation("workspace:delete", new MinimalShutdownOperation("opencode"));
+      dispatcher.registerOperation(minimalShutdown("opencode"));
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -1072,9 +1072,9 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "workspace:get-status",
-        createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+        createMinimalOperation<GetStatusHookResult | undefined>(
           GET_WORKSPACE_STATUS_OPERATION_ID,
+          INTENT_GET_WORKSPACE_STATUS,
           "get",
           {
             hookContext: (ctx) => ({
@@ -1099,9 +1099,9 @@ describe("createAgentModule", () => {
       const { dispatcher } = createTestSetup();
 
       dispatcher.registerOperation(
-        "workspace:get-status",
-        createMinimalOperation<Intent, GetStatusHookResult | undefined>(
+        createMinimalOperation<GetStatusHookResult | undefined>(
           GET_WORKSPACE_STATUS_OPERATION_ID,
+          INTENT_GET_WORKSPACE_STATUS,
           "get",
           {
             hookContext: (ctx) => ({
@@ -1132,9 +1132,9 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "agent:get-session",
-        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+        createMinimalOperation<GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
+          INTENT_GET_AGENT_SESSION,
           "get",
           {
             hookContext: (ctx) => ({
@@ -1162,9 +1162,9 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "agent:get-session",
-        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+        createMinimalOperation<GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
+          INTENT_GET_AGENT_SESSION,
           "get",
           {
             hookContext: (ctx) => ({
@@ -1189,9 +1189,9 @@ describe("createAgentModule", () => {
       const { dispatcher } = createTestSetup();
 
       dispatcher.registerOperation(
-        "agent:get-session",
-        createMinimalOperation<Intent, GetAgentSessionHookResult | undefined>(
+        createMinimalOperation<GetAgentSessionHookResult | undefined>(
           GET_AGENT_SESSION_OPERATION_ID,
+          INTENT_GET_AGENT_SESSION,
           "get",
           {
             hookContext: (ctx) => ({
@@ -1222,9 +1222,9 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "agent:restart",
-        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+        createMinimalOperation<RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
+          INTENT_RESTART_AGENT,
           "restart",
           {
             hookContext: (ctx) => ({
@@ -1256,9 +1256,9 @@ describe("createAgentModule", () => {
       await activateModule(dispatcher, agentConfig);
 
       dispatcher.registerOperation(
-        "agent:restart",
-        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+        createMinimalOperation<RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
+          INTENT_RESTART_AGENT,
           "restart",
           {
             hookContext: (ctx) => ({
@@ -1282,9 +1282,9 @@ describe("createAgentModule", () => {
       const { dispatcher, mockProvider } = createTestSetup();
 
       dispatcher.registerOperation(
-        "agent:restart",
-        createMinimalOperation<Intent, RestartAgentHookResult | undefined>(
+        createMinimalOperation<RestartAgentHookResult | undefined>(
           RESTART_AGENT_OPERATION_ID,
+          INTENT_RESTART_AGENT,
           "restart",
           {
             hookContext: (ctx) => ({
@@ -1313,15 +1313,19 @@ describe("createAgentModule", () => {
   describe("lifecycle", () => {
     function registerLifecycleOp(dispatcher: Dispatcher, agent: string): void {
       dispatcher.registerOperation(
-        "agent:lifecycle",
-        createMinimalOperation<Intent, void>(AGENT_LIFECYCLE_OPERATION_ID, "lifecycle", {
-          hookContext: (ctx) => ({
-            intent: ctx.intent,
-            workspacePath: (ctx.intent.payload as { workspacePath: string }).workspacePath,
-            event: (ctx.intent.payload as { event: "open" | "close" }).event,
-            capabilities: { agent },
-          }),
-        })
+        createMinimalOperation<void>(
+          AGENT_LIFECYCLE_OPERATION_ID,
+          INTENT_AGENT_LIFECYCLE,
+          "lifecycle",
+          {
+            hookContext: (ctx) => ({
+              intent: ctx.intent,
+              workspacePath: (ctx.intent.payload as { workspacePath: string }).workspacePath,
+              event: (ctx.intent.payload as { event: "open" | "close" }).event,
+              capabilities: { agent },
+            }),
+          }
+        )
       );
     }
 
@@ -1375,11 +1379,10 @@ describe("createAgentModule", () => {
         onStatusChange: vi.fn().mockReturnValue(cleanupFn),
       });
       // Initialize provider via lazy path so dispose has something to clean up.
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -1390,8 +1393,9 @@ describe("createAgentModule", () => {
       } as unknown as OpenWorkspaceIntent);
 
       dispatcher.registerOperation(
-        "app:shutdown",
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
@@ -1402,12 +1406,13 @@ describe("createAgentModule", () => {
 
     it("skips dispose when provider was never initialized", async () => {
       const { dispatcher, mockProvider } = createTestSetup();
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "app:shutdown",
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
 
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
@@ -1420,11 +1425,10 @@ describe("createAgentModule", () => {
         dispose: vi.fn().mockRejectedValue(new Error("dispose failed")),
       });
       // Initialize first so dispose runs
-      dispatcher.registerOperation("app:start", new MinimalStartWithMcpPortOperation(9999));
+      dispatcher.registerOperation(minimalStart(9999));
       await dispatcher.dispatch({ type: "app:start", payload: {} });
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalSetupOperation({
+        minimalSetup({
           workspacePath: "/test/workspace",
           projectPath: "/test/project",
         })
@@ -1435,8 +1439,9 @@ describe("createAgentModule", () => {
       } as unknown as OpenWorkspaceIntent);
 
       dispatcher.registerOperation(
-        "app:shutdown",
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
 
       await expect(

--- a/src/modules/auto-updater-module.integration.test.ts
+++ b/src/modules/auto-updater-module.integration.test.ts
@@ -184,11 +184,10 @@ function createTestSetup(overrides?: {
   });
 
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, "start")
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
   );
-  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
-  dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+  dispatcher.registerOperation(new AppShutdownOperation());
+  dispatcher.registerOperation(new AppResumeOperation());
 
   dispatcher.registerModule(autoUpdaterModule);
 

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -11,7 +11,14 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
 import { Dispatcher } from "../../intents/lib/dispatcher";
 
-import type { Operation, OperationContext, HookContext } from "../../intents/lib/operation";
+import { z } from "zod/v4";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+  HookContext,
+} from "../../intents/lib/operation";
 import type { Project, ProjectId, WorkspaceName } from "../../shared/api/types";
 import {
   APP_START_OPERATION_ID,
@@ -44,7 +51,7 @@ import {
   type GetProjectBasesResult,
 } from "../../intents/get-project-bases";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "../../intents/set-metadata";
-import { INTENT_LIST_PROJECTS, type ListProjectsIntent } from "../../intents/list-projects";
+import { INTENT_LIST_PROJECTS } from "../../intents/list-projects";
 import {
   createFileSystemMock,
   file,
@@ -66,10 +73,16 @@ function entriesOf(state: MockStateService): Record<string, StateEntry | null> {
 // Minimal Test Operations
 // =============================================================================
 
-class MinimalActivateOperation implements Operation<AppStartIntent, void> {
-  readonly id = APP_START_OPERATION_ID;
+const activateSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
+class MinimalActivateOperation implements Operation<typeof activateSchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = activateSchemas;
+
+  async execute(ctx: OperationContext<IntentOf<typeof activateSchemas>>): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
     const { errors } = await ctx.hooks.collect<void>("start", hookCtx);
     if (errors.length > 0) throw errors[0]!;
@@ -78,11 +91,18 @@ class MinimalActivateOperation implements Operation<AppStartIntent, void> {
   }
 }
 
-class TrackingOpenProjectOperation implements Operation<OpenProjectIntent, Project> {
-  readonly id = "open-project";
-  readonly dispatched: OpenProjectIntent[] = [];
+const openProjectSchemas = {
+  type: INTENT_OPEN_PROJECT,
+  payload: z.custom<OpenProjectIntent["payload"]>(),
+  result: z.custom<Project>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project> {
+class TrackingOpenProjectOperation implements Operation<typeof openProjectSchemas> {
+  readonly id = "open-project";
+  readonly schemas = openProjectSchemas;
+  readonly dispatched: IntentOf<typeof openProjectSchemas>[] = [];
+
+  async execute(ctx: OperationContext<IntentOf<typeof openProjectSchemas>>): Promise<Project> {
     this.dispatched.push(ctx.intent);
     const gitUrl = ctx.intent.payload.git ?? "";
     const pathStr = ctx.intent.payload.path?.toString() ?? "";
@@ -97,26 +117,28 @@ class TrackingOpenProjectOperation implements Operation<OpenProjectIntent, Proje
   }
 }
 
-class TrackingOpenWorkspaceOperation implements Operation<
-  OpenWorkspaceIntent,
-  {
-    projectId: string;
-    name: string;
-    path: string;
-    branch: string;
-    metadata: Record<string, string>;
-  }
-> {
-  readonly id = "open-workspace";
-  readonly dispatched: OpenWorkspaceIntent[] = [];
+interface OpenWorkspaceTestResult {
+  projectId: string;
+  name: string;
+  path: string;
+  branch: string;
+  metadata: Record<string, string>;
+}
 
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<{
-    projectId: string;
-    name: string;
-    path: string;
-    branch: string;
-    metadata: Record<string, string>;
-  }> {
+const openWorkspaceSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.custom<OpenWorkspaceIntent["payload"]>(),
+  result: z.custom<OpenWorkspaceTestResult>(),
+} satisfies OperationSchemas;
+
+class TrackingOpenWorkspaceOperation implements Operation<typeof openWorkspaceSchemas> {
+  readonly id = "open-workspace";
+  readonly schemas = openWorkspaceSchemas;
+  readonly dispatched: IntentOf<typeof openWorkspaceSchemas>[] = [];
+
+  async execute(
+    ctx: OperationContext<IntentOf<typeof openWorkspaceSchemas>>
+  ): Promise<OpenWorkspaceTestResult> {
     this.dispatched.push(ctx.intent);
     return {
       projectId: "project-1",
@@ -128,15 +150,21 @@ class TrackingOpenWorkspaceOperation implements Operation<
   }
 }
 
-class TrackingDeleteWorkspaceOperation implements Operation<
-  DeleteWorkspaceIntent,
-  { started: true }
-> {
+const deleteWorkspaceSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.custom<DeleteWorkspaceIntent["payload"]>(),
+  result: z.custom<{ started: true }>(),
+} satisfies OperationSchemas;
+
+class TrackingDeleteWorkspaceOperation implements Operation<typeof deleteWorkspaceSchemas> {
   readonly id = "delete-workspace";
-  readonly dispatched: DeleteWorkspaceIntent[] = [];
+  readonly schemas = deleteWorkspaceSchemas;
+  readonly dispatched: IntentOf<typeof deleteWorkspaceSchemas>[] = [];
   readonly failForPaths = new Set<string>();
 
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof deleteWorkspaceSchemas>>
+  ): Promise<{ started: true }> {
     this.dispatched.push(ctx.intent);
     if (this.failForPaths.has(ctx.intent.payload.workspacePath)) {
       const failedEvent: WorkspaceDeleteFailedEvent = {
@@ -161,12 +189,18 @@ class TrackingDeleteWorkspaceOperation implements Operation<
   }
 }
 
-class TrackingSetMetadataOperation implements Operation<SetMetadataIntent, void> {
+const setMetadataSchemas = {
+  type: INTENT_SET_METADATA,
+  payload: z.custom<SetMetadataIntent["payload"]>(),
+} satisfies OperationSchemas;
+
+class TrackingSetMetadataOperation implements Operation<typeof setMetadataSchemas> {
   readonly id = "set-metadata";
-  readonly dispatched: SetMetadataIntent[] = [];
+  readonly schemas = setMetadataSchemas;
+  readonly dispatched: IntentOf<typeof setMetadataSchemas>[] = [];
   readonly failForPaths = new Set<string>();
 
-  async execute(ctx: OperationContext<SetMetadataIntent>): Promise<void> {
+  async execute(ctx: OperationContext<IntentOf<typeof setMetadataSchemas>>): Promise<void> {
     this.dispatched.push(ctx.intent);
     if (this.failForPaths.has(ctx.intent.payload.workspacePath)) {
       throw new Error(`Workspace not found: ${ctx.intent.payload.workspacePath}`);
@@ -174,8 +208,15 @@ class TrackingSetMetadataOperation implements Operation<SetMetadataIntent, void>
   }
 }
 
-class TrackingListProjectsOperation implements Operation<ListProjectsIntent, Project[]> {
+const listProjectsSchemas = {
+  type: INTENT_LIST_PROJECTS,
+  payload: z.unknown(),
+  result: z.custom<Project[]>(),
+} satisfies OperationSchemas;
+
+class TrackingListProjectsOperation implements Operation<typeof listProjectsSchemas> {
   readonly id = "list-projects";
+  readonly schemas = listProjectsSchemas;
   projects: Project[] = [];
 
   async execute(): Promise<Project[]> {
@@ -183,31 +224,41 @@ class TrackingListProjectsOperation implements Operation<ListProjectsIntent, Pro
   }
 }
 
-class TrackingResolveWorkspaceOperation implements Operation<
-  ResolveWorkspaceIntent,
-  { projectPath: string; workspaceName: WorkspaceName }
-> {
+const resolveWorkspaceSchemas = {
+  type: INTENT_RESOLVE_WORKSPACE,
+  payload: z.custom<ResolveWorkspaceIntent["payload"]>(),
+  result: z.custom<{ projectPath: string; workspaceName: WorkspaceName }>(),
+} satisfies OperationSchemas;
+
+class TrackingResolveWorkspaceOperation implements Operation<typeof resolveWorkspaceSchemas> {
   readonly id = "resolve-workspace";
-  readonly dispatched: ResolveWorkspaceIntent[] = [];
+  readonly schemas = resolveWorkspaceSchemas;
+  readonly dispatched: IntentOf<typeof resolveWorkspaceSchemas>[] = [];
   projectPath = "/home/user/projects/repo";
 
   async execute(
-    ctx: OperationContext<ResolveWorkspaceIntent>
+    ctx: OperationContext<IntentOf<typeof resolveWorkspaceSchemas>>
   ): Promise<{ projectPath: string; workspaceName: WorkspaceName }> {
     this.dispatched.push(ctx.intent);
     return { projectPath: this.projectPath, workspaceName: "auto-ws" as WorkspaceName };
   }
 }
 
-class TrackingGetProjectBasesOperation implements Operation<
-  GetProjectBasesIntent,
-  GetProjectBasesResult
-> {
+const getProjectBasesSchemas = {
+  type: INTENT_GET_PROJECT_BASES,
+  payload: z.custom<GetProjectBasesIntent["payload"]>(),
+  result: z.custom<GetProjectBasesResult>(),
+} satisfies OperationSchemas;
+
+class TrackingGetProjectBasesOperation implements Operation<typeof getProjectBasesSchemas> {
   readonly id = "get-project-bases";
-  readonly dispatched: GetProjectBasesIntent[] = [];
+  readonly schemas = getProjectBasesSchemas;
+  readonly dispatched: IntentOf<typeof getProjectBasesSchemas>[] = [];
   shouldFail = false;
 
-  async execute(ctx: OperationContext<GetProjectBasesIntent>): Promise<GetProjectBasesResult> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof getProjectBasesSchemas>>
+  ): Promise<GetProjectBasesResult> {
     this.dispatched.push(ctx.intent);
     if (this.shouldFail) throw new Error("fetch failed");
     return {
@@ -366,15 +417,15 @@ function createTestSetup(options?: {
 
   const mockConfig = createMockConfig({ defaults: configValues });
 
-  dispatcher.registerOperation(INTENT_APP_START, new MinimalActivateOperation());
-  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
-  dispatcher.registerOperation(INTENT_OPEN_PROJECT, openProjectOp);
-  dispatcher.registerOperation(INTENT_OPEN_WORKSPACE, openWorkspaceOp);
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteWorkspaceOp);
-  dispatcher.registerOperation(INTENT_SET_METADATA, setMetadataOp);
-  dispatcher.registerOperation(INTENT_LIST_PROJECTS, listProjectsOp);
-  dispatcher.registerOperation(INTENT_RESOLVE_WORKSPACE, resolveWorkspaceOp);
-  dispatcher.registerOperation(INTENT_GET_PROJECT_BASES, getProjectBasesOp);
+  dispatcher.registerOperation(new MinimalActivateOperation());
+  dispatcher.registerOperation(new AppShutdownOperation());
+  dispatcher.registerOperation(openProjectOp);
+  dispatcher.registerOperation(openWorkspaceOp);
+  dispatcher.registerOperation(deleteWorkspaceOp);
+  dispatcher.registerOperation(setMetadataOp);
+  dispatcher.registerOperation(listProjectsOp);
+  dispatcher.registerOperation(resolveWorkspaceOp);
+  dispatcher.registerOperation(getProjectBasesOp);
 
   const module = createAutoWorkspaceModule({
     fs,

--- a/src/modules/badge-module.integration.test.ts
+++ b/src/modules/badge-module.integration.test.ts
@@ -14,10 +14,7 @@ import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 
-import {
-  UpdateAgentStatusOperation,
-  INTENT_UPDATE_AGENT_STATUS,
-} from "../intents/update-agent-status";
+import { UpdateAgentStatusOperation } from "../intents/update-agent-status";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
 import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
@@ -467,8 +464,8 @@ function createModuleTestSetup(): ModuleTestSetup {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, createDeleteEventOperation());
+  dispatcher.registerOperation(new UpdateAgentStatusOperation());
+  dispatcher.registerOperation(createDeleteEventOperation());
 
   // Every workspace path resolves; workspaceName derives from the path basename.
   registerTestInfrastructure(dispatcher, {
@@ -644,8 +641,9 @@ describe("BadgeModule Integration", () => {
 
       // Register shutdown operation and dispatch
       dispatcher.registerOperation(
-        INTENT_APP_SHUTDOWN,
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
       await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
 
@@ -665,8 +663,9 @@ describe("BadgeModule Integration", () => {
       });
 
       dispatcher.registerOperation(
-        INTENT_APP_SHUTDOWN,
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
 
       // Should not throw - collect() catches the error

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -11,8 +11,13 @@ import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 import { Path } from "../utils/path/path";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 
-import type { Operation, OperationContext } from "../intents/lib/operation";
-import type { Intent } from "../intents/lib/types";
+import { z } from "zod/v4";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, ConfigureResult } from "../intents/app-start";
@@ -29,10 +34,19 @@ import { createMockConfig } from "../boundaries/platform/config.test-utils";
 // Minimal Test Operations
 // =============================================================================
 
+const beforeReadySchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<ConfigureResult>(),
+} satisfies OperationSchemas;
+
 /** Runs "before-ready" hook point only. */
-class MinimalBeforeReadyOperation implements Operation<Intent, ConfigureResult> {
+class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas> {
   readonly id = APP_START_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<ConfigureResult> {
+  readonly schemas = beforeReadySchemas;
+  async execute(
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+  ): Promise<ConfigureResult> {
     const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
       intent: ctx.intent,
     });
@@ -88,8 +102,7 @@ describe("ElectronLifecycleModule Integration", () => {
     const dispatcher = createMockDispatcher();
 
     dispatcher.registerOperation(
-      INTENT_APP_START,
-      createMinimalOperation(APP_START_OPERATION_ID, "init")
+      createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init")
     );
 
     const module = createElectronLifecycleModule(
@@ -114,8 +127,7 @@ describe("ElectronLifecycleModule Integration", () => {
     const dispatcher = createMockDispatcher();
 
     dispatcher.registerOperation(
-      INTENT_APP_START,
-      createMinimalOperation(APP_START_OPERATION_ID, "init")
+      createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init")
     );
 
     const module = createElectronLifecycleModule(
@@ -138,7 +150,7 @@ describe("ElectronLifecycleModule Integration", () => {
 
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+    dispatcher.registerOperation(new AppShutdownOperation());
 
     const module = createElectronLifecycleModule(
       createDeps({
@@ -163,7 +175,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -191,7 +203,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const mockPathProvider = {
         dataPath: (subpath: string) => new Path(`/data/${subpath}`),
@@ -233,7 +245,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -262,7 +274,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -288,7 +300,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -311,7 +323,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -334,7 +346,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -368,7 +380,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -394,7 +406,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockApp = createMockApp();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -419,7 +431,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const logger = createMockLogger();
       const dispatcher = createMockDispatcher();
 
-      dispatcher.registerOperation(INTENT_APP_START, new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const module = createElectronLifecycleModule(
         createDeps({
@@ -462,8 +474,7 @@ describe("ElectronLifecycleModule Integration", () => {
       const dispatcher = createMockDispatcher();
 
       dispatcher.registerOperation(
-        INTENT_APP_START,
-        createMinimalOperation(APP_START_OPERATION_ID, "start")
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
       );
 
       const module = createElectronLifecycleModule(

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -135,8 +135,7 @@ async function registerCrashHandlers(
   try {
     const dispatcher = createMockDispatcher();
     dispatcher.registerOperation(
-      INTENT_APP_START,
-      createMinimalOperation(APP_START_OPERATION_ID, "before-ready")
+      createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "before-ready")
     );
     dispatcher.registerModule(module);
     await dispatcher.dispatch({

--- a/src/modules/extension-module.integration.test.ts
+++ b/src/modules/extension-module.integration.test.ts
@@ -9,7 +9,7 @@
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID } from "../intents/app-start";
+import { APP_START_OPERATION_ID, INTENT_APP_START } from "../intents/app-start";
 import type { InitResult } from "../intents/app-start";
 import { createExtensionModule, type ExtensionModuleDeps } from "./extension-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
@@ -46,8 +46,7 @@ function createTestSetup(deps: ExtensionModuleDeps) {
   dispatcher.registerModule(module);
 
   dispatcher.registerOperation(
-    "app:start",
-    createMinimalOperation<never, InitResult>(APP_START_OPERATION_ID, "init", {
+    createMinimalOperation<InitResult>(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
       hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
     })
   );

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -14,9 +14,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 
+import { z } from "zod/v4";
 import type {
   Operation,
-  OperationContext,
+  OperationSchemas,
   HookContext,
   HookOutput,
 } from "../intents/lib/operation";
@@ -26,26 +27,40 @@ import type { GitWorktreeProvider } from "../boundaries/platform/git-worktree-pr
 import type { PathProvider } from "../boundaries/platform/path-provider";
 import { createMockPathProvider } from "../boundaries/platform/path-provider.test-utils";
 import type { Workspace } from "../boundaries/platform/git-types";
-import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
+import { OPEN_PROJECT_OPERATION_ID, INTENT_OPEN_PROJECT } from "../intents/open-project";
 import type { DiscoverHookResult } from "../intents/open-project";
-import { CLOSE_PROJECT_OPERATION_ID } from "../intents/close-project";
-import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
+import { CLOSE_PROJECT_OPERATION_ID, INTENT_CLOSE_PROJECT } from "../intents/close-project";
+import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import type { OpenWorkspaceIntent } from "../intents/open-workspace";
 import type { CreateHookResult } from "../intents/open-workspace";
-import { GET_PROJECT_BASES_OPERATION_ID } from "../intents/get-project-bases";
+import {
+  GET_PROJECT_BASES_OPERATION_ID,
+  INTENT_GET_PROJECT_BASES,
+} from "../intents/get-project-bases";
 import type { ListBasesHookResult } from "../intents/get-project-bases";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
+} from "../intents/delete-workspace";
 import type { DeleteWorkspaceIntent, DeletePipelineHookInput } from "../intents/delete-workspace";
 import type { DeleteHookResult, PreflightHookResult } from "../intents/delete-workspace";
-import { GET_WORKSPACE_STATUS_OPERATION_ID } from "../intents/get-workspace-status";
+import {
+  GET_WORKSPACE_STATUS_OPERATION_ID,
+  INTENT_GET_WORKSPACE_STATUS,
+} from "../intents/get-workspace-status";
 import type { GetStatusHookInput, GetStatusHookResult } from "../intents/get-workspace-status";
-import { RESOLVE_WORKSPACE_OPERATION_ID } from "../intents/resolve-workspace";
+import {
+  RESOLVE_WORKSPACE_OPERATION_ID,
+  INTENT_RESOLVE_WORKSPACE,
+} from "../intents/resolve-workspace";
 import {
   SWITCH_WORKSPACE_OPERATION_ID,
+  INTENT_SWITCH_WORKSPACE,
   type FindCandidatesHookResult,
 } from "../intents/switch-workspace";
 import {
   LIST_PROJECTS_OPERATION_ID,
+  INTENT_LIST_PROJECTS,
   type ListWorkspacesHookResult,
 } from "../intents/list-projects";
 import { EVENT_METADATA_CHANGED, type MetadataChangedEvent } from "../intents/set-metadata";
@@ -80,8 +95,9 @@ function createMockGitWorktreeProvider() {
 // Minimal Test Operations
 // =============================================================================
 
-const openProjectOperation = createMinimalOperation<Intent, DiscoverHookResult>(
+const openProjectOperation = createMinimalOperation<DiscoverHookResult>(
   OPEN_PROJECT_OPERATION_ID,
+  INTENT_OPEN_PROJECT,
   "discover",
   {
     hookContext: (ctx) => ({
@@ -91,8 +107,9 @@ const openProjectOperation = createMinimalOperation<Intent, DiscoverHookResult>(
   }
 );
 
-const closeProjectOperation = createMinimalOperation<Intent, Record<string, never>>(
+const closeProjectOperation = createMinimalOperation<Record<string, never>>(
   CLOSE_PROJECT_OPERATION_ID,
+  INTENT_CLOSE_PROJECT,
   "close",
   {
     hookContext: (ctx) => ({
@@ -103,8 +120,9 @@ const closeProjectOperation = createMinimalOperation<Intent, Record<string, neve
   }
 );
 
-const openWorkspaceOperation = createMinimalOperation<OpenWorkspaceIntent, CreateHookResult>(
+const openWorkspaceOperation = createMinimalOperation<CreateHookResult>(
   OPEN_WORKSPACE_OPERATION_ID,
+  INTENT_OPEN_WORKSPACE,
   "create",
   {
     hookContext: (ctx) => ({
@@ -116,18 +134,24 @@ const openWorkspaceOperation = createMinimalOperation<OpenWorkspaceIntent, Creat
 
 /** Preflight result from the delete-workspace preflight hook. */
 interface PreflightResult {
-  readonly isDirty?: boolean;
-  readonly unmergedCommits?: number;
-  readonly error?: string;
+  readonly isDirty?: boolean | undefined;
+  readonly unmergedCommits?: number | undefined;
+  readonly error?: string | undefined;
 }
 
 /**
  * Preflight-only operation: dispatches workspace:resolve then runs "preflight" hook point.
  */
-class MinimalPreflightOperation implements Operation<DeleteWorkspaceIntent, PreflightResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
+const preflightSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.custom<DeleteWorkspaceIntent["payload"]>(),
+  result: z.custom<PreflightResult>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<PreflightResult> {
+const minimalPreflightOperation: Operation<typeof preflightSchemas> = {
+  id: DELETE_WORKSPACE_OPERATION_ID,
+  schemas: preflightSchemas,
+  async execute(ctx): Promise<PreflightResult> {
     const { payload } = ctx.intent;
 
     let resolvedProjectPath = "";
@@ -154,8 +178,8 @@ class MinimalPreflightOperation implements Operation<DeleteWorkspaceIntent, Pref
     );
     if (errors.length > 0) return { error: errors[0]!.message };
     return results[0] ?? {};
-  }
-}
+  },
+};
 
 /** Extended delete result that includes the resolved path and possible error. */
 interface DeleteResult extends DeleteHookResult {
@@ -165,10 +189,16 @@ interface DeleteResult extends DeleteHookResult {
 /**
  * Delete-workspace operation: dispatches workspace:resolve then runs "delete" hook point.
  */
-class MinimalDeleteWorkspaceOperation implements Operation<DeleteWorkspaceIntent, DeleteResult> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
+const deleteWorkspaceSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.custom<DeleteWorkspaceIntent["payload"]>(),
+  result: z.custom<DeleteResult>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<DeleteResult> {
+const minimalDeleteWorkspaceOperation: Operation<typeof deleteWorkspaceSchemas> = {
+  id: DELETE_WORKSPACE_OPERATION_ID,
+  schemas: deleteWorkspaceSchemas,
+  async execute(ctx): Promise<DeleteResult> {
     const { payload } = ctx.intent;
 
     // Dispatch workspace:resolve (matching real operation)
@@ -199,8 +229,8 @@ class MinimalDeleteWorkspaceOperation implements Operation<DeleteWorkspaceIntent
       ...deleteResults[0],
       ...(resolvedProjectPath !== "" && { resolvedPath: payload.workspacePath }),
     };
-  }
-}
+  },
+};
 
 /** Result from workspace path resolution (reverse lookup: workspacePath → projectPath + workspaceName). */
 interface ResolveResult {
@@ -215,10 +245,16 @@ interface ResolveResult {
  * resolve hook under that operation. Accepts workspacePath and reverse-looks
  * up projectPath + workspaceName.
  */
-class MinimalResolveWorkspaceOperation implements Operation<Intent, ResolveResult> {
-  readonly id = RESOLVE_WORKSPACE_OPERATION_ID;
+const resolveWorkspaceSchemas = {
+  type: INTENT_RESOLVE_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<ResolveResult>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<ResolveResult> {
+const minimalResolveWorkspaceOperation: Operation<typeof resolveWorkspaceSchemas> = {
+  id: RESOLVE_WORKSPACE_OPERATION_ID,
+  schemas: resolveWorkspaceSchemas,
+  async execute(ctx): Promise<ResolveResult> {
     const payload = ctx.intent.payload as { workspacePath: string };
     const resolveInput = {
       intent: ctx.intent,
@@ -231,24 +267,30 @@ class MinimalResolveWorkspaceOperation implements Operation<Intent, ResolveResul
     const projectPath = resolveResults[0]?.projectPath;
     const workspaceName = resolveResults[0]?.workspaceName;
     return projectPath ? { projectPath, workspaceName } : {};
-  }
-}
+  },
+};
 
 /** Result from get-project-bases list + refresh dispatch. */
 interface GetProjectBasesTestResult {
-  readonly bases?: readonly { name: string; isRemote: boolean }[];
-  readonly defaultBaseBranch?: string;
-  readonly refreshed?: boolean;
+  readonly bases?: readonly { name: string; isRemote: boolean }[] | undefined;
+  readonly defaultBaseBranch?: string | undefined;
+  readonly refreshed?: boolean | undefined;
 }
 
 /**
  * Minimal get-project-bases operation: calls "list" hook, then optionally "refresh".
  * The intent payload controls which hooks to run via a `hookPoint` field.
  */
-class MinimalGetProjectBasesOperation implements Operation<Intent, GetProjectBasesTestResult> {
-  readonly id = GET_PROJECT_BASES_OPERATION_ID;
+const getProjectBasesSchemas = {
+  type: INTENT_GET_PROJECT_BASES,
+  payload: z.unknown(),
+  result: z.custom<GetProjectBasesTestResult>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<GetProjectBasesTestResult> {
+const minimalGetProjectBasesOperation: Operation<typeof getProjectBasesSchemas> = {
+  id: GET_PROJECT_BASES_OPERATION_ID,
+  schemas: getProjectBasesSchemas,
+  async execute(ctx): Promise<GetProjectBasesTestResult> {
     const payload = ctx.intent.payload as {
       projectPath: string;
       hookPoint?: "list" | "refresh";
@@ -265,8 +307,8 @@ class MinimalGetProjectBasesOperation implements Operation<Intent, GetProjectBas
     const { results, errors } = await ctx.hooks.collect<ListBasesHookResult>("list", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
-  }
-}
+  },
+};
 
 /** Result from get-workspace-status: resolve-workspace + get. */
 interface GetStatusResult {
@@ -278,10 +320,16 @@ interface GetStatusResult {
  * Get-workspace-status operation: dispatches workspace:resolve then runs "get" hook point.
  * Mirrors the real GetWorkspaceStatusOperation.
  */
-class MinimalGetStatusOperation implements Operation<Intent, GetStatusResult> {
-  readonly id = GET_WORKSPACE_STATUS_OPERATION_ID;
+const getStatusSchemas = {
+  type: INTENT_GET_WORKSPACE_STATUS,
+  payload: z.unknown(),
+  result: z.custom<GetStatusResult>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<GetStatusResult> {
+const minimalGetStatusOperation: Operation<typeof getStatusSchemas> = {
+  id: GET_WORKSPACE_STATUS_OPERATION_ID,
+  schemas: getStatusSchemas,
+  async execute(ctx): Promise<GetStatusResult> {
     const payload = ctx.intent.payload as { workspacePath: string };
 
     // Dispatch workspace:resolve (matching real operation)
@@ -310,29 +358,36 @@ class MinimalGetStatusOperation implements Operation<Intent, GetStatusResult> {
       }
     }
     return { isDirty, unmergedCommits };
-  }
-}
+  },
+};
 
 /**
  * Emit-event operation: emits a domain event from within an operation context.
  * Used to trigger event subscriptions registered by modules.
  */
-class MinimalEmitEventOperation implements Operation<Intent, void> {
-  readonly id = "emit-event";
+const emitEventSchemas = {
+  type: "emit-event",
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
+const minimalEmitEventOperation: Operation<typeof emitEventSchemas> = {
+  id: "emit-event",
+  schemas: emitEventSchemas,
+  async execute(ctx): Promise<void> {
     const event = ctx.intent.payload as DomainEvent;
     ctx.emit(event);
-  }
-}
+  },
+};
 
-const switchWorkspaceOperation = createMinimalOperation<Intent, FindCandidatesHookResult>(
+const switchWorkspaceOperation = createMinimalOperation<FindCandidatesHookResult>(
   SWITCH_WORKSPACE_OPERATION_ID,
+  INTENT_SWITCH_WORKSPACE,
   "find-candidates"
 );
 
-const listProjectsOperation = createMinimalOperation<Intent, ListWorkspacesHookResult>(
+const listProjectsOperation = createMinimalOperation<ListWorkspacesHookResult>(
   LIST_PROJECTS_OPERATION_ID,
+  INTENT_LIST_PROJECTS,
   "list-workspaces"
 );
 
@@ -356,16 +411,16 @@ function createTestSetup(): TestSetup {
   const dispatcher = createMockDispatcher();
 
   // Register operations
-  dispatcher.registerOperation("project:open", openProjectOperation);
-  dispatcher.registerOperation("project:close", closeProjectOperation);
-  dispatcher.registerOperation("workspace:open", openWorkspaceOperation);
-  dispatcher.registerOperation("workspace:delete", new MinimalDeleteWorkspaceOperation());
-  dispatcher.registerOperation("workspace:resolve", new MinimalResolveWorkspaceOperation());
-  dispatcher.registerOperation("project:get-bases", new MinimalGetProjectBasesOperation());
-  dispatcher.registerOperation("workspace:get-status", new MinimalGetStatusOperation());
-  dispatcher.registerOperation("emit-event", new MinimalEmitEventOperation());
-  dispatcher.registerOperation("workspace:switch", switchWorkspaceOperation);
-  dispatcher.registerOperation("project:list", listProjectsOperation);
+  dispatcher.registerOperation(openProjectOperation);
+  dispatcher.registerOperation(closeProjectOperation);
+  dispatcher.registerOperation(openWorkspaceOperation);
+  dispatcher.registerOperation(minimalDeleteWorkspaceOperation);
+  dispatcher.registerOperation(minimalResolveWorkspaceOperation);
+  dispatcher.registerOperation(minimalGetProjectBasesOperation);
+  dispatcher.registerOperation(minimalGetStatusOperation);
+  dispatcher.registerOperation(minimalEmitEventOperation);
+  dispatcher.registerOperation(switchWorkspaceOperation);
+  dispatcher.registerOperation(listProjectsOperation);
 
   // Wire the module under test
   const module = createGitWorktreeWorkspaceModule(
@@ -386,9 +441,9 @@ function createPreflightTestSetup(): Omit<TestSetup, "module"> {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation("project:open", openProjectOperation);
-  dispatcher.registerOperation("workspace:delete", new MinimalPreflightOperation());
-  dispatcher.registerOperation("workspace:resolve", new MinimalResolveWorkspaceOperation());
+  dispatcher.registerOperation(openProjectOperation);
+  dispatcher.registerOperation(minimalPreflightOperation);
+  dispatcher.registerOperation(minimalResolveWorkspaceOperation);
 
   const module = createGitWorktreeWorkspaceModule(
     provider as unknown as GitWorktreeProvider,

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -15,17 +15,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 vi.mock("./watcher-shim", () => ({ applyWatcherShim: vi.fn().mockResolvedValue(1) }));
 import { delimiter, join } from "node:path";
 
-import type { Operation, OperationContext } from "../../intents/lib/operation";
-import type { Intent } from "../../intents/lib/types";
+import { z } from "zod/v4";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../../intents/lib/operation";
 import type { IntentModule } from "../../intents/lib/module";
 import { createMinimalOperation } from "../../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID } from "../../intents/app-start";
+import { APP_START_OPERATION_ID, INTENT_APP_START } from "../../intents/app-start";
 import type {
   CheckDepsHookContext,
   CheckDepsResult,
   ConfigureResult,
 } from "../../intents/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../../intents/app-shutdown";
+import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../../intents/app-shutdown";
 import {
   AppResumeOperation,
   INTENT_APP_RESUME,
@@ -34,15 +39,18 @@ import {
   EVENT_IDE_SERVER_RESTARTED,
 } from "../../intents/app-resume";
 import type { DomainEvent } from "../../intents/lib/types";
-import { SETUP_OPERATION_ID } from "../../intents/setup";
+import { SETUP_OPERATION_ID, INTENT_SETUP } from "../../intents/setup";
 import type {
   BinaryHookInput,
   ExtensionsHookInput,
   SetupProgressPayload,
 } from "../../intents/setup";
-import { OPEN_WORKSPACE_OPERATION_ID } from "../../intents/open-workspace";
+import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../../intents/open-workspace";
 import type { FinalizeHookInput, OpenWorkspaceIntent } from "../../intents/open-workspace";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../../intents/delete-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
+} from "../../intents/delete-workspace";
 import type {
   DeleteWorkspaceIntent,
   DeletePipelineHookInput,
@@ -68,10 +76,19 @@ import type { ProjectId, WorkspaceName } from "../../shared/api/types";
 // Minimal Test Operations
 // =============================================================================
 
-class MinimalBeforeReadyOperation implements Operation<Intent, readonly ConfigureResult[]> {
-  readonly id = APP_START_OPERATION_ID;
+const beforeReadySchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<readonly ConfigureResult[]>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<readonly ConfigureResult[]> {
+class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = beforeReadySchemas;
+
+  async execute(
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+  ): Promise<readonly ConfigureResult[]> {
     const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
       intent: ctx.intent,
     });
@@ -80,15 +97,24 @@ class MinimalBeforeReadyOperation implements Operation<Intent, readonly Configur
   }
 }
 
-class MinimalCheckDepsOperation implements Operation<Intent, CheckDepsResult> {
+const checkDepsSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<CheckDepsResult>(),
+} satisfies OperationSchemas;
+
+class MinimalCheckDepsOperation implements Operation<typeof checkDepsSchemas> {
   readonly id = APP_START_OPERATION_ID;
+  readonly schemas = checkDepsSchemas;
   private readonly extensionRequirements: readonly ExtensionRequirement[];
 
   constructor(extensionRequirements: readonly ExtensionRequirement[] = []) {
     this.extensionRequirements = extensionRequirements;
   }
 
-  async execute(ctx: OperationContext<Intent>): Promise<CheckDepsResult> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof checkDepsSchemas>>
+  ): Promise<CheckDepsResult> {
     const hookCtx: CheckDepsHookContext = {
       intent: ctx.intent,
       configuredAgent: "claude",
@@ -115,10 +141,17 @@ class MinimalCheckDepsOperation implements Operation<Intent, CheckDepsResult> {
   }
 }
 
-class MinimalStartOperation implements Operation<Intent, number | undefined> {
-  readonly id = APP_START_OPERATION_ID;
+const startSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<number | undefined>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<number | undefined> {
+class MinimalStartOperation implements Operation<typeof startSchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = startSchemas;
+
+  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | undefined> {
     const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
       intent: ctx.intent,
     });
@@ -127,8 +160,15 @@ class MinimalStartOperation implements Operation<Intent, number | undefined> {
   }
 }
 
-class MinimalBinaryOperation implements Operation<Intent, void> {
+const binarySchemas = {
+  type: INTENT_SETUP,
+  payload: z.unknown(),
+  result: z.custom<void>(),
+} satisfies OperationSchemas;
+
+class MinimalBinaryOperation implements Operation<typeof binarySchemas> {
   readonly id = SETUP_OPERATION_ID;
+  readonly schemas = binarySchemas;
   private readonly hookInput: Partial<BinaryHookInput>;
   /** Progress frames yielded by the streaming binary handler. */
   readonly frames: SetupProgressPayload[] = [];
@@ -137,7 +177,7 @@ class MinimalBinaryOperation implements Operation<Intent, void> {
     this.hookInput = hookInput;
   }
 
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
+  async execute(ctx: OperationContext<IntentOf<typeof binarySchemas>>): Promise<void> {
     const { errors } = await ctx.hooks.collect(
       "binary",
       { intent: ctx.intent, ...this.hookInput },
@@ -151,8 +191,15 @@ class MinimalBinaryOperation implements Operation<Intent, void> {
   }
 }
 
-class MinimalExtensionsOperation implements Operation<Intent, void> {
+const extensionsSchemas = {
+  type: INTENT_SETUP,
+  payload: z.unknown(),
+  result: z.custom<void>(),
+} satisfies OperationSchemas;
+
+class MinimalExtensionsOperation implements Operation<typeof extensionsSchemas> {
   readonly id = SETUP_OPERATION_ID;
+  readonly schemas = extensionsSchemas;
   private readonly hookInput: Partial<ExtensionsHookInput>;
   /** Progress frames yielded by the streaming extensions handler. */
   readonly frames: SetupProgressPayload[] = [];
@@ -161,7 +208,7 @@ class MinimalExtensionsOperation implements Operation<Intent, void> {
     this.hookInput = hookInput;
   }
 
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
+  async execute(ctx: OperationContext<IntentOf<typeof extensionsSchemas>>): Promise<void> {
     const { errors } = await ctx.hooks.collect(
       "extensions",
       { intent: ctx.intent, ...this.hookInput },
@@ -175,15 +222,24 @@ class MinimalExtensionsOperation implements Operation<Intent, void> {
   }
 }
 
-class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, string | undefined> {
+const finalizeSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<string | undefined>(),
+} satisfies OperationSchemas;
+
+class MinimalFinalizeOperation implements Operation<typeof finalizeSchemas> {
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
+  readonly schemas = finalizeSchemas;
   private readonly hookInput: Partial<FinalizeHookInput>;
 
   constructor(hookInput: Partial<FinalizeHookInput> = {}) {
     this.hookInput = hookInput;
   }
 
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<string | undefined> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof finalizeSchemas>>
+  ): Promise<string | undefined> {
     const { errors, results } = await ctx.hooks.collect<string>("finalize", {
       intent: ctx.intent,
       workspacePath: "/test/project/.worktrees/feature-1",
@@ -197,15 +253,16 @@ class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, string 
 }
 
 /** Runs the "delete" hook point with a canned delete-pipeline context. */
-function createMinimalDeleteOperation(): Operation<DeleteWorkspaceIntent, DeleteHookResult> {
-  return createMinimalOperation<DeleteWorkspaceIntent, DeleteHookResult>(
+function createMinimalDeleteOperation() {
+  return createMinimalOperation<DeleteHookResult>(
     DELETE_WORKSPACE_OPERATION_ID,
+    INTENT_DELETE_WORKSPACE,
     "delete",
     {
       hookContext: (ctx): DeletePipelineHookInput => ({
         intent: ctx.intent,
         projectPath: "/projects/test",
-        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        workspacePath: (ctx.intent as DeleteWorkspaceIntent).payload.workspacePath ?? "",
         workspaceName: "test-workspace" as WorkspaceName,
         active: false,
       }),
@@ -324,7 +381,7 @@ describe("CodeServerModule", () => {
     it("declares code-server wrapper scripts", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalBeforeReadyOperation());
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
 
       const results = (await dispatcher.dispatch({
         type: "app:start",
@@ -348,7 +405,7 @@ describe("CodeServerModule", () => {
         new FileSystemError("ENOENT", "/bundles/code-server", "not found")
       );
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+      dispatcher.registerOperation(new MinimalCheckDepsOperation());
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -361,7 +418,7 @@ describe("CodeServerModule", () => {
     it("returns empty missingBinaries when up-to-date", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+      dispatcher.registerOperation(new MinimalCheckDepsOperation());
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -376,7 +433,7 @@ describe("CodeServerModule", () => {
       delete (allDeps as unknown as Record<string, unknown>).archiveExtractor;
       const deps = allDeps;
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation());
+      dispatcher.registerOperation(new MinimalCheckDepsOperation());
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -396,7 +453,7 @@ describe("CodeServerModule", () => {
         { id: "ext.one", version: "1.0.0", vsixPath: "/path/ext-one.vsix" },
         { id: "ext.two", version: "2.0.0", vsixPath: "/path/ext-two.vsix" },
       ];
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation(requirements));
+      dispatcher.registerOperation(new MinimalCheckDepsOperation(requirements));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -422,7 +479,7 @@ describe("CodeServerModule", () => {
       const requirements: ExtensionRequirement[] = [
         { id: "ext.one", version: "1.0.0", vsixPath: "/path/ext-one.vsix" },
       ];
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation(requirements));
+      dispatcher.registerOperation(new MinimalCheckDepsOperation(requirements));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -447,7 +504,7 @@ describe("CodeServerModule", () => {
       const requirements: ExtensionRequirement[] = [
         { id: "ext.one", version: "1.0.0", vsixPath: "/path/ext-one.vsix" },
       ];
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation(requirements));
+      dispatcher.registerOperation(new MinimalCheckDepsOperation(requirements));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -460,7 +517,7 @@ describe("CodeServerModule", () => {
     it("returns empty install plan when no requirements provided", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalCheckDepsOperation([]));
+      dispatcher.registerOperation(new MinimalCheckDepsOperation([]));
 
       const result = (await dispatcher.dispatch({
         type: "app:start",
@@ -479,7 +536,7 @@ describe("CodeServerModule", () => {
     it("starts code-server and returns port", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       const codeServerPort = (await dispatcher.dispatch({
         type: "app:start",
@@ -494,7 +551,7 @@ describe("CodeServerModule", () => {
     it("ensures required directories exist", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -504,7 +561,7 @@ describe("CodeServerModule", () => {
     it("checks port availability before spawning", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -514,7 +571,7 @@ describe("CodeServerModule", () => {
     it("spawns code-server with correct arguments", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -553,7 +610,7 @@ describe("CodeServerModule", () => {
     it("spawns codium-server with reh-web arguments on the vscodium port", async () => {
       const deps = vscodiumDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -579,7 +636,7 @@ describe("CodeServerModule", () => {
     it("points the wrappers at the vscodium remote-cli and root-level node", async () => {
       const deps = vscodiumDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -602,13 +659,14 @@ describe("CodeServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
 
       // Start first
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       // Then stop
       dispatcher.registerOperation(
-        "app:shutdown",
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
       await dispatcher.dispatch({ type: "app:shutdown", payload: {} });
 
@@ -670,9 +728,9 @@ describe("CodeServerModule", () => {
       const deps = createDownloadDeps({ archiveExtractor });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(archiveExtractor.$.extractions.length).toBeGreaterThan(0);
       expect(op.frames).toContainEqual({ id: "vscode", status: "done" });
@@ -683,9 +741,9 @@ describe("CodeServerModule", () => {
       const deps = createDownloadDeps({ archiveExtractor });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: [] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(archiveExtractor).toHaveNoExtractions();
       expect(op.frames).toContainEqual({ id: "vscode", status: "done" });
@@ -702,9 +760,9 @@ describe("CodeServerModule", () => {
       });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(op.frames).toContainEqual({
         id: "vscode",
@@ -731,9 +789,9 @@ describe("CodeServerModule", () => {
       const deps = createDownloadDeps({ archiveExtractor });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(op.frames).toContainEqual({
         id: "vscode",
@@ -756,9 +814,11 @@ describe("CodeServerModule", () => {
       const deps = createDownloadDeps({ archiveExtractor });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
+      await expect(dispatcher.dispatch({ type: INTENT_SETUP, payload: {} })).rejects.toThrow(
+        SetupError
+      );
       expect(op.frames).toContainEqual(
         expect.objectContaining({
           id: "vscode",
@@ -777,9 +837,9 @@ describe("CodeServerModule", () => {
       });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(applyWatcherShim).toHaveBeenCalledWith(
         expect.objectContaining({ fileSystemLayer: deps.fileSystemLayer }),
@@ -792,9 +852,9 @@ describe("CodeServerModule", () => {
       const deps = createDownloadDeps({ archiveExtractor: createArchiveExtractorMock() });
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalBinaryOperation({ missingBinaries: ["code-server"] });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(applyWatcherShim).not.toHaveBeenCalled();
     });
@@ -812,9 +872,9 @@ describe("CodeServerModule", () => {
         { id: "ext.one", vsixPath: "/path/ext-one.vsix" },
       ];
       const op = new MinimalExtensionsOperation({ extensionInstallPlan: installPlan });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(asMockRunner(deps)).toHaveSpawned([
         {
@@ -843,9 +903,9 @@ describe("CodeServerModule", () => {
         { id: "ext.one", vsixPath: "/path/ext-one.vsix" },
       ];
       const op = new MinimalExtensionsOperation({ extensionInstallPlan: installPlan });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       // Should remove old directory
       expect(deps.fileSystemLayer.rm).toHaveBeenCalledWith(
@@ -858,9 +918,9 @@ describe("CodeServerModule", () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
       const op = new MinimalExtensionsOperation();
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await dispatcher.dispatch({ type: "setup", payload: {} });
+      await dispatcher.dispatch({ type: INTENT_SETUP, payload: {} });
 
       expect(() => asMockRunner(deps).$.spawned(0)).toThrow();
       expect(op.frames).toContainEqual({ id: "setup", status: "done" });
@@ -884,9 +944,11 @@ describe("CodeServerModule", () => {
         { id: "ext.one", vsixPath: "/path/ext-one.vsix" },
       ];
       const op = new MinimalExtensionsOperation({ extensionInstallPlan: installPlan });
-      dispatcher.registerOperation("setup", op);
+      dispatcher.registerOperation(op);
 
-      await expect(dispatcher.dispatch({ type: "setup", payload: {} })).rejects.toThrow(SetupError);
+      await expect(dispatcher.dispatch({ type: INTENT_SETUP, payload: {} })).rejects.toThrow(
+        SetupError
+      );
       expect(op.frames).toContainEqual(
         expect.objectContaining({
           id: "setup",
@@ -912,12 +974,11 @@ describe("CodeServerModule", () => {
       dispatcher.registerModule(module);
 
       // Register start operation and run it to set port
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       // Now register finalize operation and test it
       dispatcher.registerOperation(
-        "workspace:open",
         new MinimalFinalizeOperation({
           workspacePath: "/test/project/.worktrees/feature-1",
           envVars: { OPENCODE_PORT: "8080" },
@@ -970,12 +1031,11 @@ describe("CodeServerModule", () => {
       dispatcher.registerModule(module);
 
       // Start to set port
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       // Finalize
       dispatcher.registerOperation(
-        "workspace:open",
         new MinimalFinalizeOperation({
           workspacePath: "/test/project/.worktrees/feature-1",
           envVars: {},
@@ -1004,7 +1064,7 @@ describe("CodeServerModule", () => {
     it("deletes workspace file", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       await dispatcher.dispatch({
         type: "workspace:delete",
@@ -1040,7 +1100,7 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       // Should not throw
       const result = (await dispatcher.dispatch({
@@ -1074,7 +1134,7 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       await expect(
         dispatcher.dispatch({
@@ -1102,7 +1162,7 @@ describe("CodeServerModule", () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps, 9876);
 
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       const runCall = asMockRunner(deps).$.spawned(0).$;
@@ -1139,7 +1199,7 @@ describe("CodeServerModule", () => {
 
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1152,7 +1212,7 @@ describe("CodeServerModule", () => {
     it("includes EDITOR with absolute path and flags", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1169,7 +1229,7 @@ describe("CodeServerModule", () => {
     it("includes GIT_SEQUENCE_EDITOR same as EDITOR", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1186,7 +1246,7 @@ describe("CodeServerModule", () => {
 
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1200,7 +1260,7 @@ describe("CodeServerModule", () => {
     it("sets VSCODE_PROXY_URI to empty string", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1212,7 +1272,7 @@ describe("CodeServerModule", () => {
     it("omits _CH_PLUGIN_PORT when plugin port not set", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1224,7 +1284,7 @@ describe("CodeServerModule", () => {
     it("points the wrappers at the code-server remote-cli/node, plus opencode dir", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -1249,7 +1309,7 @@ describe("CodeServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).rejects.toThrow(
         "already in use"
@@ -1268,7 +1328,7 @@ describe("CodeServerModule", () => {
           },
         });
         const { dispatcher } = createTestSetup(deps);
-        dispatcher.registerOperation("app:start", new MinimalStartOperation());
+        dispatcher.registerOperation(new MinimalStartOperation());
 
         let caughtError: unknown;
         const startPromise = dispatcher
@@ -1302,9 +1362,9 @@ describe("CodeServerModule", () => {
       deps: IdeServerModuleDeps
     ): Promise<{ dispatcher: ReturnType<typeof createTestSetup>["dispatcher"] }> {
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
-      dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+      dispatcher.registerOperation(new AppResumeOperation());
       return { dispatcher };
     }
 
@@ -1412,7 +1472,7 @@ describe("CodeServerModule", () => {
     it("skips probe when code-server was never started", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+      dispatcher.registerOperation(new AppResumeOperation());
 
       const fetchMock = deps.httpClient.fetch as ReturnType<typeof vi.fn>;
       fetchMock.mockClear();

--- a/src/modules/keepfiles-module.integration.test.ts
+++ b/src/modules/keepfiles-module.integration.test.ts
@@ -12,7 +12,11 @@ import { Dispatcher } from "../intents/lib/dispatcher";
 
 import type { Intent } from "../intents/lib/types";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import { OPEN_WORKSPACE_OPERATION_ID, type SetupHookResult } from "../intents/open-workspace";
+import {
+  OPEN_WORKSPACE_OPERATION_ID,
+  INTENT_OPEN_WORKSPACE,
+  type SetupHookResult,
+} from "../intents/open-workspace";
 import { createKeepFilesModule } from "./keepfiles-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createBehavioralLogger } from "../boundaries/platform/logging.test-utils";
@@ -43,17 +47,21 @@ function createTestSetup(
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(
-    "workspace:open",
-    createMinimalOperation<Intent, SetupHookResult>(OPEN_WORKSPACE_OPERATION_ID, "setup", {
-      hookContext: (ctx) => {
-        const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
-        return {
-          intent: ctx.intent,
-          projectPath: payload.projectPath,
-          workspacePath: payload.workspacePath,
-        };
-      },
-    })
+    createMinimalOperation<SetupHookResult>(
+      OPEN_WORKSPACE_OPERATION_ID,
+      INTENT_OPEN_WORKSPACE,
+      "setup",
+      {
+        hookContext: (ctx) => {
+          const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
+          return {
+            intent: ctx.intent,
+            projectPath: payload.projectPath,
+            workspacePath: payload.workspacePath,
+          };
+        },
+      }
+    )
   );
 
   const module = createKeepFilesModule({
@@ -109,17 +117,21 @@ describe("KeepFilesModule Integration", () => {
       const dispatcher = createMockDispatcher();
 
       dispatcher.registerOperation(
-        "workspace:open",
-        createMinimalOperation<Intent, SetupHookResult>(OPEN_WORKSPACE_OPERATION_ID, "setup", {
-          hookContext: (ctx) => {
-            const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
-            return {
-              intent: ctx.intent,
-              projectPath: payload.projectPath,
-              workspacePath: payload.workspacePath,
-            };
-          },
-        })
+        createMinimalOperation<SetupHookResult>(
+          OPEN_WORKSPACE_OPERATION_ID,
+          INTENT_OPEN_WORKSPACE,
+          "setup",
+          {
+            hookContext: (ctx) => {
+              const payload = ctx.intent.payload as { projectPath: string; workspacePath: string };
+              return {
+                intent: ctx.intent,
+                projectPath: payload.projectPath,
+                workspacePath: payload.workspacePath,
+              };
+            },
+          }
+        )
       );
 
       const module = createKeepFilesModule({

--- a/src/modules/logging-module.integration.test.ts
+++ b/src/modules/logging-module.integration.test.ts
@@ -7,9 +7,15 @@
 
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
+import { z } from "zod/v4";
 
-import type { Operation, OperationContext, HookContext } from "../intents/lib/operation";
-import type { Intent } from "../intents/lib/types";
+import type {
+  Operation,
+  OperationContext,
+  HookContext,
+  OperationSchemas,
+  IntentOf,
+} from "../intents/lib/operation";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, InitHookContext, ConfigureResult } from "../intents/app-start";
 import { INTENT_APP_SHUTDOWN, APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
@@ -22,10 +28,16 @@ import { createMockConfig } from "../boundaries/platform/config.test-utils";
 // Minimal Test Operation
 // =============================================================================
 
+const appStartSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
+
 /** Runs "before-ready" and "init" hook points in sequence. */
-class MinimalAppStartOperation implements Operation<Intent, void> {
+class MinimalAppStartOperation implements Operation<typeof appStartSchemas> {
   readonly id = APP_START_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
+  readonly schemas = appStartSchemas;
+  async execute(ctx: OperationContext<IntentOf<typeof appStartSchemas>>): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
 
     const { errors: beforeReadyErrors } = await ctx.hooks.collect<ConfigureResult>(
@@ -44,10 +56,16 @@ class MinimalAppStartOperation implements Operation<Intent, void> {
   }
 }
 
+const appShutdownSchemas = {
+  type: INTENT_APP_SHUTDOWN,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
+
 /** Runs the "stop" hook for shutdown. */
-class MinimalAppShutdownOperation implements Operation<Intent, void> {
+class MinimalAppShutdownOperation implements Operation<typeof appShutdownSchemas> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
+  readonly schemas = appShutdownSchemas;
+  async execute(ctx: OperationContext<IntentOf<typeof appShutdownSchemas>>): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
     await ctx.hooks.collect<void>("stop", hookCtx);
   }
@@ -129,7 +147,7 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
@@ -150,7 +168,7 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
@@ -165,7 +183,7 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
@@ -186,7 +204,7 @@ describe("LoggingModule Integration", () => {
     });
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
@@ -211,7 +229,7 @@ describe("LoggingModule Integration", () => {
     });
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({
@@ -232,7 +250,7 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
@@ -249,7 +267,7 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
@@ -266,7 +284,7 @@ describe("LoggingModule Integration", () => {
     deps.files.set("/logs/electron.log", oversize);
 
     const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
 
@@ -285,7 +303,7 @@ describe("LoggingModule Integration", () => {
     deps.files.set("/logs/electron.log", "small");
 
     const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
 
@@ -301,7 +319,7 @@ describe("LoggingModule Integration", () => {
     // No file seeded — readFile rejects with ENOENT
 
     const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
 
@@ -315,8 +333,8 @@ describe("LoggingModule Integration", () => {
     const deps = createDeps();
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalAppStartOperation());
-    dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new MinimalAppShutdownOperation());
+    dispatcher.registerOperation(new MinimalAppStartOperation());
+    dispatcher.registerOperation(new MinimalAppShutdownOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
     await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);

--- a/src/modules/mcp-module.integration.test.ts
+++ b/src/modules/mcp-module.integration.test.ts
@@ -186,8 +186,9 @@ describe("McpModule Integration", () => {
       const mockSdkFactory: McpServerFactory = () => createMockMcpSdk();
 
       dispatcher.registerOperation(
-        INTENT_APP_START,
-        createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start", {
+          throwOnError: false,
+        })
       );
 
       const mcpModule = createMcpModule({
@@ -214,10 +215,11 @@ describe("McpModule Integration", () => {
       const portManager = createPortManagerMock([9999]);
       const mockSdkFactory: McpServerFactory = () => createMockMcpSdk();
 
-      shutdownDispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+      shutdownDispatcher.registerOperation(new AppShutdownOperation());
       shutdownDispatcher.registerOperation(
-        INTENT_APP_START,
-        createMinimalOperation(APP_START_OPERATION_ID, "start", { throwOnError: false })
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start", {
+          throwOnError: false,
+        })
       );
 
       const mcpModule = createMcpModule({

--- a/src/modules/mcp-server.test-utils.ts
+++ b/src/modules/mcp-server.test-utils.ts
@@ -10,9 +10,10 @@
 
 import { createServer } from "node:net";
 import { vi } from "vitest";
+import { z } from "zod/v4";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { Intent } from "../intents/lib/types";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import type { Operation, OperationContext, OperationSchemas } from "../intents/lib/operation";
 import { type ProjectId, type DeletionProgress } from "../shared/api/types";
 import {
   INTENT_GET_WORKSPACE_STATUS,
@@ -193,58 +194,67 @@ export function createMockToolOperations(
       capturedIntents.push(ctx.intent);
       return result;
     });
-    const operation: Operation<Intent, unknown> = { id: def.operationId, execute };
-    dispatcher.registerOperation(def.intent, operation);
+    const schemas = {
+      type: def.intent,
+      payload: z.unknown(),
+      result: z.unknown(),
+    } satisfies OperationSchemas;
+    const operation: Operation<typeof schemas> = { id: def.operationId, schemas, execute };
+    dispatcher.registerOperation(operation);
     operations[key] = execute;
   }
 
   // workspace_delete waits for a terminal deletion-progress event to learn the
   // real outcome, so the mock delete op emits one.
   const deleteControl: DeleteControl = { mode: "success" };
-  const deleteExecute = vi.fn(
-    async (ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: true }> => {
-      capturedIntents.push(ctx.intent);
-      if (deleteControl.mode === "reject") {
-        throw new Error("Preflight check failed: Workspace has uncommitted changes");
-      }
-      const { workspacePath, keepBranch } = ctx.intent.payload;
-      const hasErrors = deleteControl.mode === "blocked";
-      const progress: DeletionProgress = {
-        workspacePath: workspacePath as DeletionProgress["workspacePath"],
-        workspaceName: "feature-branch" as DeletionProgress["workspaceName"],
-        projectId: "test-12345678" as ProjectId,
-        keepBranch,
-        operations: [
-          {
-            id: "cleanup-workspace",
-            label: "Removing workspace",
-            status: hasErrors ? "error" : "done",
-            ...(hasErrors ? { error: "EBUSY: resource busy or locked" } : {}),
-          },
-        ],
-        completed: true,
-        hasErrors,
-        ...(deleteControl.blockingProcesses
-          ? {
-              blockingProcesses: deleteControl.blockingProcesses.map((p) => ({
-                pid: p.pid,
-                name: p.name,
-                commandLine: p.name,
-                files: [],
-                cwd: null,
-              })),
-            }
-          : {}),
-      };
-      await ctx.emit({ type: EVENT_WORKSPACE_DELETION_PROGRESS, payload: progress });
-      return { started: true };
+  const deleteExecute = vi.fn(async (ctx: OperationContext<Intent>): Promise<{ started: true }> => {
+    capturedIntents.push(ctx.intent);
+    if (deleteControl.mode === "reject") {
+      throw new Error("Preflight check failed: Workspace has uncommitted changes");
     }
-  );
-  const deleteOperation: Operation<DeleteWorkspaceIntent, { started: true }> = {
+    const { workspacePath, keepBranch } = ctx.intent.payload as DeleteWorkspaceIntent["payload"];
+    const hasErrors = deleteControl.mode === "blocked";
+    const progress: DeletionProgress = {
+      workspacePath: workspacePath as DeletionProgress["workspacePath"],
+      workspaceName: "feature-branch" as DeletionProgress["workspaceName"],
+      projectId: "test-12345678" as ProjectId,
+      keepBranch,
+      operations: [
+        {
+          id: "cleanup-workspace",
+          label: "Removing workspace",
+          status: hasErrors ? "error" : "done",
+          ...(hasErrors ? { error: "EBUSY: resource busy or locked" } : {}),
+        },
+      ],
+      completed: true,
+      hasErrors,
+      ...(deleteControl.blockingProcesses
+        ? {
+            blockingProcesses: deleteControl.blockingProcesses.map((p) => ({
+              pid: p.pid,
+              name: p.name,
+              commandLine: p.name,
+              files: [],
+              cwd: null,
+            })),
+          }
+        : {}),
+    };
+    await ctx.emit({ type: EVENT_WORKSPACE_DELETION_PROGRESS, payload: progress });
+    return { started: true };
+  });
+  const deleteSchemas = {
+    type: INTENT_DELETE_WORKSPACE,
+    payload: z.unknown(),
+    result: z.custom<{ started: true }>(),
+  } satisfies OperationSchemas;
+  const deleteOperation: Operation<typeof deleteSchemas> = {
     id: DELETE_WORKSPACE_OPERATION_ID,
+    schemas: deleteSchemas,
     execute: deleteExecute,
   };
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, deleteOperation);
+  dispatcher.registerOperation(deleteOperation);
   operations.deleteWorkspace = deleteExecute;
 
   return { operations, capturedIntents, deleteControl };

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -9,7 +9,7 @@ import {
   SERVER_INSTRUCTIONS,
   type McpServerFactory,
 } from "./mcp-module";
-import { agentSpecSchema } from "../shared/api/types";
+import { agentSpecSchema } from "../intents/contract";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockDispatcher as createBaseMockDispatcher } from "../intents/lib/dispatcher.test-utils";

--- a/src/modules/metadata-module.integration.test.ts
+++ b/src/modules/metadata-module.integration.test.ts
@@ -79,8 +79,8 @@ function createTestSetup(): TestSetup {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_SET_METADATA, new SetMetadataOperation());
-  dispatcher.registerOperation(INTENT_GET_METADATA, new GetMetadataOperation());
+  dispatcher.registerOperation(new SetMetadataOperation());
+  dispatcher.registerOperation(new GetMetadataOperation());
 
   registerTestInfrastructure(dispatcher, {
     workspaces: {

--- a/src/modules/plugin-server-module.integration.test.ts
+++ b/src/modules/plugin-server-module.integration.test.ts
@@ -12,14 +12,22 @@
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
 
-import type { Operation, OperationContext } from "../intents/lib/operation";
-import type { Intent } from "../intents/lib/types";
+import { z } from "zod/v4";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID } from "../intents/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
-import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
+import { APP_START_OPERATION_ID, INTENT_APP_START } from "../intents/app-start";
+import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
+import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import type { FinalizeHookInput, OpenWorkspaceIntent } from "../intents/open-workspace";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
+} from "../intents/delete-workspace";
 import type {
   DeleteWorkspaceIntent,
   DeletePipelineHookInput,
@@ -34,10 +42,17 @@ import { COMMAND_TIMEOUT_MS } from "../shared/plugin-protocol";
 // Minimal Test Operations
 // =============================================================================
 
-class MinimalStartOperation implements Operation<Intent, number | null> {
-  readonly id = APP_START_OPERATION_ID;
+const startSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<number | null>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<number | null> {
+class MinimalStartOperation implements Operation<typeof startSchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = startSchemas;
+
+  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | null> {
     const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
       intent: ctx.intent,
     });
@@ -46,36 +61,46 @@ class MinimalStartOperation implements Operation<Intent, number | null> {
   }
 }
 
-class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, void> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-  private readonly hookInput: Partial<FinalizeHookInput>;
+const finalizeSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  constructor(hookInput: Partial<FinalizeHookInput> = {}) {
-    this.hookInput = hookInput;
-  }
-
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect<void>("finalize", {
-      intent: ctx.intent,
-      workspacePath: "/test/project/.worktrees/feature-1",
-      envVars: { OPENCODE_PORT: "8080" },
-      agentType: "opencode" as const,
-      ...this.hookInput,
-    });
-    if (errors.length > 0) throw errors[0]!;
-  }
+/**
+ * Finalize operation whose hook input is captured in a closure. The dispatcher
+ * invokes `execute` detached from the object, so `this` is unavailable — read the
+ * config from the enclosing scope instead.
+ */
+function createMinimalFinalizeOperation(
+  hookInput: Partial<FinalizeHookInput> = {}
+): Operation<typeof finalizeSchemas> {
+  return {
+    id: OPEN_WORKSPACE_OPERATION_ID,
+    schemas: finalizeSchemas,
+    async execute(ctx: OperationContext<IntentOf<typeof finalizeSchemas>>): Promise<void> {
+      const { errors } = await ctx.hooks.collect<void>("finalize", {
+        intent: ctx.intent,
+        workspacePath: "/test/project/.worktrees/feature-1",
+        envVars: { OPENCODE_PORT: "8080" },
+        agentType: "opencode" as const,
+        ...hookInput,
+      });
+      if (errors.length > 0) throw errors[0]!;
+    },
+  };
 }
 
 /** Runs the "delete" hook point with a canned delete-pipeline context. */
-function createMinimalDeleteOperation(): Operation<DeleteWorkspaceIntent, DeleteHookResult> {
-  return createMinimalOperation<DeleteWorkspaceIntent, DeleteHookResult>(
+function createMinimalDeleteOperation() {
+  return createMinimalOperation<DeleteHookResult>(
     DELETE_WORKSPACE_OPERATION_ID,
+    INTENT_DELETE_WORKSPACE,
     "delete",
     {
       hookContext: (ctx): DeletePipelineHookInput => ({
         intent: ctx.intent,
         projectPath: "/projects/test",
-        workspacePath: ctx.intent.payload.workspacePath ?? "",
+        workspacePath: (ctx.intent.payload as DeleteWorkspaceIntent["payload"]).workspacePath ?? "",
         workspaceName: "test-workspace" as WorkspaceName,
         active: false,
       }),
@@ -141,7 +166,7 @@ describe("PluginServerModule", () => {
         },
       });
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
 
       const pluginPort = await dispatcher.dispatch({ type: "app:start", payload: {} });
 
@@ -164,8 +189,9 @@ describe("PluginServerModule", () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
       dispatcher.registerOperation(
-        "app:shutdown",
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
 
       await expect(
@@ -184,12 +210,11 @@ describe("PluginServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
 
       // Start the server first
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalFinalizeOperation({
+        createMinimalFinalizeOperation({
           workspacePath: "/test/project/.worktrees/feature-1",
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
@@ -214,8 +239,7 @@ describe("PluginServerModule", () => {
 
       // Do NOT start the server
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalFinalizeOperation({
+        createMinimalFinalizeOperation({
           workspacePath: "/test/project/.worktrees/feature-1",
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
@@ -240,8 +264,7 @@ describe("PluginServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
 
       dispatcher.registerOperation(
-        "workspace:open",
-        new MinimalFinalizeOperation({
+        createMinimalFinalizeOperation({
           workspacePath: "/test/project/.worktrees/feature-1",
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
@@ -271,10 +294,10 @@ describe("PluginServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
 
       // Start the server first
-      dispatcher.registerOperation("app:start", new MinimalStartOperation());
+      dispatcher.registerOperation(new MinimalStartOperation());
       await dispatcher.dispatch({ type: "app:start", payload: {} });
 
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -295,7 +318,7 @@ describe("PluginServerModule", () => {
     it("is a no-op when server has not been started (io is null)", async () => {
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",
@@ -317,7 +340,7 @@ describe("PluginServerModule", () => {
       // Force mode delete should not throw even if internal state is inconsistent
       const deps = createMockDeps();
       const { dispatcher } = createTestSetup(deps);
-      dispatcher.registerOperation("workspace:delete", createMinimalDeleteOperation());
+      dispatcher.registerOperation(createMinimalDeleteOperation());
 
       const result = (await dispatcher.dispatch({
         type: "workspace:delete",

--- a/src/modules/plugin-server.test-utils.ts
+++ b/src/modules/plugin-server.test-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { vi, type Mock } from "vitest";
+import { z } from "zod/v4";
 import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 import { io as ioClient, type Socket as ClientSocket } from "socket.io-client";
 import type {
@@ -23,8 +24,12 @@ import {
 import { DefaultNetworkLayer } from "../boundaries/platform/network";
 import { SILENT_LOGGER } from "../boundaries/platform/logging.test-utils";
 import { Dispatcher, IntentHandle } from "../intents/lib/dispatcher";
-import type { Intent } from "../intents/lib/types";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../intents/lib/operation";
 import { APP_START_OPERATION_ID, INTENT_APP_START } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import {
@@ -194,10 +199,17 @@ function createMockDispatch(resolveWith?: unknown, options?: { accepted?: boolea
 // Minimal Test Operations
 // ============================================================================
 
-class MinimalStartOperation implements Operation<Intent, number | null> {
-  readonly id = APP_START_OPERATION_ID;
+const startSchemas = {
+  type: INTENT_APP_START,
+  payload: z.unknown(),
+  result: z.custom<number | null>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<Intent>): Promise<number | null> {
+class MinimalStartOperation implements Operation<typeof startSchemas> {
+  readonly id = APP_START_OPERATION_ID;
+  readonly schemas = startSchemas;
+
+  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | null> {
     const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
       intent: ctx.intent,
     });
@@ -206,29 +218,50 @@ class MinimalStartOperation implements Operation<Intent, number | null> {
   }
 }
 
-/** Minimal finalize operation that reads hook input from a mutable config. */
-class MinimalFinalizeOperation implements Operation<OpenWorkspaceIntent, void> {
-  readonly id = OPEN_WORKSPACE_OPERATION_ID;
-  hookInput: Partial<FinalizeHookInput> = {};
+const finalizeSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<void> {
-    const { errors } = await ctx.hooks.collect<void>("finalize", {
-      intent: ctx.intent,
-      workspacePath: "/test/workspace",
-      envVars: {},
-      agentType: "opencode" as const,
-      ...this.hookInput,
-    });
-    if (errors.length > 0) throw errors[0]!;
-  }
+/**
+ * Minimal finalize operation that reads hook input from a mutable `hookInput`
+ * property. The dispatcher invokes `execute` detached from the object, so `this`
+ * is unavailable — `execute` reads the property off the captured `op` reference.
+ */
+function createMinimalFinalizeOperation(): Operation<typeof finalizeSchemas> & {
+  hookInput: Partial<FinalizeHookInput>;
+} {
+  const op = {
+    id: OPEN_WORKSPACE_OPERATION_ID,
+    schemas: finalizeSchemas,
+    hookInput: {} as Partial<FinalizeHookInput>,
+    async execute(ctx: OperationContext<IntentOf<typeof finalizeSchemas>>): Promise<void> {
+      const { errors } = await ctx.hooks.collect<void>("finalize", {
+        intent: ctx.intent,
+        workspacePath: "/test/workspace",
+        envVars: {},
+        agentType: "opencode" as const,
+        ...op.hookInput,
+      });
+      if (errors.length > 0) throw errors[0]!;
+    },
+  };
+  return op;
 }
 
-/** Minimal vscode-command operation that skips workspace resolution. */
-class MinimalCommandOperation implements Operation<VscodeCommandIntent, unknown> {
-  readonly id = VSCODE_COMMAND_OPERATION_ID;
+const commandSchemas = {
+  type: INTENT_VSCODE_COMMAND,
+  payload: z.unknown(),
+  result: z.custom<unknown>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<VscodeCommandIntent>): Promise<unknown> {
-    const { payload } = ctx.intent;
+/** Minimal vscode-command operation that skips workspace resolution. */
+class MinimalCommandOperation implements Operation<typeof commandSchemas> {
+  readonly id = VSCODE_COMMAND_OPERATION_ID;
+  readonly schemas = commandSchemas;
+
+  async execute(ctx: OperationContext<IntentOf<typeof commandSchemas>>): Promise<unknown> {
+    const payload = ctx.intent.payload as VscodeCommandIntent["payload"];
     const executeCtx: ExecuteHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
@@ -244,12 +277,21 @@ class MinimalCommandOperation implements Operation<VscodeCommandIntent, unknown>
   }
 }
 
-/** Minimal vscode-show-message operation that skips workspace resolution. */
-class MinimalShowMessageOperation implements Operation<VscodeShowMessageIntent, string | null> {
-  readonly id = VSCODE_SHOW_MESSAGE_OPERATION_ID;
+const showMessageSchemas = {
+  type: INTENT_VSCODE_SHOW_MESSAGE,
+  payload: z.unknown(),
+  result: z.custom<string | null>(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<VscodeShowMessageIntent>): Promise<string | null> {
-    const { payload } = ctx.intent;
+/** Minimal vscode-show-message operation that skips workspace resolution. */
+class MinimalShowMessageOperation implements Operation<typeof showMessageSchemas> {
+  readonly id = VSCODE_SHOW_MESSAGE_OPERATION_ID;
+  readonly schemas = showMessageSchemas;
+
+  async execute(
+    ctx: OperationContext<IntentOf<typeof showMessageSchemas>>
+  ): Promise<string | null> {
+    const payload = ctx.intent.payload as VscodeShowMessageIntent["payload"];
     const showCtx: ShowHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
@@ -301,17 +343,18 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
   // Wire up a real dispatcher to drive the module through hooks
   const testDispatcher = new Dispatcher({ logger: createMockLogger() });
   testDispatcher.registerModule(module);
-  testDispatcher.registerOperation(INTENT_APP_START, new MinimalStartOperation());
+  testDispatcher.registerOperation(new MinimalStartOperation());
   testDispatcher.registerOperation(
-    INTENT_APP_SHUTDOWN,
-    createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+    createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+      throwOnError: false,
+    })
   );
-  testDispatcher.registerOperation(INTENT_VSCODE_COMMAND, new MinimalCommandOperation());
-  testDispatcher.registerOperation(INTENT_VSCODE_SHOW_MESSAGE, new MinimalShowMessageOperation());
+  testDispatcher.registerOperation(new MinimalCommandOperation());
+  testDispatcher.registerOperation(new MinimalShowMessageOperation());
 
   // Register finalize operation with mutable hook input (shared across setWorkspaceConfig calls)
-  const finalizeOp = new MinimalFinalizeOperation();
-  testDispatcher.registerOperation(INTENT_OPEN_WORKSPACE, finalizeOp);
+  const finalizeOp = createMinimalFinalizeOperation();
+  testDispatcher.registerOperation(finalizeOp);
 
   // Start the server via the hook
   const port = (await testDispatcher.dispatch({

--- a/src/modules/posix-process-cleanup-module.integration.test.ts
+++ b/src/modules/posix-process-cleanup-module.integration.test.ts
@@ -13,11 +13,13 @@ import type { Intent } from "../intents/lib/types";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
   type DeleteWorkspaceIntent,
   type ReleaseHookResult,
 } from "../intents/delete-workspace";
 import {
   HIBERNATE_WORKSPACE_OPERATION_ID,
+  INTENT_HIBERNATE_WORKSPACE,
   type HibernateReleaseHookResult,
 } from "../intents/hibernate-workspace";
 import {
@@ -50,8 +52,9 @@ function makeDeleteIntent(overrides?: Partial<DeleteWorkspaceIntent["payload"]>)
   } as unknown as Intent;
 }
 
-const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
+const releaseOperation = createMinimalOperation<ReleaseHookResult>(
   DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
   "release",
   {
     hookContext: (ctx) => ({
@@ -69,7 +72,7 @@ function createReleaseSetup(runner: MockProcessRunner, logger = SILENT_LOGGER) {
     logger: createMockLogger(),
     initialCapabilities: { posix: true },
   });
-  dispatcher.registerOperation("workspace:delete", releaseOperation);
+  dispatcher.registerOperation(releaseOperation);
 
   const module = createPosixProcessCleanupModule({
     processRunner: runner,
@@ -372,8 +375,9 @@ describe("PosixProcessCleanupModule Integration", () => {
   });
 
   describe("hibernate-workspace -> release", () => {
-    const hibernateReleaseOperation = createMinimalOperation<Intent, HibernateReleaseHookResult>(
+    const hibernateReleaseOperation = createMinimalOperation<HibernateReleaseHookResult>(
       HIBERNATE_WORKSPACE_OPERATION_ID,
+      INTENT_HIBERNATE_WORKSPACE,
       "release",
       {
         hookContext: (ctx) => ({
@@ -392,7 +396,7 @@ describe("PosixProcessCleanupModule Integration", () => {
         logger: createMockLogger(),
         initialCapabilities: { posix: true },
       });
-      dispatcher.registerOperation("workspace:hibernate", hibernateReleaseOperation);
+      dispatcher.registerOperation(hibernateReleaseOperation);
       dispatcher.registerModule(
         createPosixProcessCleanupModule({ processRunner: r, logger: SILENT_LOGGER })
       );

--- a/src/modules/power-module.integration.test.ts
+++ b/src/modules/power-module.integration.test.ts
@@ -14,10 +14,7 @@ import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 
-import {
-  UpdateAgentStatusOperation,
-  INTENT_UPDATE_AGENT_STATUS,
-} from "../intents/update-agent-status";
+import { UpdateAgentStatusOperation } from "../intents/update-agent-status";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
 import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
@@ -46,8 +43,8 @@ function createModuleTestSetup(): ModuleTestSetup {
   const appLayer = createAppBoundaryMock();
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_UPDATE_AGENT_STATUS, new UpdateAgentStatusOperation());
-  dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, createDeleteEventOperation());
+  dispatcher.registerOperation(new UpdateAgentStatusOperation());
+  dispatcher.registerOperation(createDeleteEventOperation());
 
   // Every workspace path resolves; workspaceName derives from the path basename.
   registerTestInfrastructure(dispatcher, {
@@ -187,8 +184,9 @@ describe("PowerModule Integration", () => {
       expect(appLayer).toBePreventingSleep();
 
       dispatcher.registerOperation(
-        INTENT_APP_SHUTDOWN,
-        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, "stop", { throwOnError: false })
+        createMinimalOperation(APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN, "stop", {
+          throwOnError: false,
+        })
       );
       await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
 

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -959,7 +959,7 @@ describe("PresentationModule - sidebar resize", () => {
 describe("PresentationModule - shutdown", () => {
   it("removes the ui:event listener on app:shutdown", async () => {
     const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+    dispatcher.registerOperation(new AppShutdownOperation());
 
     const deps = createDeps();
     const presentationModule = createPresentationModule(deps);

--- a/src/modules/script-module.integration.test.ts
+++ b/src/modules/script-module.integration.test.ts
@@ -8,8 +8,7 @@
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
 
-import type { Operation, OperationContext } from "../intents/lib/operation";
-import type { Intent } from "../intents/lib/types";
+import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, InitHookContext } from "../intents/app-start";
 import { createScriptModule } from "./script-module";
@@ -21,23 +20,14 @@ import { Path } from "../utils/path/path";
 // =============================================================================
 
 /** Runs "init" hook point with InitHookContext. */
-class MinimalInitOperation implements Operation<Intent, void> {
-  readonly id = APP_START_OPERATION_ID;
-  private readonly scripts: readonly string[];
-
-  constructor(scripts: readonly string[] = ["ch-claude", "code"]) {
-    this.scripts = scripts;
-  }
-
-  async execute(ctx: OperationContext<Intent>): Promise<void> {
-    const initCtx: InitHookContext = {
+function createMinimalInitOperation(scripts: readonly string[] = ["ch-claude", "code"]) {
+  return createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
+    hookContext: (ctx): InitHookContext => ({
       intent: ctx.intent,
-      requiredScripts: this.scripts,
+      requiredScripts: scripts,
       capabilities: { "app-ready": true },
-    };
-    const { errors } = await ctx.hooks.collect<void>("init", initCtx);
-    if (errors.length > 0) throw errors[0]!;
-  }
+    }),
+  });
 }
 
 // =============================================================================
@@ -61,7 +51,7 @@ describe("ScriptModule Integration", () => {
     const dispatcher = createMockDispatcher();
 
     const scripts = ["ch-claude", "ch-claude.cjs", "ch-claude.cmd", "code"];
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation(scripts));
+    dispatcher.registerOperation(createMinimalInitOperation(scripts));
 
     const module = createScriptModule({
       fileSystem: fileSystem as never,
@@ -121,7 +111,7 @@ describe("ScriptModule Integration", () => {
 
     const dispatcher = createMockDispatcher();
 
-    dispatcher.registerOperation(INTENT_APP_START, new MinimalInitOperation([]));
+    dispatcher.registerOperation(createMinimalInitOperation([]));
 
     const module = createScriptModule({
       fileSystem: fileSystem as never,

--- a/src/modules/shortcut-module.integration.test.ts
+++ b/src/modules/shortcut-module.integration.test.ts
@@ -165,14 +165,13 @@ async function createHarness(
   const dialogManager = { isModalOpen: vi.fn(() => modalIsOpen) };
 
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, "init", {
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
       hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "ui-ready": true } }),
     })
   );
-  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
-  dispatcher.registerOperation(INTENT_SHORTCUT_KEY, new ShortcutKeyOperation());
-  dispatcher.registerOperation(INTENT_SET_SHORTCUT_ACTIVE, new SetShortcutActiveOperation());
+  dispatcher.registerOperation(new AppShutdownOperation());
+  dispatcher.registerOperation(new ShortcutKeyOperation());
+  dispatcher.registerOperation(new SetShortcutActiveOperation());
 
   const dispatchSpy = vi.fn((intent: { type: string; payload: unknown }) =>
     dispatcher.dispatch(intent)

--- a/src/modules/state-module.integration.test.ts
+++ b/src/modules/state-module.integration.test.ts
@@ -85,11 +85,10 @@ async function runMigration(entries: Entries): Promise<{
   config.load();
 
   const dispatcher = createMockDispatcher();
+  // The state module's init handler requires the "app-ready" capability
+  // (provided in production by electron-lifecycle); seed it for the test.
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    // The state module's init handler requires the "app-ready" capability
-    // (provided in production by electron-lifecycle); seed it for the test.
-    createMinimalOperation(APP_START_OPERATION_ID, "init", {
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
       hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
     })
   );

--- a/src/modules/telemetry-module.integration.test.ts
+++ b/src/modules/telemetry-module.integration.test.ts
@@ -38,19 +38,29 @@ import type { ConfigAgentType } from "../boundaries/platform/config";
 import { createMockConfig, createMockAccessor } from "../boundaries/platform/config.test-utils";
 import { createMockState, type MockStateService } from "../boundaries/platform/state.test-utils";
 import { createStateMigrationRegistry } from "./state-module";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import { z } from "zod/v4";
+import type { Operation, OperationSchemas } from "../intents/lib/operation";
 
 // =============================================================================
 // Helpers
 // =============================================================================
 
 /** Minimal workspace:open operation that emits workspace:created. */
-class MinimalOpenWorkspaceOperation implements Operation<OpenWorkspaceIntent, void> {
-  readonly id = "open-workspace";
-  constructor(private readonly eventPayload: WorkspaceCreatedPayload) {}
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<void> {
-    ctx.emit({ type: "workspace:created", payload: this.eventPayload });
-  }
+const minimalOpenWorkspaceSchemas = {
+  type: INTENT_OPEN_WORKSPACE,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
+
+function createMinimalOpenWorkspaceOperation(
+  eventPayload: WorkspaceCreatedPayload
+): Operation<typeof minimalOpenWorkspaceSchemas> {
+  return {
+    id: "open-workspace",
+    schemas: minimalOpenWorkspaceSchemas,
+    async execute(ctx) {
+      await ctx.emit({ type: "workspace:created", payload: eventPayload });
+    },
+  };
 }
 
 const NEW_WORKSPACE_PAYLOAD: WorkspaceCreatedPayload = {
@@ -120,15 +130,17 @@ function createTestSetup(overrides?: {
   });
 
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, overrides?.startHookPoint ?? "start")
+    createMinimalOperation(
+      APP_START_OPERATION_ID,
+      INTENT_APP_START,
+      overrides?.startHookPoint ?? "start"
+    )
   );
-  dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+  dispatcher.registerOperation(new AppShutdownOperation());
   dispatcher.registerOperation(
-    INTENT_OPEN_WORKSPACE,
-    new MinimalOpenWorkspaceOperation(overrides?.workspacePayload ?? NEW_WORKSPACE_PAYLOAD)
+    createMinimalOpenWorkspaceOperation(overrides?.workspacePayload ?? NEW_WORKSPACE_PAYLOAD)
   );
-  dispatcher.registerOperation(INTENT_APP_RESUME, new AppResumeOperation());
+  dispatcher.registerOperation(new AppResumeOperation());
   dispatcher.registerModule(module);
 
   return { dispatcher, boundary, state };

--- a/src/modules/temp-dir-module.integration.test.ts
+++ b/src/modules/temp-dir-module.integration.test.ts
@@ -43,8 +43,7 @@ function createTestSetup(): TestSetup {
   const pathProvider = createMockPathProvider();
 
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, "init", {
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
       throwOnError: false,
       hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
     })

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -12,9 +12,15 @@
 
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
+import { z } from "zod/v4";
 import { Dispatcher } from "../intents/lib/dispatcher";
-import type { Operation, OperationContext, HookOutput } from "../intents/lib/operation";
-import type { Intent } from "../intents/lib/types";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+  HookOutput,
+} from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import type { IntentModule } from "../intents/lib/module";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
@@ -81,11 +87,17 @@ function createMockShellLayers() {
 // Minimal Test Operations
 // =============================================================================
 
+const switchOpSchemas = {
+  type: INTENT_SWITCH_WORKSPACE,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
+
 /** Runs "activate" hook point + emits workspace:switched event. */
-class MinimalSwitchOperation implements Operation<SwitchWorkspaceIntent, void> {
+class MinimalSwitchOperation implements Operation<typeof switchOpSchemas> {
   readonly id = SWITCH_WORKSPACE_OPERATION_ID;
+  readonly schemas = switchOpSchemas;
   constructor(private readonly active: boolean = false) {}
-  async execute(ctx: OperationContext<SwitchWorkspaceIntent>): Promise<void> {
+  async execute(ctx: OperationContext<IntentOf<typeof switchOpSchemas>>): Promise<void> {
     const workspacePath = (ctx.intent.payload as { workspacePath: string }).workspacePath;
     const activateCtx: ActivateHookInput = {
       intent: ctx.intent,
@@ -119,12 +131,21 @@ class MinimalSwitchOperation implements Operation<SwitchWorkspaceIntent, void> {
   }
 }
 
+const deleteOpSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<ShutdownHookResult>(),
+} satisfies OperationSchemas;
+
 /** Runs "shutdown" hook point only. */
-class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, ShutdownHookResult> {
+class MinimalDeleteOperation implements Operation<typeof deleteOpSchemas> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
+  readonly schemas = deleteOpSchemas;
   constructor(private readonly active: boolean = false) {}
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<ShutdownHookResult> {
-    const { payload } = ctx.intent;
+  async execute(
+    ctx: OperationContext<IntentOf<typeof deleteOpSchemas>>
+  ): Promise<ShutdownHookResult> {
+    const payload = ctx.intent.payload as DeleteWorkspaceIntent["payload"];
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
       projectPath: "/projects/test",
@@ -143,10 +164,19 @@ class MinimalDeleteOperation implements Operation<DeleteWorkspaceIntent, Shutdow
   }
 }
 
+const selectFolderOpSchemas = {
+  type: INTENT_OPEN_PROJECT,
+  payload: z.unknown(),
+  result: z.custom<SelectFolderHookResult | null>(),
+} satisfies OperationSchemas;
+
 /** Runs "select-folder" hook point (matches OpenProjectOperation's conditional hook). */
-class MinimalSelectFolderOperation implements Operation<Intent, SelectFolderHookResult | null> {
+class MinimalSelectFolderOperation implements Operation<typeof selectFolderOpSchemas> {
   readonly id = OPEN_PROJECT_OPERATION_ID;
-  async execute(ctx: OperationContext<Intent>): Promise<SelectFolderHookResult | null> {
+  readonly schemas = selectFolderOpSchemas;
+  async execute(
+    ctx: OperationContext<IntentOf<typeof selectFolderOpSchemas>>
+  ): Promise<SelectFolderHookResult | null> {
     const { results, errors } = await ctx.hooks.collect<SelectFolderHookResult>("select-folder", {
       intent: ctx.intent,
     });
@@ -170,8 +200,8 @@ interface TestSetup {
   module: IntentModule;
 }
 
-function createTestSetup(
-  operationOverride?: { intentType: string; operation: Operation<Intent, unknown> },
+function createTestSetup<S extends OperationSchemas = OperationSchemas>(
+  operationOverride?: { intentType: string; operation: Operation<S> },
   options?: {
     nullLayers?: boolean;
     dialogLayer?: ViewModuleDeps["dialogLayer"];
@@ -200,7 +230,7 @@ function createTestSetup(
   const module = createViewModule(deps);
 
   if (operationOverride) {
-    dispatcher.registerOperation(operationOverride.intentType, operationOverride.operation);
+    dispatcher.registerOperation(operationOverride.operation);
   }
 
   dispatcher.registerModule(module);
@@ -272,7 +302,7 @@ describe("ViewModule Integration", () => {
         intentType: INTENT_SWITCH_WORKSPACE,
         operation: new MinimalSwitchOperation(),
       });
-      dispatcher.registerOperation(INTENT_DELETE_WORKSPACE, new MinimalDeleteOperation(true));
+      dispatcher.registerOperation(new MinimalDeleteOperation(true));
 
       await dispatcher.dispatch({
         type: INTENT_SWITCH_WORKSPACE,
@@ -346,7 +376,7 @@ describe("ViewModule Integration", () => {
       });
 
       // Register get-active-workspace so we can verify the cache
-      dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
+      dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
       // Switch to ws1 first to populate cache
       await dispatcher.dispatch({
@@ -366,9 +396,14 @@ describe("ViewModule Integration", () => {
       // Now emit workspace:switched with null payload by dispatching delete
       // that triggers auto-switch. Instead, manually fire the event through dispatcher.
       // We use a custom operation to emit the null event.
-      const nullSwitchOp: Operation<Intent, void> = {
+      const nullSwitchSchemas = {
+        type: "test:emit-null-switch",
+        payload: z.unknown(),
+      } satisfies OperationSchemas;
+      const nullSwitchOp: Operation<typeof nullSwitchSchemas> = {
         id: "emit-null-switch",
-        async execute(ctx: OperationContext<Intent>): Promise<void> {
+        schemas: nullSwitchSchemas,
+        async execute(ctx): Promise<void> {
           const event: WorkspaceSwitchedEvent = {
             type: EVENT_WORKSPACE_SWITCHED,
             payload: null,
@@ -376,7 +411,7 @@ describe("ViewModule Integration", () => {
           ctx.emit(event);
         },
       };
-      dispatcher.registerOperation("test:emit-null-switch", nullSwitchOp);
+      dispatcher.registerOperation(nullSwitchOp);
       await dispatcher.dispatch({
         type: "test:emit-null-switch",
         payload: {},
@@ -404,7 +439,7 @@ describe("ViewModule Integration", () => {
         operation: new MinimalSwitchOperation(),
       });
 
-      dispatcher.registerOperation(INTENT_GET_ACTIVE_WORKSPACE, new GetActiveWorkspaceOperation());
+      dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
       await dispatcher.dispatch({
         type: INTENT_SWITCH_WORKSPACE,
@@ -445,7 +480,7 @@ describe("ViewModule Integration", () => {
       const viewManager = createMockViewManager();
       const layers = createMockShellLayers();
 
-      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+      dispatcher.registerOperation(new AppShutdownOperation());
 
       const module = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
@@ -487,7 +522,7 @@ describe("ViewModule Integration", () => {
       const dispatcher = createMockDispatcher();
       const viewManager = createMockViewManager();
 
-      dispatcher.registerOperation(INTENT_APP_SHUTDOWN, new AppShutdownOperation());
+      dispatcher.registerOperation(new AppShutdownOperation());
 
       const module = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
@@ -519,8 +554,7 @@ describe("ViewModule Integration", () => {
       const layers = createMockShellLayers();
 
       dispatcher.registerOperation(
-        INTENT_APP_START,
-        createMinimalOperation(APP_START_OPERATION_ID, "init", {
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
           hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
         })
       );
@@ -564,8 +598,7 @@ describe("ViewModule Integration", () => {
       const viewManager = createMockViewManager();
 
       dispatcher.registerOperation(
-        INTENT_APP_START,
-        createMinimalOperation(APP_START_OPERATION_ID, "init", {
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
           hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
         })
       );

--- a/src/modules/window-title-module.integration.test.ts
+++ b/src/modules/window-title-module.integration.test.ts
@@ -12,9 +12,10 @@ import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 
+import { z } from "zod/v4";
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import type { WorkspaceSwitchedEvent } from "../intents/switch-workspace";
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import type { Operation, OperationSchemas } from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import type { Intent } from "../intents/lib/types";
 import {
@@ -43,11 +44,16 @@ interface MinimalSwitchIntent extends Intent<void> {
   readonly payload: MinimalSwitchPayload | null;
 }
 
-class MinimalSwitchOperation implements Operation<MinimalSwitchIntent, void> {
-  readonly id = "switch-workspace";
+const minimalSwitchSchemas = {
+  type: INTENT_MINIMAL_SWITCH,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
 
-  async execute(ctx: OperationContext<MinimalSwitchIntent>): Promise<void> {
-    const { payload } = ctx.intent;
+const minimalSwitchOperation: Operation<typeof minimalSwitchSchemas> = {
+  id: "switch-workspace",
+  schemas: minimalSwitchSchemas,
+  async execute(ctx): Promise<void> {
+    const payload = ctx.intent.payload as MinimalSwitchPayload | null;
 
     const event: WorkspaceSwitchedEvent = {
       type: EVENT_WORKSPACE_SWITCHED,
@@ -62,8 +68,8 @@ class MinimalSwitchOperation implements Operation<MinimalSwitchIntent, void> {
         : null,
     };
     ctx.emit(event);
-  }
-}
+  },
+};
 
 // =============================================================================
 // Test Setup
@@ -79,10 +85,9 @@ function createTestSetup(titleVersion?: string): TestSetup {
 
   const dispatcher = createMockDispatcher();
 
-  dispatcher.registerOperation(INTENT_MINIMAL_SWITCH, new MinimalSwitchOperation());
+  dispatcher.registerOperation(minimalSwitchOperation);
   dispatcher.registerOperation(
-    INTENT_APP_START,
-    createMinimalOperation(APP_START_OPERATION_ID, "start")
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
   );
 
   const windowTitleModule = createWindowTitleModule({
@@ -158,8 +163,7 @@ describe("WindowTitleModule Integration", () => {
     const dispatcher = createMockDispatcher();
 
     dispatcher.registerOperation(
-      INTENT_APP_START,
-      createMinimalOperation(APP_START_OPERATION_ID, "start")
+      createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
     );
 
     const windowTitleModule = createWindowTitleModule({

--- a/src/modules/windows-file-lock-module.integration.test.ts
+++ b/src/modules/windows-file-lock-module.integration.test.ts
@@ -9,12 +9,19 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockLogger } from "../boundaries/platform/logging.test-utils";
 
-import type { Operation, OperationContext } from "../intents/lib/operation";
+import { z } from "zod/v4";
+import type {
+  Operation,
+  OperationContext,
+  OperationSchemas,
+  IntentOf,
+} from "../intents/lib/operation";
 import type { Intent } from "../intents/lib/types";
 import type { WorkspaceName } from "../shared/api/types";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
   type DeleteWorkspaceIntent,
   type ReleaseHookResult,
   type DetectHookResult,
@@ -23,6 +30,7 @@ import {
 } from "../intents/delete-workspace";
 import {
   HIBERNATE_WORKSPACE_OPERATION_ID,
+  INTENT_HIBERNATE_WORKSPACE,
   type HibernateReleaseHookResult,
 } from "../intents/hibernate-workspace";
 import { createWindowsFileLockModule } from "./windows-file-lock-module";
@@ -75,8 +83,9 @@ function makeDeleteIntent(overrides?: Partial<DeleteWorkspaceIntent["payload"]>)
 // Minimal Test Operations
 // =============================================================================
 
-const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
+const releaseOperation = createMinimalOperation<ReleaseHookResult>(
   DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
   "release",
   {
     hookContext: (ctx) => ({
@@ -89,8 +98,9 @@ const releaseOperation = createMinimalOperation<Intent, ReleaseHookResult>(
   }
 );
 
-const detectOperation = createMinimalOperation<Intent, DetectHookResult>(
+const detectOperation = createMinimalOperation<DetectHookResult>(
   DELETE_WORKSPACE_OPERATION_ID,
+  INTENT_DELETE_WORKSPACE,
   "detect",
   {
     hookContext: (ctx) => ({
@@ -106,12 +116,19 @@ const detectOperation = createMinimalOperation<Intent, DetectHookResult>(
 /**
  * Runs only the "flush" hook point with provided blockingPids.
  */
-class FlushOperation implements Operation<Intent, FlushHookResult> {
+const flushOpSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<FlushHookResult>(),
+} satisfies OperationSchemas;
+
+class FlushOperation implements Operation<typeof flushOpSchemas> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
+  readonly schemas = flushOpSchemas;
 
   constructor(private readonly blockingPids: readonly number[]) {}
 
-  async execute(ctx: OperationContext<Intent>): Promise<FlushHookResult> {
+  async execute(ctx: OperationContext<IntentOf<typeof flushOpSchemas>>): Promise<FlushHookResult> {
     const flushCtx: FlushHookInput = {
       intent: ctx.intent,
       projectPath: "/projects/my-app",
@@ -137,7 +154,7 @@ function createReleaseSetup(runner: MockProcessRunner, logger = SILENT_LOGGER) {
     logger: createMockLogger(),
     initialCapabilities: { platform: "win32" },
   });
-  dispatcher.registerOperation("workspace:delete", releaseOperation);
+  dispatcher.registerOperation(releaseOperation);
 
   const module = createWindowsFileLockModule({
     processRunner: runner,
@@ -154,7 +171,7 @@ function createDetectSetup(runner: MockProcessRunner, logger = SILENT_LOGGER) {
     logger: createMockLogger(),
     initialCapabilities: { platform: "win32" },
   });
-  dispatcher.registerOperation("workspace:delete", detectOperation);
+  dispatcher.registerOperation(detectOperation);
 
   const module = createWindowsFileLockModule({
     processRunner: runner,
@@ -175,7 +192,7 @@ function createFlushSetup(
     logger: createMockLogger(),
     initialCapabilities: { platform: "win32" },
   });
-  dispatcher.registerOperation("workspace:delete", new FlushOperation(blockingPids));
+  dispatcher.registerOperation(new FlushOperation(blockingPids));
 
   const module = createWindowsFileLockModule({
     processRunner: runner,
@@ -365,8 +382,9 @@ describe("WindowsFileLockModule Integration", () => {
   });
 
   describe("hibernate-workspace -> release", () => {
-    const hibernateReleaseOperation = createMinimalOperation<Intent, HibernateReleaseHookResult>(
+    const hibernateReleaseOperation = createMinimalOperation<HibernateReleaseHookResult>(
       HIBERNATE_WORKSPACE_OPERATION_ID,
+      INTENT_HIBERNATE_WORKSPACE,
       "release",
       {
         hookContext: (ctx) => ({
@@ -385,7 +403,7 @@ describe("WindowsFileLockModule Integration", () => {
         logger: createMockLogger(),
         initialCapabilities: { platform: "win32" },
       });
-      dispatcher.registerOperation("workspace:hibernate", hibernateReleaseOperation);
+      dispatcher.registerOperation(hibernateReleaseOperation);
       dispatcher.registerModule(
         createWindowsFileLockModule({
           processRunner: r,

--- a/src/renderer/tsconfig.web.json
+++ b/src/renderer/tsconfig.web.json
@@ -16,6 +16,7 @@
     "../env.d.ts",
     "./**/*",
     "../shared/**/*",
+    "../intents/contract.ts",
     "../test/**/*",
     "../services/test-utils.ts"
   ],

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -3,32 +3,17 @@
  * Provides branded types for compile-time safety and runtime type guards for validation.
  */
 
-import { z } from "zod/v4";
-import type { WorkspacePath } from "../ipc";
+import type { ProjectId, WorkspaceName } from "../../intents/contract";
 
 // =============================================================================
-// Branded Type Symbols
+// Identifier Types (Branded) — re-exported type-only from the intent contract
 // =============================================================================
+// zod is the single source of truth for these brands (src/intents/contract). This is a
+// type-only re-export, erased at build, so renderer/preload keep importing ProjectId /
+// WorkspaceName from here without pulling zod into their bundles. Imported locally too so
+// the domain types below can reference them.
 
-declare const ProjectIdBrand: unique symbol;
-declare const WorkspaceNameBrand: unique symbol;
-
-// =============================================================================
-// Identifier Types (Branded)
-// =============================================================================
-
-/**
- * Unique identifier for a project.
- * Format: `<name>-<8-char-hex-hash>`
- * Example: "my-app-12345678"
- */
-export type ProjectId = string & { readonly [ProjectIdBrand]: true };
-
-/**
- * Name of a workspace within a project.
- * Typically matches the git branch name.
- */
-export type WorkspaceName = string & { readonly [WorkspaceNameBrand]: true };
+export type { ProjectId, WorkspaceName };
 
 // =============================================================================
 // Type Guards
@@ -161,291 +146,30 @@ export function extractTags(metadata: Readonly<Record<string, string>>): Workspa
 }
 
 // =============================================================================
-// Domain Types
+// Domain Types — re-exported type-only from the intent contract
 // =============================================================================
+// zod is the single source of truth for these (src/intents/contract). Type-only re-exports,
+// erased at build, so renderer/preload import them from here without pulling zod into their
+// bundles. The runtime helpers above (validateWorkspaceName, isValidMetadataKey, extractTags)
+// and WorkspaceTag stay here — they carry no zod.
 
-/**
- * A project in CodeHydra (represents a git repository).
- */
-export interface Project {
-  readonly id: ProjectId;
-  readonly name: string;
-  readonly path: string;
-  readonly workspaces: readonly Workspace[];
-  readonly defaultBaseBranch?: string;
-  /** Original git remote URL if project was cloned from URL */
-  readonly remoteUrl?: string;
-}
-
-/**
- * A workspace within a project (represents a git worktree).
- */
-export interface Workspace {
-  readonly projectId: ProjectId;
-  readonly name: WorkspaceName;
-  /** Current branch name, or null for detached HEAD state */
-  readonly branch: string | null;
-  /**
-   * Metadata for the workspace stored in git config.
-   * Always contains `base` key (with fallback to branch ?? name if not explicitly set).
-   * Additional keys can be added for custom workspace metadata.
-   */
-  readonly metadata: Readonly<Record<string, string>>;
-  readonly path: string;
-  /**
-   * code-server URL for embedding this workspace as an iframe.
-   * Absent for hibernated workspaces (no runtime) until they wake.
-   */
-  readonly url?: string;
-}
-
-/**
- * Reference to a workspace (includes path for efficiency).
- * Used in events so consumers don't need to resolve IDs.
- */
-export interface WorkspaceRef {
-  readonly projectId: ProjectId;
-  readonly workspaceName: WorkspaceName;
-  readonly path: string;
-}
-
-/**
- * Combined status of a workspace.
- */
-export interface WorkspaceStatus {
-  readonly isDirty: boolean;
-  readonly unmergedCommits: number;
-  readonly agent: AgentStatus;
-}
-
-/**
- * Agent status for a workspace.
- */
-export type AgentStatus =
-  | { readonly type: "none" }
-  | { readonly type: "idle"; readonly counts: AgentStatusCounts }
-  | { readonly type: "busy"; readonly counts: AgentStatusCounts }
-  | { readonly type: "mixed"; readonly counts: AgentStatusCounts };
-
-/**
- * Agent status counts for a workspace.
- */
-export interface AgentStatusCounts {
-  readonly idle: number;
-  readonly busy: number;
-  readonly total: number;
-}
-
-/**
- * Information about a base branch.
- */
-export interface BaseInfo {
-  /** Full branch reference (e.g., "main" or "origin/main") */
-  readonly name: string;
-  /** Whether this is a remote-tracking branch */
-  readonly isRemote: boolean;
-  /**
-   * Suggested base branch for creating a workspace from this branch.
-   * For local branches: codehydra.base config value, or matching origin/* branch if exists.
-   * For remote branches: the full ref itself (e.g., "origin/feature-x").
-   */
-  readonly base?: string;
-  /**
-   * Derivable workspace name if a workspace can be created from this branch.
-   * Set when:
-   * - Local branch without an existing worktree (derives = branch name)
-   * - Remote branch without a local counterpart (derives = name without remote prefix, e.g., "feature-x")
-   * Undefined when a workspace already exists or local counterpart exists.
-   */
-  readonly derives?: string;
-}
-
-/**
- * Agent types that can be selected by the user.
- */
-export type ConfigAgentType = "claude" | "opencode";
-
-// =============================================================================
-// Setup Screen Progress Types
-// =============================================================================
-
-/**
- * Identifiers for setup screen rows.
- * - "vscode": VSCode/code-server download and setup
- * - "agent": Agent binary (Claude/OpenCode) download
- * - "setup": Extensions and configuration
- */
-export type SetupRowId = "vscode" | "agent" | "setup";
-
-/**
- * Status of a setup row.
- */
-export type SetupRowStatus = "pending" | "running" | "done" | "failed";
-
-// =============================================================================
-// Blocking Process Types
-// =============================================================================
-
-/**
- * Information about a process blocking workspace deletion.
- * Used on Windows to identify processes holding file handles.
- */
-export interface BlockingProcess {
-  /** Process ID */
-  readonly pid: number;
-  /** Process name (e.g., "node.exe", "Code.exe") */
-  readonly name: string;
-  /** Full command line that started the process */
-  readonly commandLine: string;
-  /** Files locked by this process, relative to workspace (max 20) */
-  readonly files: readonly string[];
-  /** Current working directory relative to workspace, or null if CWD is outside workspace */
-  readonly cwd: string | null;
-}
-
-// =============================================================================
-// Deletion Progress Types
-// =============================================================================
-
-/**
- * Identifiers for deletion operations.
- */
-export type DeletionOperationId =
-  | "killing-blockers"
-  | "kill-terminals"
-  | "stop-server"
-  | "cleanup-vscode"
-  | "detecting-blockers"
-  | "cleanup-workspace";
-
-/**
- * Status of a deletion operation.
- */
-export type DeletionOperationStatus = "pending" | "in-progress" | "done" | "error";
-
-/**
- * A single operation in the deletion process.
- */
-export interface DeletionOperation {
-  readonly id: DeletionOperationId;
-  readonly label: string;
-  readonly status: DeletionOperationStatus;
-  readonly error?: string;
-}
-
-/**
- * Progress state for workspace deletion.
- * Contains the full state of all operations, emitted with each update.
- */
-export interface DeletionProgress {
-  readonly workspacePath: WorkspacePath;
-  readonly workspaceName: WorkspaceName;
-  readonly projectId: ProjectId;
-  readonly keepBranch: boolean;
-  readonly operations: readonly DeletionOperation[];
-  readonly completed: boolean;
-  readonly hasErrors: boolean;
-  /**
-   * Processes blocking workspace deletion (Windows only).
-   * Present when cleanup-workspace fails with EBUSY/EACCES/EPERM.
-   */
-  readonly blockingProcesses?: readonly BlockingProcess[];
-}
-
-// =============================================================================
-// Agent Spec Types
-// =============================================================================
-
-/**
- * Model identifier (provider + model id) carried by an agent spec.
- */
-export interface PromptModel {
-  readonly providerID: string;
-  readonly modelID: string;
-}
-
-/**
- * Agent specification for workspace creation — a discriminated union by backend.
- *
- * Carries both the prompt and the backend-specific launch config in one object,
- * so each backend only exposes the options it actually understands:
- * - "default": no backend chosen → resolved late from git metadata / config.
- *   Accepts a prompt only. To set a model, permission mode or named agent you
- *   must name the backend (a typed arm).
- * - "claude": Claude. Supports prompt, model, permissionMode (e.g. "plan"),
- *   and a named agent (--agent).
- * - "opencode": OpenCode. Supports prompt, model and a named agent (e.g.
- *   "build"). No permission mode (Claude-only concept).
- *
- * @example
- * // Just a prompt under whatever the resolved-default backend is
- * agent: { type: "default", prompt: "Implement the login feature" }
- *
- * // Read-only/plan mode on Claude
- * agent: { type: "claude", prompt: "Investigate the bug", permissionMode: "plan" }
- *
- * // OpenCode 'build' agent with an explicit model
- * agent: { type: "opencode", prompt: "Ship it", agentName: "build", model: { providerID: "anthropic", modelID: "claude-sonnet" } }
- */
-export type AgentSpec =
-  | { readonly type: "default"; readonly prompt?: string }
-  | {
-      readonly type: "claude";
-      readonly prompt?: string;
-      readonly model?: PromptModel;
-      readonly permissionMode?: string;
-      readonly agentName?: string;
-    }
-  | {
-      readonly type: "opencode";
-      readonly prompt?: string;
-      readonly model?: PromptModel;
-      readonly agentName?: string;
-    };
-
-/**
- * Zod schema for validating PromptModel.
- */
-const promptModelSchema = z.object({
-  providerID: z.string().min(1),
-  modelID: z.string().min(1),
-});
-
-/**
- * Zod schema for validating AgentSpec. Discriminated on `type` so each backend
- * only accepts the options it understands (e.g. permissionMode is Claude-only).
- */
-export const agentSpecSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("default"),
-    prompt: z.string().min(1).optional(),
-  }),
-  z.object({
-    type: z.literal("claude"),
-    prompt: z.string().min(1).optional(),
-    model: promptModelSchema.optional(),
-    permissionMode: z.string().min(1).optional(),
-    agentName: z.string().min(1).optional(),
-  }),
-  z.object({
-    type: z.literal("opencode"),
-    prompt: z.string().min(1).optional(),
-    model: promptModelSchema.optional(),
-    agentName: z.string().min(1).optional(),
-  }),
-]);
-
-// =============================================================================
-// Agent Session Types
-// =============================================================================
-
-/**
- * Agent session information for a workspace.
- * Used to track the primary session created/found when the agent server starts.
- */
-export interface AgentSession {
-  /** Port of the agent server */
-  readonly port: number;
-  /** Session ID of the primary session */
-  readonly sessionId: string;
-}
+export type {
+  Project,
+  Workspace,
+  WorkspaceRef,
+  WorkspaceStatus,
+  AgentStatus,
+  AgentStatusCounts,
+  BaseInfo,
+  ConfigAgentType,
+  SetupRowId,
+  SetupRowStatus,
+  BlockingProcess,
+  DeletionOperationId,
+  DeletionOperationStatus,
+  DeletionOperation,
+  DeletionProgress,
+  PromptModel,
+  AgentSpec,
+  AgentSession,
+} from "../../intents/contract";

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -7,19 +7,11 @@
  */
 
 // ============ Branded Path Types ============
+// zod is the single source of truth for these brands (src/intents/contract). This is a
+// type-only re-export, erased at build, so this browser-safe module pulls no zod at runtime
+// and renderer/preload keep importing ProjectPath/WorkspacePath from here unchanged.
 
-declare const ProjectPathBrand: unique symbol;
-declare const WorkspacePathBrand: unique symbol;
-
-/**
- * Branded type for project paths (git repository root directories).
- */
-export type ProjectPath = string & { readonly [ProjectPathBrand]: true };
-
-/**
- * Branded type for workspace paths (git worktree directories).
- */
-export type WorkspacePath = string & { readonly [WorkspacePathBrand]: true };
+export type { ProjectPath, WorkspacePath } from "../intents/contract";
 
 // ============ Domain Types ============
 

--- a/src/shared/plugin-protocol.ts
+++ b/src/shared/plugin-protocol.ts
@@ -7,7 +7,8 @@
 
 import { z } from "zod/v4";
 import type { WorkspaceStatus, Workspace, AgentSpec, AgentSession } from "./api/types";
-import { METADATA_KEY_REGEX, isValidMetadataKey, agentSpecSchema } from "./api/types";
+import { METADATA_KEY_REGEX, isValidMetadataKey } from "./api/types";
+import { agentSpecSchema } from "../intents/contract";
 
 // ============================================================================
 // Result Types


### PR DESCRIPTION
Makes runtime validation a first-class feature of the intent system (item 2 of the remote-workspaces plan), and parameterizes `Operation` by its schema bundle.

- **zod is the single source of truth** for the intent contract. The contract vocabulary (branded ids, `AgentSpec`, domain value objects) lives in `src/intents/contract.ts`; `shared/api/types.ts` and `shared/ipc.ts` become type-only re-export façades, with an eslint rule confining zod to the intent system.
- **The dispatcher validates every carrier** on each dispatch — intent payload, hook input context, hook result, provided capabilities, event payload, and operation result — replacing the previous unchecked `as` casts.
- **`Operation<S extends OperationSchemas>`**: an operation is `implements Operation<typeof schemas>`; its Intent/result types derive from the bundle via `IntentOf`/`ResultOf` and are never restated. `registerOperation(op)` is single-arg (key = `schemas.type`).
- Test mock operations consolidated onto the generic `createMinimalOperation` helper (permissive schema, `z.custom<R>()` result keeps dispatched results typed).

Validation: node + renderer typecheck clean, eslint `--max-warnings 0`, full suite (3537 tests) green.