### PR TITLE
fix(badge): remove no-op Linux badge that failed 100% of calls

### DIFF
--- a/src/boundaries/shell/app.state-mock.ts
+++ b/src/boundaries/shell/app.state-mock.ts
@@ -6,7 +6,6 @@
  *
  * Custom matchers:
  * - `toHaveDockBadge(text)` - Assert current dock badge text
- * - `toHaveBadgeCount(count)` - Assert current badge count
  */
 
 import { expect } from "vitest";
@@ -28,7 +27,6 @@ import { CallbackSet, countMatcher, createSnapshot } from "../../test/state-mock
  * State is not directly exposed - use matchers for assertions.
  */
 class AppBoundaryMockStateImpl implements MockState {
-  badgeCount = 0;
   dockBadge = "";
   shouldUseDarkColors = true;
   /** True when a sleep blocker is currently active (OS prevented from sleeping). */
@@ -50,7 +48,7 @@ class AppBoundaryMockStateImpl implements MockState {
   }
 
   toString(): string {
-    return `AppBoundaryMockState { badgeCount: ${this.badgeCount}, dockBadge: "${this.dockBadge}", preventingSleep: ${this.preventingSleep} }`;
+    return `AppBoundaryMockState { dockBadge: "${this.dockBadge}", preventingSleep: ${this.preventingSleep} }`;
   }
 }
 
@@ -97,11 +95,9 @@ export interface MockAppBoundaryOptions {
  * The mock maintains in-memory state and provides the same
  * platform-specific behavior as the real implementation:
  * - dock is undefined on non-macOS platforms
- * - setBadgeCount always returns true in the mock
  *
  * Use custom matchers for assertions:
  * - `expect(mock).toHaveDockBadge("text")`
- * - `expect(mock).toHaveBadgeCount(5)`
  *
  * @example Basic usage
  * ```ts
@@ -114,13 +110,6 @@ export interface MockAppBoundaryOptions {
  * ```ts
  * const appLayer = createAppBoundaryMock({ platform: "win32" });
  * expect(appLayer.dock).toBeUndefined();
- * ```
- *
- * @example Badge count
- * ```ts
- * const appLayer = createAppBoundaryMock();
- * appLayer.setBadgeCount(5);
- * expect(appLayer).toHaveBadgeCount(5);
  * ```
  */
 export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): MockAppBoundary {
@@ -142,11 +131,6 @@ export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): Moc
   return {
     $: state,
     dock,
-
-    setBadgeCount(count: number): boolean {
-      state.badgeCount = count;
-      return true;
-    },
 
     allowPowerSaving(allow: boolean): void {
       // Mirror the real boundary's idempotent single-blocker semantics.
@@ -195,12 +179,6 @@ export interface AppBoundaryMatchers {
   toHaveDockBadge(text: string): void;
 
   /**
-   * Assert current badge count.
-   * @param count - Expected badge count
-   */
-  toHaveBadgeCount(count: number): void;
-
-  /**
    * Assert that the OS is currently being prevented from sleeping
    * (a sleep blocker is active). Use `.not` to assert sleep is allowed.
    */
@@ -244,11 +222,6 @@ const appBoundaryMatchers: MatcherImplementationsFor<
           : `Expected dock badge to be "${text}", but got "${actual}"`,
     };
   },
-
-  toHaveBadgeCount: countMatcher<MockAppBoundary & { $: AppBoundaryMockStateImpl }>(
-    "badge",
-    (mock) => mock.$.badgeCount
-  ),
 
   toBePreventingSleep(received) {
     const actual = received.$.preventingSleep;

--- a/src/boundaries/shell/app.ts
+++ b/src/boundaries/shell/app.ts
@@ -40,7 +40,6 @@ export interface AppDock {
  *
  * Platform-specific behavior:
  * - `dock` is only available on macOS (undefined on other platforms)
- * - `setBadgeCount` works on Linux Unity launcher only
  */
 export interface AppBoundary {
   /**
@@ -48,15 +47,6 @@ export interface AppBoundary {
    * Returns undefined on non-macOS platforms.
    */
   readonly dock: AppDock | undefined;
-
-  /**
-   * Set the app badge count.
-   * Works on Linux Unity launcher. No-op on Windows/macOS.
-   *
-   * @param count - Badge count (0 to clear)
-   * @returns true if successful, false otherwise
-   */
-  setBadgeCount(count: number): boolean;
 
   /**
    * Open a URL in the system's default handler (browser for http/https, mail client for mailto).
@@ -134,12 +124,6 @@ export class DefaultAppBoundary implements AppBoundary {
         },
       };
     }
-  }
-
-  setBadgeCount(count: number): boolean {
-    const result = app.setBadgeCount(count);
-    this.logger.debug("Badge count set", { count, success: result });
-    return result;
   }
 
   async openUrl(url: string): Promise<void> {

--- a/src/modules/badge-module.integration.test.ts
+++ b/src/modules/badge-module.integration.test.ts
@@ -190,7 +190,10 @@ describe("BadgeManager", () => {
   });
 
   describe("updateBadge (linux)", () => {
-    it("sets badge count to 1 for all-working state", () => {
+    // Electron's setBadgeCount() only ever worked on the Unity launcher, which no
+    // modern Linux desktop provides. The Linux badge was removed, so every state
+    // must be a no-op: no dock badge, no overlay icon, no generated images.
+    it.each(["all-working", "mixed", "none"] as const)("is a no-op for %s state", (state) => {
       const platformInfo = createMockPlatformInfo({ platform: "linux" });
       appLayer = createAppBoundaryMock({ platform: "linux" });
 
@@ -202,43 +205,11 @@ describe("BadgeManager", () => {
         SILENT_LOGGER
       );
 
-      manager.updateBadge("all-working");
+      manager.updateBadge(state);
 
-      expect(appLayer).toHaveBadgeCount(1);
-    });
-
-    it("sets badge count to 1 for mixed state", () => {
-      const platformInfo = createMockPlatformInfo({ platform: "linux" });
-      appLayer = createAppBoundaryMock({ platform: "linux" });
-
-      const manager = new BadgeManager(
-        platformInfo,
-        appLayer,
-        imageLayer,
-        windowManager as unknown as WindowManager,
-        SILENT_LOGGER
-      );
-
-      manager.updateBadge("mixed");
-
-      expect(appLayer).toHaveBadgeCount(1);
-    });
-
-    it("clears badge for none state", () => {
-      const platformInfo = createMockPlatformInfo({ platform: "linux" });
-      appLayer = createAppBoundaryMock({ platform: "linux" });
-
-      const manager = new BadgeManager(
-        platformInfo,
-        appLayer,
-        imageLayer,
-        windowManager as unknown as WindowManager,
-        SILENT_LOGGER
-      );
-
-      manager.updateBadge("none");
-
-      expect(appLayer).toHaveBadgeCount(0);
+      expect(appLayer.dock).toBeUndefined();
+      expect(windowManager.getOverlayIconCalls()).toHaveLength(0);
+      expect(imageLayer).toHaveImages([]);
     });
   });
 

--- a/src/modules/badge-module.ts
+++ b/src/modules/badge-module.ts
@@ -41,7 +41,9 @@ export type BadgeState = "none" | "all-working" | "mixed";
  * Platform behavior:
  * - macOS: Uses dock.setBadge() with status indicator
  * - Windows: Uses overlay icon on taskbar (16x16 generated image)
- * - Linux: Uses setBadgeCount() for Unity launcher (1 for working, 0 otherwise)
+ * - Linux: No badge. Electron's setBadgeCount() only ever worked on the Unity
+ *   launcher, which no modern desktop (GNOME/Wayland, KDE, …) provides, so the
+ *   call was a guaranteed no-op and has been removed.
  */
 export class BadgeManager {
   private readonly platformInfo: PlatformInfo;
@@ -83,11 +85,8 @@ export class BadgeManager {
       case "win32":
         this.updateWindowsBadge(state);
         break;
-      case "linux":
-        this.updateLinuxBadge(state);
-        break;
       default:
-        // Other platforms: no-op
+        // Linux and other platforms: no-op (no supported badge mechanism)
         break;
     }
   }
@@ -129,17 +128,6 @@ export class BadgeManager {
       state === "all-working" ? "All workspaces working" : "Some workspaces ready";
     this.windowManager.setOverlayIcon(handle, description);
     this.logger.debug("Updated Windows overlay icon", { state, description });
-  }
-
-  /**
-   * Updates the Linux badge count (Unity launcher).
-   * Uses 1 for any active state, 0 for none.
-   */
-  private updateLinuxBadge(state: BadgeState): void {
-    // Linux badge only supports counts, so use 1 for any visible state
-    const count = state === "none" ? 0 : 1;
-    const success = this.appLayer.setBadgeCount(count);
-    this.logger.debug("Updated Linux badge count", { state, count, success });
   }
 
   /**


### PR DESCRIPTION
- Electron's `app.setBadgeCount()` only ever worked on the Unity launcher; on modern Linux desktops (GNOME/Wayland, KDE, …) it always returned false — a guaranteed no-op that still logged a debug line on every agent status change (~5,840 failing calls / 100% `success=false` over a week of production logs).
- Removed the Linux badge path entirely: dropped `updateLinuxBadge()` and the `"linux"` case (now falls through to the default no-op).
- Removed the newly-dead `setBadgeCount()` from the `AppBoundary` interface, its Electron implementation, and the test mock + `toHaveBadgeCount` matcher.
- Linux badge tests now assert the no-op behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)