### PR TITLE
fix: cleanup of electron project worktrees was broken

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -51,7 +51,10 @@ export default defineConfig({
     },
     plugins: [
       // bufferutil and utf-8-validate are optional native deps for ws (used by socket.io)
-      codehydraDefaults({ external: ["bufferutil", "utf-8-validate"] }),
+      // original-fs is an Electron runtime builtin (not an npm package); it must be
+      // externalized so Rollup doesn't try to resolve/bundle it (which would trip the
+      // throw-on-warning onLog in codehydraDefaults and fail the build).
+      codehydraDefaults({ external: ["bufferutil", "utf-8-validate", "original-fs"] }),
       viteStaticCopy({
         targets: [
           { src: "dist/extensions/*", dest: "assets/extensions" },

--- a/src/boundaries/platform/filesystem.boundary.test.ts
+++ b/src/boundaries/platform/filesystem.boundary.test.ts
@@ -13,6 +13,9 @@ import type * as NodeFs from "node:fs/promises";
  * When rmOverride is non-null, the mocked rm delegates to it instead of the real implementation.
  * This allows the ETIMEDOUT test to inject a never-resolving promise while keeping all
  * other tests using real filesystem operations.
+ *
+ * Outside the Electron runtime (Vitest), the boundary's original-fs require throws and
+ * falls back to node:fs/promises, so mocking node:fs/promises intercepts the boundary's rm.
  */
 const { rmControl } = vi.hoisted(() => ({
   rmControl: { override: null as (() => Promise<void>) | null },
@@ -497,6 +500,22 @@ describe("DefaultFileSystemBoundary", () => {
       await fs.rm(dirPath, { recursive: true, force: true });
 
       await expect(fs.readdir(dirPath)).rejects.toThrow();
+    });
+
+    it("recursively removes a tree containing a *.asar file (orphan-cleanup regression)", async () => {
+      // A workspace's installed electron leaves .../dist/resources/default_app.asar.
+      // In the packaged app, node:fs is asar-patched and treats that file as a virtual
+      // directory, so recursive rm leaves it behind and rmdir fails with ENOTEMPTY.
+      // The boundary uses original-fs to avoid asar handling; this asserts the .asar
+      // file is treated as a plain file and the whole tree is removed.
+      const resourcesDir = join(tempDir.path, "electron", "dist", "resources");
+      const asarPath = join(resourcesDir, "default_app.asar");
+      await nodeMkdir(resourcesDir, { recursive: true });
+      await nodeWriteFile(asarPath, "not a real asar", "utf-8");
+
+      await fs.rm(join(tempDir.path, "electron"), { recursive: true, force: true });
+
+      await expect(fs.readdir(join(tempDir.path, "electron"))).rejects.toThrow();
     });
 
     it("rm with timeout succeeds when operation completes within timeout", async () => {

--- a/src/boundaries/platform/filesystem.ts
+++ b/src/boundaries/platform/filesystem.ts
@@ -281,8 +281,27 @@ export interface FileSystemBoundary {
 // Helper Functions
 // ============================================================================
 
-import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as nodeFsPromises from "node:fs/promises";
 import { FileSystemError } from "../../shared/errors/service-errors";
+
+// In the packaged Electron main process, node:fs is asar-patched: any op on a path
+// containing a *.asar treats it as a virtual directory and caches the archive fd for
+// the process lifetime, so recursive rm/readdir over a workspace's node_modules opens
+// and locks an embedded electron default_app.asar — which made orphaned-workspace
+// cleanup fail with ENOTEMPTY in packaged builds (process.noAsar is intentionally left
+// off there so the app can load its own asar). original-fs is Electron's un-patched fs,
+// present ONLY in the Electron runtime; fall back to node:fs/promises everywhere else
+// (Vitest, tsx-run build/install scripts, plain Node) where it does not resolve.
+function resolveFsPromises(): typeof nodeFsPromises {
+  try {
+    return (createRequire(import.meta.url)("original-fs") as { promises: typeof nodeFsPromises })
+      .promises;
+  } catch {
+    return nodeFsPromises;
+  }
+}
+const fs = resolveFsPromises();
 import type { Logger } from "./logging";
 
 /**


### PR DESCRIPTION
- Orphaned-workspace cleanup failed with `ENOTEMPTY` on every startup for any workspace with an installed electron, leaking disk permanently.
- Root cause: in packaged builds `process.noAsar` is intentionally left off (the app needs asar to load itself), so the main process's `node:fs` is asar-patched. The recursive `rm` then treats a workspace's electron `default_app.asar` as a virtual directory, never unlinks the real file, and `rmdir('resources')` throws `ENOTEMPTY`.
- Fix: back `FileSystemBoundary` with Electron's un-patched `original-fs`, scoped to the boundary so the app's own asar handling is untouched. Aliased to `node:fs` for Vitest/plain Node and externalized in the Electron build.