### PR TITLE
fix: VSCodium secrets were not shared between workspaces

### DIFF
--- a/src/boundaries/shell/session.state-mock.ts
+++ b/src/boundaries/shell/session.state-mock.ts
@@ -48,6 +48,11 @@ export interface MockSessionState {
    * drive them directly and assert what a URL resolves to.
    */
   readonly protocolInterceptors: ReadonlyMap<string, ProtocolInterceptor>;
+  /**
+   * How many times the caches were dropped. A count, not a flag: whether a
+   * startup clears once or not at all is the behavior under test.
+   */
+  readonly cacheClearCount: number;
 }
 
 /**
@@ -85,6 +90,7 @@ interface MutableSessionState {
   hasPermissionCheckHandler: boolean;
   hasHeadersReceivedHandler: boolean;
   protocolInterceptors: Map<string, ProtocolInterceptor>;
+  cacheClearCount: number;
 }
 
 class SessionBoundaryMockStateImpl implements SessionBoundaryMockState {
@@ -210,6 +216,7 @@ export function createSessionBoundaryMock(
         hasPermissionCheckHandler: sessionState.hasPermissionCheckHandler ?? false,
         hasHeadersReceivedHandler: sessionState.hasHeadersReceivedHandler ?? false,
         protocolInterceptors: new Map(),
+        cacheClearCount: 0,
       });
       partitionToId.set(partition, id);
     }
@@ -239,6 +246,7 @@ export function createSessionBoundaryMock(
         hasPermissionCheckHandler: false,
         hasHeadersReceivedHandler: false,
         protocolInterceptors: new Map(),
+        cacheClearCount: 0,
       });
       partitionToId.set(partition, id);
 
@@ -270,6 +278,11 @@ export function createSessionBoundaryMock(
     ): void {
       const session = getSession(handle);
       session.protocolInterceptors.set(scheme, interceptor);
+    },
+
+    async clearCache(handle: SessionHandle): Promise<void> {
+      const session = getSession(handle);
+      session.cacheClearCount++;
     },
 
     async dispose(): Promise<void> {

--- a/src/boundaries/shell/session.ts
+++ b/src/boundaries/shell/session.ts
@@ -146,6 +146,19 @@ export interface SessionBoundary {
   setProtocolHandler(handle: SessionHandle, scheme: string, interceptor: ProtocolInterceptor): void;
 
   /**
+   * Drop everything this session has cached for the content it loads: the HTTP
+   * cache and the V8 code cache derived from it.
+   *
+   * Caches only — never storage. Cookies, localStorage and IndexedDB are
+   * untouched, so the extension `globalState` and `secretStorage` that live in
+   * this partition survive the call.
+   *
+   * @param handle - Handle to the session
+   * @throws ShellError with code SESSION_NOT_FOUND if handle is invalid
+   */
+  clearCache(handle: SessionHandle): Promise<void>;
+
+  /**
    * Dispose of all resources.
    */
   dispose(): Promise<void>;
@@ -256,6 +269,18 @@ export class DefaultSessionBoundary implements SessionBoundary {
     });
 
     this.logger.debug("Protocol handler set", { id: handle.id, scheme });
+  }
+
+  async clearCache(handle: SessionHandle): Promise<void> {
+    const state = this.getSession(handle);
+
+    // Both, and in this order: clearCache drops the response bodies, and
+    // clearCodeCaches ({urls: []} means every entry) drops the compiled form
+    // Chromium kept alongside them.
+    await state.session.clearCache();
+    await state.session.clearCodeCaches({ urls: [] });
+
+    this.logger.debug("Session cache cleared", { id: handle.id });
   }
 
   async dispose(): Promise<void> {

--- a/src/modules/ide-server-module/bundle-patches.integration.test.ts
+++ b/src/modules/ide-server-module/bundle-patches.integration.test.ts
@@ -29,6 +29,17 @@ const REAL_WIRING =
   'async writeText(y,w){return g.writeText(w,y==="p"?"selection":"clipboard")}}),' +
   "this.raw.loadAddon(this._clipboardAddon))});";
 
+/** The workbench bootstrap's secretStorageProvider wiring, as shipped. */
+const REAL_SECRET_WIRING =
+  'const s=Xe.document.getElementById("vscode-workbench-web-configuration"),' +
+  'e=s?s.getAttribute("data-settings"):void 0;const t=JSON.parse(e),i=ldo("vscode-secret-key-path"),' +
+  "n=i&&Yns.supported()?new Yns(i):new odo;sdo(Xe.document.body,{...t," +
+  "urlCallbackProvider:new rdo(t.callbackRoute)," +
+  "secretStorageProvider:t.remoteAuthority&&!i?void 0:new Qns(n)})})();";
+
+/** The workbench as shipped, carrying both of its patch targets. */
+const REAL_WORKBENCH = REAL_WIRING + REAL_SECRET_WIRING;
+
 /** The normalizeOptions loop the watcher patch anchors on, as shipped. */
 const REAL_WRAPPER_LOOP =
   "  if (Array.isArray(ignore)) {\n" +
@@ -37,8 +48,8 @@ const REAL_WRAPPER_LOOP =
   "    for (const value of ignore) {\n" +
   "      if (isGlob(value)) {\n";
 
-/** A bundle carrying both patch targets. */
-function bundle(workbench: string = REAL_WIRING): MockFileSystemBoundary {
+/** A bundle carrying every patch target. */
+function bundle(workbench: string = REAL_WORKBENCH): MockFileSystemBoundary {
   const fsLayer = createFileSystemMock();
   fsLayer.$.setEntry(WRAPPER, file(REAL_WRAPPER_LOOP));
   fsLayer.$.setEntry(WORKBENCH, file(workbench));
@@ -112,6 +123,51 @@ describe("OSC 52 clipboard patch", () => {
       await applyBundlePatches(deps(fsLayer, platform), "/bundle");
 
       expect(fsLayer).toHaveFileContaining(WORKBENCH, '?"selection":void 0');
+    }
+  });
+});
+
+// =============================================================================
+// The secret-storage persistence patch, through the registry
+// =============================================================================
+
+describe("secret storage persistence patch", () => {
+  it("installs the storage provider unconditionally, so secrets survive a reload", async () => {
+    const fsLayer = bundle();
+
+    await applyBundlePatches(deps(fsLayer), "/bundle");
+
+    // Without this, the provider is `void 0` under reh-web (which always sets a
+    // remoteAuthority) and every secret lives only in the iframe's heap.
+    expect(fsLayer).toHaveFileContaining(WORKBENCH, "secretStorageProvider:new Qns(n)");
+    expect(fsLayer).not.toHaveFileContaining(WORKBENCH, "?void 0:new Qns(n)");
+  });
+
+  it("keeps the crypto the bootstrap already built", async () => {
+    const fsLayer = bundle();
+
+    await applyBundlePatches(deps(fsLayer), "/bundle");
+
+    // `n` is the cookie-less bootstrap's transparent crypto — secrets persist as
+    // plaintext in localStorage, shared across every same-origin workspace.
+    expect(fsLayer).toHaveFileContaining(WORKBENCH, "n=i&&Yns.supported()?new Yns(i):new odo;");
+  });
+
+  it("matches regardless of the minifier's identifiers", async () => {
+    const fsLayer = bundle("secretStorageProvider:$c.remoteAuthority&&!$k?void 0:new $P($x)})");
+
+    await applyBundlePatches(deps(fsLayer), "/bundle");
+
+    expect(fsLayer).toHaveFile(WORKBENCH, "secretStorageProvider:new $P($x)})");
+  });
+
+  it("applies on every platform", async () => {
+    for (const platform of ["linux", "darwin", "win32"] as const) {
+      const fsLayer = bundle();
+
+      await applyBundlePatches(deps(fsLayer, platform), "/bundle");
+
+      expect(fsLayer).toHaveFileContaining(WORKBENCH, "secretStorageProvider:new Qns(n)");
     }
   });
 });
@@ -245,7 +301,7 @@ describe("applyBundlePatches", () => {
   it("applies the remaining patches when one target is missing", async () => {
     // No wrapper.js — the workbench patch must still land.
     const fsLayer = createFileSystemMock();
-    fsLayer.$.setEntry(WORKBENCH, file(REAL_WIRING));
+    fsLayer.$.setEntry(WORKBENCH, file(REAL_WORKBENCH));
 
     await applyBundlePatches(deps(fsLayer, "win32"), "/bundle");
 
@@ -304,7 +360,7 @@ describe("when a patch no longer matches the bundle", () => {
         },
         "/bundle"
       )
-    ).rejects.toThrow(/osc52-clipboard, watcher-ignore-separators/);
+    ).rejects.toThrow(/osc52-clipboard, secret-storage-persistence, watcher-ignore-separators/);
   });
 
   it("logs and starts anyway when packaged: a stale anchor must not brick the app", async () => {

--- a/src/modules/ide-server-module/bundle-patches.integration.test.ts
+++ b/src/modules/ide-server-module/bundle-patches.integration.test.ts
@@ -311,7 +311,32 @@ describe("applyBundlePatches", () => {
   it("never throws when the bundle is missing entirely", async () => {
     const fsLayer = createFileSystemMock();
 
-    await expect(applyBundlePatches(deps(fsLayer, "win32"), "/bundle")).resolves.toBeUndefined();
+    await expect(applyBundlePatches(deps(fsLayer, "win32"), "/bundle")).resolves.toBe(false);
+  });
+
+  it("reports a rewrite, so the caller knows the caches are now stale", async () => {
+    const fsLayer = bundle();
+
+    // The bundle on disk no longer matches what the IDE server may have served.
+    await expect(applyBundlePatches(deps(fsLayer, "win32"), "/bundle")).resolves.toBe(true);
+  });
+
+  it("reports no rewrite once every patch is already applied", async () => {
+    const fsLayer = bundle();
+
+    await applyBundlePatches(deps(fsLayer, "win32"), "/bundle");
+
+    // Steady state: nothing changed, so nothing needs invalidating.
+    await expect(applyBundlePatches(deps(fsLayer, "win32"), "/bundle")).resolves.toBe(false);
+  });
+
+  it("reports no rewrite when a patch merely drifted", async () => {
+    // Nothing was written, so there is nothing to invalidate — a stale anchor
+    // must not also cost a cache.
+    const fsLayer = createFileSystemMock();
+    fsLayer.$.setEntry(WORKBENCH, file("async writeText(y,w){return g.setClipboard(w,y)}"));
+
+    await expect(applyBundlePatches(deps(fsLayer, "linux"), "/bundle")).resolves.toBe(false);
   });
 });
 
@@ -372,7 +397,7 @@ describe("when a patch no longer matches the bundle", () => {
         { fileSystemLayer: fsLayer, logger, platform: "linux", isPackaged: true },
         "/bundle"
       )
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
 
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("neither the original nor the patched shape found"),
@@ -389,8 +414,8 @@ describe("when a patch no longer matches the bundle", () => {
       isPackaged: false,
     };
 
-    await expect(applyBundlePatches(devDeps, "/bundle")).resolves.toBeUndefined();
+    await expect(applyBundlePatches(devDeps, "/bundle")).resolves.toBe(true);
     // Second startup: everything is already applied, still no throw.
-    await expect(applyBundlePatches(devDeps, "/bundle")).resolves.toBeUndefined();
+    await expect(applyBundlePatches(devDeps, "/bundle")).resolves.toBe(false);
   });
 });

--- a/src/modules/ide-server-module/bundle-patches.ts
+++ b/src/modules/ide-server-module/bundle-patches.ts
@@ -130,6 +130,68 @@ const OSC52_CLIPBOARD: TextPatch = {
 };
 
 /**
+ * Persist extension secrets (sign-in tokens).
+ *
+ * `context.secrets` is where extensions keep credentials — the GitHub Pull
+ * Requests extension reaches it through `vscode.authentication.getSession`, which
+ * the built-in `github-authentication` extension backs with a secret under
+ * `{"extensionId":"vscode.github-authentication","key":"github.auth"}`. The
+ * extension host is remote, so that call proxies to the *workbench page's*
+ * `ISecretStorageService`: the iframe decides where the token lives, not the
+ * server.
+ *
+ * In web, that service never persists on its own. `BrowserSecretStorageService`
+ * hands its base class `_useInMemoryStorage: true` outright (`super(!0,…)`), and
+ * the browser's encryption service answers `isEncryptionAvailable()` with a flat
+ * `false`, so the one remaining branch logs "Encryption is not available, falling
+ * back to in-memory storage" and keeps secrets in a plain `Map`. The only escape
+ * is an embedder-supplied `secretStorageProvider`, and the workbench bootstrap
+ * gates that on:
+ *
+ *     secretStorageProvider: config.remoteAuthority && !secretKeyPath ? void 0 : new LocalStorageSecretStorageProvider(crypto)
+ *
+ * reh-web always sets `remoteAuthority` (the server fills it from the request
+ * host), and `secretKeyPath` comes from a `vscode-secret-key-path` cookie that
+ * only Codespaces-style embedders set — nothing in the bundle or in CodeHydra
+ * does. So the provider is always `undefined` and every secret lives in the
+ * iframe's heap: a token minted in one workspace is invisible to the next, and any
+ * reload, hibernation or restart drops it. That is the whole bug — users had to
+ * sign in to GitHub again in every workspace, over and over.
+ *
+ * This is a regression from our own migration, not new upstream breakage.
+ * code-server — the IDE server we shipped before VSCodium — patched this exact
+ * expression, replacing the cookie lookup with a path it always computes
+ * (`location.pathname + "/mint-key"`), so `!secretKeyPath` was never true and the
+ * provider was always installed, sealed against a 256-bit key from its own
+ * `/mint-key` route. Stock VSCodium has no such route and no such patch.
+ *
+ * Forcing the provider on restores persistence. The crypto argument is whatever
+ * the bootstrap already built, which — with the cookie absent — is the
+ * *transparent* crypto, so secrets land as plaintext JSON in `localStorage` under
+ * `secrets.provider`. That is a deliberate trade: every workspace is an iframe on
+ * the same `127.0.0.1` origin inside the shared `persist:codehydra-global`
+ * partition, so localStorage is exactly the storage that makes one sign-in cover
+ * every workspace and survive a restart. code-server's encryption bought little
+ * over it — its key came from an unauthenticated localhost route that any local
+ * process could mint from, the same process that could already read the
+ * partition off disk.
+ *
+ * A `secrets.provider` blob left behind by the code-server era is sealed with a
+ * key we no longer have, so the provider's `load()` fails to `JSON.parse` it,
+ * catches, and clears the key — old data degrades to a fresh sign-in rather than
+ * breaking startup.
+ */
+const SECRET_STORAGE_PERSISTENCE: TextPatch = {
+  id: "secret-storage-persistence",
+  file: "out/vs/code/browser/workbench/workbench.js",
+  find: /secretStorageProvider:[\w$]+\.remoteAuthority&&![\w$]+\?void 0:new ([\w$]+)\(([\w$]+)\)/g,
+  replace: (provider, crypto) => `secretStorageProvider:new ${provider}(${crypto})`,
+  applied: /secretStorageProvider:new [\w$]+\([\w$]+\)/,
+  whenMissing:
+    "extension sign-ins (e.g. the GitHub Pull Requests extension) will not persist and must be repeated in every workspace",
+};
+
+/**
  * Forward-slash-normalize the native file watcher's ignore globs (Windows only).
  *
  * `@parcel/watcher` compiles each glob `ignore` pattern into a C++ `std::regex`
@@ -166,7 +228,11 @@ const WATCHER_IGNORE_SEPARATORS: TextPatch = {
 };
 
 /** Every patch. */
-const TEXT_PATCHES: readonly TextPatch[] = [OSC52_CLIPBOARD, WATCHER_IGNORE_SEPARATORS];
+const TEXT_PATCHES: readonly TextPatch[] = [
+  OSC52_CLIPBOARD,
+  SECRET_STORAGE_PERSISTENCE,
+  WATCHER_IGNORE_SEPARATORS,
+];
 
 // =============================================================================
 // Engine

--- a/src/modules/ide-server-module/bundle-patches.ts
+++ b/src/modules/ide-server-module/bundle-patches.ts
@@ -32,6 +32,16 @@
  * its own marker (`applied`), so there is no sidecar marker file that could go
  * stale when the bundle is re-downloaded.
  *
+ * ## Patching the file is only half of it
+ *
+ * The distribution serves its static assets with a year-long `Cache-Control` and
+ * no ETag, under a URL keyed on the VSCodium commit — which patching does not
+ * change. A patched file on disk is therefore *not* a patched workbench in the
+ * iframe: the session keeps serving the copy it cached the first time it loaded
+ * that version, and the patch sits inert behind it. `applyBundlePatches` reports
+ * whether it rewrote anything so its caller can drop those caches; the `start`
+ * hook in `ide-server-module.ts` is where that happens, and why.
+ *
  * ## When a patch stops matching
  *
  * A patch that finds neither its original nor its patched shape has drifted from
@@ -320,14 +330,22 @@ export async function applyTextPatch(
 /**
  * Apply every bundle patch that targets this platform.
  *
+ * Returns whether any patch actually rewrote a file — i.e. whether the bundle on
+ * disk now differs from what the IDE server may already have served. The caller
+ * owes the caches an invalidation when it does; see the module doc.
+ *
  * Unpackaged (dev): a patch that cannot be applied throws, failing startup, so the
  * developer who bumped the bundle cannot miss it. Packaged: every failure is
  * logged and swallowed — one stale anchor must not keep the IDE server (and with
  * it every workspace) from starting. See the module doc.
  */
-export async function applyBundlePatches(deps: BundlePatchDeps, bundleDir: string): Promise<void> {
+export async function applyBundlePatches(
+  deps: BundlePatchDeps,
+  bundleDir: string
+): Promise<boolean> {
   const { fileSystemLayer, logger, platform, isPackaged } = deps;
   const failed: string[] = [];
+  let rewroteBundle = false;
 
   for (const patch of TEXT_PATCHES) {
     if (patch.platform !== undefined && patch.platform !== platform) continue;
@@ -335,6 +353,7 @@ export async function applyBundlePatches(deps: BundlePatchDeps, bundleDir: strin
     try {
       const result = await applyTextPatch({ fileSystemLayer, logger }, bundleDir, patch);
       logger.debug("Bundle patch pass complete", { id: patch.id, result });
+      if (result === "applied") rewroteBundle = true;
       if (result === "not-found") failed.push(patch.id);
     } catch (error) {
       // An I/O failure (unwritable bundle, …) rather than a stale anchor.
@@ -351,4 +370,6 @@ export async function applyBundlePatches(deps: BundlePatchDeps, bundleDir: strin
         `patterns in bundle-patches.ts. (Packaged builds log this and start anyway.)`
     );
   }
+
+  return rewroteBundle;
 }

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -8,12 +8,18 @@
  */
 
 import { createMockDispatcher } from "../../intents/lib/dispatcher.test-utils";
-import { createSessionBoundaryMock } from "../../boundaries/shell/session.state-mock";
+import {
+  createSessionBoundaryMock,
+  type MockSessionBoundary,
+} from "../../boundaries/shell/session.state-mock";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // The patches' own behavior is covered in bundle-patches.integration.test.ts;
 // here we only assert the start hook wires them in, against the bundle dir.
-vi.mock("./bundle-patches", () => ({ applyBundlePatches: vi.fn().mockResolvedValue(undefined) }));
+// Resolves false by default — the steady state is a bundle that is already
+// patched. Passed as vi.fn's implementation rather than mockResolvedValue so the
+// suite's `mockReset` restores it between tests; a rewrite is opted into per test.
+vi.mock("./bundle-patches", () => ({ applyBundlePatches: vi.fn(async () => false) }));
 import { delimiter, join } from "node:path";
 
 import { z } from "zod/v4";
@@ -639,6 +645,56 @@ describe("IdeServerModule", () => {
       const patchedAt = vi.mocked(applyBundlePatches).mock.invocationCallOrder[0]!;
       const startedAt = vi.mocked(deps.portManager.isPortAvailable).mock.invocationCallOrder[0]!;
       expect(patchedAt).toBeLessThan(startedAt);
+    });
+
+    /** How many times the workspace session's caches were dropped. */
+    function cacheClears(deps: ReturnType<typeof createMockDeps>): number {
+      const sessionLayer = deps.sessionLayer as MockSessionBoundary;
+      const handle = sessionLayer.fromPartition("persist:test");
+      return sessionLayer.$.sessions.get(handle.id)?.cacheClearCount ?? 0;
+    }
+
+    it("drops the stale caches when a patch rewrote the bundle", async () => {
+      vi.mocked(applyBundlePatches).mockResolvedValue(true);
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      // The distribution serves the workbench with a year-long Cache-Control and
+      // no ETag, under a URL a patch does not change — so without this the iframe
+      // keeps loading the copy it cached before the patch existed.
+      expect(cacheClears(deps)).toBe(1);
+    });
+
+    it("leaves the caches alone when every patch was already applied", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      // Steady state on every startup: re-fetching 17 MB would cost real time
+      // for nothing.
+      expect(cacheClears(deps)).toBe(0);
+    });
+
+    it("starts the server anyway when the caches refuse to clear", async () => {
+      vi.mocked(applyBundlePatches).mockResolvedValue(true);
+      const deps = createMockDeps();
+      const sessionLayer = deps.sessionLayer as MockSessionBoundary;
+      vi.spyOn(sessionLayer, "clearCache").mockRejectedValue(new Error("cache locked"));
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      const ideServerPort = (await dispatcher.dispatch({
+        type: "app:start",
+        payload: {},
+      })) as number | undefined;
+
+      // A cache that will not clear costs the patch, not every workspace.
+      expect(ideServerPort).toBe(25448);
     });
 
     it("checks port availability before spawning", async () => {

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -159,7 +159,10 @@ export interface IdeServerModuleDeps {
    * Session the workspace iframes load in. The module intercepts the webview
    * shell requests on it (see `IdeServer.webviewAsset`).
    */
-  readonly sessionLayer: Pick<SessionBoundary, "fromPartition" | "setProtocolHandler">;
+  readonly sessionLayer: Pick<
+    SessionBoundary,
+    "fromPartition" | "setProtocolHandler" | "clearCache"
+  >;
   /** Partition name of that session. */
   readonly sessionPartition: string;
   readonly pathProvider: Pick<PathProvider, "bundlePath" | "dataPath">;
@@ -360,6 +363,30 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
     );
 
     logger.debug("Webview interceptor registered", { partition: deps.sessionPartition });
+  }
+
+  /**
+   * Drop what the workspace iframes have cached of the bundle, so a freshly
+   * patched file is the one they actually load (see the `start` hook).
+   *
+   * Caches only: the session's cookies, localStorage and IndexedDB are left
+   * alone, so extension `globalState` and `secretStorage` — including the GitHub
+   * sign-in — survive. Best-effort, because a cache that refuses to clear is not
+   * worth failing every workspace over; the patch simply stays dormant until the
+   * next startup, which is where it already was.
+   */
+  async function clearIdeCaches(): Promise<void> {
+    try {
+      const handle = deps.sessionLayer.fromPartition(deps.sessionPartition);
+      await deps.sessionLayer.clearCache(handle);
+      logger.info("Cleared IDE caches after patching the bundle", {
+        partition: deps.sessionPartition,
+      });
+    } catch (error) {
+      logger.error("Failed to clear IDE caches; bundle patches may not take effect", {
+        error: getErrorMessage(error),
+      });
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -696,7 +723,7 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
             // missing; patches are idempotent, so installs that predate a patch
             // are fixed here too. Throws in dev if a patch no longer matches the
             // bundle, so a version bump can't silently un-fix it (bundle-patches.ts).
-            await applyBundlePatches(
+            const rewroteBundle = await applyBundlePatches(
               {
                 fileSystemLayer: deps.fileSystemLayer,
                 logger,
@@ -705,6 +732,21 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
               },
               resolveIdeServerPaths().ideServerDir
             );
+
+            // A patched file on disk is not a patched workbench in the iframe.
+            // The distribution serves its static assets with `Cache-Control:
+            // public, max-age=31536000` and no ETag, under a URL keyed on the
+            // VSCodium commit — which a patch does not change. So the session
+            // holds a year-long, never-revalidated copy of the *unpatched*
+            // workbench, and every patch we apply is inert until that copy goes.
+            // Dropping the caches here — before the server can serve a request
+            // and long before the first iframe loads — is what makes a patch
+            // reach the user. Only when a patch actually rewrote something:
+            // steady state is "already-applied", and re-fetching 17 MB on every
+            // startup would be a real cost for no gain.
+            if (rewroteBundle) {
+              await clearIdeCaches();
+            }
 
             // Ensure required directories exist
             await Promise.all([


### PR DESCRIPTION
Reported twice via PostHog on 2026-07-17: the GitHub Pull Requests extension lost its authentication — users had to sign in again in every workspace, and the login never survived a reload.

**Root cause**

- `context.secrets` proxies from the remote extension host to the workbench page's `ISecretStorageService`. In web, that service never persists on its own: `BrowserSecretStorageService` passes `_useInMemoryStorage: true` outright, and the browser encryption service reports no encryption — so secrets land in a plain `Map`.
- The only escape is an embedder-supplied `secretStorageProvider`, which the bootstrap withholds whenever a `remoteAuthority` is set without a `vscode-secret-key-path` cookie. reh-web always sets the former; nothing sets the latter. Every token therefore lived in one iframe's heap: invisible to the next workspace, gone on reload.
- A regression from our own migration rather than upstream breakage — code-server patched this same expression to always install the provider; 7369e502 switched to stock VSCodium and lost that patch.

**Fixes**

- Force the provider on via a new `secret-storage-persistence` bundle patch, reusing the crypto the bootstrap already built. Secrets persist under `secrets.provider` in localStorage — the storage that makes one sign-in cover every workspace, since they are all iframes on the same origin inside the shared `persist:codehydra-global` partition.
- Drop the IDE caches when a patch actually rewrites the bundle. The distribution serves static assets with `Cache-Control: public, max-age=31536000` and no ETag, under a URL keyed on the VSCodium commit — which patching does not change. **Every bundle patch was inert behind that cache**; the cached body for the current commit predated the OSC 52 clipboard fix, so that fix had never once run. Caches only (HTTP + V8 code cache), never storage, so `globalState` and `secretStorage` survive.

**Verification**

- Patch matches the real 17MB bundle exactly once, is idempotent, and the `applied` marker does not false-positive on the original.
- Startup applies it to the real bundle and clears the caches (25 entries/23M → 2/28K, workbench.js gone) while Local Storage and Cookies stay intact.
- A live workspace iframe then re-fetches and runs the patched code (patched: 1, unpatched: 0, OSC 52 patched: 1), with `remoteAuthority` set and the cookie absent — the exact bug precondition.

Note: a full GitHub sign-in round-trip was not exercised (needs real credentials); the mechanism the token depends on was verified instead.