### PR TITLE
fix(plugin-server): don't let a deleting workspace respawn its agent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,11 +58,12 @@ jobs:
   # default parallel run only catches a cross-file module-state regression when
   # the two colliding files happen to land in the same worker.
   #
-  # Serial, so ~3-4x the parallel suite. Kept off the PR path: it would become the
-  # critical path. A regression surfaces on the merge that introduced it.
+  # Serial, so ~3-4x the parallel suite, but it runs on PRs: "which worker did the file
+  # land in" is not a property a reviewer can reason about. A vi.mock that another test
+  # file had already defeated (by importing the module first) passed the parallel suite
+  # locally and failed on the ubuntu runner; only this job reproduced it every run.
   canary:
     name: Test Canary
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -63,7 +63,18 @@ import {
 import type { OpenSystemPathRequest } from "../shared/plugin-protocol";
 import type { FinalizeHookInput, OpenWorkspaceIntent } from "../intents/open-workspace";
 import type { DeleteWorkspaceIntent } from "../intents/delete-workspace";
-import type { DeleteHookResult, DeletePipelineHookInput } from "../intents/delete-workspace";
+import type {
+  DeleteHookResult,
+  DeletePipelineHookInput,
+  ShutdownHookResult,
+  WorkspaceDeletedEvent,
+  WorkspaceDeleteFailedEvent,
+} from "../intents/delete-workspace";
+import {
+  EVENT_WORKSPACE_DELETED,
+  EVENT_WORKSPACE_DELETE_FAILED,
+} from "../intents/delete-workspace";
+import type { DomainEvent } from "../intents/lib/types";
 import type { GetWorkspaceStatusIntent } from "../intents/get-workspace-status";
 import type { GetAgentSessionIntent } from "../intents/get-agent-session";
 import type { RestartAgentIntent } from "../intents/restart-agent";
@@ -158,6 +169,21 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
     string,
     { env: Record<string, string>; agentType: AgentType; resetWorkspace: boolean }
   >();
+  /**
+   * Workspaces whose deletion is in flight (normalized paths).
+   *
+   * A workspace's sidekick extension connects whenever its VS Code window finishes
+   * starting, which can be seconds after the window was created — and receiving the
+   * config is what makes it open the agent terminal. Delete a freshly-opened
+   * workspace and that connection can land *after* the shutdown hook has killed the
+   * agent: the extension then spawns a brand-new agent rooted in the worktree we are
+   * about to remove, and `git worktree remove` fails on Windows because the process
+   * holds a handle on the directory.
+   *
+   * Entered by the delete shutdown hook, cleared on `workspace:deleted` (gone) or
+   * `workspace:delete-failed` (the workspace survives, so it must be usable again).
+   */
+  const deletingWorkspaces = new Set<string>();
 
   // ---------------------------------------------------------------------------
   // Server lifecycle functions
@@ -399,6 +425,17 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
         logger.warn("Connection rejected: invalid path", {
           socketId: socket.id,
           path: auth.workspacePath,
+        });
+        socket.disconnect(true);
+        return;
+      }
+
+      // Its worktree is being torn down. Sending the config would make the extension
+      // open an agent terminal in a directory that is about to disappear.
+      if (deletingWorkspaces.has(workspacePath)) {
+        logger.info("Connection rejected: workspace is being deleted", {
+          workspace: workspacePath,
+          socketId: socket.id,
         });
         socket.disconnect(true);
         return;
@@ -910,6 +947,21 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
       },
 
       [DELETE_WORKSPACE_OPERATION_ID]: {
+        // Runs before the agent is killed and long before the worktree is removed:
+        // from here on, no sidekick may (re)connect for this workspace and open a
+        // terminal in it. Drop the stored config and hang up on any live client.
+        shutdown: {
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
+            const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
+            const normalized = new Path(wsPath).toString();
+
+            deletingWorkspaces.add(normalized);
+            removeWorkspaceConfig(normalized);
+            connections.get(normalized)?.disconnect(true);
+
+            return { result: {} };
+          },
+        },
         delete: {
           handler: async (ctx: HookContext): Promise<HookOutput<DeleteHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
@@ -976,6 +1028,23 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
 
             return { result: { result: commandResult.data } };
           },
+        },
+      },
+    },
+    events: {
+      // The worktree is gone; nothing can connect for it again.
+      [EVENT_WORKSPACE_DELETED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { workspacePath } = (event as WorkspaceDeletedEvent).payload;
+          deletingWorkspaces.delete(new Path(workspacePath).toString());
+        },
+      },
+      // The workspace survived (blocked, or the user cancelled). Let it work again,
+      // otherwise its sidekick could never reconnect until the app restarts.
+      [EVENT_WORKSPACE_DELETE_FAILED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { workspacePath } = (event as WorkspaceDeleteFailedEvent).payload;
+          deletingWorkspaces.delete(new Path(workspacePath).toString());
         },
       },
     },

--- a/src/modules/plugin-server.boundary.test.ts
+++ b/src/modules/plugin-server.boundary.test.ts
@@ -25,10 +25,65 @@ import { INTENT_GET_WORKSPACE_STATUS } from "../intents/get-workspace-status";
 import { INTENT_GET_AGENT_SESSION } from "../intents/get-agent-session";
 import { INTENT_SET_METADATA } from "../intents/set-metadata";
 import { INTENT_AGENT_LIFECYCLE } from "../intents/agent-lifecycle";
-import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
+import {
+  DELETE_WORKSPACE_OPERATION_ID,
+  EVENT_WORKSPACE_DELETED,
+  EVENT_WORKSPACE_DELETE_FAILED,
+  INTENT_DELETE_WORKSPACE,
+} from "../intents/delete-workspace";
+import type { DeletePipelineHookInput, DeleteWorkspaceIntent } from "../intents/delete-workspace";
+import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import type { Operation, OperationSchemas } from "../intents/lib/operation";
+import { z } from "zod/v4";
 import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import { INTENT_RESOLVE_WORKSPACE } from "../intents/resolve-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
+
+/**
+ * A delete-workspace operation reduced to what this file needs: run the "shutdown"
+ * hook (where the plugin server closes the workspace for business), then optionally
+ * emit the event that ends the deletion.
+ */
+function createDeleteShutdownOperation(
+  ends?: typeof EVENT_WORKSPACE_DELETED | typeof EVENT_WORKSPACE_DELETE_FAILED
+): Operation<typeof deleteShutdownSchemas> {
+  return {
+    id: DELETE_WORKSPACE_OPERATION_ID,
+    schemas: deleteShutdownSchemas,
+    async execute(ctx): Promise<void> {
+      const { workspacePath } = ctx.intent.payload as { workspacePath: string };
+      const hookCtx: DeletePipelineHookInput = {
+        // The minimal schema types the payload as `unknown`, so widen before narrowing.
+        intent: ctx.intent as unknown as DeleteWorkspaceIntent,
+        projectPath: "/projects/test",
+        workspacePath,
+        workspaceName: "ws" as WorkspaceName,
+        active: false,
+      };
+      await ctx.hooks.collect("shutdown", hookCtx);
+      if (ends === EVENT_WORKSPACE_DELETED) {
+        await ctx.emit({
+          type: EVENT_WORKSPACE_DELETED,
+          payload: {
+            projectId: "test-12345678" as ProjectId,
+            workspaceName: "ws" as WorkspaceName,
+            workspacePath,
+            projectPath: "/projects/test",
+            worktreeRemoved: true,
+          },
+        });
+      } else if (ends === EVENT_WORKSPACE_DELETE_FAILED) {
+        await ctx.emit({ type: EVENT_WORKSPACE_DELETE_FAILED, payload: { workspacePath } });
+      }
+    },
+  };
+}
+
+const deleteShutdownSchemas = {
+  type: INTENT_DELETE_WORKSPACE,
+  payload: z.unknown(),
+  result: z.custom<void>(),
+} satisfies OperationSchemas;
 
 // Longer timeout for CI environments
 const TEST_TIMEOUT = 15000;
@@ -1127,6 +1182,77 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
       expect(elapsed).toBeGreaterThanOrEqual(500 - TIMING_TOLERANCE_MS);
       expect(elapsed).toBeLessThan(2000);
+    });
+  });
+
+  // A workspace's sidekick connects whenever its VS Code window finishes starting,
+  // which can land *after* the user hit Remove. Receiving the config is what makes it
+  // open an agent terminal — a live process inside the worktree about to be removed.
+  // On Windows that handle makes `git worktree remove` fail.
+  describe("connections during deletion", () => {
+    const WS = "/test/workspace";
+
+    async function startDeleting(
+      ends?: typeof EVENT_WORKSPACE_DELETED | typeof EVENT_WORKSPACE_DELETE_FAILED
+    ): Promise<void> {
+      env.testDispatcher.registerOperation(createDeleteShutdownOperation(ends));
+      await env.testDispatcher.dispatch({
+        type: INTENT_DELETE_WORKSPACE,
+        payload: { workspacePath: WS, removeWorktree: true },
+      } as Intent);
+    }
+
+    it("rejects a client that connects after deletion has begun", async () => {
+      await startDeleting();
+
+      // The server hangs up rather than refusing the handshake, so connect() may
+      // briefly succeed. `disconnect(true)` stops the client from reconnecting.
+      const client = createClient(WS);
+      client.connect();
+      await delay(500);
+
+      expect(client.connected).toBe(false);
+    });
+
+    it("sends no config to a client that connects after deletion has begun", async () => {
+      await startDeleting();
+
+      const client = createClient(WS);
+      const config = vi.fn();
+      client.on("config", config);
+      client.connect();
+      await delay(500);
+
+      // Receiving the config is what makes the sidekick open an agent terminal.
+      expect(config).not.toHaveBeenCalled();
+    });
+
+    it("disconnects a client that was already connected", async () => {
+      const client = createClient(WS);
+      await waitForConnect(client);
+
+      await startDeleting();
+      await waitForDisconnect(client);
+
+      expect(client.connected).toBe(false);
+    });
+
+    it("leaves other workspaces connectable", async () => {
+      await startDeleting();
+
+      const other = createClient("/test/other");
+      await waitForConnect(other);
+
+      expect(other.connected).toBe(true);
+    });
+
+    it("accepts clients again once deletion fails, since the workspace survives", async () => {
+      await startDeleting(EVENT_WORKSPACE_DELETE_FAILED);
+
+      const client = createClient(WS);
+      await waitForConnect(client);
+
+      expect(client.connected).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Removing a workspace shortly after it was opened could fail with **Deletion failed**, leaving the worktree behind. Caught by `E2E (windows)` on #597.

A workspace's sidekick extension connects when its VS Code window finishes starting — seconds after the window is created. Receiving its config is what makes it open the agent terminal. Remove a freshly-opened workspace and that connection lands *after* the delete pipeline's shutdown hook has killed the agent, so the extension opens a **new** agent terminal rooted in the worktree about to be removed:

```
12:09:04.989  Killed opencode pid 5816 (TASKKILL)   <- delete shutdown hook
12:09:05.004  hook shutdown completed
12:09:05.727  [api] Client connected    .../beta     <- sidekick finally connects
12:09:05.920  [extension] Agent terminal opened  command: ch-opencode
12:09:09.5    hook delete                            <- worktree removal
12:09:14.4    blocking: [{"pid":1216,"name":"opencode"}]
```

`git worktree remove` then fails on Windows because that process holds a handle on the directory. Nothing stopped a workspace from being re-armed after its own teardown ran. Windows is only where it fails loudly — on POSIX the directory is deleted out from under a running agent instead.

**Fix.** The plugin server tracks deletions in flight. A new `shutdown` hook — before the agent is killed, long before the worktree is touched — drops the stored config and hangs up on any live client. A client connecting afterwards is disconnected without ever receiving a config, so no terminal opens. The workspace is released on `workspace:deleted` (gone) and on `workspace:delete-failed` (it survived, so its sidekick must reconnect).

**Test Canary now runs on PRs.** It is the only configuration where a cross-file module-state regression is deterministic. A `vi.mock` already defeated by another test file importing the module first passed the parallel suite locally and failed on the ubuntu runner; the canary reproduced it every run. `Test Canary` and the four `E2E` jobs are now required checks — `E2E (windows)` was red when #597 auto-merged.

**Tests.** Five boundary tests against a real Socket.IO server, each verified by mutation: dropping the connect guard fails the two rejection tests; never clearing on `delete-failed` fails the reconnect test.

Verified: `pnpm validate:fix` green (3493), `pnpm test:canary` green, 17/17 e2e against a freshly packaged AppImage.