### PR TITLE
fix: project could not be closed after being re-opened in the same session

### DIFF
--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -478,6 +478,10 @@ describe("CloseProjectOperation", () => {
     const event = receivedEvents[0] as ProjectClosedEvent;
     expect(event.type).toBe(EVENT_PROJECT_CLOSED);
     expect(event.payload.projectId).toBe(PROJECT_ID);
+    // Regression: project:closed must carry projectPath so the per-projectPath
+    // idempotency guard resets on success (not only on project:close-failed).
+    // Without it the guard leaks and a reopened project can never be closed again.
+    expect(event.payload.projectPath).toBe(PROJECT_PATH);
   });
 
   it("test 13: close with unknown projectPath throws", async () => {

--- a/src/intents/close-project.ts
+++ b/src/intents/close-project.ts
@@ -70,6 +70,13 @@ export const closeProjectPayloadSchema = z
 export const projectClosedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
+    /**
+     * The closed project's path. Carried so the per-projectPath idempotency
+     * guard (keyed by projectPath) resets on this success event — not just on
+     * project:close-failed. Without it, getKey(payload) is undefined and a
+     * successfully-closed-then-reopened project can never be closed again.
+     */
+    projectPath: z.string(),
   })
   .readonly();
 
@@ -332,7 +339,7 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
     // 6. Emit project:closed event
     const event: ProjectClosedEvent = {
       type: EVENT_PROJECT_CLOSED,
-      payload: { projectId },
+      payload: { projectId, projectPath },
     };
     ctx.emit(event);
   }

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -1100,7 +1100,7 @@ describe("CreationModule", () => {
       expect(field(panel.config, "project")["value"]).toBe(PROJECT_A.path);
 
       projects.splice(0, 1); // PROJECT_A closed
-      await s.emit(EVENT_PROJECT_CLOSED, { projectId: PROJECT_A.id });
+      await s.emit(EVENT_PROJECT_CLOSED, { projectId: PROJECT_A.id, projectPath: PROJECT_A.path });
 
       expect(field(panel.config, "project")["value"]).toBe(PROJECT_B.path);
     });
@@ -1111,7 +1111,7 @@ describe("CreationModule", () => {
       const panel = await s.start();
 
       projects.splice(0, 1);
-      await s.emit(EVENT_PROJECT_CLOSED, { projectId: PROJECT_A.id });
+      await s.emit(EVENT_PROJECT_CLOSED, { projectId: PROJECT_A.id, projectPath: PROJECT_A.path });
 
       expect(sectionById(panel.config, "project")).toBeUndefined();
       expect(field(panel.config, "project-placeholder")["disabled"]).toBe(true);

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -898,7 +898,7 @@ describe("PresentationModule - ui:state snapshots", () => {
       path: workspaceB.path,
     });
 
-    await emit(module, EVENT_PROJECT_CLOSED, { projectId: otherId });
+    await emit(module, EVENT_PROJECT_CLOSED, { projectId: otherId, projectPath: "/projects/beta" });
     await flush();
 
     const snapshot = lastSnapshot(deps);


### PR DESCRIPTION
- The per-projectPath idempotency guard on `project:close` resets on `project:closed` / `project:close-failed`, but `project:closed` only carried `projectId` — so the reset key extractor got `undefined` and never cleared the guard.
- A successful close thus leaked its guard key for the life of the process; reopening the same path left its trash icon permanently dead (every `project:close` silently blocked, no confirm dialog).
- Carry `projectPath` on the `project:closed` event so the guard resets on success too (`project:close-failed` already carried it, so cancel was never affected).
- Regression test asserts `project:closed` carries `projectPath`; updated two direct-handler test emits to keep payloads schema-honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3FiJb7J8UoXSGeAguVxTp