### PR TITLE
fix: simple browser was broken

### DIFF
--- a/src/boundaries/shell/session.state-mock.ts
+++ b/src/boundaries/shell/session.state-mock.ts
@@ -15,7 +15,12 @@
  */
 
 import { expect } from "vitest";
-import type { SessionBoundary, PermissionRequestHandler, PermissionCheckHandler } from "./session";
+import type {
+  SessionBoundary,
+  PermissionRequestHandler,
+  PermissionCheckHandler,
+  ProtocolInterceptor,
+} from "./session";
 import type { SessionHandle } from "./types";
 import { ShellError } from "../../shared/errors/shell-errors";
 import type {
@@ -38,6 +43,11 @@ export interface MockSessionState {
   readonly hasPermissionRequestHandler: boolean;
   readonly hasPermissionCheckHandler: boolean;
   readonly hasHeadersReceivedHandler: boolean;
+  /**
+   * Interceptors registered per scheme. Held (not just flagged) so tests can
+   * drive them directly and assert what a URL resolves to.
+   */
+  readonly protocolInterceptors: ReadonlyMap<string, ProtocolInterceptor>;
 }
 
 /**
@@ -74,6 +84,7 @@ interface MutableSessionState {
   hasPermissionRequestHandler: boolean;
   hasPermissionCheckHandler: boolean;
   hasHeadersReceivedHandler: boolean;
+  protocolInterceptors: Map<string, ProtocolInterceptor>;
 }
 
 class SessionBoundaryMockStateImpl implements SessionBoundaryMockState {
@@ -198,6 +209,7 @@ export function createSessionBoundaryMock(
         hasPermissionRequestHandler: sessionState.hasPermissionRequestHandler ?? false,
         hasPermissionCheckHandler: sessionState.hasPermissionCheckHandler ?? false,
         hasHeadersReceivedHandler: sessionState.hasHeadersReceivedHandler ?? false,
+        protocolInterceptors: new Map(),
       });
       partitionToId.set(partition, id);
     }
@@ -226,6 +238,7 @@ export function createSessionBoundaryMock(
         hasPermissionRequestHandler: false,
         hasPermissionCheckHandler: false,
         hasHeadersReceivedHandler: false,
+        protocolInterceptors: new Map(),
       });
       partitionToId.set(partition, id);
 
@@ -248,6 +261,15 @@ export function createSessionBoundaryMock(
     ): void {
       const session = getSession(handle);
       session.hasHeadersReceivedHandler = true;
+    },
+
+    setProtocolHandler(
+      handle: SessionHandle,
+      scheme: string,
+      interceptor: ProtocolInterceptor
+    ): void {
+      const session = getSession(handle);
+      session.protocolInterceptors.set(scheme, interceptor);
     },
 
     async dispose(): Promise<void> {

--- a/src/boundaries/shell/session.ts
+++ b/src/boundaries/shell/session.ts
@@ -57,6 +57,25 @@ export type PermissionRequestHandler = (permission: Permission) => boolean;
  */
 export type PermissionCheckHandler = (permission: Permission) => boolean;
 
+/**
+ * An asset served in place of a network response by a protocol interceptor.
+ */
+export interface InterceptedAsset {
+  readonly body: Uint8Array;
+  readonly contentType: string;
+  /** Extra response headers (e.g. `service-worker-allowed`). */
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Resolves an intercepted request URL to a locally-served asset, or `null` to
+ * forward the request to the built-in (network) handler untouched.
+ *
+ * Interceptors are given only the URL — no Electron or fetch types cross the
+ * boundary, so callers stay trivially testable.
+ */
+export type ProtocolInterceptor = (url: string) => Promise<InterceptedAsset | null>;
+
 // ============================================================================
 // Interface
 // ============================================================================
@@ -112,6 +131,19 @@ export interface SessionBoundary {
     handle: SessionHandle,
     handler: (headers: Record<string, string[]>) => Record<string, string[]>
   ): void;
+
+  /**
+   * Intercept `scheme` on this session, serving the interceptor's asset when it
+   * returns one and forwarding to the network otherwise.
+   *
+   * Registration is idempotent: re-registering replaces the previous handler.
+   *
+   * @param handle - Handle to the session
+   * @param scheme - Scheme to intercept (e.g. "https")
+   * @param interceptor - Resolves a URL to a local asset, or null to pass through
+   * @throws ShellError with code SESSION_NOT_FOUND if handle is invalid
+   */
+  setProtocolHandler(handle: SessionHandle, scheme: string, interceptor: ProtocolInterceptor): void;
 
   /**
    * Dispose of all resources.
@@ -195,6 +227,35 @@ export class DefaultSessionBoundary implements SessionBoundary {
     });
 
     this.logger.debug("Headers received handler set", { id: handle.id });
+  }
+
+  setProtocolHandler(
+    handle: SessionHandle,
+    scheme: string,
+    interceptor: ProtocolInterceptor
+  ): void {
+    const state = this.getSession(handle);
+    const { protocol } = state.session;
+
+    // Idempotent: protocol.handle throws if the scheme is already handled.
+    if (protocol.isProtocolHandled(scheme)) {
+      protocol.unhandle(scheme);
+    }
+
+    protocol.handle(scheme, async (request) => {
+      const asset = await interceptor(request.url);
+      if (!asset) {
+        // Forward to Electron's built-in handler. Without the bypass this would
+        // re-enter this same handler and loop forever.
+        return state.session.fetch(request, { bypassCustomProtocolHandlers: true });
+      }
+      return new Response(asset.body as BodyInit, {
+        status: 200,
+        headers: { "content-type": asset.contentType, ...asset.headers },
+      });
+    });
+
+    this.logger.debug("Protocol handler set", { id: handle.id, scheme });
   }
 
   async dispose(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ import { DefaultWindowBoundary } from "./boundaries/shell/window";
 import { DefaultViewBoundary } from "./boundaries/shell/view";
 import { DefaultSessionBoundary } from "./boundaries/shell/session";
 import { WindowManager } from "./boundaries/shell/window-manager";
-import { UiViewManager } from "./boundaries/shell/ui-view-manager";
+import { UiViewManager, GLOBAL_SESSION_PARTITION } from "./boundaries/shell/ui-view-manager";
 // Services (stayed)
 import { AutoUpdater } from "./modules/auto-updater";
 import { DefaultArchiveExtractor } from "./boundaries/platform/archive-extractor";
@@ -508,6 +508,8 @@ const ideServerModule = createIdeServerModule({
   httpClient: networkLayer,
   portManager: networkLayer,
   fileSystemLayer,
+  sessionLayer,
+  sessionPartition: GLOBAL_SESSION_PARTITION,
   pathProvider,
   buildInfo,
   platform,

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { createMockDispatcher } from "../../intents/lib/dispatcher.test-utils";
+import { createSessionBoundaryMock } from "../../boundaries/shell/session.state-mock";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // The watcher shim's own behavior is covered in watcher-shim.integration.test.ts;
@@ -307,12 +308,15 @@ function createMockDeps(overrides?: Partial<IdeServerModuleDeps>): IdeServerModu
       readdir: vi.fn().mockResolvedValue([]),
       rm: vi.fn().mockResolvedValue(undefined),
       readFile: vi.fn().mockResolvedValue("[]"),
+      readFileBuffer: vi.fn().mockResolvedValue(Buffer.from("")),
       writeFile: vi.fn().mockResolvedValue(undefined),
       writeFileBuffer: vi.fn().mockResolvedValue(undefined),
       unlink: vi.fn().mockResolvedValue(undefined),
       rename: vi.fn().mockResolvedValue(undefined),
       makeExecutable: vi.fn().mockResolvedValue(undefined),
     },
+    sessionLayer: createSessionBoundaryMock(),
+    sessionPartition: "persist:test",
     pathProvider: {
       bundlePath: vi.fn().mockImplementation((subpath: string) => {
         return new Path(`/bundles/${subpath}`);
@@ -531,6 +535,66 @@ describe("IdeServerModule", () => {
   // ---------------------------------------------------------------------------
   // start
   // ---------------------------------------------------------------------------
+
+  describe("webview interception", () => {
+    /** Drive the `start` hook, then hand back the https interceptor it registered. */
+    async function startAndGetInterceptor(deps: IdeServerModuleDeps) {
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      const sessions = (deps.sessionLayer as ReturnType<typeof createSessionBoundaryMock>).$
+        .sessions;
+      const session = [...sessions.values()].find((s) => s.partition === "persist:test");
+      return session?.protocolInterceptors.get("https");
+    }
+
+    it("serves the webview shell from the bundle, not the baked-in CDN", async () => {
+      // VSCodium points webviews at a Microsoft insider commit on vscode-cdn.net
+      // whose service-worker is v4, while its own workbench demands v5 — and the
+      // CDN has no assets for VSCodium's commit at all. We answer at that URL
+      // with the bundle's own (matching) copy, keeping the origin intact.
+      const deps = createMockDeps();
+      deps.fileSystemLayer.readFileBuffer = vi.fn().mockResolvedValue(Buffer.from("SW_V5"));
+
+      const intercept = await startAndGetInterceptor(deps);
+      const asset = await intercept!(
+        "https://abc.vscode-cdn.net/insider/ef65ac/out/vs/workbench/contrib/webview/browser/pre/service-worker.js?v=5"
+      );
+
+      expect(asset?.body).toEqual(Buffer.from("SW_V5"));
+      expect(asset?.contentType).toBe("text/javascript; charset=utf-8");
+      // Never let a stale service-worker version get pinned again.
+      expect(asset?.headers?.["cache-control"]).toBe("no-cache");
+      expect(deps.fileSystemLayer.readFileBuffer).toHaveBeenCalledWith(
+        new Path(
+          "/bundles/vscodium/1.126.04524/out/vs/workbench/contrib/webview/browser/pre/service-worker.js"
+        )
+      );
+    });
+
+    it("passes other https requests through to the network", async () => {
+      const deps = createMockDeps();
+      const intercept = await startAndGetInterceptor(deps);
+
+      // A page opened in Simple Browser must not be served from the bundle.
+      await expect(intercept!("https://example.com/index.html")).resolves.toBeNull();
+      expect(deps.fileSystemLayer.readFileBuffer).not.toHaveBeenCalled();
+    });
+
+    it("falls through to the network when the asset cannot be read", async () => {
+      const deps = createMockDeps();
+      deps.fileSystemLayer.readFileBuffer = vi.fn().mockRejectedValue(new Error("ENOENT"));
+
+      const intercept = await startAndGetInterceptor(deps);
+
+      await expect(
+        intercept!(
+          "https://abc.vscode-cdn.net/insider/ef65ac/out/vs/workbench/contrib/webview/browser/pre/index.html"
+        )
+      ).resolves.toBeNull();
+    });
+  });
 
   describe("start", () => {
     it("starts the IDE server and returns port", async () => {
@@ -1013,6 +1077,7 @@ describe("IdeServerModule", () => {
           readdir: vi.fn().mockResolvedValue([]),
           rm: vi.fn().mockResolvedValue(undefined),
           readFile: vi.fn().mockResolvedValue("[]"),
+          readFileBuffer: vi.fn().mockResolvedValue(Buffer.from("")),
           writeFile: vi.fn().mockRejectedValue(new Error("disk full")),
           writeFileBuffer: vi.fn().mockResolvedValue(undefined),
           unlink: vi.fn().mockResolvedValue(undefined),
@@ -1088,6 +1153,7 @@ describe("IdeServerModule", () => {
           readdir: vi.fn().mockResolvedValue([]),
           rm: vi.fn().mockRejectedValue(new Error("permission denied")),
           readFile: vi.fn().mockResolvedValue("[]"),
+          readFileBuffer: vi.fn().mockResolvedValue(Buffer.from("")),
           writeFile: vi.fn().mockResolvedValue(undefined),
           writeFileBuffer: vi.fn().mockResolvedValue(undefined),
           unlink: vi.fn().mockResolvedValue(undefined),
@@ -1122,6 +1188,7 @@ describe("IdeServerModule", () => {
           readdir: vi.fn().mockResolvedValue([]),
           rm: vi.fn().mockRejectedValue(new Error("permission denied")),
           readFile: vi.fn().mockResolvedValue("[]"),
+          readFileBuffer: vi.fn().mockResolvedValue(Buffer.from("")),
           writeFile: vi.fn().mockResolvedValue(undefined),
           writeFileBuffer: vi.fn().mockResolvedValue(undefined),
           unlink: vi.fn().mockResolvedValue(undefined),

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -25,6 +25,7 @@ import {
   PROCESS_KILL_FORCE_TIMEOUT_MS,
 } from "../../boundaries/platform/process";
 import type { HttpClient, PortManager } from "../../boundaries/platform/network";
+import type { SessionBoundary, InterceptedAsset } from "../../boundaries/shell/session";
 import type { PathProvider } from "../../boundaries/platform/path-provider";
 import type { Logger } from "../../boundaries/platform/logging-types";
 import type { SupportedPlatform, SupportedArch } from "../../boundaries/platform/platform-info";
@@ -147,12 +148,20 @@ export interface IdeServerModuleDeps {
     | "readdir"
     | "rm"
     | "readFile"
+    | "readFileBuffer"
     | "writeFile"
     | "unlink"
     | "rename"
     | "writeFileBuffer"
     | "makeExecutable"
   >;
+  /**
+   * Session the workspace iframes load in. The module intercepts the webview
+   * shell requests on it (see `IdeServer.webviewAsset`).
+   */
+  readonly sessionLayer: Pick<SessionBoundary, "fromPartition" | "setProtocolHandler">;
+  /** Partition name of that session. */
+  readonly sessionPartition: string;
   readonly pathProvider: Pick<PathProvider, "bundlePath" | "dataPath">;
   readonly buildInfo: Pick<BuildInfo, "isPackaged" | "gitBranch">;
   readonly platform: SupportedPlatform;
@@ -297,6 +306,61 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
 
   // Internal state: port set by start hook, read by finalize hook
   let ideServerPort = 0;
+
+  // -------------------------------------------------------------------------
+  // Webview shell interception
+  // -------------------------------------------------------------------------
+
+  /** Content type for the flat webview shell files (html + the service worker). */
+  function webviewContentType(assetPath: string): string {
+    return assetPath.endsWith(".js")
+      ? "text/javascript; charset=utf-8"
+      : "text/html; charset=utf-8";
+  }
+
+  /**
+   * Serve the webview shell from the bundle instead of the CDN the distribution
+   * bakes in (see `IdeServer.webviewAsset` for why). Registered on the session
+   * the workspace iframes load in; every other https request passes through.
+   */
+  function registerWebviewInterceptor(): void {
+    const ide = getIdeServer();
+    const bundleDir = deps.pathProvider.bundlePath(ide.bundleSubdir());
+    const handle = deps.sessionLayer.fromPartition(deps.sessionPartition);
+
+    deps.sessionLayer.setProtocolHandler(
+      handle,
+      "https",
+      async (url): Promise<InterceptedAsset | null> => {
+        const assetPath = ide.webviewAsset(url);
+        if (assetPath === null) return null;
+
+        try {
+          const body = await fileSystemLayer.readFileBuffer(new Path(bundleDir, assetPath));
+          return {
+            body,
+            contentType: webviewContentType(assetPath),
+            headers: {
+              // The shell is cheap to re-read and must never pin a stale
+              // service-worker version the way the CDN's immutable assets did.
+              "cache-control": "no-cache",
+              // The worker's scope sits above its own directory.
+              "service-worker-allowed": "/",
+            },
+          };
+        } catch (error) {
+          // Fall through to the network rather than fail the frame outright.
+          logger.warn("Failed to serve webview asset from bundle", {
+            assetPath,
+            error: getErrorMessage(error),
+          });
+          return null;
+        }
+      }
+    );
+
+    logger.debug("Webview interceptor registered", { partition: deps.sessionPartition });
+  }
 
   // -------------------------------------------------------------------------
   // Process lifecycle functions
@@ -636,6 +700,10 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
             if (pluginPort !== null) {
               config.pluginPort = pluginPort;
             }
+
+            // Before any workspace iframe loads, so the first webview already
+            // resolves to the bundle's shell rather than the baked-in CDN.
+            registerWebviewInterceptor();
 
             // Ensure required directories exist
             await Promise.all([

--- a/src/modules/ide-server-module/types.ts
+++ b/src/modules/ide-server-module/types.ts
@@ -70,6 +70,24 @@ export interface IdeServer {
   /** Readiness probe URL for the given port. */
   healthUrl(port: number): string;
 
+  /**
+   * Map a request URL to the bundle-relative path of the webview asset that
+   * should answer it, or `null` when the URL is not a webview asset request.
+   *
+   * Why this exists: the distribution bakes an external webview base URL into
+   * its compiled workbench (`webviewContentExternalBaseUrlTemplate`), and for
+   * VSCodium that URL points at a *Microsoft* build on `vscode-cdn.net` whose
+   * webview service-worker is v4 while VSCodium's own workbench requires v5.
+   * The mismatch breaks every webview (Simple Browser, markdown preview, ...),
+   * and it is unfixable by repointing the URL: the CDN hosts no assets for
+   * VSCodium's commit at all. So the shell intercepts these requests and serves
+   * the bundle's own matching assets *at the original URL* — which keeps the
+   * per-webview origin isolation the CDN hostname provides, and works offline.
+   *
+   * Pure: parses the URL only. The caller does the reading.
+   */
+  webviewAsset(url: string): string | null;
+
   /** URL that opens a folder path. */
   urlForFolder(port: number, folderPath: string): string;
   /** URL that opens a `.code-workspace` file. */

--- a/src/modules/ide-server-module/vscodium.test.ts
+++ b/src/modules/ide-server-module/vscodium.test.ts
@@ -140,3 +140,46 @@ describe("vscodium descriptor: wrapper invocations", () => {
     expect(ide.nodeBinary("C:\\b\\vsc", "win32")).toBe("C:\\b\\vsc\\node.exe");
   });
 });
+
+describe("vscodium descriptor: webviewAsset", () => {
+  const ide = createVscodiumIdeServer();
+  const PRE = "out/vs/workbench/contrib/webview/browser/pre";
+  // The base URL VSCodium actually bakes in: a Microsoft *insider* commit whose
+  // webview service-worker is v4, while this build's workbench requires v5.
+  const cdn = (file: string) =>
+    `https://07uscgn4lhh36t8.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/${PRE}/${file}`;
+
+  it("maps the webview shell files onto the bundle", () => {
+    expect(ide.webviewAsset(cdn("index.html"))).toBe(`${PRE}/index.html`);
+    expect(ide.webviewAsset(cdn("fake.html"))).toBe(`${PRE}/fake.html`);
+    // The service worker is the whole point: serving the bundle's v5 copy here
+    // is what resolves the "Found: 4. Expected: 5" mismatch.
+    expect(ide.webviewAsset(cdn("service-worker.js"))).toBe(`${PRE}/service-worker.js`);
+  });
+
+  it("ignores the query string the workbench appends", () => {
+    expect(ide.webviewAsset(`${cdn("index.html")}?id=abc&swVersion=5&platform=browser`)).toBe(
+      `${PRE}/index.html`
+    );
+  });
+
+  it("serves index.html for the bare directory", () => {
+    expect(ide.webviewAsset(cdn(""))).toBe(`${PRE}/index.html`);
+  });
+
+  it("passes through everything that is not a webview shell request", () => {
+    // Arbitrary pages (e.g. opened in Simple Browser) must reach the network.
+    expect(ide.webviewAsset("https://example.com/index.html")).toBeNull();
+    // Right host, but not the webview shell path.
+    expect(ide.webviewAsset("https://x.vscode-cdn.net/stable/abc/out/vs/other.js")).toBeNull();
+    // A lookalike host must not match.
+    expect(ide.webviewAsset(`https://evil-vscode-cdn.net/insider/c/${PRE}/index.html`)).toBeNull();
+    expect(ide.webviewAsset(`http://x.vscode-cdn.net/insider/c/${PRE}/index.html`)).toBeNull();
+    expect(ide.webviewAsset("not a url")).toBeNull();
+  });
+
+  it("refuses to escape the webview directory", () => {
+    expect(ide.webviewAsset(cdn("../../../../product.json"))).toBeNull();
+    expect(ide.webviewAsset(cdn("nested/index.html"))).toBeNull();
+  });
+});

--- a/src/modules/ide-server-module/vscodium.ts
+++ b/src/modules/ide-server-module/vscodium.ts
@@ -20,6 +20,12 @@ import { folderUrl, workspaceUrl } from "./url-scheme";
 /** Current VSCodium version to download (reh-web build; VS Code <major.minor>.<build>). */
 export const VSCODIUM_VERSION = "1.126.04524";
 
+/** Bundle-relative directory holding the webview shell (index/fake html + service worker). */
+const WEBVIEW_PRE_DIR = "out/vs/workbench/contrib/webview/browser/pre";
+
+/** The same directory as it appears in the baked webview base URL. */
+const WEBVIEW_PRE_PATH = `/${WEBVIEW_PRE_DIR}/`;
+
 /** Map Node's platform to the VSCodium release asset OS token. */
 function osToken(platform: SupportedPlatform): string {
   // VSCodium asset names use "darwin"/"linux"/"win32" directly.
@@ -85,6 +91,30 @@ export function createVscodiumIdeServer(version: string = VSCODIUM_VERSION): Ide
     healthUrl(port: number): string {
       // reh-web has no /healthz; /version returns 200 once the server is up.
       return `http://127.0.0.1:${port}/version`;
+    },
+
+    webviewAsset(url: string): string | null {
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return null;
+      }
+      // Webviews are framed from `https://<uuid>.vscode-cdn.net/<quality>/<commit>{WEBVIEW_PRE_PATH}`.
+      if (parsed.protocol !== "https:" || !parsed.hostname.endsWith(".vscode-cdn.net")) {
+        return null;
+      }
+      const index = parsed.pathname.indexOf(WEBVIEW_PRE_PATH);
+      if (index === -1) return null;
+
+      // The workbench only ever asks for flat files here (index.html, fake.html,
+      // service-worker.js). Reject anything with a separator or traversal so a
+      // crafted URL can't escape the bundle.
+      const file = parsed.pathname.slice(index + WEBVIEW_PRE_PATH.length);
+      if (file === "") return `${WEBVIEW_PRE_DIR}/index.html`;
+      if (file.includes("/") || file.includes("\\") || file.includes("..")) return null;
+
+      return `${WEBVIEW_PRE_DIR}/${file}`;
     },
 
     urlForFolder(port: number, folderPath: string): string {


### PR DESCRIPTION
Every webview — Simple Browser, markdown preview, extension webviews — has been broken since the switch to VSCodium, rendering unstyled with no content.

**Root cause**: VSCodium bakes `webviewContentExternalBaseUrlTemplate` into its compiled workbench, pointing at a *Microsoft* build on `vscode-cdn.net` pinned to insider commit `ef65ac1b`. That build's webview service-worker is **v4**, while VSCodium's own workbench requires **v5**, so the webview loops on `Found unexpected service worker version. Found: 4. Expected: 5` and never loads a single resource.

Repointing the URL can't fix it: the CDN hosts **no assets for VSCodium's commit at all** (404). code-server never hit this because it patched VS Code to serve webviews from its own origin; VSCodium ships stock VS Code, which assumes you are Microsoft and have a CDN to mint isolated webview origins on.

**Fix**: rather than patch the downloaded bundle, intercept the request — the webview keeps asking for the CDN URL and we answer *at that URL* with the bundle's own matching assets.

- Keeps the per-webview origin isolation the CDN hostname provides (strictly better than code-server's same-origin webviews)
- Bakes in no port or commit; survives version bumps and re-downloads
- Works offline
- Self-heals existing installs: a registered v4 worker re-fetches its script on its next update check, gets our v5 bytes, and installs — no cache clear or migration

**Changes**
- `SessionBoundary.setProtocolHandler`: generic scheme interception. Electron, `Response`, and the net-fetch passthrough stay inside the boundary; interceptors see only a URL and return bytes or `null`.
- `IdeServer.webviewAsset`: pure URL → bundle-path mapping, so the distribution fact lives with the descriptor (rejects lookalike hosts and directory escape).
- `ide-server-module` registers the interceptor on the workspace session in the `app:start` "start" hook, before any workspace iframe loads.

**Testing**
- Pure mapping tests (serves the shell files, ignores the query string, passes external URLs through, rejects lookalike hosts, refuses directory escape)
- Integration tests driving the real `start` hook through the session mock
- Verified live: Simple Browser renders, webview stays on its isolated `*.vscode-cdn.net` origin, no service-worker error, and the VSCodium bundle on disk is never written to