### PR TITLE
fix: startup failed due to missing files

### DIFF
--- a/src/modules/script-module.integration.test.ts
+++ b/src/modules/script-module.integration.test.ts
@@ -43,8 +43,13 @@ describe("ScriptModule Integration", () => {
       makeExecutable: vi.fn().mockResolvedValue(undefined),
     };
 
+    // Distinct runtime vs asset roots: the wrappers MUST be copied from
+    // runtimePath (extraResources / resources/bin, real files), NOT assetPath
+    // (inside app.asar, unreadable via original-fs in the packaged app). If this
+    // regresses to assetPath, the /runtime assertions below fail.
     const pathProvider = createMockPathProvider({
       dataRootDir: "/app-data",
+      runtimeRootDir: "/runtime",
       assetsRootDir: "/assets",
     });
 
@@ -71,22 +76,22 @@ describe("ScriptModule Integration", () => {
     );
     expect(fileSystem.mkdir).toHaveBeenCalledWith(new Path("/app-data/bin"));
 
-    // Should copy each declared script
+    // Should copy each declared script from runtimePath (/runtime/bin), not assetPath
     expect(fileSystem.copyTree).toHaveBeenCalledTimes(4);
     expect(fileSystem.copyTree).toHaveBeenCalledWith(
-      new Path("/assets/bin/ch-claude"),
+      new Path("/runtime/bin/ch-claude"),
       new Path("/app-data/bin/ch-claude")
     );
     expect(fileSystem.copyTree).toHaveBeenCalledWith(
-      new Path("/assets/bin/ch-claude.cjs"),
+      new Path("/runtime/bin/ch-claude.cjs"),
       new Path("/app-data/bin/ch-claude.cjs")
     );
     expect(fileSystem.copyTree).toHaveBeenCalledWith(
-      new Path("/assets/bin/ch-claude.cmd"),
+      new Path("/runtime/bin/ch-claude.cmd"),
       new Path("/app-data/bin/ch-claude.cmd")
     );
     expect(fileSystem.copyTree).toHaveBeenCalledWith(
-      new Path("/assets/bin/code"),
+      new Path("/runtime/bin/code"),
       new Path("/app-data/bin/code")
     );
 

--- a/src/modules/script-module.ts
+++ b/src/modules/script-module.ts
@@ -41,7 +41,13 @@ export function createScriptModule(deps: ScriptModuleDeps): IntentModule {
             const { requiredScripts } = ctx as InitHookContext;
 
             const binDir = deps.pathProvider.dataPath("bin");
-            const binAssetsDir = deps.pathProvider.assetPath("bin");
+            // Source the bundled wrappers from runtimePath (extraResources /
+            // resources/bin), NOT assetPath (inside app.asar). In the packaged
+            // app the FileSystemBoundary uses Electron's original-fs, which has
+            // no asar virtualization, so copying out of app.asar throws
+            // ENOTDIR/ENOENT and aborts app:start. runtimePath points at the
+            // real, un-archived copy on every target (dev + prod).
+            const binAssetsDir = deps.pathProvider.runtimePath("bin");
 
             // Clean bin directory to remove stale scripts before copying new ones
             await deps.fileSystem.rm(binDir, { recursive: true, force: true });


### PR DESCRIPTION
Fixes the v2026.7.9 packaged-app startup crash (`FileSystemError: ENOTDIR/ENOENT lstat …/app.asar/out/main/assets/bin/code`) that left the app unbootable on Linux and Windows.

- `script-module` copied the bundled CLI wrappers out of `app.asar` via `assetPath`. Since `5ee15a6b` the `FileSystemBoundary` uses Electron's `original-fs` (no asar virtualization), so `copyTree`'s `lstat` on the in-asar source threw and rejected `app:start`.
- Source the wrappers from `runtimePath` (the already-un-archived `resources/bin` copy that `extraResources` produces, and that every other bundled-external-file consumer already uses). Leaves `assetPath` with no remaining consumers.
- Update the script-module integration test to assert the copy sources from `runtimePath` (distinct asset root), guarding against a regression back to the in-asar path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)