### PR TITLE
test(renderer): mock happy-dom iframe loading instead of disabling it

### DIFF
--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment-options {"settings": {"disableIframePageLoading": true}}
 /**
  * Tests for the App component.
  *

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment-options {"settings": {"disableIframePageLoading": true}}
 /**
  * Tests for the MainView component.
  *

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment-options {"settings": {"disableIframePageLoading": true}}
 /**
  * Tests for the WorkspaceFrames component.
  *

--- a/src/test/setup-renderer.ts
+++ b/src/test/setup-renderer.ts
@@ -3,6 +3,46 @@
  * Loads vscode-elements and provides happy-dom compatibility mocks.
  */
 
+import { PropertySymbol } from "happy-dom";
+
+// Neuter <iframe> page loading. happy-dom's HTMLIFrameElement navigates a real
+// child frame whenever it is connected, or its src/srcdoc changes — for
+// WorkspaceFrames that means HTTP requests to the IDE server. Overriding the
+// four hooks that reach #loadPage() skips the navigation; each delegates to the
+// HTMLElement implementation, i.e. what the real hook calls as super. Nothing we
+// render reads contentWindow (it stays null either way).
+//
+// This mock is the only thing keeping renderer tests off the network, so a
+// happy-dom upgrade that renames the hooks must fail here rather than quietly
+// let the iframes load.
+{
+  const hooks = [
+    PropertySymbol.connectedToDocument,
+    PropertySymbol.disconnectedFromDocument,
+    PropertySymbol.onSetAttribute,
+    PropertySymbol.onRemoveAttribute,
+  ];
+  const iframeProto = HTMLIFrameElement.prototype as unknown as Record<
+    symbol,
+    (this: HTMLIFrameElement, ...args: unknown[]) => unknown
+  >;
+  const elementProto = Object.getPrototypeOf(HTMLIFrameElement.prototype) as Record<
+    symbol,
+    ((this: HTMLIFrameElement, ...args: unknown[]) => unknown) | undefined
+  >;
+  for (const hook of hooks) {
+    const inherited = elementProto[hook];
+    if (typeof inherited !== "function") {
+      // happy-dom renamed or dropped the hook: fail loudly instead of silently
+      // letting the tests issue real requests to the IDE server URL.
+      throw new Error(`happy-dom iframe mock is stale: no HTMLElement hook ${String(hook)}`);
+    }
+    iframeProto[hook] = function (...args) {
+      return inherited.apply(this, args);
+    };
+  }
+}
+
 // Mock attachInternals for vscode-elements in happy-dom
 if (typeof HTMLElement.prototype.attachInternals === "undefined") {
   HTMLElement.prototype.attachInternals = function () {


### PR DESCRIPTION
- Override the four happy-dom `HTMLIFrameElement` hooks that reach `#loadPage()` (`connectedToDocument`, `disconnectedFromDocument`, `onSetAttribute`, `onRemoveAttribute`) so renderer tests never navigate a real child frame
- Removes 16 `DOMException [NotSupportedError]` stack traces from every `pnpm validate` run
- Drops the `@vitest-environment-options {"settings":{"disableIframePageLoading":true}}` comments from `App.test.ts`, `MainView.test.ts`, and `WorkspaceFrames.test.ts` — that setting blocked the navigation but made happy-dom print the exception on each mount
- The mock throws at setup if happy-dom ever renames a hook, so a stale mock fails the suite instead of silently letting tests hit the IDE server
- No behavior change: `contentWindow` was already `null` under the old setting, and `WorkspaceFrames.svelte` only reads it as `el.contentWindow?.focus()`