### PR TITLE
feat: leftovers in workspaces are shown as warning in deletion dialog

### DIFF
--- a/src/modules/deletion-dialog-module.integration.test.ts
+++ b/src/modules/deletion-dialog-module.integration.test.ts
@@ -557,6 +557,12 @@ describe("DeletionDialogModule - remove confirm", () => {
       `Remove workspace "${WS_NAME_A}"?`,
       "Checking workspace status...",
     ]);
+    // Remove is live while the check runs, so the notice carries the warning style.
+    expect(handle.config.sections).toContainEqual({
+      type: "text",
+      content: "Checking workspace status...",
+      style: "warning",
+    });
     expect(handle.config.sections).toContainEqual({
       type: "checkbox",
       id: "keep-branch",
@@ -593,7 +599,7 @@ describe("DeletionDialogModule - remove confirm", () => {
     await pending;
   });
 
-  it("falls back to no warnings when the status check fails", async () => {
+  it("warns that the status is unknown when the check fails", async () => {
     const setup = createConfirmSetup();
     const pending = setup.confirm();
 
@@ -602,8 +608,17 @@ describe("DeletionDialogModule - remove confirm", () => {
       expect(setup.dialogManager.lastHandle!.configs.length).toBeGreaterThan(1);
     });
 
-    const texts = textsOf(setup.dialogManager.lastHandle!.config);
-    expect(texts).toEqual(["Remove Workspace", `Remove workspace "${WS_NAME_A}"?`]);
+    const config = setup.dialogManager.lastHandle!.config;
+    expect(textsOf(config)).toEqual([
+      "Remove Workspace",
+      `Remove workspace "${WS_NAME_A}"?`,
+      "Could not check workspace status. Uncommitted changes or unmerged commits may be lost.",
+    ]);
+    // A failed check must not render as a verified-clean workspace.
+    const warnings = config.sections.filter(
+      (s) => s.type === "text" && "style" in s && s.style === "warning"
+    );
+    expect(warnings).toHaveLength(1);
 
     setup.dialogManager.lastHandle!.emitAction("cancel");
     await pending;

--- a/src/modules/deletion-dialog-module.ts
+++ b/src/modules/deletion-dialog-module.ts
@@ -151,6 +151,8 @@ interface RemoveConfirmState {
   readonly workspaceName: string;
   /** The background dirty/unmerged status check is still running. */
   readonly checking: boolean;
+  /** The background status check failed — dirty/unmerged state is unknown. */
+  readonly checkFailed: boolean;
   readonly isDirty: boolean;
   readonly unmergedCommits: number;
   /** Base branch name (workspace metadata), for the unmerged warning text. */
@@ -165,7 +167,16 @@ function buildRemoveConfirmConfig(state: RemoveConfirmState): DialogConfig {
   ];
 
   if (state.checking) {
-    sections.push({ type: "text", content: "Checking workspace status...", style: "subtitle" });
+    // Warning, not a dim subtitle: Remove is live while the check runs, so
+    // "we don't know yet whether this loses your work" is a caution to weigh.
+    sections.push({ type: "text", content: "Checking workspace status...", style: "warning" });
+  } else if (state.checkFailed) {
+    sections.push({
+      type: "text",
+      content:
+        "Could not check workspace status. Uncommitted changes or unmerged commits may be lost.",
+      style: "warning",
+    });
   } else {
     if (state.isDirty) {
       sections.push({
@@ -346,6 +357,7 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
     let state: RemoveConfirmState = {
       workspaceName: input.workspaceName,
       checking: true,
+      checkFailed: false,
       isDirty: false,
       unmergedCommits: 0,
       base: undefined,
@@ -355,8 +367,8 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
     let dialogOpen = true;
 
     // Background status check (refresh fetches remotes — slow). Never blocks
-    // the dialog; failures fall back to "no warnings", like the old renderer
-    // dialog did.
+    // the dialog; a failure warns that the status is unknown rather than
+    // silently rendering as "verified clean".
     void (async (): Promise<void> => {
       try {
         const [status, metadata] = await Promise.all([
@@ -372,16 +384,17 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
         state = {
           ...state,
           checking: false,
+          checkFailed: false,
           isDirty: status.isDirty,
           unmergedCommits: status.unmergedCommits,
           base: metadata["base"],
         };
       } catch (error) {
-        deps.logger.debug("Remove-confirm status check failed", {
+        deps.logger.warn("Remove-confirm status check failed", {
           workspace: input.workspacePath,
           error: getErrorMessage(error),
         });
-        state = { ...state, checking: false };
+        state = { ...state, checking: false, checkFailed: true };
       }
       if (dialogOpen) {
         handle.update(buildRemoveConfirmConfig(state));


### PR DESCRIPTION
- The remove-confirmation dialog now shows "Checking workspace status..." as a warning alert box instead of a dim subtitle, while the background dirty/unmerged check runs
- A failed status check now warns that the status is unknown ("Could not check workspace status. Uncommitted changes or unmerged commits may be lost.") instead of rendering nothing, which made it indistinguishable from a verified-clean workspace
- The failed check logs at `warn` instead of `debug`, so it is visible at the default log level now that it is surfaced to the user

Remove is live while the check runs, so both states could lose uncommitted work on a fast Enter — they now render in the same slot, and with the same styling, as the dirty/unmerged warnings they are replaced by.

Reported via PostHog bug report: https://eu.posthog.com/project/119202/error_tracking/019f65ab-c2dd-7cc2-a308-5758fb60673c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwSfHf3xMuarc5wnTwR9SE