### PR TITLE
fix(boundary-tests): warm opencode binary before first spawn

### DIFF
--- a/src/modules/agent-module/opencode/client.boundary.test.ts
+++ b/src/modules/agent-module/opencode/client.boundary.test.ts
@@ -22,6 +22,8 @@ import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
 import {
   ensureBinaryForTests,
   getBinaryPathForTests,
+  warmBinaryForTests,
+  BINARY_WARM_TIMEOUT_MS,
 } from "../../../utils/testing/ensure-binaries";
 import type { ClientStatus } from "./types";
 
@@ -32,7 +34,11 @@ describe("OpenCodeClient boundary tests", () => {
   beforeAll(async () => {
     await ensureBinaryForTests("opencode");
     binaryPath = getBinaryPathForTests("opencode");
-  });
+
+    // First exec of a fresh binary can stall on macOS (Gatekeeper assessment);
+    // pay that cost here instead of inside the first test's timeout
+    await warmBinaryForTests("opencode");
+  }, BINARY_WARM_TIMEOUT_MS);
 
   // ===========================================================================
   // Phase 1.3: Mock LLM Integration

--- a/src/modules/agent-module/opencode/server-manager.boundary.test.ts
+++ b/src/modules/agent-module/opencode/server-manager.boundary.test.ts
@@ -11,7 +11,12 @@ import { OpenCodeServerManager } from "./server-manager";
 import { ExecaProcessRunner } from "../../../boundaries/platform/process";
 import { DefaultNetworkLayer } from "../../../boundaries/platform/network";
 import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
-import { ensureBinaryForTests, getTestPathProvider } from "../../../utils/testing/ensure-binaries";
+import {
+  ensureBinaryForTests,
+  getTestPathProvider,
+  warmBinaryForTests,
+  BINARY_WARM_TIMEOUT_MS,
+} from "../../../utils/testing/ensure-binaries";
 import { existsSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -33,6 +38,10 @@ describe("OpenCodeServerManager Boundary Tests", () => {
     // Ensure opencode binary is available (downloads if missing)
     await ensureBinaryForTests("opencode");
 
+    // First exec of a fresh binary can stall on macOS (Gatekeeper assessment);
+    // pay that cost here instead of inside the first test's timeout
+    await warmBinaryForTests("opencode");
+
     // Create test directory
     testDir = join(tmpdir(), `opencode-server-test-${Date.now()}`);
     await mkdir(testDir, { recursive: true });
@@ -45,7 +54,7 @@ describe("OpenCodeServerManager Boundary Tests", () => {
     // Create dependencies using silent loggers (no Electron dependency)
     networkLayer = new DefaultNetworkLayer(SILENT_LOGGER);
     processRunner = new ExecaProcessRunner(SILENT_LOGGER);
-  });
+  }, BINARY_WARM_TIMEOUT_MS);
 
   afterEach(async () => {
     // Dispose manager to stop any running servers

--- a/src/utils/testing/ensure-binaries.ts
+++ b/src/utils/testing/ensure-binaries.ts
@@ -22,6 +22,7 @@ import {
   getOpencodeExecutablePath,
 } from "../../modules/agent-module/opencode/setup-info";
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
+import { ExecaProcessRunner } from "../../boundaries/platform/process";
 import { createMockBuildInfo } from "../../boundaries/platform/build-info.test-utils";
 import { NodePlatformInfo } from "../../boundaries/platform/node-platform-info";
 import { downloadBinary } from "../binary-download";
@@ -159,6 +160,41 @@ export async function ensureBinaryForTests(
 
   process.stdout.write("\n");
   console.log(`Downloaded ${binary} to ${binaryPath}`);
+}
+
+/**
+ * Timeout for warmBinaryForTests, also intended as the beforeAll hook timeout
+ * of tests that call it (the default 10s hook timeout is too short for a
+ * first-exec Gatekeeper stall).
+ */
+export const BINARY_WARM_TIMEOUT_MS = 120_000;
+
+/**
+ * Warm a binary by executing it once (`--version`) and waiting for exit.
+ *
+ * On macOS, the first execution of a freshly written unsigned binary triggers
+ * a Gatekeeper/syspolicyd code-signature assessment that can stall for many
+ * seconds on CI runners. Calling this in a beforeAll hook (with
+ * BINARY_WARM_TIMEOUT_MS as the hook timeout) pays that one-time cost outside
+ * the per-test timeout budget.
+ *
+ * Best-effort: a non-zero exit is ignored (the exec itself is what warms the
+ * binary); a process still running after the timeout is killed.
+ *
+ * @param binary - Binary type (must already be installed)
+ * @param options - Options for path provider
+ */
+export async function warmBinaryForTests(
+  binary: TestBinaryType,
+  options?: EnsureBinaryOptions
+): Promise<void> {
+  const binaryPath = getBinaryPathForTests(binary, options);
+  const runner = new ExecaProcessRunner(SILENT_LOGGER);
+  const proc = runner.run(binaryPath, ["--version"]);
+  const result = await proc.wait(BINARY_WARM_TIMEOUT_MS);
+  if (result.running) {
+    await proc.kill(1000, 1000);
+  }
 }
 
 /**


### PR DESCRIPTION
- Fixes a macOS CI flake where the first `opencode serve` boundary test timed out at 30s (run 29091501861): the first exec of a freshly written binary pays a one-time Gatekeeper/syspolicyd code-signature assessment that landed inside the first test's timeout budget, while the three subsequent identical spawns passed.
- Adds `warmBinaryForTests()` to `src/utils/testing/ensure-binaries.ts`: executes the installed binary once (`--version`) and waits for exit, best-effort (non-zero exit ignored, killed if still running after timeout).
- Calls the warm-up in the `beforeAll` of both `server-manager.boundary.test.ts` and `client.boundary.test.ts` with an explicit 120s hook timeout (no `hookTimeout` is configured, so the 10s vitest default would defeat the purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M6UCdM87o4t8abxDvpPC2