### PR TITLE
test(claude-wrapper): compile fake binary once per file to fix flaky CI

### DIFF
--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -11,7 +11,7 @@
  * - Exit code propagation
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
 import { join, resolve, dirname, delimiter } from "node:path";
 import { writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -134,15 +134,27 @@ function buildPath(fakeBinDir: string): string {
 
 describe("ch-claude.cjs boundary tests", () => {
   let tempDir: { path: string; cleanup: () => Promise<void> };
+  let sharedBinTempDir: { path: string; cleanup: () => Promise<void> };
   let fakeBinDir: string;
 
   beforeAll(async () => {
     await assertCompiledScript(COMPILED_SCRIPT_PATH);
+    // Compile the fake claude binary ONCE for the whole file. On Windows,
+    // createFakeClaudeBinary invokes @yao-pkg/pkg to bundle a real .exe, which
+    // takes seconds; doing it per-test in beforeEach blew the default 10s hook
+    // timeout under CI contention (the dominant flaky-test failure). The fake
+    // binary's behavior is driven entirely by env vars (CLAUDE_EXIT_CODE,
+    // CLAUDE_COUNTER_FILE, …), so a single shared binary serves every test.
+    sharedBinTempDir = await createTempDir();
+    fakeBinDir = await createFakeClaudeBinary(join(sharedBinTempDir.path, "bin"));
+  });
+
+  afterAll(async () => {
+    await sharedBinTempDir.cleanup();
   });
 
   beforeEach(async () => {
     tempDir = await createTempDir();
-    fakeBinDir = await createFakeClaudeBinary(join(tempDir.path, "bin"));
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Fixes the dominant flaky-test failure in the Windows `Validate` CI job.

- The claude wrapper boundary test compiled a fake `claude.exe` via `@yao-pkg/pkg` in `beforeEach` — once per test (~15× per file run). On Windows each compile takes seconds, so under CI contention a single one exceeded the default 10 s hook timeout, producing `Error: Hook timed out in 10000ms`.
- Hoisted the compile into `beforeAll`: the fake binary is now built **once per file** and shared across tests. Behavior is unchanged because the fake binary is driven entirely by env vars (`CLAUDE_EXIT_CODE`, `CLAUDE_COUNTER_FILE`, …); each test still gets its own isolated `tempDir` for counter/prompt files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdpYMG1uS4Nxi6XZWj55wc