### PR TITLE
fix(site): move the landing page to codehydra.stho.net

### DIFF
--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -33,7 +33,7 @@ Supported platforms:
 
 ## Links
 
-- [Website](https://codehydra.dev)
+- [Website](https://codehydra.stho.net)
 - [GitHub Repository](https://github.com/stefanhoelzl/codehydra)
 - [Releases](https://github.com/stefanhoelzl/codehydra/releases)
 

--- a/packages/pypi/README.md
+++ b/packages/pypi/README.md
@@ -33,7 +33,7 @@ Supported platforms:
 
 ## Links
 
-- [Website](https://codehydra.dev)
+- [Website](https://codehydra.stho.net)
 - [GitHub Repository](https://github.com/stefanhoelzl/codehydra)
 - [Releases](https://github.com/stefanhoelzl/codehydra/releases)
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -15,8 +15,8 @@
       property="og:description"
       content="Learn how to use CodeHydra for parallel AI-assisted development with isolated workspaces."
     />
-    <meta property="og:image" content="https://codehydra.dev/logo.png" />
-    <meta property="og:url" content="https://codehydra.dev/docs" />
+    <meta property="og:image" content="https://codehydra.stho.net/logo.png" />
+    <meta property="og:url" content="https://codehydra.stho.net/docs" />
     <meta property="og:type" content="website" />
 
     <link rel="icon" href="/logo.png" />

--- a/site/index.html
+++ b/site/index.html
@@ -18,8 +18,8 @@
       property="og:description"
       content="Run multiple AI coding assistants simultaneously in isolated git worktrees with real-time status monitoring."
     />
-    <meta property="og:image" content="https://codehydra.dev/logo.png" />
-    <meta property="og:url" content="https://codehydra.dev" />
+    <meta property="og:image" content="https://codehydra.stho.net/logo.png" />
+    <meta property="og:url" content="https://codehydra.stho.net" />
     <meta property="og:type" content="website" />
 
     <link rel="icon" href="/logo.png" />

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,1 +1,1 @@
-codehydra.dev
+codehydra.stho.net


### PR DESCRIPTION
`codehydra.dev` is registered outside our control and is expected to lapse within weeks.

The Pages `CNAME` file also makes `stefanhoelzl.github.io/codehydra/` 301 to the custom domain, so a lapsed `.dev` would leave the site with **no working URL** — and would keep forwarding visitors to whoever registers it next. This points the custom domain at a subdomain we own.

## Changes

- `site/public/CNAME` → `codehydra.stho.net` (this file *is* the GitHub Pages custom-domain binding)
- `og:image` / `og:url` in `site/index.html` and `site/docs.html` — the only absolute self-references in the site
- The `Website` link in the npm and PyPI READMEs (ships with the next release; published package metadata already points at GitHub, so nothing live is broken)

## DNS

`codehydra.stho.net` → `CNAME` → `stefanhoelzl.github.io`, already live at Bunny and resolving through public resolvers to all four Pages IPs.

## Not affected

Assets are relative via `base: "./"`. Auto-update resolves its feed from `electron-builder.yaml`'s GitHub provider, telemetry points at `eu.posthog.com`, and the npm/PyPI downloaders fetch from GitHub releases — none referenced the domain.

`planning/README_AND_LANDING_PAGE.md` keeps its old references; it is a historical record per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RFe3QBwNwRExHeTjoP1cF