### PR TITLE
feat: workspace title is shown in the title bar

### DIFF
--- a/docs/USER_INTERFACE.md
+++ b/docs/USER_INTERFACE.md
@@ -43,7 +43,7 @@ The sidebar minimizes by default to 20px, showing status indicators only. Hover 
 - **Sidebar**: 250px wide when expanded, 20px when minimized (hover to expand)
 - **VS Code area**: Starts at x=20px, expanded sidebar overlays it
 - **Window minimum size**: 800x600
-- **Window title**: "CodeHydra - Project / Workspace - (version)" or "CodeHydra - (version)" if no workspace
+- **Window title**: "Title / Workspace / Project - CodeHydra (version)", dropping the leading "Title / " when the workspace has no user-given title, or "CodeHydra (version)" if no workspace. Most-specific-first so the workspace survives taskbar truncation; the title is the workspace metadata `title`, shown alongside the branch name rather than replacing it
 - **Update available**: Title includes " - (X.Y.Z update available)" suffix when an update is downloaded and ready
 
 ### Sidebar Expansion Behavior

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -51,6 +51,8 @@ export interface MockWorkspaceEntry {
   readonly branch?: string | null;
   /** Explicit active flag; when omitted, derived from the viewManager (if any). */
   readonly active?: boolean;
+  /** Raw domain metadata; when omitted, resolve defaults it to empty. */
+  readonly metadata?: Readonly<Record<string, string>>;
 }
 
 export interface MockProjectEntry {
@@ -87,7 +89,10 @@ export interface TestMockConfig {
 /** Minimal project shape for {@link workspacesFromProjects}. */
 export interface ProjectWithWorkspaces {
   readonly path: string;
-  readonly workspaces?: ReadonlyArray<{ readonly path: string }>;
+  readonly workspaces?: ReadonlyArray<{
+    readonly path: string;
+    readonly metadata?: Readonly<Record<string, string>>;
+  }>;
 }
 
 /**
@@ -100,10 +105,12 @@ export function workspacesFromProjects(
 ): (workspacePath: string) => MockWorkspaceEntry | undefined {
   return (workspacePath) => {
     for (const project of getProjects()) {
-      if (project.workspaces?.some((w) => w.path === workspacePath)) {
+      const workspace = project.workspaces?.find((w) => w.path === workspacePath);
+      if (workspace) {
         return {
           projectPath: project.path,
           workspaceName: workspacePath.slice(workspacePath.lastIndexOf("/") + 1) as WorkspaceName,
+          ...(workspace.metadata !== undefined && { metadata: workspace.metadata }),
         };
       }
     }

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -92,7 +92,25 @@ describe("ResolveWorkspaceOperation Integration", () => {
         active: false,
         // Defaults to null when no handler provides a branch.
         branch: null,
+        // Defaults to empty when no handler provides metadata.
+        metadata: {},
       });
+    });
+
+    it("returns the metadata when a handler provides it", async () => {
+      const { dispatcher } = createTestSetup(
+        async (): Promise<HookOutput<ResolveHookResult>> => ({
+          result: {
+            projectPath: PROJECT_PATH,
+            workspaceName: WORKSPACE_NAME,
+            metadata: { title: "Fix login bug", hibernated: "true" },
+          },
+        })
+      );
+
+      const result = await dispatcher.dispatch(resolveIntent(WORKSPACE_PATH));
+
+      expect(result.metadata).toEqual({ title: "Fix login bug", hibernated: "true" });
     });
 
     it("returns the branch when a handler provides it", async () => {

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -41,6 +41,9 @@ export const resolveWorkspaceResultSchema = z
     active: z.boolean(),
     /** Current branch name, or null for detached HEAD. */
     branch: z.string().nullable(),
+    /** The workspace's raw domain metadata. Consumers interpret it (never store
+     *  it raw) — see `readTitle`/`extractTags` in shared/api/types. */
+    metadata: z.record(z.string(), z.string()).readonly(),
   })
   .readonly();
 
@@ -51,6 +54,7 @@ export const resolveHookResultSchema = z
     workspaceName: workspaceNameSchema.optional(),
     active: z.boolean().optional(),
     branch: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.string()).readonly().optional(),
   })
   .readonly();
 
@@ -108,17 +112,19 @@ export class ResolveWorkspaceOperation implements Operation<typeof schemas> {
     // branch can legitimately be null (detached HEAD), so track "provided"
     // separately from the null value.
     let branch: string | null = null;
+    let metadata: Readonly<Record<string, string>> = {};
     for (const r of results) {
       if (r.projectPath !== undefined) projectPath = r.projectPath;
       if (r.workspaceName !== undefined) workspaceName = r.workspaceName;
       if (r.active === true) active = true;
       if (r.branch !== undefined) branch = r.branch;
+      if (r.metadata !== undefined) metadata = r.metadata;
     }
 
     if (!projectPath || !workspaceName) {
       throw new Error(`Workspace not found: ${payload.workspacePath}`);
     }
 
-    return { projectPath, workspaceName, active, branch };
+    return { projectPath, workspaceName, active, branch, metadata };
   }
 }

--- a/src/intents/switch-workspace.integration.test.ts
+++ b/src/intents/switch-workspace.integration.test.ts
@@ -293,7 +293,24 @@ describe("SwitchWorkspace Operation", () => {
         projectPath: TEST_PROJECT_PATH,
         workspaceName: TEST_WORKSPACE_NAME,
         path: TEST_WORKSPACE_PATH,
+        metadata: {},
       });
+    });
+
+    it("carries the resolved workspace's metadata", async () => {
+      const project = createTestProject();
+      project.workspaces[0]!.metadata = { title: "Fix login bug", "tags.wip": "{}" };
+      const { dispatcher } = createTestSetup({ projects: [project] });
+
+      const receivedEvents: DomainEvent[] = [];
+      dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
+        receivedEvents.push(event);
+      });
+
+      await dispatcher.dispatch(switchIntent());
+
+      const event = receivedEvents[0] as WorkspaceSwitchedEvent;
+      expect(event.payload?.metadata).toEqual({ title: "Fix login bug", "tags.wip": "{}" });
     });
   });
 

--- a/src/intents/switch-workspace.ts
+++ b/src/intents/switch-workspace.ts
@@ -91,6 +91,12 @@ export const workspaceSwitchedPayloadSchema = z
     projectPath: z.string(),
     workspaceName: workspaceNameSchema,
     path: z.string(),
+    /** The workspace's raw domain metadata, as resolved at switch time. It is
+     *  the baseline consumers can't reconstruct from workspace:metadata-changed
+     *  alone: metadata persists in git config across restarts, so a title set in
+     *  an earlier run never re-emits as a change. Consumers interpret it (see
+     *  `readTitle`/`extractTags`) and keep the meanings, never the raw map. */
+    metadata: z.record(z.string(), z.string()).readonly(),
   })
   .readonly();
 
@@ -320,7 +326,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
     }
 
     // 1. Dispatch shared workspace resolution
-    const { projectPath, workspaceName, active } = await ctx.dispatch({
+    const { projectPath, workspaceName, active, metadata } = await ctx.dispatch({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath: payload.workspacePath },
     } as ResolveWorkspaceIntent);
@@ -359,6 +365,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
         projectPath,
         workspaceName,
         path: resolvedPath,
+        metadata,
       },
     };
     ctx.emit(event);

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -111,6 +111,7 @@ export function createGitWorktreeWorkspaceModule(
         projectPath: string;
         workspaceName: WorkspaceName;
         branch: string | null;
+        metadata: Readonly<Record<string, string>>;
       }
     | undefined {
     const normalizedPath = new Path(workspacePath).toString();
@@ -125,6 +126,7 @@ export function createGitWorktreeWorkspaceModule(
             // case-sensitive name matching for uppercase workspace names.
             workspaceName: ws.name as WorkspaceName,
             branch: ws.branch,
+            metadata: ws.metadata,
           };
         }
       }

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -40,7 +40,7 @@ import type { IViewManager } from "../../boundaries/shell/view-manager.interface
 import type { Theme } from "../../boundaries/shell/window-manager";
 import type { Unsubscribe } from "../../shared/api/interfaces";
 import type { AgentStatus, DeletionProgress, WorkspaceTag } from "../../shared/api/types";
-import { extractTags, TAGS_METADATA_KEY_PREFIX } from "../../shared/api/types";
+import { extractTags, readTitle, TAGS_METADATA_KEY_PREFIX } from "../../shared/api/types";
 import {
   APP_SHUTDOWN_OPERATION_ID,
   INTENT_APP_SHUTDOWN,
@@ -228,15 +228,6 @@ interface WorkspaceModel {
   tags: WorkspaceTag[];
   url: string | undefined;
   creating: boolean;
-}
-
-/**
- * Interpret a raw metadata `title` into the model field: trim, and treat an
- * empty string as unset (undefined) so an emptied title reverts to the branch.
- */
-function readTitle(value: string | null | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
 }
 
 /** Interpret a workspace's domain metadata into the semantic model fields. */

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -124,6 +124,7 @@ class MinimalSwitchOperation implements Operation<typeof switchOpSchemas> {
           projectPath: "/projects/test",
           workspaceName: workspaceName as WorkspaceName,
           path: resolvedPath,
+          metadata: {},
         },
       };
       ctx.emit(event);

--- a/src/modules/window-title-module.integration.test.ts
+++ b/src/modules/window-title-module.integration.test.ts
@@ -15,6 +15,8 @@ import { Dispatcher } from "../intents/lib/dispatcher";
 import { z } from "zod/v4";
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import type { WorkspaceSwitchedEvent } from "../intents/switch-workspace";
+import { EVENT_METADATA_CHANGED } from "../intents/set-metadata";
+import type { MetadataChangedEvent } from "../intents/set-metadata";
 import type { Operation, OperationSchemas } from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import type { Intent } from "../intents/lib/types";
@@ -37,6 +39,7 @@ interface MinimalSwitchPayload {
   readonly projectName: string;
   readonly workspaceName: WorkspaceName;
   readonly path: string;
+  readonly metadata?: Readonly<Record<string, string>>;
 }
 
 interface MinimalSwitchIntent extends Intent<void> {
@@ -64,8 +67,53 @@ const minimalSwitchOperation: Operation<typeof minimalSwitchSchemas> = {
             projectPath: "/projects/test",
             workspaceName: payload.workspaceName,
             path: payload.path,
+            metadata: payload.metadata ?? {},
           }
         : null,
+    };
+    ctx.emit(event);
+  },
+};
+
+// =============================================================================
+// Minimal set-metadata operation that emits workspace:metadata-changed
+// =============================================================================
+
+const INTENT_MINIMAL_SET_METADATA = "workspace:set-metadata" as const;
+
+interface MinimalSetMetadataPayload {
+  readonly projectId: ProjectId;
+  readonly workspaceName: WorkspaceName;
+  readonly workspacePath: string;
+  readonly key: string;
+  readonly value: string | null;
+}
+
+interface MinimalSetMetadataIntent extends Intent<void> {
+  readonly type: typeof INTENT_MINIMAL_SET_METADATA;
+  readonly payload: MinimalSetMetadataPayload;
+}
+
+const minimalSetMetadataSchemas = {
+  type: INTENT_MINIMAL_SET_METADATA,
+  payload: z.unknown(),
+} satisfies OperationSchemas;
+
+const minimalSetMetadataOperation: Operation<typeof minimalSetMetadataSchemas> = {
+  id: "set-metadata",
+  schemas: minimalSetMetadataSchemas,
+  async execute(ctx): Promise<void> {
+    const payload = ctx.intent.payload as MinimalSetMetadataPayload;
+
+    const event: MetadataChangedEvent = {
+      type: EVENT_METADATA_CHANGED,
+      payload: {
+        projectId: payload.projectId,
+        workspaceName: payload.workspaceName,
+        workspacePath: payload.workspacePath,
+        key: payload.key,
+        value: payload.value,
+      },
     };
     ctx.emit(event);
   },
@@ -86,6 +134,7 @@ function createTestSetup(titleVersion?: string): TestSetup {
   const dispatcher = createMockDispatcher();
 
   dispatcher.registerOperation(minimalSwitchOperation);
+  dispatcher.registerOperation(minimalSetMetadataOperation);
   dispatcher.registerOperation(
     createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
   );
@@ -114,24 +163,60 @@ function startIntent(): AppStartIntent {
   };
 }
 
+function setMetadataIntent(payload: MinimalSetMetadataPayload): MinimalSetMetadataIntent {
+  return {
+    type: INTENT_MINIMAL_SET_METADATA,
+    payload,
+  };
+}
+
+/** The active workspace used by the title/rename tests. */
+const ACTIVE: MinimalSwitchPayload = {
+  projectId: "test-project" as ProjectId,
+  projectName: "MyProject",
+  workspaceName: "feature-branch" as WorkspaceName,
+  path: "/workspaces/feature-branch",
+};
+
 // =============================================================================
 // Tests
 // =============================================================================
 
 describe("WindowTitleModule Integration", () => {
-  it("sets title with project/workspace on workspace switch", async () => {
+  it("sets title with workspace/project on workspace switch", async () => {
+    const { dispatcher, setTitle } = createTestSetup();
+
+    await dispatcher.dispatch(switchIntent(ACTIVE));
+
+    expect(setTitle).toHaveBeenCalledWith("feature-branch / MyProject - CodeHydra (main)");
+  });
+
+  it("prefixes the user-given title when the switched workspace has one", async () => {
+    const { dispatcher, setTitle } = createTestSetup();
+
+    await dispatcher.dispatch(switchIntent({ ...ACTIVE, metadata: { title: "Fix login bug" } }));
+
+    expect(setTitle).toHaveBeenCalledWith(
+      "Fix login bug / feature-branch / MyProject - CodeHydra (main)"
+    );
+  });
+
+  it("ignores metadata other than the title on switch", async () => {
     const { dispatcher, setTitle } = createTestSetup();
 
     await dispatcher.dispatch(
-      switchIntent({
-        projectId: "test-project" as ProjectId,
-        projectName: "MyProject",
-        workspaceName: "feature-branch" as WorkspaceName,
-        path: "/workspaces/feature-branch",
-      })
+      switchIntent({ ...ACTIVE, metadata: { hibernated: "true", "tags.wip": "{}" } })
     );
 
-    expect(setTitle).toHaveBeenCalledWith("CodeHydra - MyProject / feature-branch - (main)");
+    expect(setTitle).toHaveBeenCalledWith("feature-branch / MyProject - CodeHydra (main)");
+  });
+
+  it("treats a blank title as unset, falling back to the workspace name", async () => {
+    const { dispatcher, setTitle } = createTestSetup();
+
+    await dispatcher.dispatch(switchIntent({ ...ACTIVE, metadata: { title: "   " } }));
+
+    expect(setTitle).toHaveBeenCalledWith("feature-branch / MyProject - CodeHydra (main)");
   });
 
   it("sets title with no-workspace format on null payload", async () => {
@@ -139,7 +224,22 @@ describe("WindowTitleModule Integration", () => {
 
     await dispatcher.dispatch(switchIntent(null));
 
-    expect(setTitle).toHaveBeenCalledWith("CodeHydra - (main)");
+    expect(setTitle).toHaveBeenCalledWith("CodeHydra (main)");
+  });
+
+  it("drops a stale title when switching to a workspace without one", async () => {
+    const { dispatcher, setTitle } = createTestSetup();
+
+    await dispatcher.dispatch(switchIntent({ ...ACTIVE, metadata: { title: "Fix login bug" } }));
+    await dispatcher.dispatch(
+      switchIntent({
+        ...ACTIVE,
+        workspaceName: "other-branch" as WorkspaceName,
+        path: "/workspaces/other-branch",
+      })
+    );
+
+    expect(setTitle).toHaveBeenLastCalledWith("other-branch / MyProject - CodeHydra (main)");
   });
 
   it("sets initial title with version during app:start", async () => {
@@ -147,7 +247,7 @@ describe("WindowTitleModule Integration", () => {
 
     await dispatcher.dispatch(startIntent());
 
-    expect(setTitle).toHaveBeenCalledWith("CodeHydra - (1.0.0)");
+    expect(setTitle).toHaveBeenCalledWith("CodeHydra (1.0.0)");
   });
 
   it("sets initial title with dev branch during app:start", async () => {
@@ -155,7 +255,7 @@ describe("WindowTitleModule Integration", () => {
 
     await dispatcher.dispatch(startIntent());
 
-    expect(setTitle).toHaveBeenCalledWith("CodeHydra - (my-branch)");
+    expect(setTitle).toHaveBeenCalledWith("CodeHydra (my-branch)");
   });
 
   it("sets initial title without version when titleVersion is undefined", async () => {
@@ -175,5 +275,115 @@ describe("WindowTitleModule Integration", () => {
     await dispatcher.dispatch(startIntent());
 
     expect(setTitle).toHaveBeenCalledWith("CodeHydra");
+  });
+
+  describe("retitling the active workspace (no workspace:switched is emitted)", () => {
+    it("adopts a title set on the active workspace", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent(ACTIVE));
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: ACTIVE.projectId,
+          workspaceName: ACTIVE.workspaceName,
+          workspacePath: ACTIVE.path,
+          key: "title",
+          value: "Fix login bug",
+        })
+      );
+
+      expect(setTitle).toHaveBeenLastCalledWith(
+        "Fix login bug / feature-branch / MyProject - CodeHydra (main)"
+      );
+    });
+
+    it("reverts to the workspace name when the title is cleared", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent({ ...ACTIVE, metadata: { title: "Fix login bug" } }));
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: ACTIVE.projectId,
+          workspaceName: ACTIVE.workspaceName,
+          workspacePath: ACTIVE.path,
+          key: "title",
+          value: null,
+        })
+      );
+
+      expect(setTitle).toHaveBeenLastCalledWith("feature-branch / MyProject - CodeHydra (main)");
+    });
+
+    it("ignores a title set on a different workspace", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent(ACTIVE));
+      setTitle.mockClear();
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: ACTIVE.projectId,
+          workspaceName: "other-branch" as WorkspaceName,
+          workspacePath: "/workspaces/other-branch",
+          key: "title",
+          value: "Someone else",
+        })
+      );
+
+      expect(setTitle).not.toHaveBeenCalled();
+    });
+
+    it("ignores a same-named workspace in a different project", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent(ACTIVE));
+      setTitle.mockClear();
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: "other-project" as ProjectId,
+          workspaceName: ACTIVE.workspaceName,
+          workspacePath: "/other/feature-branch",
+          key: "title",
+          value: "Someone else",
+        })
+      );
+
+      expect(setTitle).not.toHaveBeenCalled();
+    });
+
+    it("ignores metadata changes other than the title", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent(ACTIVE));
+      setTitle.mockClear();
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: ACTIVE.projectId,
+          workspaceName: ACTIVE.workspaceName,
+          workspacePath: ACTIVE.path,
+          key: "tags.wip",
+          value: "{}",
+        })
+      );
+
+      expect(setTitle).not.toHaveBeenCalled();
+    });
+
+    it("ignores a title change while no workspace is active", async () => {
+      const { dispatcher, setTitle } = createTestSetup();
+      await dispatcher.dispatch(switchIntent(null));
+      setTitle.mockClear();
+
+      await dispatcher.dispatch(
+        setMetadataIntent({
+          projectId: ACTIVE.projectId,
+          workspaceName: ACTIVE.workspaceName,
+          workspacePath: ACTIVE.path,
+          key: "title",
+          value: "Fix login bug",
+        })
+      );
+
+      expect(setTitle).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/window-title-module.ts
+++ b/src/modules/window-title-module.ts
@@ -5,7 +5,10 @@
  * - app:start → "start": sets the initial window title via updateTitle()
  *
  * Subscribes to:
- * - workspace:switched: updates internal project/workspace names, calls updateTitle()
+ * - workspace:switched: adopts the new workspace's names and display title,
+ *   calls updateTitle()
+ * - workspace:metadata-changed: retitles when the *active* workspace's `title`
+ *   changes (a rename emits no workspace:switched, so this is the only signal)
  *
  * Tracks its own state via domain events -- no external queries needed.
  */
@@ -14,32 +17,43 @@ import type { IntentModule } from "../intents/lib/module";
 import type { DomainEvent } from "../intents/lib/types";
 import type { WorkspaceSwitchedEvent } from "../intents/switch-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
+import type { MetadataChangedEvent } from "../intents/set-metadata";
+import { EVENT_METADATA_CHANGED } from "../intents/set-metadata";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
+import { readTitle, TITLE_METADATA_KEY } from "../shared/api/types";
 import type { WindowManager } from "../boundaries/shell/window-manager";
+
 /**
- * Formats the window title based on current workspace.
+ * Formats the window title based on the current workspace.
  *
- * Format: "CodeHydra - <project> / <workspace> - (<version>)"
- * No workspace: "CodeHydra - (<version>)" or "CodeHydra"
+ * Format: "<title> / <workspace> / <project> - CodeHydra (<version>)"
+ * No title: "<workspace> / <project> - CodeHydra (<version>)"
+ * No workspace: "CodeHydra (<version>)" or "CodeHydra"
+ *
+ * Most-specific-first so the part the user cares about survives taskbar
+ * truncation. The user-given title does not replace the workspace name -- both
+ * are shown, since the branch stays the identity.
  *
  * @param projectName - Name of the active project, or undefined
  * @param workspaceName - Name of the active workspace, or undefined
+ * @param title - User-given display title of the active workspace, or undefined
  * @param version - Version suffix (branch in dev mode, version in packaged mode), or undefined
  * @returns Formatted window title
  */
 function formatWindowTitle(
   projectName: string | undefined,
   workspaceName: string | undefined,
+  title: string | undefined,
   version?: string
 ): string {
-  const base = "CodeHydra";
-  const versionSuffix = version ? ` - (${version})` : "";
+  const app = version ? `CodeHydra (${version})` : "CodeHydra";
 
   if (projectName && workspaceName) {
-    return `${base} - ${projectName} / ${workspaceName}${versionSuffix}`;
+    const titlePrefix = title ? `${title} / ` : "";
+    return `${titlePrefix}${workspaceName} / ${projectName} - ${app}`;
   }
 
-  return `${base}${versionSuffix}`;
+  return app;
 }
 
 // =============================================================================
@@ -57,14 +71,25 @@ export interface WindowTitleModuleDeps {
 
 /**
  * Create a window title module that sets the initial title on startup and
- * subscribes to workspace switch events.
+ * subscribes to workspace switch and metadata-change events.
  */
 export function createWindowTitleModule(deps: WindowTitleModuleDeps): IntentModule {
   let currentProjectName: string | undefined;
   let currentWorkspaceName: string | undefined;
+  // Identity of the active workspace, used to match metadata changes. Keyed on
+  // (projectId, workspaceName) rather than path: the two events carry paths from
+  // different sources, and Path normalizes case on Windows.
+  let currentProjectId: string | undefined;
+  // Interpreted at intake -- the raw metadata map is never stored.
+  let currentTitle: string | undefined;
 
   function updateTitle(): void {
-    const title = formatWindowTitle(currentProjectName, currentWorkspaceName, deps.titleVersion);
+    const title = formatWindowTitle(
+      currentProjectName,
+      currentWorkspaceName,
+      currentTitle,
+      deps.titleVersion
+    );
     deps.windowManager.setTitle(title);
   }
 
@@ -87,11 +112,29 @@ export function createWindowTitleModule(deps: WindowTitleModuleDeps): IntentModu
           if (payload === null) {
             currentProjectName = undefined;
             currentWorkspaceName = undefined;
+            currentProjectId = undefined;
+            currentTitle = undefined;
           } else {
             currentProjectName = payload.projectName;
             currentWorkspaceName = payload.workspaceName;
+            currentProjectId = payload.projectId;
+            currentTitle = readTitle(payload.metadata[TITLE_METADATA_KEY]);
           }
 
+          updateTitle();
+        },
+      },
+      [EVENT_METADATA_CHANGED]: {
+        handler: async (event: DomainEvent): Promise<void> => {
+          const { projectId, workspaceName, key, value } = (event as MetadataChangedEvent).payload;
+
+          // Only the active workspace's title shows in the window title.
+          if (key !== TITLE_METADATA_KEY) return;
+          if (currentProjectId === undefined) return;
+          if (projectId !== currentProjectId || workspaceName !== currentWorkspaceName) return;
+
+          // A cleared title reverts the window title to the workspace name.
+          currentTitle = readTitle(value);
           updateTitle();
         },
       },

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -146,6 +146,27 @@ export function extractTags(metadata: Readonly<Record<string, string>>): Workspa
 }
 
 // =============================================================================
+// Workspace Title
+// =============================================================================
+
+/** Metadata key holding a workspace's user-given display title. */
+export const TITLE_METADATA_KEY = "title";
+
+/**
+ * Interpret a raw metadata `title` into a display title: trim, and treat an
+ * empty string as unset (undefined) so an emptied title reverts to the branch
+ * name. Shared so every consumer (sidebar rows, window title) falls back
+ * identically.
+ *
+ * @param value Raw metadata value; null/undefined when the key is unset
+ * @returns The trimmed title, or undefined when there is none
+ */
+export function readTitle(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+// =============================================================================
 // Domain Types — re-exported type-only from the intent contract
 // =============================================================================
 // zod is the single source of truth for these (src/intents/contract). Type-only re-exports,


### PR DESCRIPTION
The name set on a workspace (metadata `title`) now appears in the OS window title, not just the sidebar.

- The window title was built from the branch `name` on `workspace:switched` and never saw the metadata `title`. Retitling the *active* workspace also emits no `workspace:switched`, so nothing retriggered the title.
- `workspace:resolve` now returns the workspace's raw `metadata`, and `workspace:switched` carries it. It comes from the map `git-worktree` already holds, so there is no extra I/O — this mirrors `branch`, which `resolve` already returned for the same reason.
- The switch payload is the baseline that `workspace:metadata-changed` cannot supply: metadata persists in git config across restarts, so a title set in an earlier run never re-emits as a change.
- `window-title-module` interprets `title` at intake and subscribes to `workspace:metadata-changed` for live renames of the active workspace, matched on `(projectId, workspaceName)` rather than path (the two events carry paths from different sources, and `Path` normalizes case on Windows).
- Format redesigned most-specific-first so the workspace survives taskbar truncation, showing the title alongside the branch rather than replacing it (the branch stays the identity):
  `(<title> / )? <workspace> / <project> - CodeHydra (<version>)`
- `readTitle()` moved to `shared/api/types` so the sidebar and the window title apply the same trim/empty-reverts-to-branch rule.

Verified by driving the real app (Electron under Xvfb): switch with/without a title, live rename of the active workspace, cleared and whitespace-only titles reverting to the branch, a retitle of an *inactive* workspace correctly ignored, and a title set while inactive picked up on switch back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)