### PR TITLE
fix: base branch did not default to default branch

### DIFF
--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -175,13 +175,19 @@
   // - dropdown (controlled): when the config carries a `value` the renderer
   //   has not adopted yet, adopt it (strict mode falls back below when it
   //   names no suggestion). Re-sends of the same value preserve user edits.
+  //   Only a value the reconcile actually applies is recorded as adopted — a
+  //   rejected one must stay adoptable, or the backend re-sending it (e.g. the
+  //   creation form seeding the base branch before the branch list arrives,
+  //   then re-sending it with the list) would be dismissed as a re-send.
   // - dropdown (freeText): like input — keep existing edits/picks, else seed
   //   from initialValue on first sight.
   // - dropdown (strict): keep the existing choice if still a valid suggestion
   //   value; on first sight start at initialValue when it names a suggestion;
-  //   else the first suggestion's value. Display text follows the value
-  //   (suggestion label) unless the value is unchanged (preserving what the
-  //   user sees, e.g. typed free text).
+  //   else the first suggestion's value. An empty suggestion list accepts any
+  //   value, so a seeded default paints while the list is still loading; the
+  //   value is re-validated (and re-defaulted) once the list arrives. Display
+  //   text follows the value (suggestion label) unless the value is unchanged
+  //   (preserving what the user sees, e.g. typed free text).
   // - input: keep existing edits/seeded value; otherwise seed from initialValue
   //   on first sight (a later initialValue change does not re-seed).
   // Existing values are read via untrack to avoid a write -> retrigger loop.
@@ -199,21 +205,25 @@
           section.value !== undefined && section.value !== adoptedValues[section.id]
             ? section.value
             : undefined;
-        if (pushed !== undefined) {
-          adoptedValues[section.id] = pushed;
-        }
         if (section.freeText) {
+          if (pushed !== undefined) {
+            adoptedValues[section.id] = pushed;
+          }
           next[section.id] = pushed ?? existing ?? section.initialValue ?? "";
         } else {
+          const options = flatSuggestions(section);
           const isValid = (v: string | undefined): v is string =>
-            v !== undefined && flatSuggestions(section).some((o) => o.value === v);
+            v !== undefined && (options.length === 0 || options.some((o) => o.value === v));
+          if (pushed !== undefined && isValid(pushed)) {
+            adoptedValues[section.id] = pushed;
+          }
           next[section.id] = isValid(pushed)
             ? pushed
             : pushed === undefined && isValid(existing)
               ? existing
               : existing === undefined && pushed === undefined && isValid(section.initialValue)
                 ? section.initialValue
-                : (flatSuggestions(section)[0]?.value ?? "");
+                : (options[0]?.value ?? "");
         }
         const existingDisplay = untrack(() => dropdownDisplay[section.id]);
         nextDisplay[section.id] =

--- a/src/renderer/lib/components/form/Form.test.ts
+++ b/src/renderer/lib/components/form/Form.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
-import type { DialogConfig, DialogKind } from "@shared/dialog-types";
+import type { DialogConfig, DialogKind, DropdownSuggestionGroup } from "@shared/dialog-types";
 
 // Shared fake: src/renderer/lib/api/__mocks__/index.ts
 vi.mock("$lib/api");
@@ -459,6 +459,78 @@ describe("Form component", () => {
           dialogId: "dd",
           actionId: "confirm",
           data: { name: "seeded" },
+        });
+      });
+    });
+
+    // A strict dropdown whose suggestions arrive asynchronously (the creation
+    // form's base branch): the backend seeds the value against an empty list,
+    // then re-sends it once the list has loaded.
+    describe("value pushed before the suggestion list arrives", () => {
+      function baseConfig(
+        suggestions: DropdownSuggestionGroup[],
+        value: string,
+        extra?: { loading?: boolean }
+      ): DialogConfig {
+        return {
+          sections: [
+            {
+              type: "dropdown",
+              id: "base",
+              suggestions,
+              value,
+              placeholder: "Select branch...",
+              ...extra,
+            },
+            {
+              type: "group",
+              items: [{ type: "button", id: "confirm", label: "Confirm", variant: "primary" }],
+            },
+          ],
+        };
+      }
+
+      const loaded: DropdownSuggestionGroup[] = [
+        { header: "Local Branches", items: [{ value: "base-branch", label: "base-branch" }] },
+        { header: "Remote Branches", items: [{ value: "origin/main", label: "origin/main" }] },
+      ];
+
+      it("paints the pushed value while the list is still loading", async () => {
+        renderForm(baseConfig([], "origin/main", { loading: true }), { dialogId: "dd" });
+
+        expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("origin/main");
+      });
+
+      it("keeps the seeded value when the list arrives carrying it", async () => {
+        const { rerender } = renderForm(baseConfig([], "origin/main"), { dialogId: "dd" });
+
+        // Same value re-sent alongside the loaded list: a rejected push must
+        // not have been recorded as adopted, or this reads as a re-send and
+        // the field falls back to the first suggestion.
+        await rerender({ dialogId: "dd", config: baseConfig(loaded, "origin/main") });
+
+        expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("origin/main");
+        await fireEvent.click(screen.getByText("Confirm"));
+        expect(mockSendDialogEvent).toHaveBeenCalledWith({
+          dialogId: "dd",
+          actionId: "confirm",
+          data: { base: "origin/main" },
+        });
+      });
+
+      it("re-defaults the seeded value when the arriving list lacks it", async () => {
+        const { rerender } = renderForm(baseConfig([], "origin/gone"), { dialogId: "dd" });
+
+        expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("origin/gone");
+
+        await rerender({ dialogId: "dd", config: baseConfig(loaded, "origin/gone") });
+
+        expect((screen.getByRole("combobox") as HTMLInputElement).value).toBe("base-branch");
+        await fireEvent.click(screen.getByText("Confirm"));
+        expect(mockSendDialogEvent).toHaveBeenCalledWith({
+          dialogId: "dd",
+          actionId: "confirm",
+          data: { base: "base-branch" },
         });
       });
     });


### PR DESCRIPTION
The creation form's Base Branch field preselected the alphabetically first *local* branch instead of the repository's default branch (`origin/main` / `main` / `origin/master` / `master`).

- `Form.svelte`'s reconcile recorded a pushed dropdown value in `adoptedValues` even when it *rejected* it. The creation form seeds the base branch before the branch list arrives, so a strict dropdown rejected the seed against an empty suggestion list — then dismissed the follow-up push carrying the same value as a re-send, and fell through to the first suggestion.
- Nothing emitted a change event, so main still believed the base was `origin/main` while the renderer held the wrong branch. `handleCreate` reads the renderer's snapshot, so the worktree was actually branched off the wrong base — this was not cosmetic.
- Fix: record a value only when the reconcile applies it, and let an empty suggestion list accept any pushed value, re-validating once the list arrives. The seed now paints on the first frame, as its comment always claimed.
- Gating on the empty list rather than `loading` is load-bearing: `branchesLoading` stays true until `bases:updated`, so a `loading` gate would skip validation against the list that just arrived.

Blast radius is the strict-dropdown branch only; `input`, `checkbox`, and `freeText` dropdowns apply pushed values unconditionally and can never record an unapplied one.

Three regression tests in `Form.test.ts`: the seed survives the list's arrival, a held value paints while the list is empty, and a held value is re-defaulted when the arriving list lacks it.

Verified against the real app (appctrl) with a clone carrying `origin/main` plus a local `aaa-feature` branch: without the fix the field showed `aaa-feature`; with it, `origin/main`, and the created worktree's HEAD matched `origin/main` exactly.

Note: `open-project.e2e.ts` already asserted the base field reads `main`, but `createTestGitRepo()` builds a remote-less single-branch repo where `bases[0] === "main"` — so it passed for the wrong reason and never guarded this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsSh19FmSMg771MS4bHukk