### PR TITLE
fix: workspace branch cleanup was flaky

### DIFF
--- a/src/boundaries/platform/git-worktree-provider-factory.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider-factory.integration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createTestGitRepo, createTempDir } from "../../utils/testing/test-utils";
+import { createTestGitRepo, createTempDir, detachHead } from "../../utils/testing/test-utils";
 import { SimpleGitClient } from "./simple-git-client";
 import { GitWorktreeProvider } from "./git-worktree-provider";
 import type { IGitClient } from "./git-client";
@@ -100,6 +100,42 @@ describe("Services Integration", () => {
       // 8. Verify workspace is gone
       const finalWorkspaces = await provider.discover(projectRoot);
       expect(finalWorkspaces).toHaveLength(0);
+    }, 15000);
+
+    it("deletes the branch of a detached workspace and clears its metadata", async () => {
+      // Regression: a rebase that stops on a conflict leaves HEAD detached, so
+      // `git worktree list` reports no branch for it. The branch name was then
+      // null, which skipped both the metadata cleanup and the branch delete —
+      // the worktree went away, no error was raised, and the branch was orphaned.
+      const fileSystemLayer = new DefaultFileSystemBoundary(SILENT_LOGGER);
+      const gitClient = new SimpleGitClient(SILENT_LOGGER);
+      const workspacesDir = getWorkspacesDir(repoPath);
+      const provider = await createProvider(
+        new Path(repoPath),
+        gitClient,
+        new Path(workspacesDir),
+        fileSystemLayer,
+        SILENT_LOGGER
+      );
+      const projectRoot = new Path(repoPath);
+
+      const workspace = await provider.createWorkspace(projectRoot, "detach-me", "main");
+
+      // Detach HEAD, exactly as an interrupted rebase leaves it.
+      await detachHead(workspace.path.toNative());
+      const worktrees = await gitClient.listWorktrees(projectRoot);
+      expect(worktrees.find((wt) => wt.path.equals(workspace.path))?.branch).toBeNull();
+
+      const result = await provider.removeWorkspace(projectRoot, workspace.path, true);
+
+      expect(result.workspaceRemoved).toBe(true);
+      expect(result.baseDeleted).toBe(true);
+      const branches = await gitClient.listBranches(projectRoot);
+      expect(branches.some((b) => b.name === "detach-me" && !b.isRemote)).toBe(false);
+      const metadata = await gitClient.getGitConfig(projectRoot, {
+        regex: `^branch\\.detach-me\\.codehydra\\.`,
+      });
+      expect(metadata.size).toBe(0);
     }, 15000);
 
     it("handles multiple workspaces", async () => {

--- a/src/boundaries/platform/git-worktree-provider-factory.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider-factory.integration.test.ts
@@ -102,6 +102,45 @@ describe("Services Integration", () => {
       expect(finalWorkspaces).toHaveLength(0);
     }, 15000);
 
+    it("prunes codehydra config left behind by a hand-deleted branch", async () => {
+      const fileSystemLayer = new DefaultFileSystemBoundary(SILENT_LOGGER);
+      const gitClient = new SimpleGitClient(SILENT_LOGGER);
+      const workspacesDir = getWorkspacesDir(repoPath);
+      const provider = await createProvider(
+        new Path(repoPath),
+        gitClient,
+        new Path(workspacesDir),
+        fileSystemLayer,
+        SILENT_LOGGER
+      );
+      const projectRoot = new Path(repoPath);
+
+      const kept = await provider.createWorkspace(projectRoot, "still-here", "main");
+      await provider.createWorkspace(projectRoot, "hand-deleted", "main");
+
+      // Delete the branch the way a user would — the worktree and the
+      // [branch "hand-deleted.codehydra"] section both survive this.
+      await gitClient.removeWorktree(projectRoot, new Path(workspacesDir, "hand-deleted"));
+      await gitClient.deleteBranch(projectRoot, "hand-deleted");
+      const before = await gitClient.getGitConfig(projectRoot, {
+        regex: `^branch\\.hand-deleted\\.codehydra\\.`,
+      });
+      expect(before.size).toBeGreaterThan(0);
+
+      await provider.cleanupOrphanedWorkspaces(projectRoot);
+
+      const after = await gitClient.getGitConfig(projectRoot, {
+        regex: `^branch\\.hand-deleted\\.codehydra\\.`,
+      });
+      expect(after.size).toBe(0);
+      // The surviving branch keeps both its branch and its metadata.
+      const stillHere = await gitClient.getGitConfig(projectRoot, {
+        regex: `^branch\\.still-here\\.codehydra\\.`,
+      });
+      expect(stillHere.size).toBeGreaterThan(0);
+      expect(kept.branch).toBe("still-here");
+    }, 15000);
+
     it("deletes the branch of a detached workspace and clears its metadata", async () => {
       // Regression: a rebase that stops on a conflict leaves HEAD detached, so
       // `git worktree list` reports no branch for it. The branch name was then

--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -1474,7 +1474,7 @@ describe("GitWorktreeProvider", () => {
       );
     });
 
-    it("handles detached HEAD workspace (no branch to delete)", async () => {
+    it("leaves branches untouched when a detached workspace matches no branch", async () => {
       const worktreePath = new Path("/data/workspaces/detached");
       const mockClient = createMockGitClient({
         repositories: {
@@ -1496,7 +1496,36 @@ describe("GitWorktreeProvider", () => {
       const result = await provider.removeWorkspace(PROJECT_ROOT, worktreePath, true);
 
       expect(result.workspaceRemoved).toBe(true);
-      expect(result.baseDeleted).toBe(false);
+      expect(mockClient).toHaveBranch(PROJECT_ROOT, "main");
+    });
+
+    it("deletes the branch of a detached workspace", async () => {
+      // A rebase that stops on a conflict leaves HEAD detached, so the worktree
+      // reports no branch. The branch name is still recoverable from the directory,
+      // and skipping it here orphaned the branch with no error reported.
+      const worktreePath = new Path("/data/workspaces/feature-x");
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            currentBranch: "main",
+            worktrees: [{ name: "feature-x", path: worktreePath.toString(), branch: null }],
+          },
+        },
+      });
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        mockFs,
+        worktreeLogger
+      );
+
+      const result = await provider.removeWorkspace(PROJECT_ROOT, worktreePath, true);
+
+      expect(result.workspaceRemoved).toBe(true);
+      expect(result.baseDeleted).toBe(true);
+      expect(mockClient).not.toHaveBranch(PROJECT_ROOT, "feature-x");
     });
 
     it("returns success when worktree already removed (idempotent)", async () => {

--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -2198,6 +2198,73 @@ describe("GitWorktreeProvider", () => {
   });
 
   describe("cleanupOrphanedWorkspaces", () => {
+    it("prunes codehydra config left by branches that no longer exist", async () => {
+      // `git branch -D` drops the branch but not our [branch "<n>.codehydra"] section.
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            currentBranch: "main",
+            worktrees: [],
+            branchConfigs: {
+              "feature-x": { "codehydra.base": "main" },
+              "long-gone": { "codehydra.base": "main", "codehydra.tags.new": "{}" },
+            },
+          },
+        },
+      });
+      const spyFs = createSpyFileSystemBoundary({
+        entries: { [WORKSPACES_DIR.toString()]: directory() },
+      });
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        spyFs,
+        worktreeLogger
+      );
+
+      await provider.cleanupOrphanedWorkspaces(PROJECT_ROOT);
+
+      const remaining = await mockClient.getGitConfig(PROJECT_ROOT, {
+        regex: `^branch\\..*\\.codehydra\\.`,
+      });
+      expect([...remaining.keys()]).toEqual(["branch.feature-x.codehydra.base"]);
+    });
+
+    it("keeps metadata for an existing branch that has no worktree", async () => {
+      // A worktree removed outside CodeHydra leaves this shape; the branch may
+      // still hold unmerged work, so its metadata must survive.
+      const mockClient = createMockGitClient({
+        repositories: {
+          [PROJECT_ROOT.toString()]: {
+            branches: ["main", "feature-x"],
+            currentBranch: "main",
+            worktrees: [],
+            branchConfigs: { "feature-x": { "codehydra.base": "main" } },
+          },
+        },
+      });
+      const spyFs = createSpyFileSystemBoundary({
+        entries: { [WORKSPACES_DIR.toString()]: directory() },
+      });
+      const provider = await createProvider(
+        PROJECT_ROOT,
+        mockClient,
+        WORKSPACES_DIR,
+        spyFs,
+        worktreeLogger
+      );
+
+      await provider.cleanupOrphanedWorkspaces(PROJECT_ROOT);
+
+      expect(mockClient).toHaveBranch(PROJECT_ROOT, "feature-x");
+      const remaining = await mockClient.getGitConfig(PROJECT_ROOT, {
+        regex: `^branch\\..*\\.codehydra\\.`,
+      });
+      expect(remaining.size).toBe(1);
+    });
+
     it("removes orphaned directories", async () => {
       const mockClient = createMockGitClient({
         repositories: {

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -842,9 +842,67 @@ export class GitWorktreeProvider {
     registration.cleanupInProgress = true;
 
     try {
-      return await this.doCleanupOrphanedWorkspaces(projectRoot, registration.workspacesDir);
+      const result = await this.doCleanupOrphanedWorkspaces(
+        projectRoot,
+        registration.workspacesDir
+      );
+      await this.pruneOrphanedBranchMetadata(projectRoot);
+      return result;
     } finally {
       registration.cleanupInProgress = false;
+    }
+  }
+
+  /**
+   * Drop `codehydra.*` branch config left behind by branches that no longer exist.
+   *
+   * `git branch -D` removes the branch but not our `[branch "<name>.codehydra"]`
+   * section, so hand-deleted branches leave their metadata behind indefinitely.
+   *
+   * Config only — this never deletes a branch. A branch that still exists keeps its
+   * metadata regardless of whether it has a worktree, because "metadata but no
+   * worktree" is not evidence the branch is disposable: a worktree removed outside
+   * CodeHydra leaves exactly that shape, and the branch may hold unmerged work.
+   */
+  private async pruneOrphanedBranchMetadata(projectRoot: Path): Promise<void> {
+    let metadata: ReadonlyMap<string, Readonly<Record<string, string>>>;
+    let branches: readonly { name: string; isRemote: boolean }[];
+    try {
+      metadata = await this.getAllBranchMetadata(projectRoot);
+      branches = await this.gitClient.listBranches(projectRoot);
+    } catch (error: unknown) {
+      // Best-effort: stale config is inert, so never fail cleanup over it.
+      this.logger.warn("Failed to read branch metadata for cleanup", {
+        error: getErrorMessage(error),
+      });
+      return;
+    }
+
+    const liveBranches = new Set(branches.filter((b) => !b.isRemote).map((b) => b.name));
+    let prunedBranches = 0;
+
+    for (const [branch, entries] of metadata) {
+      if (liveBranches.has(branch)) continue;
+      for (const key of Object.keys(entries)) {
+        try {
+          await this.gitClient.unsetBranchConfig(
+            projectRoot,
+            branch,
+            `${GitWorktreeProvider.METADATA_CONFIG_PREFIX}.${key}`
+          );
+        } catch (error: unknown) {
+          this.logger.warn("Failed to prune branch metadata", {
+            branch,
+            key,
+            error: getErrorMessage(error),
+          });
+        }
+      }
+      prunedBranches++;
+    }
+
+    if (prunedBranches > 0) {
+      this.logger.info("Pruned metadata for deleted branches", { count: prunedBranches });
     }
   }
 

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -594,10 +594,15 @@ export class GitWorktreeProvider {
     // Get the branch name before removal (also checks if worktree exists)
     const worktrees = await this.gitClient.listWorktrees(projectRoot);
     const worktree = worktrees.find((wt) => wt.path.equals(workspacePath));
-    // If worktree not found (retry after partial failure), extract branch from path
-    // For git worktrees, the last path segment is the branch name
-    // Note: Use ternary (not ??) to preserve null for detached HEAD workspaces
-    const branchName = worktree ? worktree.branch : unsanitizeWorkspaceName(workspacePath.basename);
+    // A workspace's branch is named after its directory (see createWorkspace), so the
+    // basename recovers it in both cases where the worktree entry can't supply one:
+    // the entry is missing (retry after a partial failure), or HEAD is detached — a
+    // rebase that stopped on a conflict leaves it that way, and worktree.branch is then
+    // null. Falling back matters: on null, both the metadata cleanup and the branch
+    // delete below are skipped and the branch is orphaned with no error. Deleting is
+    // still guarded by the branch-exists check in step 3, so a workspace whose basename
+    // maps to no branch (detached on purpose) stays a no-op.
+    const branchName = worktree?.branch ?? unsanitizeWorkspaceName(workspacePath.basename);
 
     // Step 1: Clear codehydra metadata from branch config
     // Done before worktree removal because metadata lives in project root's .git/config,

--- a/src/boundaries/platform/simple-git-client.ts
+++ b/src/boundaries/platform/simple-git-client.ts
@@ -277,11 +277,12 @@ export class SimpleGitClient implements IGitClient {
   }
 
   async deleteBranch(repoPath: Path, name: string): Promise<void> {
-    return this.wrapGitOperation(async () => {
+    await this.wrapGitOperation(async () => {
       const git = this.getGit(repoPath);
       // Use -D to force delete (handles unmerged branches)
       await git.branch(["-D", name]);
     }, `Failed to delete branch ${name}`);
+    this.logger.debug("DeleteBranch", { path: repoPath.toString(), branch: name });
   }
 
   async getCurrentBranch(repoPath: Path): Promise<string | null> {

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -44,7 +44,20 @@ import type {
   FlushHookInput,
   DeletePipelineHookInput,
 } from "./delete-workspace";
-import type { HookContext, HookOutput, OperationContext } from "./lib/operation";
+import type {
+  HookContext,
+  HookOutput,
+  OperationContext,
+  Operation,
+  OperationSchemas,
+} from "./lib/operation";
+import {
+  INTENT_GET_PROJECT_BASES,
+  GET_PROJECT_BASES_OPERATION_ID,
+  getProjectBasesPayloadSchema,
+  getProjectBasesResultSchema,
+  type GetProjectBasesIntent,
+} from "./get-project-bases";
 import type {
   BlockingProcess,
   DeletionProgress,
@@ -274,6 +287,8 @@ interface TestHarness {
   gitWorktreeProviderMock: {
     gitWorktreeProvider: { removeWorkspace: ReturnType<typeof vi.fn> };
   };
+  /** Payloads of every project:get-bases dispatched during the run. */
+  basesRefreshes: GetProjectBasesIntent["payload"][];
 }
 
 function createTestHarness(options?: {
@@ -290,6 +305,7 @@ function createTestHarness(options?: {
   initialProjects?: TestAppState["projects"];
   isDirty?: boolean;
   unmergedCommits?: number;
+  basesRefreshError?: string;
 }): TestHarness {
   const dispatcher = createMockDispatcher();
 
@@ -333,6 +349,23 @@ function createTestHarness(options?: {
   dispatcher.registerOperation(new DeleteWorkspaceOperation());
   dispatcher.registerOperation(new SwitchWorkspaceOperation());
   dispatcher.registerOperation(new GetActiveWorkspaceOperation());
+
+  // Stub project:get-bases so the preflight's remote refresh is observable. The
+  // real operation fetches; here we only record that it was asked to.
+  const basesRefreshes: GetProjectBasesIntent["payload"][] = [];
+  dispatcher.registerOperation({
+    id: GET_PROJECT_BASES_OPERATION_ID,
+    schemas: {
+      type: INTENT_GET_PROJECT_BASES,
+      payload: getProjectBasesPayloadSchema,
+      result: getProjectBasesResultSchema,
+    },
+    execute: async (ctx: OperationContext<GetProjectBasesIntent>) => {
+      basesRefreshes.push(ctx.intent.payload);
+      if (options?.basesRefreshError) throw new Error(options.basesRefreshError);
+      return { bases: [], projectPath: PROJECT_PATH, projectId: PROJECT_ID };
+    },
+  } as unknown as Operation<OperationSchemas>);
 
   // Add interceptor via module (inline, matching bootstrap pattern)
   const inProgressDeletions = new Set<string>();
@@ -803,6 +836,7 @@ function createTestHarness(options?: {
     gitWorktreeProviderState: gitWorktreeProviderMock,
     gitWorktreeProviderMock:
       gitWorktreeProviderMock as unknown as TestHarness["gitWorktreeProviderMock"],
+    basesRefreshes,
   };
 }
 
@@ -1761,6 +1795,39 @@ describe("DeleteWorkspaceOperation.preflight", () => {
     expect(harness.testState.worktreeRemoved).toBe(false);
     expect(harness.testState.removedWorkspaces).toHaveLength(0);
     expect(harness.progressCaptures).toHaveLength(0);
+  });
+
+  it("refreshes remotes before counting unmerged commits", async () => {
+    // Without this, a delete dispatched right after a server-side merge (/ship)
+    // measures against a stale origin/main and rejects the just-merged commits.
+    const harness = createTestHarness({ isDirty: false, unmergedCommits: 0 });
+
+    await harness.dispatcher.dispatch(buildDeleteIntent());
+
+    expect(harness.basesRefreshes).toContainEqual(
+      expect.objectContaining({ projectPath: PROJECT_PATH, refresh: true })
+    );
+  });
+
+  it("proceeds with the preflight when the refresh fails", async () => {
+    const harness = createTestHarness({
+      isDirty: false,
+      unmergedCommits: 0,
+      basesRefreshError: "network down",
+    });
+
+    await harness.dispatcher.dispatch(buildDeleteIntent());
+
+    // A fetch failure must not block deletion — fall through to stale refs.
+    expect(harness.testState.worktreeRemoved).toBe(true);
+  });
+
+  it("skips the refresh when preflight is skipped", async () => {
+    const harness = createTestHarness({ isDirty: true, unmergedCommits: 5 });
+
+    await harness.dispatcher.dispatch(buildDeleteIntent({ ignoreWarnings: true }));
+
+    expect(harness.basesRefreshes).toHaveLength(0);
   });
 
   it("proceeds when workspace is clean", async () => {

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -47,6 +47,7 @@ import {
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { resolveWorkspaceIdentity } from "./lib/workspace-identity";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
+import { INTENT_GET_PROJECT_BASES, type GetProjectBasesIntent } from "./get-project-bases";
 import { throwHookErrors, collectErrorMessages, lastDefined } from "./lib/hook-helpers";
 
 export const INTENT_DELETE_WORKSPACE = "workspace:delete" as const;
@@ -512,6 +513,21 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
   ): Promise<PipelineResult> {
     // --- Preflight (dirty/unmerged check) ---
     if (payload.removeWorktree && !payload.force && !payload.ignoreWarnings) {
+      // Fetch first so the unmerged count is measured against current refs. The
+      // interactive path gets this via get-workspace-status {refresh: true}; without
+      // it here, a programmatic delete right after a server-side merge (e.g. /ship)
+      // compares against a stale origin/main and rejects the just-merged commits as
+      // unmerged. Best-effort — a fetch failure falls through to the stale-ref read
+      // rather than blocking the delete.
+      try {
+        await ctx.dispatch({
+          type: INTENT_GET_PROJECT_BASES,
+          payload: { projectPath: identity.projectPath, refresh: true, wait: true },
+        } as GetProjectBasesIntent);
+      } catch {
+        // Fall through to the preflight read with possibly-stale refs.
+      }
+
       const { results: preflightResults, errors: preflightCollectErrors } =
         await ctx.hooks.collect<PreflightHookResult>("preflight", pipelineCtx);
 

--- a/src/utils/testing/test-utils.ts
+++ b/src/utils/testing/test-utils.ts
@@ -181,6 +181,14 @@ export async function createCommitInRemote(remotePath: string, message: string):
 }
 
 /**
+ * Detach a worktree's HEAD, reproducing the state an interrupted rebase leaves
+ * behind (`git worktree list` then reports no branch for it).
+ */
+export async function detachHead(worktreePath: string): Promise<void> {
+  await simpleGit(worktreePath).raw(["checkout", "--detach", "HEAD"]);
+}
+
+/**
  * Run a test function with a temporary git repository and remote.
  * Both are automatically cleaned up after the test, even if the test fails.
  *


### PR DESCRIPTION
- Deleting a workspace whose HEAD was detached removed the worktree but silently left its branch behind. `git worktree list` reports no branch for a detached worktree, so the branch name resolved to null — and both the metadata cleanup and the branch deletion are guarded on it. The deletion reported success with no error and no log line.
- A rebase that stops on a conflict leaves HEAD detached, so this hit branches shipped through `/ship`.
- Recover the branch name from the workspace directory when the worktree reports none. Deleting stays guarded by the existing branch-exists check, so a workspace detached on purpose whose name matches no branch remains a no-op.
- Log `deleteBranch` — this leaked unnoticed because the one git operation that was failing was the only one without logging.
- Fetch before the delete preflight. The interactive path already refreshed via `get-workspace-status`; the programmatic path did not, so a delete dispatched right after a server-side merge measured against a stale `origin/main` and rejected the just-merged commits as unmerged.
- Prune `codehydra.*` branch config left behind by branches that no longer exist. `git branch -D` drops the branch but not our `[branch "<name>.codehydra"]` section, so these accumulated indefinitely. Config only — no branch is ever deleted by the cleanup pass.