### PR TITLE
perf(git): batch branch-config reads to eliminate IsRepositoryRoot polling

### DIFF
--- a/src/boundaries/platform/git-client.state-mock.ts
+++ b/src/boundaries/platform/git-client.state-mock.ts
@@ -600,16 +600,37 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
       return [...repo.remotes].sort();
     },
 
-    async getBranchConfig(repoPath: Path, branch: string, key: string): Promise<string | null> {
+    async getGitConfig(
+      repoPath: Path,
+      options: { key: string } | { regex: string }
+    ): Promise<ReadonlyMap<string, string>> {
       getRepoOrThrow(repoPath); // Validate repo exists
       const repo = state.getRepo(normalizePath(repoPath))!;
 
-      const branchConfig = repo.branchConfigs.get(branch);
-      if (!branchConfig) {
-        return null;
+      // Flatten stored branch configs into full git config keys: branch.<branch>.<subkey>
+      const entries = new Map<string, string>();
+      for (const [branch, branchConfig] of repo.branchConfigs) {
+        for (const [subKey, value] of branchConfig) {
+          entries.set(`branch.${branch}.${subKey}`, value);
+        }
       }
 
-      return branchConfig.get(key) ?? null;
+      const result = new Map<string, string>();
+      if ("key" in options) {
+        const value = entries.get(options.key);
+        if (value !== undefined) {
+          result.set(options.key, value);
+        }
+        return result;
+      }
+
+      const pattern = new RegExp(options.regex);
+      for (const [key, value] of entries) {
+        if (pattern.test(key)) {
+          result.set(key, value);
+        }
+      }
+      return result;
     },
 
     async setBranchConfig(
@@ -628,32 +649,6 @@ export function createMockGitClient(options?: MockGitClientOptions): MockGitClie
       }
 
       branchConfig.set(key, value);
-    },
-
-    async getBranchConfigsByPrefix(
-      repoPath: Path,
-      branch: string,
-      prefix: string
-    ): Promise<Readonly<Record<string, string>>> {
-      getRepoOrThrow(repoPath); // Validate repo exists
-      const repo = state.getRepo(normalizePath(repoPath))!;
-
-      const branchConfig = repo.branchConfigs.get(branch);
-      if (!branchConfig) {
-        return {};
-      }
-
-      const result: Record<string, string> = {};
-      const prefixWithDot = prefix + ".";
-
-      for (const [key, value] of branchConfig) {
-        if (key.startsWith(prefixWithDot)) {
-          const strippedKey = key.substring(prefixWithDot.length);
-          result[strippedKey] = value;
-        }
-      }
-
-      return result;
     },
 
     async unsetBranchConfig(repoPath: Path, branch: string, key: string): Promise<void> {

--- a/src/boundaries/platform/git-client.ts
+++ b/src/boundaries/platform/git-client.ts
@@ -148,14 +148,26 @@ export interface IGitClient {
   getDefaultBranch(repoPath: Path, remote?: string): Promise<string | null>;
 
   /**
-   * Get a branch-specific configuration value.
+   * Read git config entries in a single git invocation.
+   *
+   * Pass `key` for an exact lookup (`git config --get <key>`) or `regex` for a
+   * pattern match (`git config --get-regexp <regex>`). Returns a map of full
+   * config key → value; empty when nothing matches (an unset key is not an error).
+   *
+   * All keys CodeHydra reads/writes are single-valued. A broad pattern that
+   * matched a git-native multi-valued key (e.g. `remote.*.fetch`) would keep only
+   * the last value — callers must scope the filter to single-valued keys.
+   *
    * @param repoPath Absolute path to the git repository
-   * @param branch Name of the branch
-   * @param key Configuration key (without the branch prefix)
-   * @returns Promise resolving to the config value, or null if not set
+   * @param options.key   Exact config key to read
+   * @param options.regex Key pattern (git regex) to read matching entries
+   * @returns Promise resolving to a map of config key to value
    * @throws GitError if not a git repository
    */
-  getBranchConfig(repoPath: Path, branch: string, key: string): Promise<string | null>;
+  getGitConfig(
+    repoPath: Path,
+    options: { key: string } | { regex: string }
+  ): Promise<ReadonlyMap<string, string>>;
 
   /**
    * Set a branch-specific configuration value.
@@ -167,29 +179,6 @@ export interface IGitClient {
    * @throws GitError if not a git repository
    */
   setBranchConfig(repoPath: Path, branch: string, key: string, value: string): Promise<void>;
-
-  /**
-   * Get all branch configuration values under a prefix.
-   * Returns config values under `branch.<branch>.<prefix>.*` with the prefix stripped.
-   *
-   * @example
-   * // Git config has:
-   * // branch.main.codehydra.base = develop
-   * // branch.main.codehydra.note = WIP feature
-   * const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
-   * // Returns: { base: "develop", note: "WIP feature" }
-   *
-   * @param repoPath Absolute path to the git repository
-   * @param branch Name of the branch
-   * @param prefix Configuration key prefix (e.g., "codehydra")
-   * @returns Promise resolving to a record of key-value pairs (keys have prefix stripped)
-   * @throws GitError if not a git repository
-   */
-  getBranchConfigsByPrefix(
-    repoPath: Path,
-    branch: string,
-    prefix: string
-  ): Promise<Readonly<Record<string, string>>>;
 
   /**
    * Remove a branch-specific configuration value.

--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -677,6 +677,63 @@ describe("GitWorktreeProvider", () => {
     });
   });
 
+  describe("config read batching (regression)", () => {
+    it("listBases issues exactly one getGitConfig call regardless of branch count", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "a", "b", "c", "d"],
+            currentBranch: "main",
+            branchConfigs: {
+              a: { "codehydra.base": "main" },
+              b: { "codehydra.base": "main" },
+            },
+          },
+        },
+      });
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+      const spy = vi.spyOn(mockClient, "getGitConfig");
+
+      await provider.listBases(PROJECT_ROOT);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("discover issues exactly one getGitConfig call regardless of worktree count", async () => {
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "a", "b", "c"],
+            currentBranch: "main",
+            worktrees: [
+              { name: "a", path: "/data/workspaces/a", branch: "a" },
+              { name: "b", path: "/data/workspaces/b", branch: "b" },
+              { name: "c", path: "/data/workspaces/c", branch: "c" },
+            ],
+          },
+        },
+      });
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+      const spy = vi.spyOn(mockClient, "getGitConfig");
+
+      await provider.discover(PROJECT_ROOT);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("listBases", () => {
     it("returns local and remote branches", async () => {
       const mockClient = createMockGitClient({
@@ -1560,12 +1617,10 @@ describe("GitWorktreeProvider", () => {
 
       // Branch still exists but metadata should be cleared
       expect(mockClient).toHaveBranch(PROJECT_ROOT, "feature-x");
-      const metadata = await mockClient.getBranchConfigsByPrefix(
-        PROJECT_ROOT,
-        "feature-x",
-        "codehydra"
-      );
-      expect(metadata).toEqual({});
+      const metadata = await mockClient.getGitConfig(PROJECT_ROOT, {
+        regex: "^branch\\.feature-x\\.codehydra\\.",
+      });
+      expect(metadata.size).toBe(0);
     });
 
     it("clears metadata even when worktree removal fails", async () => {
@@ -1605,12 +1660,10 @@ describe("GitWorktreeProvider", () => {
       );
 
       // Metadata should still have been cleared before the failing worktree removal
-      const metadata = await mockClient.getBranchConfigsByPrefix(
-        PROJECT_ROOT,
-        "feature-x",
-        "codehydra"
-      );
-      expect(metadata).toEqual({});
+      const metadata = await mockClient.getGitConfig(PROJECT_ROOT, {
+        regex: "^branch\\.feature-x\\.codehydra\\.",
+      });
+      expect(metadata.size).toBe(0);
     });
   });
 

--- a/src/boundaries/platform/git-worktree-provider.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { GitWorktreeProvider } from "./git-worktree-provider";
+import { GitWorktreeProvider, parseBranchConfigs } from "./git-worktree-provider";
 import { WorkspaceError } from "../../shared/errors/service-errors";
 import {
   createFileSystemMock,
@@ -36,6 +36,47 @@ async function createProvider(
   return provider;
 }
 
+describe("parseBranchConfigs", () => {
+  it("groups prefix-stripped keys by branch", () => {
+    const entries = new Map([
+      ["branch.main.codehydra.base", "develop"],
+      ["branch.main.codehydra.note", "WIP feature"],
+      ["branch.feature.codehydra.base", "main"],
+    ]);
+
+    const result = parseBranchConfigs(entries, "codehydra");
+
+    expect(Object.fromEntries(result)).toEqual({
+      main: { base: "develop", note: "WIP feature" },
+      feature: { base: "main" },
+    });
+  });
+
+  it("handles branch names containing dots and slashes", () => {
+    const entries = new Map([["branch.release/1.2.codehydra.base", "main"]]);
+
+    const result = parseBranchConfigs(entries, "codehydra");
+
+    expect(result.get("release/1.2")).toEqual({ base: "main" });
+  });
+
+  it("ignores keys that do not match the branch prefix or metadata prefix", () => {
+    const entries = new Map([
+      ["remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"],
+      ["branch.main.other.key", "value"],
+      ["branch.main.codehydra.base", "develop"],
+    ]);
+
+    const result = parseBranchConfigs(entries, "codehydra");
+
+    expect(Object.fromEntries(result)).toEqual({ main: { base: "develop" } });
+  });
+
+  it("returns an empty map for empty input", () => {
+    expect(parseBranchConfigs(new Map(), "codehydra").size).toBe(0);
+  });
+});
+
 describe("GitWorktreeProvider error injection", () => {
   const PROJECT_ROOT = new Path("/home/user/projects/my-repo");
   const WORKSPACES_DIR = new Path("/home/user/app-data/projects/my-repo-abc12345/workspaces");
@@ -58,7 +99,7 @@ describe("GitWorktreeProvider error injection", () => {
   });
 
   describe("discover", () => {
-    it("logs warning and uses fallback when getBranchConfigsByPrefix throws", async () => {
+    it("logs warning and uses fallback when getGitConfig throws", async () => {
       const mockClient = createMockGitClient({
         repositories: {
           [PROJECT_ROOT.toString()]: {
@@ -71,9 +112,7 @@ describe("GitWorktreeProvider error injection", () => {
         },
       });
       // Override to throw an error
-      mockClient.getBranchConfigsByPrefix = vi
-        .fn()
-        .mockRejectedValue(new Error("Config read failed"));
+      mockClient.getGitConfig = vi.fn().mockRejectedValue(new Error("Config read failed"));
 
       const provider = await createProvider(
         PROJECT_ROOT,

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -36,6 +36,47 @@ interface ProjectRegistration {
 }
 
 /**
+ * Parse flat `git config` entries into per-branch metadata records.
+ *
+ * Each input key is a full config key (e.g. `branch.<branch>.<prefix>.<subkey>`);
+ * only keys matching `branch.<branch>.<prefix>.<subkey>` contribute, with the
+ * `branch.<branch>.<prefix>.` part stripped. Branch names may contain dots
+ * (e.g. `release/1.2`), so the branch/subkey split is anchored on the
+ * `.<prefix>.` marker rather than naive dot-splitting.
+ *
+ * @param entries Map of full git config key → value
+ * @param prefix Metadata prefix (e.g. "codehydra")
+ * @returns Map of branch name → { subkey: value }
+ */
+export function parseBranchConfigs(
+  entries: ReadonlyMap<string, string>,
+  prefix: string
+): Map<string, Record<string, string>> {
+  const result = new Map<string, Record<string, string>>();
+  const branchPrefix = "branch.";
+  const marker = `.${prefix}.`;
+
+  for (const [fullKey, value] of entries) {
+    if (!fullKey.startsWith(branchPrefix)) continue;
+    const markerIndex = fullKey.indexOf(marker);
+    if (markerIndex === -1) continue;
+
+    const branch = fullKey.substring(branchPrefix.length, markerIndex);
+    const subKey = fullKey.substring(markerIndex + marker.length);
+    if (!branch || !subKey) continue;
+
+    let record = result.get(branch);
+    if (!record) {
+      record = {};
+      result.set(branch, record);
+    }
+    record[subKey] = value;
+  }
+
+  return result;
+}
+
+/**
  * Global provider managing git worktree operations across all projects.
  *
  * Maintains two internal registries:
@@ -182,6 +223,31 @@ export class GitWorktreeProvider {
     };
   }
 
+  /**
+   * Read all `codehydra.*` branch metadata for a repository in a single git config
+   * call, keyed by branch name. Replaces per-branch / per-worktree config reads.
+   */
+  private async getAllBranchMetadata(
+    projectRoot: Path
+  ): Promise<ReadonlyMap<string, Readonly<Record<string, string>>>> {
+    const prefix = GitWorktreeProvider.METADATA_CONFIG_PREFIX;
+    const entries = await this.gitClient.getGitConfig(projectRoot, {
+      regex: `^branch\\..*\\.${prefix}\\.`,
+    });
+    return parseBranchConfigs(entries, prefix);
+  }
+
+  /**
+   * Read one branch's `codehydra.*` metadata (empty record if the branch has none).
+   */
+  private async getBranchMetadata(
+    projectRoot: Path,
+    branch: string
+  ): Promise<Readonly<Record<string, string>>> {
+    const all = await this.getAllBranchMetadata(projectRoot);
+    return all.get(branch) ?? {};
+  }
+
   async discover(projectRoot: Path): Promise<readonly Workspace[]> {
     const worktrees = await this.gitClient.listWorktrees(projectRoot);
 
@@ -196,6 +262,16 @@ export class GitWorktreeProvider {
       await this.gitClient.pruneWorktrees(projectRoot);
     }
 
+    // Read every branch's metadata in one git config call (was one read per worktree)
+    let branchMetadata: ReadonlyMap<string, Readonly<Record<string, string>>>;
+    try {
+      branchMetadata = await this.getAllBranchMetadata(projectRoot);
+    } catch (error: unknown) {
+      const message = getErrorMessage(error, "Unknown error");
+      this.logger.warn("Failed to get metadata config", { error: message });
+      branchMetadata = new Map();
+    }
+
     // Filter out the main worktree and prunable entries, map to Workspace objects
     const workspaces: Workspace[] = [];
     for (const wt of worktrees) {
@@ -204,23 +280,9 @@ export class GitWorktreeProvider {
       // Register workspace in the workspace registry for metadata resolution
       this.ensureWorkspaceRegistered(wt.path, projectRoot);
 
-      // Get metadata from git config
-      let metadata: Record<string, string>;
-      try {
-        metadata = wt.branch
-          ? {
-              ...(await this.gitClient.getBranchConfigsByPrefix(
-                projectRoot,
-                wt.branch,
-                GitWorktreeProvider.METADATA_CONFIG_PREFIX
-              )),
-            }
-          : {};
-      } catch (error: unknown) {
-        const message = getErrorMessage(error, "Unknown error");
-        this.logger.warn("Failed to get metadata config", { workspace: wt.name, error: message });
-        metadata = {};
-      }
+      const metadata: Record<string, string> = wt.branch
+        ? { ...(branchMetadata.get(wt.branch) ?? {}) }
+        : {};
 
       workspaces.push({
         name: wt.branch ?? wt.name,
@@ -235,6 +297,15 @@ export class GitWorktreeProvider {
   async listBases(projectRoot: Path): Promise<readonly BaseInfo[]> {
     const branches = await this.gitClient.listBranches(projectRoot);
     const worktrees = await this.gitClient.listWorktrees(projectRoot);
+
+    // Read every branch's metadata in one git config call (was one read per local branch)
+    let branchMetadata: ReadonlyMap<string, Readonly<Record<string, string>>>;
+    try {
+      branchMetadata = await this.getAllBranchMetadata(projectRoot);
+    } catch {
+      // Ignore config errors; bases fall back to origin/* detection below
+      branchMetadata = new Map();
+    }
 
     // Build set of branches that have worktrees
     const branchesWithWorktrees = new Set<string>();
@@ -280,24 +351,16 @@ export class GitWorktreeProvider {
 
         // Compute base: codehydra.base config or matching origin/* branch
         let base: string | undefined;
-        try {
-          const configBase = await this.gitClient.getBranchConfig(
-            projectRoot,
-            branch.name,
-            `${GitWorktreeProvider.METADATA_CONFIG_PREFIX}.base`
-          );
-          if (configBase) {
-            base = configBase;
-          } else {
-            // Check for matching origin/* branch
-            const originBranch = `origin/${branch.name}`;
-            const hasOriginBranch = branches.some((b) => b.isRemote && b.name === originBranch);
-            if (hasOriginBranch) {
-              base = originBranch;
-            }
+        const configBase = branchMetadata.get(branch.name)?.base;
+        if (configBase) {
+          base = configBase;
+        } else {
+          // Check for matching origin/* branch
+          const originBranch = `origin/${branch.name}`;
+          const hasOriginBranch = branches.some((b) => b.isRemote && b.name === originBranch);
+          if (hasOriginBranch) {
+            base = originBranch;
           }
-        } catch {
-          // Ignore config errors, base stays undefined
         }
 
         // Build BaseInfo with conditional optional properties
@@ -541,11 +604,7 @@ export class GitWorktreeProvider {
     // not in the worktree, and clearing after removal can race with shutdown hooks.
     if (branchName) {
       try {
-        const metadata = await this.gitClient.getBranchConfigsByPrefix(
-          projectRoot,
-          branchName,
-          GitWorktreeProvider.METADATA_CONFIG_PREFIX
-        );
+        const metadata = await this.getBranchMetadata(projectRoot, branchName);
         for (const key of Object.keys(metadata)) {
           await this.gitClient.unsetBranchConfig(
             projectRoot,
@@ -676,11 +735,7 @@ export class GitWorktreeProvider {
       const projectRoot = this.workspaceRegistry.get(workspacePath.toString());
       if (!projectRoot) return 0;
 
-      const metadata = await this.gitClient.getBranchConfigsByPrefix(
-        projectRoot,
-        branch,
-        GitWorktreeProvider.METADATA_CONFIG_PREFIX
-      );
+      const metadata = await this.getBranchMetadata(projectRoot, branch);
       let base = metadata.base;
       if (!base) {
         base = await this.defaultBase(projectRoot);
@@ -950,13 +1005,7 @@ export class GitWorktreeProvider {
     }
 
     const metadata: Record<string, string> = worktree.branch
-      ? {
-          ...(await this.gitClient.getBranchConfigsByPrefix(
-            projectRoot,
-            worktree.branch,
-            GitWorktreeProvider.METADATA_CONFIG_PREFIX
-          )),
-        }
+      ? { ...(await this.getBranchMetadata(projectRoot, worktree.branch)) }
       : {};
 
     return metadata;

--- a/src/boundaries/platform/simple-git-client.boundary.test.ts
+++ b/src/boundaries/platform/simple-git-client.boundary.test.ts
@@ -19,6 +19,18 @@ import { simpleGit } from "simple-git";
 import { SILENT_LOGGER } from "./logging";
 import { Path } from "../../utils/path/path";
 
+/** Read a single branch config value via getGitConfig (replaces the removed getBranchConfig). */
+async function readBranchConfig(
+  client: SimpleGitClient,
+  repoPath: Path,
+  branch: string,
+  key: string
+): Promise<string | null> {
+  const fullKey = `branch.${branch}.${key}`;
+  const map = await client.getGitConfig(repoPath, { key: fullKey });
+  return map.get(fullKey) ?? null;
+}
+
 describe("SimpleGitClient", () => {
   let client: SimpleGitClient;
   let cleanup: () => Promise<void>;
@@ -493,24 +505,43 @@ describe("SimpleGitClient", () => {
     });
   });
 
-  describe("getBranchConfigsByPrefix", () => {
-    it("returns all codehydra.* configs for a branch", async () => {
-      // Set multiple config values with codehydra prefix
+  describe("getGitConfig", () => {
+    it("returns all matching entries by regex (full keys) across branches", async () => {
       await client.setBranchConfig(repoPath, "main", "codehydra.base", "develop");
       await client.setBranchConfig(repoPath, "main", "codehydra.note", "WIP feature");
 
-      const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
+      const configs = await client.getGitConfig(repoPath, {
+        regex: "^branch\\..*\\.codehydra\\.",
+      });
 
-      expect(configs).toEqual({
-        base: "develop",
-        note: "WIP feature",
+      expect(Object.fromEntries(configs)).toEqual({
+        "branch.main.codehydra.base": "develop",
+        "branch.main.codehydra.note": "WIP feature",
       });
     });
 
-    it("returns empty object when no configs exist", async () => {
-      const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
+    it("returns an empty map when no entries match", async () => {
+      const configs = await client.getGitConfig(repoPath, {
+        regex: "^branch\\..*\\.codehydra\\.",
+      });
 
-      expect(configs).toEqual({});
+      expect(configs.size).toBe(0);
+    });
+
+    it("returns a single value by exact key", async () => {
+      await client.setBranchConfig(repoPath, "main", "codehydra.base", "develop");
+
+      const configs = await client.getGitConfig(repoPath, { key: "branch.main.codehydra.base" });
+
+      expect(Object.fromEntries(configs)).toEqual({ "branch.main.codehydra.base": "develop" });
+    });
+
+    it("returns an empty map for an unset exact key", async () => {
+      const configs = await client.getGitConfig(repoPath, {
+        key: "branch.main.codehydra.nonexistent",
+      });
+
+      expect(configs.size).toBe(0);
     });
 
     it("handles values with spaces", async () => {
@@ -521,35 +552,37 @@ describe("SimpleGitClient", () => {
         "Work in progress with spaces"
       );
 
-      const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
+      const configs = await client.getGitConfig(repoPath, { key: "branch.main.codehydra.note" });
 
-      expect(configs.note).toBe("Work in progress with spaces");
+      expect(configs.get("branch.main.codehydra.note")).toBe("Work in progress with spaces");
     });
 
     it("handles values with equals signs", async () => {
       await client.setBranchConfig(repoPath, "main", "codehydra.equation", "x=y+z");
 
-      const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
+      const configs = await client.getGitConfig(repoPath, {
+        key: "branch.main.codehydra.equation",
+      });
 
-      expect(configs.equation).toBe("x=y+z");
+      expect(configs.get("branch.main.codehydra.equation")).toBe("x=y+z");
     });
 
-    it("only returns configs matching the prefix", async () => {
-      // Set configs with different prefixes
+    it("only returns entries matching the regex", async () => {
       await client.setBranchConfig(repoPath, "main", "codehydra.base", "develop");
       await client.setBranchConfig(repoPath, "main", "other.key", "value");
 
-      const configs = await client.getBranchConfigsByPrefix(repoPath, "main", "codehydra");
+      const configs = await client.getGitConfig(repoPath, {
+        regex: "^branch\\..*\\.codehydra\\.",
+      });
 
-      expect(configs).toEqual({ base: "develop" });
-      expect(configs).not.toHaveProperty("key");
+      expect(Object.fromEntries(configs)).toEqual({ "branch.main.codehydra.base": "develop" });
     });
 
     it("throws GitError for non-repo path", async () => {
       const tempDir = await createTempDir();
       try {
         await expect(
-          client.getBranchConfigsByPrefix(new Path(tempDir.path), "main", "codehydra")
+          client.getGitConfig(new Path(tempDir.path), { regex: "^branch\\." })
         ).rejects.toThrow(GitError);
       } finally {
         await tempDir.cleanup();
@@ -561,14 +594,14 @@ describe("SimpleGitClient", () => {
     it("removes a config key", async () => {
       // Set config first
       await client.setBranchConfig(repoPath, "main", "codehydra.note", "to be removed");
-      const before = await client.getBranchConfig(repoPath, "main", "codehydra.note");
+      const before = await readBranchConfig(client, repoPath, "main", "codehydra.note");
       expect(before).toBe("to be removed");
 
       // Unset it
       await client.unsetBranchConfig(repoPath, "main", "codehydra.note");
 
       // Verify it's gone
-      const after = await client.getBranchConfig(repoPath, "main", "codehydra.note");
+      const after = await readBranchConfig(client, repoPath, "main", "codehydra.note");
       expect(after).toBeNull();
     });
 
@@ -591,17 +624,17 @@ describe("SimpleGitClient", () => {
     });
   });
 
-  describe("getBranchConfig and setBranchConfig", () => {
-    it("getBranchConfig returns null for non-existent config", async () => {
-      const value = await client.getBranchConfig(repoPath, "main", "nonexistent");
+  describe("getGitConfig and setBranchConfig", () => {
+    it("getGitConfig returns null for non-existent config", async () => {
+      const value = await readBranchConfig(client, repoPath, "main", "nonexistent");
 
       expect(value).toBeNull();
     });
 
-    it("setBranchConfig stores value retrievable by getBranchConfig", async () => {
+    it("setBranchConfig stores value retrievable by getGitConfig", async () => {
       await client.setBranchConfig(repoPath, "main", "base", "develop");
 
-      const value = await client.getBranchConfig(repoPath, "main", "base");
+      const value = await readBranchConfig(client, repoPath, "main", "base");
       expect(value).toBe("develop");
     });
 
@@ -610,7 +643,7 @@ describe("SimpleGitClient", () => {
 
       // Create a new client instance
       const newClient = new SimpleGitClient(SILENT_LOGGER);
-      const value = await newClient.getBranchConfig(repoPath, "main", "base");
+      const value = await readBranchConfig(newClient, repoPath, "main", "base");
       expect(value).toBe("feature-branch");
     });
 
@@ -620,7 +653,7 @@ describe("SimpleGitClient", () => {
 
       await client.setBranchConfig(repoPath, "feature/foo/bar", "base", "main");
 
-      const value = await client.getBranchConfig(repoPath, "feature/foo/bar", "base");
+      const value = await readBranchConfig(client, repoPath, "feature/foo/bar", "base");
       expect(value).toBe("main");
     });
 
@@ -631,15 +664,15 @@ describe("SimpleGitClient", () => {
         client.setBranchConfig(repoPath, "nonexistent-branch", "base", "main")
       ).resolves.not.toThrow();
 
-      const value = await client.getBranchConfig(repoPath, "nonexistent-branch", "base");
+      const value = await readBranchConfig(client, repoPath, "nonexistent-branch", "base");
       expect(value).toBe("main");
     });
 
-    it("getBranchConfig throws GitError for non-repo path", async () => {
+    it("getGitConfig throws GitError for non-repo path", async () => {
       const tempDir = await createTempDir();
       try {
         await expect(
-          client.getBranchConfig(new Path(tempDir.path), "main", "base")
+          client.getGitConfig(new Path(tempDir.path), { key: "branch.main.base" })
         ).rejects.toThrow(GitError);
       } finally {
         await tempDir.cleanup();
@@ -773,38 +806,40 @@ describe("SimpleGitClient", () => {
       await targetCleanup();
     });
 
-    it("getBranchConfig works on bare repository", async () => {
+    it("getGitConfig exact key works on bare repository", async () => {
       await client.setBranchConfig(bareRepoPath, "test-branch", "codehydra.base", "main");
 
-      const value = await client.getBranchConfig(bareRepoPath, "test-branch", "codehydra.base");
+      const value = await readBranchConfig(client, bareRepoPath, "test-branch", "codehydra.base");
 
       expect(value).toBe("main");
     });
 
-    it("getBranchConfigsByPrefix works on bare repository", async () => {
+    it("getGitConfig regex works on bare repository", async () => {
       await client.setBranchConfig(bareRepoPath, "test-branch", "codehydra.base", "main");
       await client.setBranchConfig(bareRepoPath, "test-branch", "codehydra.note", "a note");
 
-      const configs = await client.getBranchConfigsByPrefix(
-        bareRepoPath,
-        "test-branch",
-        "codehydra"
-      );
+      const configs = await client.getGitConfig(bareRepoPath, {
+        regex: "^branch\\..*\\.codehydra\\.",
+      });
 
-      expect(configs).toEqual({ base: "main", note: "a note" });
+      expect(Object.fromEntries(configs)).toEqual({
+        "branch.test-branch.codehydra.base": "main",
+        "branch.test-branch.codehydra.note": "a note",
+      });
     });
 
     it("unsetBranchConfig works on bare repository", async () => {
       await client.setBranchConfig(bareRepoPath, "test-branch", "codehydra.base", "main");
       await client.unsetBranchConfig(bareRepoPath, "test-branch", "codehydra.base");
 
-      const value = await client.getBranchConfig(bareRepoPath, "test-branch", "codehydra.base");
+      const value = await readBranchConfig(client, bareRepoPath, "test-branch", "codehydra.base");
 
       expect(value).toBeNull();
     });
 
-    it("getBranchConfig returns null for non-existent key on bare repo", async () => {
-      const value = await client.getBranchConfig(
+    it("getGitConfig returns null for non-existent key on bare repo", async () => {
+      const value = await readBranchConfig(
+        client,
         bareRepoPath,
         "test-branch",
         "codehydra.nonexistent"

--- a/src/boundaries/platform/simple-git-client.ts
+++ b/src/boundaries/platform/simple-git-client.ts
@@ -376,26 +376,50 @@ export class SimpleGitClient implements IGitClient {
     }, "Failed to list remotes");
   }
 
-  async getBranchConfig(repoPath: Path, branch: string, key: string): Promise<string | null> {
-    // First, verify it's a git repository
+  async getGitConfig(
+    repoPath: Path,
+    options: { key: string } | { regex: string }
+  ): Promise<ReadonlyMap<string, string>> {
+    // First, verify it's a git repository (handles bare repos correctly)
     const isRepo = await this.isInsideRepository(repoPath);
     if (!isRepo) {
       throw new GitError(`Not a git repository: ${repoPath.toString()}`);
     }
 
+    const result = new Map<string, string>();
+    const args =
+      "key" in options
+        ? ["config", "--get", options.key]
+        : ["config", "--get-regexp", options.regex];
+
     try {
       const git = this.getGit(repoPath);
-      const configKey = `branch.${branch}.${key}`;
-      const value = await git.raw(["config", "--get", configKey]);
-      return value.trim() || null;
+      const output = await git.raw(args);
+
+      if ("key" in options) {
+        // --get returns a single value; empty output means no value
+        const value = output.trim();
+        if (value) {
+          result.set(options.key, value);
+        }
+        return result;
+      }
+
+      // --get-regexp: each line is "key value" (value is everything after the first space)
+      for (const line of output.split("\n")) {
+        if (!line.trim()) continue;
+        const spaceIndex = line.indexOf(" ");
+        if (spaceIndex === -1) continue;
+        result.set(line.substring(0, spaceIndex), line.substring(spaceIndex + 1));
+      }
+      return result;
     } catch (error: unknown) {
-      // Exit code 1 means key not found - return null
-      // Exit code 128 or other errors mean git error
+      // Exit code 1 means no match / key unset - return empty map
       if (error instanceof Error && error.message.includes("exit code 1")) {
-        return null;
+        return result;
       }
       const errMsg = getErrorMessage(error);
-      throw new GitError(`Failed to get branch config: ${errMsg}`);
+      throw new GitError(`Failed to get git config: ${errMsg}`);
     }
   }
 
@@ -405,56 +429,6 @@ export class SimpleGitClient implements IGitClient {
       const configKey = `branch.${branch}.${key}`;
       await git.raw(["config", configKey, value]);
     }, `Failed to set branch config branch.${branch}.${key}`);
-  }
-
-  async getBranchConfigsByPrefix(
-    repoPath: Path,
-    branch: string,
-    prefix: string
-  ): Promise<Readonly<Record<string, string>>> {
-    // First, verify it's a git repository
-    const isRepo = await this.isInsideRepository(repoPath);
-    if (!isRepo) {
-      throw new GitError(`Not a git repository: ${repoPath.toString()}`);
-    }
-
-    try {
-      const git = this.getGit(repoPath);
-      // Pattern: branch.<branch>.<prefix>.*
-      const pattern = `^branch\\.${branch}\\.${prefix}\\.`;
-      const output = await git.raw(["config", "--get-regexp", pattern]);
-
-      const result: Record<string, string> = {};
-
-      // Parse output: each line is "key value" where value is everything after first space
-      // Example: "branch.main.codehydra.base develop"
-      for (const line of output.split("\n")) {
-        if (!line.trim()) continue;
-
-        // Find first space - everything before is key, everything after is value
-        const spaceIndex = line.indexOf(" ");
-        if (spaceIndex === -1) continue;
-
-        const fullKey = line.substring(0, spaceIndex);
-        const configValue = line.substring(spaceIndex + 1);
-
-        // Extract the key after the prefix (branch.<branch>.<prefix>.<key>)
-        const prefixPattern = `branch.${branch}.${prefix}.`;
-        if (fullKey.startsWith(prefixPattern)) {
-          const configKeyName = fullKey.substring(prefixPattern.length);
-          result[configKeyName] = configValue;
-        }
-      }
-
-      return result;
-    } catch (error: unknown) {
-      // Exit code 1 means no matching keys - return empty object
-      if (error instanceof Error && error.message.includes("exit code 1")) {
-        return {};
-      }
-      const errMsg = getErrorMessage(error);
-      throw new GitError(`Failed to get branch configs: ${errMsg}`);
-    }
   }
 
   async unsetBranchConfig(repoPath: Path, branch: string, key: string): Promise<void> {


### PR DESCRIPTION
## Problem

`IsRepositoryRoot (bare)` was the single most-called git operation in production (~7,800/week, bursting to ~37/s, always `result=true`). Root cause: `listBases` and `discover` read branch metadata **once per branch/worktree** via `getBranchConfig`/`getBranchConfigsByPrefix`, and each read pre-validates the repo through `isInsideRepository`, which for bare repos always falls back to `isRepositoryRoot(bare)`. So an N-branch bare repo cost N repository-root subprocesses per `listBases`.

## Change

- **`IGitClient`**: add `getGitConfig(repoPath, { key } | { regex })` — one thin primitive over `git config --get` / `--get-regexp`. Retire the read-side `getBranchConfig` + `getBranchConfigsByPrefix` (writes `setBranchConfig`/`unsetBranchConfig` unchanged).
- **`GitWorktreeProvider`**: `getAllBranchMetadata`/`getBranchMetadata` + a pure `parseBranchConfigs` helper; one batched read now backs `discover`, `listBases`, `removeWorkspace`, `countUnmergedCommits`, `getMetadata`.
- `isRepositoryRoot(bare)` is now **O(1) per `listBases`/`discover`**, independent of branch count.

## Tests

- `getGitConfig` boundary tests (exact key + regex, bare repos, non-repo throws)
- `parseBranchConfigs` unit tests (dotted branch names, multiple keys, non-matching keys)
- integration regression guard: exactly one config read per `listBases`/`discover` regardless of branch/worktree count
- full suite green (3545 passed)

## Verified live (appctrl)

On a 6-branch bare repo built from this branch: **one** `IsRepositoryRoot (bare)` per `listBases` (was six), 12 total for a full open→create session; `setBranchConfig`→`getMetadata` roundtrip confirmed (`branch.verify-ws.codehydra.base=feat-a`).