### PR TITLE
chore(fs): derive FileSystemErrorCode from a single source of truth

### DIFF
--- a/src/boundaries/platform/filesystem.ts
+++ b/src/boundaries/platform/filesystem.ts
@@ -61,16 +61,10 @@ export interface RmOptions {
 
 /**
  * Error codes for filesystem operations.
+ * Defined in shared/errors/service-errors (no Node dependency); re-exported here
+ * so existing consumers of this module keep working.
  */
-export type FileSystemErrorCode =
-  | "ENOENT" // File/directory not found
-  | "EACCES" // Permission denied
-  | "EEXIST" // File/directory already exists
-  | "ENOTDIR" // Not a directory
-  | "EISDIR" // Is a directory (when file expected; Linux unlink of a directory)
-  | "EPERM" // Operation not permitted (macOS unlink of a directory)
-  | "ENOTEMPTY" // Directory not empty
-  | "UNKNOWN"; // Other errors (check originalCode)
+export type { FileSystemErrorCode } from "../../shared/errors/service-errors";
 
 /**
  * Abstraction over filesystem operations.
@@ -284,7 +278,8 @@ export interface FileSystemBoundary {
 
 import { createRequire } from "node:module";
 import * as nodeFsPromises from "node:fs/promises";
-import { FileSystemError } from "../../shared/errors/service-errors";
+import { FileSystemError, KNOWN_FILESYSTEM_ERROR_CODES } from "../../shared/errors/service-errors";
+import type { KnownFileSystemErrorCode } from "../../shared/errors/service-errors";
 
 // In the packaged Electron main process, node:fs is asar-patched: any op on a path
 // containing a *.asar treats it as a virtual directory and caches the archive fd for
@@ -307,16 +302,13 @@ import type { Logger } from "./logging";
 
 /**
  * Known error codes that map to FileSystemErrorCode.
+ * Derived from the union's source tuple - cannot drift.
  */
-const KNOWN_ERROR_CODES = new Set([
-  "ENOENT",
-  "EACCES",
-  "EEXIST",
-  "ENOTDIR",
-  "EISDIR",
-  "EPERM",
-  "ENOTEMPTY",
-]);
+const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set<string>(KNOWN_FILESYSTEM_ERROR_CODES);
+
+function isKnownErrorCode(code: string): code is KnownFileSystemErrorCode {
+  return KNOWN_ERROR_CODES.has(code);
+}
 
 /**
  * SystemError info structure for fs.rm() errors.
@@ -363,8 +355,8 @@ function mapError(error: unknown, path: string): FileSystemError {
 
   const code = extractErrorCode(error);
 
-  if (code && KNOWN_ERROR_CODES.has(code)) {
-    return new FileSystemError(code as FileSystemErrorCode, path, error.message, error);
+  if (code && isKnownErrorCode(code)) {
+    return new FileSystemError(code, path, error.message, error);
   }
 
   // Unknown error code - preserve original code

--- a/src/shared/errors/service-errors.test.ts
+++ b/src/shared/errors/service-errors.test.ts
@@ -8,6 +8,7 @@ import {
   ProjectStoreError,
   OpenCodeError,
   FileSystemError,
+  KNOWN_FILESYSTEM_ERROR_CODES,
   getErrorMessage,
 } from "./service-errors";
 
@@ -214,18 +215,20 @@ describe("FileSystemError", () => {
     });
   });
 
-  it("serializes all error codes correctly", () => {
-    const testCases = [
-      { code: "ENOENT" as const, path: "/missing" },
-      { code: "EACCES" as const, path: "/forbidden" },
-      { code: "EEXIST" as const, path: "/exists" },
-      { code: "ENOTDIR" as const, path: "/notdir" },
-      { code: "EISDIR" as const, path: "/isdir" },
-      { code: "ENOTEMPTY" as const, path: "/notempty" },
-      { code: "UNKNOWN" as const, path: "/unknown" },
-    ];
+  it("does not list UNKNOWN as a known POSIX code", () => {
+    // UNKNOWN is the fallback, not a code the filesystem boundary recognises.
+    // If it leaked into the tuple, mapError would treat a literal "UNKNOWN"
+    // errno as a recognised code.
+    expect(KNOWN_FILESYSTEM_ERROR_CODES).not.toContain("UNKNOWN");
+  });
 
-    for (const { code, path } of testCases) {
+  it("serializes all error codes correctly", () => {
+    // Derived from the single source of truth, so a newly added code is covered
+    // here automatically and cannot be silently omitted.
+    const codes = [...KNOWN_FILESYSTEM_ERROR_CODES, "UNKNOWN"] as const;
+
+    for (const code of codes) {
+      const path = `/test/${code}`;
       const error = new FileSystemError(code, path, `Test error for ${code}`);
       const json = error.toJSON();
       expect(json.code).toBe(code);

--- a/src/shared/errors/service-errors.ts
+++ b/src/shared/errors/service-errors.ts
@@ -3,18 +3,25 @@
  */
 
 /**
- * Filesystem error codes (inlined to avoid pulling node-only filesystem boundary into renderer).
- * Must stay in sync with FileSystemErrorCode in boundaries/platform/filesystem.ts.
+ * POSIX error codes that map 1:1 onto a FileSystemErrorCode.
+ * Single source of truth: the runtime Set in the filesystem boundary and the
+ * FileSystemErrorCode union are both derived from this tuple.
  */
-type FileSystemErrorCode =
-  | "ENOENT"
-  | "EACCES"
-  | "EEXIST"
-  | "ENOTDIR"
-  | "EISDIR"
-  | "EPERM"
-  | "ENOTEMPTY"
-  | "UNKNOWN";
+export const KNOWN_FILESYSTEM_ERROR_CODES = [
+  "ENOENT", // File/directory not found
+  "EACCES", // Permission denied
+  "EEXIST", // File/directory already exists
+  "ENOTDIR", // Not a directory
+  "EISDIR", // Is a directory (when file expected; Linux unlink of a directory)
+  "EPERM", // Operation not permitted (macOS unlink of a dir; Windows unlink of a read-only file)
+  "ENOTEMPTY", // Directory not empty
+] as const;
+
+/** A recognised POSIX code (never "UNKNOWN"). */
+export type KnownFileSystemErrorCode = (typeof KNOWN_FILESYSTEM_ERROR_CODES)[number];
+
+/** Error codes for filesystem operations. "UNKNOWN" = other errors (check originalCode). */
+export type FileSystemErrorCode = KnownFileSystemErrorCode | "UNKNOWN";
 
 // Re-export getErrorMessage for internal services use
 export { getErrorMessage } from "../error-utils";


### PR DESCRIPTION
`FileSystemErrorCode` was defined **four** times, held together only by a "must stay in sync" comment:

- an exported union in `boundaries/platform/filesystem.ts`
- a module-local union in `shared/errors/service-errors.ts`
- the hand-listed `KNOWN_ERROR_CODES` runtime `Set`
- a `testCases` array in `service-errors.test.ts`

Three of the four possible drift directions compiled clean. And the drift had already happened: 30900f76 added `EPERM` to both unions and to the `Set`, but not to the test's list — so *"serializes all error codes correctly"* had been silently skipping a code.

## Changes

- Own the codes once, in `shared`, as an `as const` tuple. The union, the runtime `Set`, and the test's case list are all **derived** from it.
- `filesystem.ts` re-exports the type, so existing consumers (`filesystem.state-mock.ts`) are unaffected.
- Deleted `mapError`'s `code as FileSystemErrorCode` cast, replaced by an `isKnownErrorCode` type predicate grounded in the tuple. That cast was what turned a drifted `Set` into a runtime `fsCode` outside its own declared type; the compiler now enforces that Set-membership implies union-membership.
- `EPERM` is now actually exercised by the test (8 codes iterated, was 7), plus a guard that `UNKNOWN` never enters the tuple.

## Layering

This follows the dependency edge that **already existed** — `filesystem.ts` value-imports `FileSystemError` from `shared` — so no `shared -> boundaries` edge is created. Verified the renderer's tsc program is unchanged: **931 files, 0 from `src/boundaries`**. Same precedent as `git-types.ts:70`.

No IPC change: `toJSON()` untouched, `SerializedError.code` stays `string` on the wire.

## Verification

`pnpm format:check`, `pnpm lint`, `pnpm check` (4 tsc projects, svelte-check 964 files / 0 errors), `pnpm test` (**3567 passed**, 32 skipped).