### PR TITLE
infra(ci): validate on macOS and fix the Darwin bugs it surfaced

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025]
+        os: [ubuntu-24.04, windows-2025, macos-26, macos-26-intel]
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ All external access MUST use abstraction interfaces:
 **ALWAYS use the `Path` class** for internal path handling:
 
 ```typescript
-import { Path } from "../services/platform/path";
+import { Path } from "../utils/path/path";
 const projectPath = new Path(inputPath);
 map.set(path.toString(), value); // toString() for Map keys
 path1.equals(path2); // equals() for comparison
@@ -142,11 +142,11 @@ Some components use external libraries directly without abstraction layers. Thes
 
 ## Intent Dispatcher
 
-All operations use an intent-based dispatcher with operations, hook modules, and domain events. The composition root is `src/main/index.ts`, which constructs all services, registers operations and modules with the dispatcher, then dispatches `app:start`. Cross-cutting concerns (e.g., idempotency) are implemented via `createIdempotencyModule()` from `src/main/intents/infrastructure/idempotency-module.ts`. This factory accepts an array of rules and produces a single `IntentModule` with one interceptor and reset event handlers, supporting singleton, singleton-with-reset, and per-key modes.
+All operations use an intent-based dispatcher with operations, hook modules, and domain events. The composition root is `src/main.ts`, which constructs all services, registers operations and modules with the dispatcher, then dispatches `app:start`. Cross-cutting concerns (e.g., idempotency) are implemented via `createIdempotencyModule()` from `src/intents/lib/idempotency-module.ts`. This factory accepts an array of rules and produces a single `IntentModule` with one interceptor and reset event handlers, supporting singleton, singleton-with-reset, and per-key modes.
 
 Operations include workspace create/delete/switch, project open/close, agent:update-status, and app lifecycle (app:start, app:shutdown). Other operations (create, delete, open, close) dispatch `workspace:switch` intents when the active workspace changes. The `workspace:create` intent supports an `existingWorkspace` field for activating discovered workspaces without creating new git worktrees (used by `project:open`). The `workspace:delete` intent has a `removeWorktree` flag: `true` for full deletion, `false` for runtime-only teardown (used by `project:close`). The `agent:update-status` intent is a trivial operation (no hooks) that emits an `agent:status-updated` domain event consumed by the IPC event bridge and badge module. New hook modules registered on `workspace:create` must handle both the new-worktree and existing-workspace paths.
 
-The `app:start` and `app:shutdown` intents orchestrate application lifecycle. Configuration is loaded via `Config.load()` (sync) before `app:start` is dispatched. `app:start` runs five hook points in sequence: `before-ready` (script declarations, electron flags, data paths), `init` (logging, shell, scripts; electron-lifecycle module provides `"app-ready"` capability after `whenReady()`, handlers needing Electron declare `requires: { "app-ready": ANY_VALUE }`), `show-ui` (starting screen), `check-deps` (binary/extension checks), and `start` (servers, wiring). `app:shutdown` has one hook point: `stop` (best-effort disposal, each module wraps its own try/catch). All modules are constructed and registered in `src/main/index.ts`. A shutdown idempotency interceptor ensures only one shutdown execution proceeds. Hook handlers can declare `requires` and `provides` for capability-based ordering (see `src/main/intents/infrastructure/operation.ts`). See `docs/INTENTS.md` for the complete reference.
+The `app:start` and `app:shutdown` intents orchestrate application lifecycle. Configuration is loaded via `Config.load()` (sync) before `app:start` is dispatched. `app:start` runs five hook points in sequence: `before-ready` (script declarations, electron flags, data paths), `init` (logging, shell, scripts; electron-lifecycle module provides `"app-ready"` capability after `whenReady()`, handlers needing Electron declare `requires: { "app-ready": ANY_VALUE }`), `show-ui` (starting screen), `check-deps` (binary/extension checks), and `start` (servers, wiring). `app:shutdown` has one hook point: `stop` (best-effort disposal, each module wraps its own try/catch). All modules are constructed and registered in `src/main.ts`. A shutdown idempotency interceptor ensures only one shutdown execution proceeds. Hook handlers can declare `requires` and `provides` for capability-based ordering (see `src/intents/lib/operation.ts`). See `docs/INTENTS.md` for the complete reference.
 
 ---
 
@@ -167,12 +167,16 @@ The `app:start` and `app:shutdown` intents orchestrate application lifecycle. Co
 
 ```
 src/
-├── main/           # Electron main process
+├── main.ts         # Electron main process entry (composition root)
 ├── preload/        # Preload scripts
 ├── renderer/       # Svelte frontend
-└── services/       # Node.js services (pure, no Electron deps)
-    ├── platform/   # OS/runtime abstractions (Path, IPC, Dialog, etc.)
-    └── shell/      # Visual container abstractions (Window, View, Session)
+├── shared/         # Types shared across processes (IPC contracts)
+├── intents/        # Intent dispatcher, operations
+├── modules/        # Hook modules registered on the dispatcher
+├── utils/          # Pure utilities (Path, liquid templates)
+└── boundaries/     # External-system abstractions
+    ├── platform/   # OS/runtime abstractions (Filesystem, Process, Network, Config)
+    └── shell/      # Visual container abstractions (Window, View, Session, Dialog)
 ```
 
 **Dependency Rule**: Shell layers may depend on Platform layers, but not vice versa.
@@ -221,7 +225,7 @@ See docs/PATTERNS.md for full details.
 
 ## Binary Distribution
 
-Versions defined per agent in `src/agents/*/setup-info.ts`. Downloads happen during `pnpm install` (dev) and first-run setup (prod).
+Versions defined per agent in `src/modules/agent-module/*/setup-info.ts`. Downloads happen during `pnpm install` (dev) and first-run setup (prod).
 
 ## VS Code Assets
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,7 +452,7 @@ Each layer has boundary tests (`*.boundary.test.ts`) that verify behavior agains
 
 ### Platform Abstractions Overview
 
-All external system access goes through abstraction interfaces defined in `src/services/platform/`. This enables unit testing with mocks and boundary testing against real systems.
+All external system access goes through abstraction interfaces defined in `src/boundaries/platform/`. This enables unit testing with mocks and boundary testing against real systems.
 
 **CRITICAL RULE**: Services MUST use these interfaces, NOT direct library imports.
 
@@ -547,7 +547,7 @@ External Trigger (IPC / MCP / Electron lifecycle)
 5. **Hooks are unordered by default** -- any ordering must be declared explicitly
 6. **Operations decide what happens next**, based on hook outcomes
 7. **Modules never call each other**
-8. **Composition happens only in the application shell** (`src/main/index.ts`)
+8. **Composition happens only in the application shell** (`src/main.ts`)
 
 ### Key Rules
 
@@ -602,7 +602,7 @@ The v2 API uses `api:` prefixed IPC channels:
 
 ### Main Process Startup Architecture
 
-The main process uses a composition-root pattern in `src/main/index.ts`. All services are constructed (pure, no I/O), all operations and modules are registered, then `app:start` is dispatched. See [INTENTS.md — Composition Root](INTENTS.md#composition-root) for the full bootstrap diagram.
+The main process uses a composition-root pattern in `src/main.ts`. All services are constructed (pure, no I/O), all operations and modules are registered, then `app:start` is dispatched. See [INTENTS.md — Composition Root](INTENTS.md#composition-root) for the full bootstrap diagram.
 
 ### First-Run Flow
 
@@ -1004,10 +1004,10 @@ CodeHydra and VS Code extensions communicate via Socket.IO WebSocket connection.
 │  │  (PluginServer remains agnostic to API layer)                       │  │
 │  └─────────────────────────────────────────────────────────────────────┘  │
 │                                           ▲                               │
-│                                           │ wirePluginApi() registers     │
+│                                           │ plugin-server-module adds     │
 │                                           │ handlers during app:start     │
 │  ┌────────────────────────────────────────┴────────────────────────────┐  │
-│  │  wirePluginApi() - src/main/index.ts                                │  │
+│  │  createPluginServerModule() - src/modules/plugin-server-module.ts   │  │
 │  │                                                                     │  │
 │  │  Workspace path resolution:                                         │  │
 │  │  1. appState.findProjectForWorkspace(workspacePath)                 │  │
@@ -1202,10 +1202,12 @@ CodeHydra downloads VSCodium and opencode binaries from GitHub releases instead 
 
 ### Version Management
 
-Binary versions are defined in `src/services/binary-download/versions.ts`:
+Binary versions are defined per component:
 
-- `VSCODIUM_VERSION` - e.g., "1.126.04524"
-- `OPENCODE_VERSION` - e.g., "0.1.47"
+- `VSCODIUM_VERSION` - `src/modules/ide-server-module/vscodium.ts` (e.g., "1.126.04524")
+- `OPENCODE_VERSION` - `src/modules/agent-module/opencode/setup-info.ts` (e.g., "1.0.223")
+- `CLAUDE_VERSION` - `src/modules/agent-module/claude/setup-info.ts` (`null` prefers the system
+  binary, falling back to latest)
 
 **Development**: `pnpm install` runs the postinstall script which downloads binaries to `./app-data/`.
 

--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -12,7 +12,7 @@ Concrete reference for the intent-based architecture. For conceptual overview an
 | [IPC-to-Intent Mapping](#ipc-to-intent-mapping)                   | How IPC channels map to intents                              |
 | [Operations Reference](#operations-reference)                     | All operations with hook points and module contributions     |
 | [Domain Events](#domain-events)                                   | Event types, payloads, and flow                              |
-| [Composition Root](#composition-root)                             | Bootstrap pattern in src/main/index.ts                       |
+| [Composition Root](#composition-root)                             | Bootstrap pattern in src/main.ts                             |
 | [External System Access Rules](#external-system-access-rules)     | Required abstraction interfaces                              |
 | [Platform Abstractions](#platform-abstractions)                   | FileSystemBoundary, NetworkLayer, ProcessRunner, Path, etc.  |
 | [Shell and Platform Layers](#shell-and-platform-layers)           | Electron abstraction architecture                            |
@@ -387,7 +387,7 @@ The interceptor runs before any operation. For each dispatched intent, it looks 
 
 ### Usage in Composition Root
 
-From `src/main/index.ts`:
+From `src/main.ts`:
 
 ```typescript
 const idempotencyModule = createIdempotencyModule([
@@ -572,7 +572,7 @@ The `workspace:switched` event is emitted through the intent dispatcher via `Swi
 
 ## Composition Root
 
-The main process uses a composition-root pattern in `src/main/index.ts`. All services are constructed (pure, no I/O), all operations and modules are registered, then `app:start` is dispatched to orchestrate the startup flow:
+The main process uses a composition-root pattern in `src/main.ts`. All services are constructed (pure, no I/O), all operations and modules are registered, then `app:start` is dispatched to orchestrate the startup flow:
 
 ```
 index.ts (composition root)
@@ -920,7 +920,7 @@ The `Path` class normalizes filesystem paths to a canonical internal format:
 - **Clean format**: No trailing slashes, resolved `..` segments
 
 ```typescript
-import { Path } from "../services/platform/path";
+import { Path } from "../utils/path/path";
 
 const p = new Path("C:\\Users\\Name");
 p.toString(); // "c:/users/name" (Windows)
@@ -990,7 +990,7 @@ const mockPathProvider = createMockPathProvider({
 
 The application uses dependency injection to abstract build mode detection and path resolution.
 
-**Interfaces (defined in `src/services/platform/`):**
+**Interfaces (defined in `src/boundaries/platform/`):**
 
 | Interface            | Purpose                                    |
 | -------------------- | ------------------------------------------ |
@@ -1001,14 +1001,14 @@ The application uses dependency injection to abstract build mode detection and p
 
 **Implementations:**
 
-| Class                       | Location        | Description                                  |
-| --------------------------- | --------------- | -------------------------------------------- |
-| `ElectronBuildInfo`         | `src/main/`     | Uses `app.isPackaged`                        |
-| `NodePlatformInfo`          | `src/main/`     | Uses `process.platform`, `os.homedir()`      |
-| `DefaultPathProvider`       | `src/services/` | Computes paths from BuildInfo + PlatformInfo |
-| `DefaultFileSystemBoundary` | `src/services/` | Wraps `node:fs/promises` with error mapping  |
+| Class                       | Location          | Description                                  |
+| --------------------------- | ----------------- | -------------------------------------------- |
+| `ElectronBuildInfo`         | `src/main/`       | Uses `app.isPackaged`                        |
+| `NodePlatformInfo`          | `src/main/`       | Uses `process.platform`, `os.homedir()`      |
+| `DefaultPathProvider`       | `src/boundaries/` | Computes paths from BuildInfo + PlatformInfo |
+| `DefaultFileSystemBoundary` | `src/boundaries/` | Wraps `node:fs/promises` with error mapping  |
 
-**Instantiation Order (in `src/main/index.ts`):**
+**Instantiation Order (in `src/main.ts`):**
 
 1. Module level (before `app.whenReady()`):
    - Create `ElectronBuildInfo`, `NodePlatformInfo`, `DefaultPathProvider`, `DefaultFileSystemBoundary`
@@ -1430,7 +1430,7 @@ expect(config.agent).toBe("claude");
 
 ## Mock Factories Reference
 
-All paths below are relative to `src/services/`.
+All paths below are relative to `src/boundaries/`.
 
 ### Platform Layer Mocks
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -561,7 +561,7 @@ The `Path` class normalizes paths to a canonical internal format:
 - **Clean format**: No trailing slashes, no `..` or `.` segments
 
 ```typescript
-import { Path } from "../services/platform/path";
+import { Path } from "../utils/path/path";
 
 // Create normalized path
 const p = new Path("C:\\Users\\Name\\Project");

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -106,12 +106,12 @@ describe("SimpleGitClient", () => {
 
 **What to mock**: Only boundary interfaces, using **behavioral simulators**.
 
-**Entry points**: CodeHydraApi, LifecycleApi, service classes (direct), UI components.
+**Entry points**: intent operations (via the dispatcher), hook modules, service classes (direct), UI components.
 
 **Key characteristics**:
 
 - Tests behavior, not implementation ("when user does X, outcome is Y")
-- Real module interaction (modules, ProjectStore, GitWorktreeProvider all run together)
+- Real module interaction (modules, GitWorktreeProvider, KeepFilesService all run together)
 - Only mock boundaries (same interfaces tested by boundary tests)
 - **MUST be fast** - target <50ms per test, <2s per module
 
@@ -126,7 +126,7 @@ Traditional unit tests mock everything except the single module under test. This
 Integration tests solve this by:
 
 1. **Testing behavior** - "When user does X, outcome is Y"
-2. **Real module interaction** - Modules, ProjectStore, GitWorktreeProvider all run together
+2. **Real module interaction** - Modules, GitWorktreeProvider, KeepFilesService all run together
 3. **Only mock boundaries** - The external system interfaces, not internal modules
 
 ---
@@ -261,7 +261,7 @@ Code change involves external system interface?
 
 | Condition                                     | Entry Point                        | Example                                     |
 | --------------------------------------------- | ---------------------------------- | ------------------------------------------- |
-| Module is public API                          | `CodeHydraApi` or `LifecycleApi`   | ProjectStore, AgentModule                   |
+| Module is reached through an intent           | `dispatcher.dispatch()`            | GitWorktreeWorkspaceModule, AgentModule     |
 | Module is internal service with complex state | Direct service                     | IdeServerModule, PluginServer               |
 | Module is Electron wrapper                    | Direct with mocked Electron APIs   | ViewManager, WindowManager                  |
 | Module is UI component                        | Component with mocked `window.api` | Sidebar, CreateWorkspaceDialog              |
@@ -762,8 +762,8 @@ State mocks provide a standardized interface for behavioral mocks with type-safe
 
 State mock files use the `*.state-mock.ts` suffix:
 
-- `src/services/platform/filesystem.state-mock.ts`
-- `src/services/git/git-client.state-mock.ts`
+- `src/boundaries/platform/filesystem.state-mock.ts`
+- `src/boundaries/platform/git-client.state-mock.ts`
 
 ### Core Interfaces
 
@@ -966,7 +966,7 @@ import {
   createTestSession,
   type SdkClientFactory,
   type MockSdkClient,
-} from "src/services/opencode/sdk-client.state-mock";
+} from "src/modules/agent-module/opencode/sdk-client.state-mock";
 
 // Create mock with initial sessions
 const mock = createSdkClientMock({
@@ -1152,13 +1152,13 @@ For efficient development feedback, especially when multiple agents are working 
 
 ```bash
 # Single module
-pnpm test:related -- src/services/git/
+pnpm test:related -- src/boundaries/platform/
 
 # Component by name
 pnpm test:related -- CreateWorkspaceDialog
 
 # Multiple modules
-pnpm test:related -- src/services/git/ src/services/platform/
+pnpm test:related -- src/boundaries/platform/ src/modules/agent-module/
 
 # Specific test file pattern
 pnpm test:related -- workspace.integration
@@ -1212,64 +1212,64 @@ Integration tests go through specific entry points, not arbitrary internal modul
 
 ### Main Process Entry Points
 
-| Entry Point          | What It Is               | Modules Exercised                                                                              |
-| -------------------- | ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `CodeHydraApi`       | Main application facade  | ProjectStore, GitWorktreeProvider, AgentStatusManager, OpenCodeServerManager, KeepFilesService |
-| `LifecycleApi`       | Setup/bootstrap facade   | VscodeSetupService, BinaryDownloadService, WrapperScriptGenerationService                      |
-| `IdeServerModule`    | Direct (not via API)     | Just IdeServerModule                                                                           |
-| `PluginServer`       | Direct (not via API)     | Just PluginServer                                                                              |
-| `McpServerManager`   | Direct (not via API)     | McpServerManager, McpServer                                                                    |
-| `ViewManager`        | Direct (mocked Electron) | Just ViewManager                                                                               |
-| `WindowManager`      | Direct (mocked Electron) | Just WindowManager                                                                             |
-| `BadgeManager`       | Direct (mocked Electron) | Just BadgeManager                                                                              |
-| `ShortcutController` | Direct (mocked Electron) | Just ShortcutController                                                                        |
+| Entry Point                   | What It Is                   | Modules Exercised                                              |
+| ----------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| `dispatcher.dispatch(intent)` | The main-process facade      | The intent's operation plus every hook module registered on it |
+| `createXModule()`             | A single hook module, direct | Just that module                                               |
+| `PluginServer`                | Direct (not via dispatcher)  | Just PluginServer                                              |
+| `McpServerManager`            | Direct (not via dispatcher)  | McpServerManager, McpServer                                    |
+| `ViewManager`                 | Direct (mocked Electron)     | Just ViewManager                                               |
+| `WindowManager`               | Direct (mocked Electron)     | Just WindowManager                                             |
+| `BadgeManager`                | Direct (mocked Electron)     | Just BadgeManager                                              |
+| `ShortcutController`          | Direct (mocked Electron)     | Just ShortcutController                                        |
 
 ### Why Entry Points Matter
 
-Testing through `CodeHydraApi` means:
+Testing through `dispatcher.dispatch()` means:
 
-- Multiple modules work together (ProjectStore → GitWorktreeProvider → GitClient)
+- Multiple modules work together (`workspace:create` → GitWorktreeProvider → IGitClient → KeepFilesService)
 - State flows correctly between modules
-- Events are emitted properly
+- Domain events are emitted properly
 - Error handling works across layers
 
-Testing individual modules in isolation (old unit test approach) misses these interactions.
+Testing individual modules in isolation (old unit test approach) misses these interactions. Use `createMockDispatcher()` from `src/intents/lib/dispatcher.test-utils.ts` to drive an intent through its real operation and hook chain.
 
 ---
 
 ## Test File Organization
 
-Tests are organized by **entry point**, with subgroups for large entry points.
+Tests are co-located with the code they exercise — there is no separate test tree. A file's **path** decides which vitest project runs it; its **suffix** decides what kind of test it is.
+
+| Project      | Runs                                                                | Environment |
+| ------------ | ------------------------------------------------------------------- | ----------- |
+| `node`       | Everything under `src/` except `renderer/` and `*.boundary.test.ts` | node        |
+| `renderer`   | `src/renderer/**`                                                   | happy-dom   |
+| `boundary`   | `src/**/*.boundary.test.ts`                                         | node        |
+| `extensions` | `extensions/**`                                                     | node        |
+
+Each project's `include` is a blanket glob minus what its siblings claim. **Do not replace these with per-directory lists.** An enumerated `include` silently stops matching when a directory is renamed, and a test file that no project collects is indistinguishable from one whose tests all pass.
+
+| Suffix                  | Type                                  |
+| ----------------------- | ------------------------------------- |
+| `*.boundary.test.ts`    | Boundary test (real external systems) |
+| `*.integration.test.ts` | Integration test (behavioral mocks)   |
+| `*.test.ts`             | Focused test for a pure function      |
 
 ### Main Process Tests
 
-| Entry Point           | Test Location          | Subgroups                    |
-| --------------------- | ---------------------- | ---------------------------- |
-| **CodeHydraApi**      | `src/main/api/`        | `project`, `workspace`, `ui` |
-| **LifecycleApi**      | `src/main/api/`        | `lifecycle` (single file)    |
-| **Direct Services**   | `src/services/<name>/` | Per service                  |
-| **Electron Managers** | `src/main/managers/`   | Per manager                  |
+| Layer              | Location                                            | Typical type           |
+| ------------------ | --------------------------------------------------- | ---------------------- |
+| Boundaries         | `src/boundaries/platform/`, `src/boundaries/shell/` | boundary + integration |
+| Intents/operations | `src/intents/`                                      | integration            |
+| Hook modules       | `src/modules/`                                      | integration            |
+| Pure utilities     | `src/utils/`, `src/shared/`                         | focused                |
+| Composition root   | `src/main.test.ts`                                  | wiring                 |
 
-**CodeHydraApi subgroups** (large API with multiple namespaces):
-
-| File                            | Namespace     | Modules Exercised                     |
-| ------------------------------- | ------------- | ------------------------------------- |
-| `project.integration.test.ts`   | IProjectApi   | ProjectStore                          |
-| `workspace.integration.test.ts` | IWorkspaceApi | GitWorktreeProvider, KeepFilesService |
-| `ui.integration.test.ts`        | IUIApi        | ViewManager                           |
+`src/main.ts` cannot be imported under test — it pulls in Electron at module scope. So `src/main.test.ts` exercises the same wiring chain the composition root uses (`BuildInfo` → `PlatformInfo` → `PathProvider` → services) against mocked platform info, rather than importing the root itself.
 
 ### Renderer Tests
 
-| Entry Point    | Test Location                                                | Strategy                       |
-| -------------- | ------------------------------------------------------------ | ------------------------------ |
-| **App**        | `src/renderer/App.integration.test.ts`                       | Top-level routing, mode switch |
-| **MainView**   | `src/renderer/lib/components/MainView.integration.test.ts`   | Main view after setup          |
-| **Sidebar**    | `src/renderer/lib/components/Sidebar.integration.test.ts`    | Project/workspace list         |
-| **Dialogs**    | `src/renderer/lib/components/dialogs.integration.test.ts`    | All dialog components          |
-| **Dropdowns**  | `src/renderer/lib/components/dropdowns.integration.test.ts`  | Branch, project dropdowns      |
-| **Setup**      | `src/renderer/lib/components/setup.integration.test.ts`      | Setup flow components          |
-| **Indicators** | `src/renderer/lib/components/indicators.integration.test.ts` | Status indicators, overlays    |
-| **Primitives** | `src/renderer/lib/components/primitives.integration.test.ts` | Icon, Logo, EmptyState         |
+Renderer tests are co-located with their components under `src/renderer/`, run in `happy-dom`, and are mostly focused component tests (`*.test.ts`). `MainView.integration.test.ts` is the one renderer integration test, exercising the main view against a mocked API.
 
 ---
 
@@ -1322,15 +1322,13 @@ Behavioral mocks are organized at two levels:
 Each boundary interface has its mock factory co-located with the interface:
 
 ```
-src/services/platform/
-├── filesystem.ts              # Interface
-├── filesystem.test-utils.ts   # createFileSystemMock() + fileSystemMatchers
-├── network.ts                 # Interface
-├── network.test-utils.ts      # createHttpClientMock(), createPortManagerMock() + matchers
-
-src/services/git/
-├── git-client.interface.ts    # Interface
-└── git-client.test-utils.ts   # createGitClientMock() + gitClientMatchers
+src/boundaries/platform/
+├── filesystem.ts               # Interface
+├── filesystem.state-mock.ts    # createFileSystemMock()
+├── http-client.state-mock.ts   # createMockHttpClient()
+├── port-manager.state-mock.ts  # createPortManagerMock()
+├── git-client.ts               # Interface
+└── git-client.state-mock.ts    # createMockGitClient() + gitClientMatchers
 ```
 
 **Use for**: Service-level tests that only need 1-2 behavioral mocks.
@@ -1399,7 +1397,7 @@ export function createTestFixture(options?: TestFixtureOptions): TestFixture {
 }
 ```
 
-**Use for**: API-level tests (CodeHydraApi, LifecycleApi) that exercise multiple modules.
+**Use for**: dispatcher-level tests that exercise multiple modules.
 
 ### Usage in Tests
 
@@ -1560,14 +1558,14 @@ Each module migration from unit tests to integration tests requires a **separate
 - Unit test file(s): `module.test.ts` (X tests)
 - Integration test file(s): `module.integration.test.ts` (if exists - also needs migration!)
 - What it tests: [description]
-- Entry point for integration: [CodeHydraApi / LifecycleApi / Direct / Component]
+- Entry point for integration: [Dispatcher / Direct / Component]
 
 ## Proposed Integration Tests
 
-| #   | Test Case | Entry Point                        | Boundary Mocks        | Behavior Verified                  |
-| --- | --------- | ---------------------------------- | --------------------- | ---------------------------------- |
-| 1   | ...       | `CodeHydraApi.workspaces.create()` | GitClient, FileSystem | `project.workspaces.contains(...)` |
-| 2   | ...       | ...                                | ...                   | ...                                |
+| #   | Test Case | Entry Point                             | Boundary Mocks        | Behavior Verified                  |
+| --- | --------- | --------------------------------------- | --------------------- | ---------------------------------- |
+| 1   | ...       | `dispatcher.dispatch(workspace:create)` | GitClient, FileSystem | `project.workspaces.contains(...)` |
+| 2   | ...       | ...                                     | ...                   | ...                                |
 
 ## Boundary Mock Requirements
 
@@ -1599,7 +1597,7 @@ Current `*.integration.test.ts` files use **call-tracking mocks**, not **behavio
 
 ### General Helpers
 
-All general helpers are in `src/services/test-utils.ts`.
+All general helpers are in `src/utils/testing/test-utils.ts`.
 
 ### createTestGitRepo(options?)
 
@@ -1645,7 +1643,7 @@ Convenience wrapper for repos with remotes that handles cleanup automatically.
 
 ### Boundary Test Utilities
 
-Cross-platform process spawning utilities for boundary tests. All utilities are in `src/services/platform/process.boundary-test-utils.ts`.
+Cross-platform process spawning utilities for boundary tests. All utilities are in `src/boundaries/platform/process.boundary-test-utils.ts`.
 
 See [AGENTS.md Boundary Test Utilities](#boundary-test-utilities) for detailed documentation.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,28 @@ import path from "node:path";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
+const NO_INLINE_TYPE_IMPORT = {
+  selector: "TSImportType",
+  message: "Use a top-level `import type` declaration instead of inline import() type references.",
+};
+
+const NO_DYNAMIC_IMPORT = {
+  selector: "ImportExpression",
+  message: "Use a top-level `import` declaration instead of an inline dynamic import().",
+};
+
+// Files where a dynamic import() is load-bearing and cannot be hoisted:
+// - vite.config.ts: `await import("vite")` inside a plugin hook (importing vite
+//   at module scope would be circular).
+// - the two renderer tests below: they call vi.resetModules() and re-import a
+//   module that reads `window.api` at module scope, so the import must happen
+//   after the stub is installed.
+const DYNAMIC_IMPORT_ALLOWED = [
+  "**/vite.config.ts",
+  "src/renderer/lib/api/index.test.ts",
+  "src/renderer/lib/logging/index.test.ts",
+];
+
 export default tseslint.config(
   includeIgnoreFile(gitignorePath),
   // Ignore VS Code extensions node_modules and dist, but lint source
@@ -32,14 +54,13 @@ export default tseslint.config(
     },
     rules: {
       "@typescript-eslint/ban-ts-comment": "error",
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "TSImportType",
-          message:
-            "Use a top-level `import type` declaration instead of inline import() type references.",
-        },
-      ],
+      "no-restricted-syntax": ["error", NO_DYNAMIC_IMPORT, NO_INLINE_TYPE_IMPORT],
+    },
+  },
+  {
+    files: DYNAMIC_IMPORT_ALLOWED,
+    rules: {
+      "no-restricted-syntax": ["error", NO_INLINE_TYPE_IMPORT],
     },
   },
   {

--- a/extensions/dictation/src/DictationController.integration.test.ts
+++ b/extensions/dictation/src/DictationController.integration.test.ts
@@ -8,6 +8,7 @@ import type {
   CaptureErrorHandler,
 } from "./audio/AudioCapturePanel";
 import { DictationController, type DictationState } from "./DictationController";
+import * as vscode from "vscode";
 
 // Track mock function calls - must use vi.fn() inline in the factory
 // because vi.mock is hoisted to the top of the file
@@ -182,7 +183,6 @@ class MockAudioCapturePanel implements Pick<
 
 // Get references to the mocked functions after import
 async function getVscodeMocks() {
-  const vscode = await import("vscode");
   return {
     showErrorMessage: vi.mocked(vscode.window.showErrorMessage),
     showInformationMessage: vi.mocked(vscode.window.showInformationMessage),
@@ -696,7 +696,6 @@ describe("DictationController", () => {
 
   describe("terminal text insertion", () => {
     it("inserts transcript into terminal when no editor is active", async () => {
-      const vscode = await import("vscode");
       const mockTerminal = { sendText: vi.fn() };
 
       Object.defineProperty(vscode.window, "activeTextEditor", {
@@ -772,7 +771,6 @@ describe("DictationController", () => {
   describe("smart output (visibility-based)", () => {
     beforeEach(async () => {
       // Reset window properties to ensure type command is used (not terminal)
-      const vscode = await import("vscode");
       Object.defineProperty(vscode.window, "activeTextEditor", {
         value: { document: {} },
         configurable: true,

--- a/src/boundaries/platform/electron-log.boundary.test.ts
+++ b/src/boundaries/platform/electron-log.boundary.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { createMockPathProvider } from "./path-provider.test-utils";
 import type { PathProvider } from "./path-provider";
 import type { LoggingConfigureOptions } from "./logging-types";
+import { ElectronLog } from "./electron-log";
 
 // Test timeout for file operations
 const WRITE_DELAY_MS = 100;
@@ -64,7 +65,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("creates log directory if not exists", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -79,7 +79,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("writes to log file with session-based filename", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -98,7 +97,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("log format matches specification", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -120,7 +118,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("filters by level - DEBUG not written when level is WARN", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -142,7 +139,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("writes all levels when level is DEBUG", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -166,7 +162,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("includes Error stack in error logs", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -186,7 +181,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("uses configured path for log files", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);
@@ -203,7 +197,6 @@ describe("ElectronLog boundary tests", () => {
   });
 
   it("flushes buffered entries to file after configure()", async () => {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createTestPathProvider(tempDir);
 
     const service = new ElectronLog(pathProvider);

--- a/src/boundaries/platform/electron-log.test.ts
+++ b/src/boundaries/platform/electron-log.test.ts
@@ -8,20 +8,24 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createMockPathProvider } from "./path-provider.test-utils";
 import type { LoggingConfigureOptions } from "./logging-types";
+import { ElectronLog, parseLogLevel, parseLogLevelSpec, splitLogLevelSpec } from "./electron-log";
 
-// Mock electron-log/main
-const mockScope = vi.fn();
-const mockInitialize = vi.fn();
-const mockTransports = {
-  file: {
-    level: undefined as string | false | undefined,
-    format: undefined as string | ((...args: unknown[]) => string) | undefined,
+// Mock electron-log/main. Declared via vi.hoisted() so the hoisted vi.mock
+// factory below can reference these without hitting their temporal dead zone.
+const { mockScope, mockInitialize, mockTransports } = vi.hoisted(() => ({
+  mockScope: vi.fn(),
+  mockInitialize: vi.fn(),
+  mockTransports: {
+    file: {
+      level: undefined as string | false | undefined,
+      format: undefined as string | ((...args: unknown[]) => string) | undefined,
+    },
+    console: {
+      level: undefined as string | false | undefined,
+      format: undefined as string | ((...args: unknown[]) => string) | undefined,
+    },
   },
-  console: {
-    level: undefined as string | false | undefined,
-    format: undefined as string | ((...args: unknown[]) => string) | undefined,
-  },
-};
+}));
 
 vi.mock("electron-log/main", () => ({
   default: {
@@ -64,7 +68,6 @@ describe("ElectronLog", () => {
     dataRootDir?: string;
     skipConfigure?: boolean;
   }) {
-    const { ElectronLog } = await import("./electron-log");
     const pathProvider = createMockPathProvider({
       dataRootDir: options?.dataRootDir ?? "/test/app-data",
     });
@@ -339,7 +342,6 @@ describe("ElectronLog", () => {
       };
       mockScope.mockReturnValue(scopeLogger);
 
-      const { ElectronLog } = await import("./electron-log");
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLog(pathProvider);
 
@@ -369,7 +371,6 @@ describe("ElectronLog", () => {
       };
       mockScope.mockReturnValue(scopeLogger);
 
-      const { ElectronLog } = await import("./electron-log");
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLog(pathProvider);
 
@@ -411,7 +412,6 @@ describe("ElectronLog", () => {
       };
       mockScope.mockReturnValue(scopeLogger);
 
-      const { ElectronLog } = await import("./electron-log");
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLog(pathProvider);
 
@@ -426,7 +426,6 @@ describe("ElectronLog", () => {
     });
 
     it("configure() can be called multiple times (reconfigures)", async () => {
-      const { ElectronLog } = await import("./electron-log");
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLog(pathProvider);
 
@@ -460,7 +459,6 @@ describe("ElectronLog", () => {
       };
       mockScope.mockReturnValue(scopeLogger);
 
-      const { ElectronLog } = await import("./electron-log");
       const pathProvider = createMockPathProvider({ dataRootDir: "/test/app-data" });
       const service = new ElectronLog(pathProvider);
 
@@ -476,7 +474,6 @@ describe("ElectronLog", () => {
 
   describe("parseLogLevel", () => {
     it("parses valid log levels", async () => {
-      const { parseLogLevel } = await import("./electron-log");
       expect(parseLogLevel("debug")).toBe("debug");
       expect(parseLogLevel("info")).toBe("info");
       expect(parseLogLevel("warn")).toBe("warn");
@@ -485,18 +482,15 @@ describe("ElectronLog", () => {
     });
 
     it("handles uppercase input", async () => {
-      const { parseLogLevel } = await import("./electron-log");
       expect(parseLogLevel("ERROR")).toBe("error");
       expect(parseLogLevel("DEBUG")).toBe("debug");
     });
 
     it("handles whitespace", async () => {
-      const { parseLogLevel } = await import("./electron-log");
       expect(parseLogLevel("  info  ")).toBe("info");
     });
 
     it("returns undefined for invalid input", async () => {
-      const { parseLogLevel } = await import("./electron-log");
       expect(parseLogLevel("invalid")).toBeUndefined();
       expect(parseLogLevel("")).toBeUndefined();
       expect(parseLogLevel(undefined)).toBeUndefined();
@@ -505,7 +499,6 @@ describe("ElectronLog", () => {
 
   describe("parseLogLevelSpec", () => {
     it("validates plain log levels", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("debug")).toBe("debug");
       expect(parseLogLevelSpec("warn")).toBe("warn");
       expect(parseLogLevelSpec("error")).toBe("error");
@@ -514,56 +507,47 @@ describe("ElectronLog", () => {
     });
 
     it("validates combined level:filter format", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("debug:git,process")).toBe("debug:git,process");
       expect(parseLogLevelSpec("warn:network")).toBe("warn:network");
     });
 
     it("validates wildcard filter", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("debug:*")).toBe("debug:*");
     });
 
     it("trims whitespace", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("  debug  ")).toBe("debug");
     });
 
     it("returns undefined for invalid level", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("invalid")).toBeUndefined();
       expect(parseLogLevelSpec("invalid:git")).toBeUndefined();
     });
 
     it("returns undefined for empty or undefined input", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec(undefined)).toBeUndefined();
       expect(parseLogLevelSpec("")).toBeUndefined();
       expect(parseLogLevelSpec("  ")).toBeUndefined();
     });
 
     it("returns undefined for level with empty filter", async () => {
-      const { parseLogLevelSpec } = await import("./electron-log");
       expect(parseLogLevelSpec("debug:")).toBeUndefined();
     });
   });
 
   describe("splitLogLevelSpec", () => {
     it("extracts level from plain spec", async () => {
-      const { splitLogLevelSpec } = await import("./electron-log");
       expect(splitLogLevelSpec("debug")).toEqual({ level: "debug", filter: undefined });
       expect(splitLogLevelSpec("warn")).toEqual({ level: "warn", filter: undefined });
     });
 
     it("extracts level and filter from combined spec", async () => {
-      const { splitLogLevelSpec } = await import("./electron-log");
       const result = splitLogLevelSpec("debug:git,process");
       expect(result.level).toBe("debug");
       expect(result.filter).toEqual(new Set(["git", "process"]));
     });
 
     it("treats * filter as undefined (all loggers)", async () => {
-      const { splitLogLevelSpec } = await import("./electron-log");
       expect(splitLogLevelSpec("debug:*")).toEqual({ level: "debug", filter: undefined });
     });
   });

--- a/src/boundaries/platform/filesystem.boundary.test.ts
+++ b/src/boundaries/platform/filesystem.boundary.test.ts
@@ -390,20 +390,27 @@ describe("DefaultFileSystemBoundary", () => {
       }
     });
 
-    it.skipIf(process.platform === "win32")("throws EISDIR when path is a directory", async () => {
-      const dirPath = join(tempDir.path, "subdir");
-      await nodeMkdir(dirPath);
+    // POSIX lets unlink() of a directory fail with either EISDIR or EPERM.
+    // Linux picks EISDIR, macOS picks EPERM.
+    it.skipIf(process.platform === "win32")(
+      "throws EISDIR/EPERM when path is a directory",
+      async () => {
+        const dirPath = join(tempDir.path, "subdir");
+        await nodeMkdir(dirPath);
 
-      await expect(fs.unlink(dirPath)).rejects.toThrow(FileSystemError);
+        await expect(fs.unlink(dirPath)).rejects.toThrow(FileSystemError);
 
-      try {
-        await fs.unlink(dirPath);
-      } catch (error) {
-        expect(error).toBeInstanceOf(FileSystemError);
-        expect((error as FileSystemError).fsCode).toBe("EISDIR");
-        expect((error as FileSystemError).path).toBe(dirPath);
+        const expectedCode = process.platform === "darwin" ? "EPERM" : "EISDIR";
+
+        try {
+          await fs.unlink(dirPath);
+        } catch (error) {
+          expect(error).toBeInstanceOf(FileSystemError);
+          expect((error as FileSystemError).fsCode).toBe(expectedCode);
+          expect((error as FileSystemError).path).toBe(dirPath);
+        }
       }
-    });
+    );
   });
 
   describe("rm", () => {

--- a/src/boundaries/platform/filesystem.ts
+++ b/src/boundaries/platform/filesystem.ts
@@ -67,7 +67,8 @@ export type FileSystemErrorCode =
   | "EACCES" // Permission denied
   | "EEXIST" // File/directory already exists
   | "ENOTDIR" // Not a directory
-  | "EISDIR" // Is a directory (when file expected)
+  | "EISDIR" // Is a directory (when file expected; Linux unlink of a directory)
+  | "EPERM" // Operation not permitted (macOS unlink of a directory)
   | "ENOTEMPTY" // Directory not empty
   | "UNKNOWN"; // Other errors (check originalCode)
 
@@ -307,7 +308,15 @@ import type { Logger } from "./logging";
 /**
  * Known error codes that map to FileSystemErrorCode.
  */
-const KNOWN_ERROR_CODES = new Set(["ENOENT", "EACCES", "EEXIST", "ENOTDIR", "EISDIR", "ENOTEMPTY"]);
+const KNOWN_ERROR_CODES = new Set([
+  "ENOENT",
+  "EACCES",
+  "EEXIST",
+  "ENOTDIR",
+  "EISDIR",
+  "EPERM",
+  "ENOTEMPTY",
+]);
 
 /**
  * SystemError info structure for fs.rm() errors.

--- a/src/boundaries/platform/logging-types.ts
+++ b/src/boundaries/platform/logging-types.ts
@@ -58,6 +58,10 @@ export type LoggerName =
   | "auto-workspace" // AutoWorkspaceModule - auto-workspace orchestrator
   | "auto-workspace:github" // GitHubSource - GitHub PR polling
   | "auto-workspace:youtrack" // YouTrackSource - YouTrack issue polling
+  | "state" // StateService - state.json persistence
+  | "settings" // SettingsModule - settings UI
+  | "agent-resolver" // AgentResolver - agent selection
+  | "power" // AppBoundary.allowPowerSaving - sleep prevention
   | "error-report"; // ErrorReportModule - crash + manual bug report
 
 /**

--- a/src/boundaries/platform/network.test.ts
+++ b/src/boundaries/platform/network.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DefaultNetworkLayer, type HttpClient } from "./network";
 import { SILENT_LOGGER } from "./logging";
+import { waitForPort, createTestServer } from "./network.test-utils";
+import { createServer } from "net";
 
 describe("DefaultNetworkLayer", () => {
   describe("HttpClient.fetch()", () => {
@@ -157,12 +159,10 @@ describe("DefaultNetworkLayer", () => {
 describe("waitForPort", () => {
   // Import the function dynamically to avoid import issues
   const getWaitForPort = async () => {
-    const { waitForPort } = await import("./network.test-utils");
     return waitForPort;
   };
 
   it("resolves when port is accepting connections", async () => {
-    const { createTestServer } = await import("./network.test-utils");
     const waitForPort = await getWaitForPort();
     const server = createTestServer();
     await server.start();
@@ -176,7 +176,6 @@ describe("waitForPort", () => {
   });
 
   it("times out when port is not available", async () => {
-    const { createServer } = await import("net");
     const waitForPort = await getWaitForPort();
 
     // Find an unused port by binding to 0, then immediately closing
@@ -200,7 +199,6 @@ describe("waitForPort", () => {
   });
 
   it("handles port becoming available during wait", async () => {
-    const { createServer } = await import("net");
     const waitForPort = await getWaitForPort();
 
     // Find an unused port by binding to 0

--- a/src/boundaries/platform/process.boundary.test.ts
+++ b/src/boundaries/platform/process.boundary.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { mkdtemp, writeFile, chmod, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, chmod, rm, realpath } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ExecaProcessRunner, type SpawnedProcess, type ProcessRunner } from "./process";
@@ -170,8 +170,9 @@ describe("ExecaProcessRunner", () => {
     it(
       "supports custom working directory",
       async () => {
-        // Use os.tmpdir() for cross-platform temp directory
-        const tempDir = os.tmpdir();
+        // realpath: on macOS os.tmpdir() is /var/... , a symlink to /private/var/... ,
+        // and the child process reports its cwd already resolved.
+        const tempDir = await realpath(os.tmpdir());
         // Use Node.js to print cwd - cross-platform
         const proc = runner.run(process.execPath, ["-e", "console.log(process.cwd())"], {
           cwd: tempDir,

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -240,9 +240,11 @@ class ExecaSpawnedProcess implements SpawnedProcess {
       // Unix: kill children first with pkill -P, then kill parent
       const signal = force ? "SIGKILL" : "SIGTERM";
 
-      // Kill all child processes by parent PID
+      // Kill all child processes by parent PID.
+      // The signal must come first: BSD pkill (macOS) only accepts a signal as
+      // its first argument and rejects it anywhere else as an invalid option.
       try {
-        await execa("pkill", ["-P", String(pid), force ? "-9" : "-15"]);
+        await execa("pkill", [force ? "-9" : "-15", "-P", String(pid)]);
       } catch {
         // pkill returns non-zero if no processes matched - that's fine
       }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -17,6 +17,7 @@ import { OPENCODE_VERSION } from "./modules/agent-module/opencode/setup-info";
 import { Path } from "./utils/path/path";
 import type { PathProvider } from "./boundaries/platform/path-provider";
 import type { SupportedPlatform } from "./boundaries/platform/platform-info";
+import { ElectronBuildInfo } from "./boundaries/platform/electron-build-info";
 
 // Track mock isPackaged value for ElectronBuildInfo tests
 let mockIsPackaged = false;
@@ -129,8 +130,6 @@ describe("Main process wiring", () => {
       // if (buildInfo.isDevelopment) { ... register DevTools handler ... }
       // isDevelopment now comes from __IS_DEV_BUILD__, not app.isPackaged
 
-      const { ElectronBuildInfo } = await import("../boundaries/platform/electron-build-info");
-
       // Dev build (default __IS_DEV_BUILD__ = true)
       const devBuildInfo = new ElectronBuildInfo();
       expect(devBuildInfo.isDevelopment).toBe(true);
@@ -143,7 +142,7 @@ describe("Main process wiring", () => {
     });
   });
 
-  describe.skipIf(process.platform !== "darwin")("Full wiring chain (Darwin)", () => {
+  describe.skipIf(process.platform === "win32")("Full wiring chain (Darwin)", () => {
     it("BuildInfo -> PlatformInfo -> PathProvider -> services", () => {
       const buildInfo = createMockBuildInfo({ isDevelopment: false, isPackaged: true });
       const platformInfo = createMockPlatformInfo({

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,7 @@ import { AppReadyOperation, INTENT_APP_READY } from "./intents/app-ready";
 import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "./intents/app-shutdown";
 import { AppResumeOperation, INTENT_APP_RESUME, EVENT_APP_RESUMED } from "./intents/app-resume";
 import type { AppShutdownIntent } from "./intents/app-shutdown";
+import type { AgentInfo } from "./shared/ipc";
 import { SetupOperation, INTENT_SETUP, EVENT_SETUP_ERROR } from "./intents/setup";
 import { SetMetadataOperation } from "./intents/set-metadata";
 import { GetMetadataOperation } from "./intents/get-metadata";
@@ -756,7 +757,6 @@ const shortcutModule = createShortcutModule({
 
 const devtoolsModule = createDevtoolsModule({
   viewManager,
-  viewLayer,
 });
 
 const debugModule = createDebugModule({ configService, ui: presentationModule });

--- a/src/modules/agent-module/claude/wrapper.integration.test.ts
+++ b/src/modules/agent-module/claude/wrapper.integration.test.ts
@@ -12,6 +12,7 @@ import type {
   getInitialPromptConfig as GetInitialPromptConfigFn,
   runClaude as RunClaudeFn,
 } from "./wrapper";
+import * as wrapper from "./wrapper";
 
 // Must mock fs before importing wrapper
 vi.mock("node:fs", () => ({
@@ -32,7 +33,6 @@ describe("getInitialPromptConfig integration", () => {
 
   beforeAll(async () => {
     // Dynamic import after mock is set up
-    const wrapper = await import("./wrapper");
     getInitialPromptConfig = wrapper.getInitialPromptConfig;
     runClaude = wrapper.runClaude;
   });

--- a/src/renderer/tsconfig.web.json
+++ b/src/renderer/tsconfig.web.json
@@ -8,17 +8,9 @@
     "baseUrl": "../..",
     "paths": {
       "$lib/*": ["src/renderer/lib/*"],
-      "@shared/*": ["src/shared/*"],
-      "@services/*": ["src/services/*"]
+      "@shared/*": ["src/shared/*"]
     }
   },
-  "include": [
-    "../env.d.ts",
-    "./**/*",
-    "../shared/**/*",
-    "../intents/contract.ts",
-    "../test/**/*",
-    "../services/test-utils.ts"
-  ],
+  "include": ["../env.d.ts", "./**/*", "../shared/**/*", "../intents/contract.ts", "../test/**/*"],
   "exclude": ["../../node_modules", "../../app-data", "../test/setup-matchers.ts"]
 }

--- a/src/shared/errors/service-errors.ts
+++ b/src/shared/errors/service-errors.ts
@@ -4,6 +4,7 @@
 
 /**
  * Filesystem error codes (inlined to avoid pulling node-only filesystem boundary into renderer).
+ * Must stay in sync with FileSystemErrorCode in boundaries/platform/filesystem.ts.
  */
 type FileSystemErrorCode =
   | "ENOENT"
@@ -11,6 +12,7 @@ type FileSystemErrorCode =
   | "EEXIST"
   | "ENOTDIR"
   | "EISDIR"
+  | "EPERM"
   | "ENOTEMPTY"
   | "UNKNOWN";
 

--- a/src/tsconfig.node.json
+++ b/src/tsconfig.node.json
@@ -9,16 +9,6 @@
     },
     "types": ["node"]
   },
-  "include": [
-    "env.d.ts",
-    "main/**/*",
-    "preload/**/*",
-    "shared/**/*",
-    "test/**/*",
-    "modules/agent-module/**/*.json",
-    "intents/**/*",
-    "modules/**/*",
-    "utils/**/*",
-    "boundaries/**/*"
-  ]
+  "include": ["**/*", "modules/agent-module/**/*.json"],
+  "exclude": ["renderer/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,17 +48,11 @@ export default defineConfig({
         test: {
           name: "node",
           environment: "node",
-          include: [
-            "src/main/**/*.{test,spec}.{js,ts}",
-            "src/shared/**/*.{test,spec}.{js,ts}",
-            "src/preload/**/*.{test,spec}.{js,ts}",
-            "src/bin/**/*.{test,spec}.{js,ts}",
-            "src/boundaries/**/*.{test,spec}.{js,ts}",
-            "src/intents/**/*.{test,spec}.{js,ts}",
-            "src/modules/**/*.{test,spec}.{js,ts}",
-            "src/utils/**/*.{test,spec}.{js,ts}",
-          ],
-          exclude: ["**/*.boundary.test.{js,ts}"],
+          // Everything under src/ that the renderer and boundary projects
+          // don't claim. Enumerating directories here silently drops tests
+          // whenever the tree is reorganized.
+          include: ["src/**/*.{test,spec}.{js,ts}"],
+          exclude: ["**/*.boundary.test.{js,ts}", "src/renderer/**"],
           setupFiles: ["./src/test/setup.ts", "./src/test/setup-matchers.ts"],
           // Use forks pool for better ESM/CJS interop with native modules like ws/socket.io
           pool: "forks",
@@ -70,12 +64,7 @@ export default defineConfig({
         test: {
           name: "boundary",
           environment: "node",
-          include: [
-            "src/main/**/*.boundary.test.{js,ts}",
-            "src/boundaries/**/*.boundary.test.{js,ts}",
-            "src/intents/**/*.boundary.test.{js,ts}",
-            "src/modules/**/*.boundary.test.{js,ts}",
-          ],
+          include: ["src/**/*.boundary.test.{js,ts}"],
           setupFiles: ["./src/test/setup.ts", "./src/test/setup-matchers.ts"],
           pool: "forks",
         },


### PR DESCRIPTION
The validate matrix has been `[ubuntu, windows]` since 40b48352 — the commit that added macOS to the *build* matrix. Windows had a written justification; macOS was never argued either way. Meanwhile `darwin-x64` and `darwin-arm64` ship as required release artifacts, so we built and published a platform we never ran a single test against.

Adding `macos-26` and `macos-26-intel` to the matrix immediately turned up three real bugs.

## Bugs found

- **Child processes were never killed on macOS.** `killProcess` passed `pkill` its signal *after* `-P`. procps (Linux) scans all argv for a `-<signal>` token, so it worked. BSD `pkill` (macOS) only accepts a signal as its first argument and rejects it anywhere else with a usage error — which the adjacent `catch` swallowed as "no processes matched". The app spawns IDE servers and agent processes, so this leaked orphans on every teardown. Verified fixed on both new runners.
- **`FileSystemBoundary` silently dropped an errno on macOS.** POSIX lets `unlink()` of a directory fail with either `EISDIR` or `EPERM`; Linux picks the former, macOS the latter. `EPERM` was missing from `KNOWN_ERROR_CODES`, so it degraded to `fsCode: "UNKNOWN"`. No production impact today (every consumer only checks `ENOENT`), but the information was lost.
- **A boundary test compared an unresolved temp path.** `os.tmpdir()` is `/var/…` on macOS, a symlink to `/private/var/…`, and the child reports its cwd already resolved.

## Dead globs hid 44 tests and the composition root

A refactor flattened `src/main/index.ts` into `src/main.ts` and deleted `src/services/`, but the globs referencing those paths were left behind. A glob matching nothing is indistinguishable from a glob whose files all pass, so nothing ever failed.

- `src/main.test.ts` — collected by no vitest project, *and* outside the tsc program. Its stale dynamic-import specifier had been broken the whole time.
- `src/test/fixtures/mock-llm-server.test.ts` — no project's include mentioned `src/test/`.
- `src/utils/extension.boundary.test.ts` — orphaned twice: the node project excluded it as a boundary test, and the boundary project's includes had no `src/utils` entry.
- **`src/main.ts`, the composition root, was type-checked by nothing.** Enabling it surfaced 8 real errors: a missing `AgentInfo` import, a dead `viewLayer` argument, and four logger names absent from the `LoggerName` union.

Fixed the mechanism, not the instances: each vitest project and the node tsconfig are now "everything the sibling projects don't claim" (blanket include, minus an exclude). The tsconfig conversion is byte-identical today — same 363 files, same 2 json, no renderer leakage.

Collected tests: **3522 → 3566**.

## Also

- `no-restricted-syntax` now bans `ImportExpression`, mirroring the existing `TSImportType` ban. Production had zero violations; 37 test-side dynamic imports became top-level. Converting `electron-log.test.ts` exposed a latent hoisting bug (its `vi.mock` factory closed over a plain top-level `const`), fixed at the root with `vi.hoisted()`. The 8 load-bearing dynamic imports are listed in `DYNAMIC_IMPORT_ALLOWED` with reasons.
- Docs corrected for paths and symbols left behind by the same refactor: `wirePluginApi()`, `CodeHydraApi`, `LifecycleApi`, `ProjectStore` and others were documented as live but deleted from the codebase.

## Follow-up

`Validate (macos-26)` and `Validate (macos-26-intel)` must be added to the `main` ruleset's required status checks, or the new jobs stay advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M5hFnmAbpYJRHB8vQC6Uo