### PR TITLE
fix(logging): drop the native Chromium electron.log

### DIFF
--- a/src/boundaries/platform/electron-log.ts
+++ b/src/boundaries/platform/electron-log.ts
@@ -431,7 +431,6 @@ export class ElectronLog implements Logging {
   private logFormat: LogFormat = "text";
   private allowedLoggers: Set<LoggerName> | undefined;
   private readonly logPath: string;
-  private readonly electronLogPath: string;
 
   constructor(pathProvider: PathProvider) {
     // Transports start silent — configure() enables them
@@ -442,8 +441,6 @@ export class ElectronLog implements Logging {
     const logsDir = pathProvider.dataPath("logs").toNative();
     const filename = generateSessionFilename();
     this.logPath = join(logsDir, filename);
-    // Fixed filename: Chromium overwrites on each launch with --log-file.
-    this.electronLogPath = join(logsDir, "electron.log");
     log.transports.file.resolvePathFn = (): string => this.logPath;
 
     // 20 MB before rotation. Bug reports include the rotated archive plus the
@@ -518,9 +515,5 @@ export class ElectronLog implements Logging {
 
   getLogFilePath(): string {
     return this.logPath;
-  }
-
-  getElectronLogFilePath(): string {
-    return this.electronLogPath;
   }
 }

--- a/src/boundaries/platform/logging-types.ts
+++ b/src/boundaries/platform/logging-types.ts
@@ -194,15 +194,6 @@ export interface Logging {
    * @returns Absolute path to the session log file
    */
   getLogFilePath(): string;
-
-  /**
-   * Get the path where Chromium writes its native log when --enable-logging=file
-   * is set. This is a fixed path (not session-suffixed) because Chromium
-   * overwrites the file on each launch.
-   *
-   * @returns Absolute path to the Electron/Chromium log file
-   */
-  getElectronLogFilePath(): string;
 }
 
 /**

--- a/src/boundaries/platform/logging.test-utils.ts
+++ b/src/boundaries/platform/logging.test-utils.ts
@@ -104,7 +104,6 @@ export function createMockLogging(): MockLogging {
     configure: vi.fn(),
     initialize: vi.fn(),
     getLogFilePath: vi.fn().mockReturnValue("/mock/logs/test-session.log"),
-    getElectronLogFilePath: vi.fn().mockReturnValue("/mock/logs/electron.log"),
 
     getCreatedLoggerNames(): LoggerName[] {
       return Array.from(loggers.keys());

--- a/src/main.ts
+++ b/src/main.ts
@@ -732,8 +732,6 @@ const loggingModule = createLoggingModule({
   platformInfo,
   logger: appLogger,
   configService,
-  app,
-  fileSystem: fileSystemLayer,
 });
 
 const scriptModule = createScriptModule({

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -46,7 +46,6 @@ import type { DialogConfig } from "../shared/dialog-types";
 
 function defaultReadFile(path: string): Promise<string> {
   if (path === "/logs/test-session.log") return Promise.resolve("test log content\nline 2");
-  if (path === "/logs/electron.log") return Promise.resolve("electron log content");
   return Promise.reject(new Error("ENOENT"));
 }
 
@@ -76,7 +75,6 @@ function setup(overrides?: SetupOverrides) {
     fileSystem: { readFile: vi.fn().mockImplementation(defaultReadFile) },
     loggingService: {
       getLogFilePath: vi.fn().mockReturnValue("/logs/test-session.log"),
-      getElectronLogFilePath: vi.fn().mockReturnValue("/logs/electron.log"),
     },
     dispatcher: {
       dispatch: vi.fn(overrides?.dispatch ?? (async () => {})),
@@ -253,7 +251,7 @@ describe("ErrorReportModule — bug-report:submitted capture", () => {
     });
 
     // The handler gathers logs from the filesystem; the event carries only the
-    // description (defaultReadFile supplies the log/electron-log content).
+    // description (defaultReadFile supplies the log content).
     await emitBugReport(module, { description: "It crashed" });
 
     const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
@@ -262,7 +260,6 @@ describe("ErrorReportModule — bug-report:submitted capture", () => {
     expect(props["$exception_list"]).toEqual([{ type: "BugReport", value: "It crashed" }]);
     expect(props["logs_format"]).toBe("gzip+base64");
     expect(decompressLog(props["logs"])).toBe("test log content\nline 2");
-    expect(decompressLog(props["electron_logs"])).toBe("electron log content");
     expect(props["config"]).toEqual({ agent: "claude", "log.level": "debug" });
     expect(props["state"]).toEqual({
       "auto-workspaces": { "github/1": { workspaceName: "pr-1" } },

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -84,11 +84,10 @@ const MAX_LOG_SIZE = 20 * 1024 * 1024;
 const DESCRIPTION_INITIAL = "# describe your issue";
 
 /**
- * Per-field compressed cap for log payloads. With two log streams (app +
- * electron) this gives ~900 KB combined, leaving ~148 KB under PostHog's 1 MB
- * hard cap for description, metadata, and SDK overhead.
+ * Compressed cap for the log payload. A single app-log stream leaves ~148 KB
+ * under PostHog's 1 MB hard cap for description, metadata, and SDK overhead.
  */
-const LOG_FIELD_COMPRESSED_CAP = 450_000;
+const LOG_FIELD_COMPRESSED_CAP = 900_000;
 const COMPRESS_SAFETY_FACTOR = 0.95;
 
 /** How long to wait for a flush before forcing the process to exit on a crash. */
@@ -151,7 +150,7 @@ function buildDialogConfig(): DialogConfig {
 export interface ErrorReportModuleDeps {
   readonly ui: Pick<UiPresenter, "dialog">;
   readonly fileSystem: Pick<FileSystemBoundary, "readFile">;
-  readonly loggingService: Pick<Logging, "getLogFilePath" | "getElectronLogFilePath">;
+  readonly loggingService: Pick<Logging, "getLogFilePath">;
   readonly dispatcher: Pick<IDispatcher, "dispatch">;
   /** The shared PostHog sink. */
   readonly boundary: PostHogBoundary;
@@ -205,15 +204,6 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
     return combined.length > MAX_LOG_SIZE ? combined.slice(-MAX_LOG_SIZE) : combined;
   }
 
-  async function readElectronLogContent(): Promise<string> {
-    const path = deps.loggingService.getElectronLogFilePath();
-    const content = await deps.fileSystem.readFile(path).catch(() => {
-      deps.logger.warn("Failed to read electron log file");
-      return "";
-    });
-    return content.length > MAX_LOG_SIZE ? content.slice(-MAX_LOG_SIZE) : content;
-  }
-
   // ---------------------------------------------------------------------------
   // Incident capture (shared by crashes and manual reports)
   // ---------------------------------------------------------------------------
@@ -222,14 +212,8 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
    * Compress logs, attach redacted config + state, and send the exception
    * through the boundary. The boundary stamps version/platform/arch/agent.
    */
-  function captureIncident(
-    error: Error,
-    logs: string,
-    electronLogs: string,
-    extraProps?: Record<string, unknown>
-  ): void {
+  function captureIncident(error: Error, logs: string, extraProps?: Record<string, unknown>): void {
     const appLogs = compressAndTrim(logs);
-    const electronLogsBlob = compressAndTrim(electronLogs);
 
     deps.boundary.captureException(error, {
       ...extraProps,
@@ -237,19 +221,15 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
       logs_format: appLogs.compressed ? "gzip+base64" : "none",
       logs_raw_bytes: appLogs.rawBytesKept,
       logs_raw_bytes_dropped: logs.length - appLogs.rawBytesKept,
-      electron_logs: electronLogsBlob.compressed,
-      electron_logs_format: electronLogsBlob.compressed ? "gzip+base64" : "none",
-      electron_logs_raw_bytes: electronLogsBlob.rawBytesKept,
-      electron_logs_raw_bytes_dropped: electronLogs.length - electronLogsBlob.rawBytesKept,
       config: deps.configService.getRedactedOverrides(),
       state: deps.stateService.getRedactedOverrides(),
     });
   }
 
-  /** Read both log streams, then capture the crash. */
+  /** Read the app log, then capture the crash. */
   async function captureCrash(error: Error, extraProps?: Record<string, unknown>): Promise<void> {
-    const [logs, electronLogs] = await Promise.all([readLogContent(), readElectronLogContent()]);
-    captureIncident(error, logs, electronLogs, extraProps);
+    const logs = await readLogContent();
+    captureIncident(error, logs, extraProps);
   }
 
   /** Flush (and close) the boundary, but never block the exit beyond the cap. */
@@ -489,11 +469,8 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
 
           // The module owns log-gathering for every bug report, so both the
           // dialog and the MCP report_bug tool only need to supply a
-          // description. Read both streams here, then capture + flush.
-          const [logs, electronLogs] = await Promise.all([
-            readLogContent(),
-            readElectronLogContent(),
-          ]);
+          // description. Read the app log here, then capture + flush.
+          const logs = await readLogContent();
 
           // Synthetic error so the SDK formats it as $exception_list. Manual
           // reports always send (explicit consent), even with telemetry off.
@@ -501,7 +478,7 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
           bugError.name = "BugReport";
           bugError.stack = "";
 
-          captureIncident(bugError, logs, electronLogs);
+          captureIncident(bugError, logs);
           await deps.boundary.flush();
         },
       },

--- a/src/modules/logging-module.integration.test.ts
+++ b/src/modules/logging-module.integration.test.ts
@@ -18,8 +18,6 @@ import type {
 } from "../intents/lib/operation";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, InitHookContext, ConfigureResult } from "../intents/app-start";
-import { INTENT_APP_SHUTDOWN, APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
-import type { AppShutdownIntent } from "../intents/app-shutdown";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { createLoggingModule } from "./logging-module";
 import { createMockConfig } from "../boundaries/platform/config.test-utils";
@@ -56,21 +54,6 @@ class MinimalAppStartOperation implements Operation<typeof appStartSchemas> {
   }
 }
 
-const appShutdownSchemas = {
-  type: INTENT_APP_SHUTDOWN,
-  payload: z.unknown(),
-} satisfies OperationSchemas;
-
-/** Runs the "stop" hook for shutdown. */
-class MinimalAppShutdownOperation implements Operation<typeof appShutdownSchemas> {
-  readonly id = APP_SHUTDOWN_OPERATION_ID;
-  readonly schemas = appShutdownSchemas;
-  async execute(ctx: OperationContext<IntentOf<typeof appShutdownSchemas>>): Promise<void> {
-    const hookCtx: HookContext = { intent: ctx.intent };
-    await ctx.hooks.collect<void>("stop", hookCtx);
-  }
-}
-
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -79,7 +62,6 @@ function createDeps(configValues?: Record<string, unknown>) {
   const loggingService = {
     initialize: vi.fn(),
     configure: vi.fn(),
-    getElectronLogFilePath: vi.fn().mockReturnValue("/logs/electron.log"),
   };
   const buildInfo = {
     version: "2026.2.0-test",
@@ -99,30 +81,6 @@ function createDeps(configValues?: Record<string, unknown>) {
       ...configValues,
     },
   });
-  const app = {
-    commandLine: { appendSwitch: vi.fn() },
-  };
-  const files = new Map<string, string>();
-  const fileSystem = {
-    readFile: vi.fn(async (path: string) => {
-      if (!files.has(path)) throw new Error("ENOENT");
-      return files.get(path)!;
-    }),
-    writeFile: vi.fn(async (path: string, content: string) => {
-      files.set(path, content);
-    }),
-  };
-  const scheduledTicks: Array<{ handler: () => void; ms: number; cleared: boolean }> = [];
-  const scheduler = {
-    setInterval: vi.fn((handler: () => void, ms: number) => {
-      const entry = { handler, ms, cleared: false };
-      scheduledTicks.push(entry);
-      return entry;
-    }),
-    clearInterval: vi.fn((handle: unknown) => {
-      (handle as { cleared: boolean }).cleared = true;
-    }),
-  };
 
   return {
     loggingService,
@@ -130,11 +88,6 @@ function createDeps(configValues?: Record<string, unknown>) {
     platformInfo,
     logger,
     configService,
-    app,
-    fileSystem,
-    scheduler,
-    scheduledTicks,
-    files,
   };
 }
 
@@ -244,103 +197,5 @@ describe("LoggingModule Integration", () => {
       allowedLoggers: undefined,
       logFormat: "text",
     });
-  });
-
-  it("appends --enable-logging=file, --log-file, and --v=1 during before-ready", async () => {
-    const deps = createDeps();
-    const dispatcher = createMockDispatcher();
-
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-
-    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith("enable-logging", "file");
-    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith(
-      "log-file",
-      "/logs/electron.log"
-    );
-    expect(deps.app.commandLine.appendSwitch).toHaveBeenCalledWith("v", "1");
-  });
-
-  it("starts the truncation watcher during init", async () => {
-    const deps = createDeps();
-    const dispatcher = createMockDispatcher();
-
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-
-    expect(deps.scheduler.setInterval).toHaveBeenCalledOnce();
-    expect(deps.scheduledTicks).toHaveLength(1);
-    expect(deps.scheduledTicks[0]!.ms).toBe(15 * 60 * 1000);
-  });
-
-  it("truncates electron.log to last 20 MB when the watcher fires on an oversize file", async () => {
-    const deps = createDeps();
-    // Seed an oversize file (21 MB of 'A')
-    const oversize = "A".repeat(21 * 1024 * 1024);
-    deps.files.set("/logs/electron.log", oversize);
-
-    const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-
-    // Manually fire the watcher tick
-    deps.scheduledTicks[0]!.handler();
-    // Tick handler is sync-scheduled but async-internal; wait a microtask
-    await new Promise((r) => setImmediate(r));
-
-    const truncated = deps.files.get("/logs/electron.log");
-    expect(truncated).toBeDefined();
-    expect(Buffer.byteLength(truncated!, "utf8")).toBe(20 * 1024 * 1024);
-  });
-
-  it("does nothing when the watcher fires and the file is within size", async () => {
-    const deps = createDeps();
-    deps.files.set("/logs/electron.log", "small");
-
-    const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-
-    deps.scheduledTicks[0]!.handler();
-    await new Promise((r) => setImmediate(r));
-
-    expect(deps.fileSystem.writeFile).not.toHaveBeenCalled();
-    expect(deps.files.get("/logs/electron.log")).toBe("small");
-  });
-
-  it("silently ignores missing electron.log when the watcher fires", async () => {
-    const deps = createDeps();
-    // No file seeded — readFile rejects with ENOENT
-
-    const dispatcher = createMockDispatcher();
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-
-    deps.scheduledTicks[0]!.handler();
-    await new Promise((r) => setImmediate(r));
-
-    expect(deps.fileSystem.writeFile).not.toHaveBeenCalled();
-  });
-
-  it("stops the truncation watcher on app:shutdown stop hook", async () => {
-    const deps = createDeps();
-    const dispatcher = createMockDispatcher();
-
-    dispatcher.registerOperation(new MinimalAppStartOperation());
-    dispatcher.registerOperation(new MinimalAppShutdownOperation());
-    dispatcher.registerModule(createLoggingModule(deps));
-
-    await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
-    await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
-
-    expect(deps.scheduler.clearInterval).toHaveBeenCalledOnce();
-    expect(deps.scheduledTicks[0]!.cleared).toBe(true);
   });
 });

--- a/src/modules/logging-module.ts
+++ b/src/modules/logging-module.ts
@@ -2,12 +2,9 @@
  * LoggingModule - Initializes the logging service and logs startup info.
  *
  * Hooks:
- * - app:start → "before-ready": configures logging from Config, enables
- *   Chromium's --enable-logging=file with --v=1 so native Electron/Chromium
- *   logs are captured to a known path, logs build info
- * - app:start → "init": initializes logging service, starts the electron.log
- *   truncation watcher (Chromium has no native log rotation)
- * - app:shutdown → "stop": stops the truncation watcher
+ * - app:start → "before-ready": configures logging from Config, logs build info
+ * - app:start → "init": initializes logging service (enables renderer IPC
+ *   logging) once Electron is ready
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -16,47 +13,20 @@ import type { Logger } from "../boundaries/platform/logging-types";
 import type { BuildInfo } from "../boundaries/platform/build-info";
 import type { PlatformInfo } from "../boundaries/platform/platform-info";
 import type { Config } from "../boundaries/platform/config";
-import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import { parseLogLevelSpec, splitLogLevelSpec } from "../boundaries/platform/electron-log";
 import { storeCustom, storeEnum, storeEnumList } from "../boundaries/platform/store-definition";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
-import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-/** Hard cap on the electron.log file. Watcher truncates to this size when exceeded. */
-const ELECTRON_LOG_MAX_BYTES = 20 * 1024 * 1024;
-
-/** How often the truncation watcher runs. */
-const ELECTRON_LOG_WATCHER_INTERVAL_MS = 15 * 60 * 1000;
 
 // =============================================================================
 // Dependency Interface
 // =============================================================================
 
-/** Minimal app.commandLine surface used by this module. */
-export interface CommandLineLike {
-  appendSwitch(key: string, value?: string): void;
-}
-
 export interface LoggingModuleDeps {
-  readonly loggingService: Pick<Logging, "initialize" | "configure" | "getElectronLogFilePath">;
+  readonly loggingService: Pick<Logging, "initialize" | "configure">;
   readonly buildInfo: Pick<BuildInfo, "version" | "isDevelopment" | "isPackaged">;
   readonly platformInfo: Pick<PlatformInfo, "platform" | "arch">;
   readonly logger: Logger;
   readonly configService: Config;
-  readonly app: { commandLine: CommandLineLike };
-  readonly fileSystem: Pick<FileSystemBoundary, "readFile" | "writeFile">;
-  /**
-   * Schedule a recurring tick. Defaults to setInterval/clearInterval. Injectable
-   * so integration tests can drive ticks deterministically.
-   */
-  readonly scheduler?: {
-    setInterval(handler: () => void, ms: number): unknown;
-    clearInterval(handle: unknown): void;
-  };
 }
 
 // =============================================================================
@@ -90,45 +60,12 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
     ...storeEnum(["text", "json"]),
   });
 
-  const scheduler = deps.scheduler ?? {
-    setInterval: (h: () => void, ms: number) => setInterval(h, ms),
-    clearInterval: (handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>),
-  };
-
-  let watcherHandle: unknown = null;
-
-  async function truncateElectronLogIfOversize(): Promise<void> {
-    const path = deps.loggingService.getElectronLogFilePath();
-    const content = await deps.fileSystem.readFile(path).catch(() => null);
-    if (content === null) return; // not yet created
-    const bytes = Buffer.byteLength(content, "utf8");
-    if (bytes <= ELECTRON_LOG_MAX_BYTES) return;
-    // Slice the last N bytes off the end. Slicing by code-unit count would
-    // mis-handle multi-byte UTF-8 sequences; convert via Buffer to be exact.
-    const buf = Buffer.from(content, "utf8");
-    const tail = buf.subarray(buf.length - ELECTRON_LOG_MAX_BYTES).toString("utf8");
-    await deps.fileSystem.writeFile(path, tail).catch((err: unknown) =>
-      deps.logger.warn("Failed to truncate electron.log", {
-        error: err instanceof Error ? err.message : String(err),
-      })
-    );
-  }
-
   return {
     name: "logging",
     hooks: {
       [APP_START_OPERATION_ID]: {
         "before-ready": {
           handler: async (): Promise<void> => {
-            // Enable Chromium/Electron native logging to a known file. Must be
-            // appended before app.whenReady. --v=1 captures verbose internals
-            // useful in bug reports (GPU, IPC, renderer crashes). The file is
-            // overwritten on each launch by Chromium itself.
-            const electronLogPath = deps.loggingService.getElectronLogFilePath();
-            deps.app.commandLine.appendSwitch("enable-logging", "file");
-            deps.app.commandLine.appendSwitch("log-file", electronLogPath);
-            deps.app.commandLine.appendSwitch("v", "1");
-
             // Configure logging from loaded config
             const levelSpec = logLevelConfig.get();
             const { level, filter } = splitLogLevelSpec(levelSpec);
@@ -155,25 +92,6 @@ export function createLoggingModule(deps: LoggingModuleDeps): IntentModule {
           requires: { "app-ready": true },
           handler: async (): Promise<void> => {
             deps.loggingService.initialize();
-            // Chromium has no native log rotation. Cap on-disk size with a
-            // simple periodic watcher (stat-then-truncate-tail). Memory cost
-            // is bounded by ELECTRON_LOG_MAX_BYTES on each tick.
-            if (watcherHandle === null) {
-              watcherHandle = scheduler.setInterval(
-                () => void truncateElectronLogIfOversize(),
-                ELECTRON_LOG_WATCHER_INTERVAL_MS
-              );
-            }
-          },
-        },
-      },
-      [APP_SHUTDOWN_OPERATION_ID]: {
-        stop: {
-          handler: async (): Promise<void> => {
-            if (watcherHandle !== null) {
-              scheduler.clearInterval(watcherHandle);
-              watcherHandle = null;
-            }
           },
         },
       },


### PR DESCRIPTION
Drops the native Chromium `electron.log`, which `--v=1` had turned into ~70% VERBOSE1 spam (IME "Unknown surrounding text", audio-glitch, per-request net traces) — ~21 MB per launch, with **zero** `gpu*`/`ipc*` verbose lines (the diagnostics the switch claimed to justify). Its only consumer was bug/crash reports, where the noise crowded useful context out of the compressed payload budget.

- Remove the `--enable-logging=file` / `--log-file` / `--v=1` switches and the truncation watcher from `logging-module`.
- Stop attaching `electron_logs*` to `$exception` payloads in `error-report-module`; reports carry the app log only, and the freed budget goes to a larger single-stream cap (450 KB → 900 KB).
- Remove the now-dead `getElectronLogFilePath` from the `Logging` boundary (interface, impl, mock) and rewire the composition root + affected tests.

Trade-off: native GPU/driver and code-server-iframe console diagnostics are no longer in reports. The app's own structured log and the UI-view crash guard are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)