### PR TITLE
fix(ci): stop wrapper.boundary.test.ts flaking on Windows pkg downloads

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -38,3 +38,52 @@ runs:
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ steps.pnpm-store.outputs.cache-primary-key }}
+
+    # @yao-pkg/pkg base-binary cache, Windows only. wrapper.boundary.test.ts
+    # compiles a fake claude.exe with pkg (the wrapper spawns with shell:false,
+    # so a .cmd shim won't do); pkg-fetch first downloads a prebuilt base Node
+    # binary from GitHub into PKG_CACHE_PATH. Uncached, every Windows run paid
+    # that download inside vitest's hook-timeout budget — the dominant CI
+    # flake. Unix never invokes pkg (the fake binary is a shell script there).
+    #
+    # PKG_CACHE_PATH is exported for the whole job so the test process and the
+    # cache steps agree on the directory (default would be ~/.pkg-cache).
+    - if: runner.os == 'Windows'
+      shell: bash
+      run: echo "PKG_CACHE_PATH=${{ runner.temp }}/pkg-cache" >> $GITHUB_ENV
+
+    # pkg-fetch picks the base binary by host Node version, and its download
+    # tag moves with the pkg version — so both are part of the cache key.
+    # Must run after `pnpm install` (reads the installed package).
+    - id: pkg-cache-key
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "NODE_MAJOR=$(node -p 'process.version.split(".")[0]')" >> $GITHUB_OUTPUT
+        echo "PKG_VERSION=$(node -p 'require("@yao-pkg/pkg/package.json").version')" >> $GITHUB_OUTPUT
+
+    - id: pkg-cache
+      if: runner.os == 'Windows'
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ runner.temp }}/pkg-cache
+        key: ${{ runner.os }}-${{ runner.arch }}-pkg-cache-${{ steps.pkg-cache-key.outputs.NODE_MAJOR }}-pkg${{ steps.pkg-cache-key.outputs.PKG_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-pkg-cache-
+
+    # pkg only populates the cache when it runs — at test time, after this
+    # composite action has finished — so saving here would capture an empty
+    # directory. On main + miss, warm it by compiling a trivial script (the
+    # same --target host fetch the tests trigger), then save. Same
+    # restore-always/save-only-on-main pattern as the pnpm store above.
+    - if: runner.os == 'Windows' && github.ref == 'refs/heads/main' && steps.pkg-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "console.log('pkg cache warmup')" > "$RUNNER_TEMP/pkg-warmup.js"
+        pnpm exec pkg "$RUNNER_TEMP/pkg-warmup.js" --target host --output "$RUNNER_TEMP/pkg-warmup/warmup.exe"
+
+    - if: runner.os == 'Windows' && github.ref == 'refs/heads/main' && steps.pkg-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.temp }}/pkg-cache
+        key: ${{ steps.pkg-cache.outputs.cache-primary-key }}

--- a/src/modules/agent-module/claude/fake-claude-binary.ts
+++ b/src/modules/agent-module/claude/fake-claude-binary.ts
@@ -1,0 +1,61 @@
+import { createFakeAgentBinary } from "../wrapper-boundary-test-utils";
+
+/**
+ * Create the fake claude binary used by wrapper.boundary.test.ts.
+ * Outputs JSON with received args and selected env vars, exits with configurable code.
+ *
+ * Supports per-invocation exit codes via CLAUDE_EXIT_CODES env var (comma-separated)
+ * and CLAUDE_COUNTER_FILE for tracking invocation count across calls.
+ *
+ * Lives outside the test file so the boundary project's globalSetup
+ * (src/test/global-setup-boundary.ts) can compile it once per run without
+ * importing the test file (which would execute its describe blocks).
+ */
+export async function createFakeClaudeBinary(binDir: string): Promise<string> {
+  const fakeNodeContent = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+// Always succeed for --version (used by findSystemClaude discovery)
+if (process.argv.includes("--version")) {
+  console.log("fake-claude 1.0.0");
+  process.exit(0);
+}
+
+const output = {
+  args: process.argv.slice(2),
+  env: {
+    CLAUDECODE: process.env.CLAUDECODE ?? null,
+  },
+};
+
+// Track invocation count for multi-call tests
+const counterFile = process.env.CLAUDE_COUNTER_FILE;
+let callIndex = 0;
+if (counterFile) {
+  try {
+    callIndex = parseInt(fs.readFileSync(counterFile, "utf-8"), 10);
+  } catch { /* first call */ }
+  fs.writeFileSync(counterFile, String(callIndex + 1));
+}
+
+// Support per-invocation exit codes: "1,0" means first exits 1, second exits 0
+const exitCodes = process.env.CLAUDE_EXIT_CODES;
+let exitCode = 0;
+if (exitCodes) {
+  const codes = exitCodes.split(",").map(Number);
+  exitCode = codes[callIndex] ?? codes[codes.length - 1] ?? 0;
+} else {
+  exitCode = parseInt(process.env.CLAUDE_EXIT_CODE || "0", 10);
+}
+
+console.log(JSON.stringify(output));
+process.exit(isNaN(exitCode) ? 0 : exitCode);
+`;
+  // Real .exe on Windows so shell:false works (no cmd.exe involvement)
+  return createFakeAgentBinary({
+    dir: binDir,
+    binaryName: "claude",
+    scriptBody: fakeNodeContent,
+    windowsMode: "exe",
+  });
+}

--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -11,7 +11,7 @@
  * - Exit code propagation
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll, inject } from "vitest";
 import { join, resolve, dirname, delimiter } from "node:path";
 import { writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -70,62 +70,6 @@ function parseAllFakeClaudeOutputs(stdout: string): FakeClaudeOutput[] {
 }
 
 /**
- * Create a fake claude binary for testing.
- * Outputs JSON with received args and selected env vars, exits with configurable code.
- *
- * Supports per-invocation exit codes via CLAUDE_EXIT_CODES env var (comma-separated)
- * and CLAUDE_COUNTER_FILE for tracking invocation count across calls.
- */
-async function createFakeClaudeBinary(binDir: string): Promise<string> {
-  const fakeNodeContent = `#!/usr/bin/env node
-const fs = require("node:fs");
-
-// Always succeed for --version (used by findSystemClaude discovery)
-if (process.argv.includes("--version")) {
-  console.log("fake-claude 1.0.0");
-  process.exit(0);
-}
-
-const output = {
-  args: process.argv.slice(2),
-  env: {
-    CLAUDECODE: process.env.CLAUDECODE ?? null,
-  },
-};
-
-// Track invocation count for multi-call tests
-const counterFile = process.env.CLAUDE_COUNTER_FILE;
-let callIndex = 0;
-if (counterFile) {
-  try {
-    callIndex = parseInt(fs.readFileSync(counterFile, "utf-8"), 10);
-  } catch { /* first call */ }
-  fs.writeFileSync(counterFile, String(callIndex + 1));
-}
-
-// Support per-invocation exit codes: "1,0" means first exits 1, second exits 0
-const exitCodes = process.env.CLAUDE_EXIT_CODES;
-let exitCode = 0;
-if (exitCodes) {
-  const codes = exitCodes.split(",").map(Number);
-  exitCode = codes[callIndex] ?? codes[codes.length - 1] ?? 0;
-} else {
-  exitCode = parseInt(process.env.CLAUDE_EXIT_CODE || "0", 10);
-}
-
-console.log(JSON.stringify(output));
-process.exit(isNaN(exitCode) ? 0 : exitCode);
-`;
-  // Real .exe on Windows so shell:false works (no cmd.exe involvement)
-  return createFakeAgentBinary({
-    dir: binDir,
-    binaryName: "claude",
-    scriptBody: fakeNodeContent,
-    windowsMode: "exe",
-  });
-}
-
-/**
  * Build a PATH that includes the fake binary dir and node's directory.
  */
 function buildPath(fakeBinDir: string): string {
@@ -134,23 +78,18 @@ function buildPath(fakeBinDir: string): string {
 
 describe("ch-claude.cjs boundary tests", () => {
   let tempDir: { path: string; cleanup: () => Promise<void> };
-  let sharedBinTempDir: { path: string; cleanup: () => Promise<void> };
   let fakeBinDir: string;
 
   beforeAll(async () => {
     await assertCompiledScript(COMPILED_SCRIPT_PATH);
-    // Compile the fake claude binary ONCE for the whole file. On Windows,
-    // createFakeClaudeBinary invokes @yao-pkg/pkg to bundle a real .exe, which
-    // takes seconds; doing it per-test in beforeEach blew the default 10s hook
-    // timeout under CI contention (the dominant flaky-test failure). The fake
+    // The fake claude binary is compiled once per run by the boundary
+    // project's globalSetup (src/test/global-setup-boundary.ts). On Windows
+    // that means bundling a real .exe with @yao-pkg/pkg — on a cold pkg cache
+    // a network download plus a multi-second compile, which blew the 10s hook
+    // timeout when it ran here (the dominant flaky-test failure). The fake
     // binary's behavior is driven entirely by env vars (CLAUDE_EXIT_CODE,
     // CLAUDE_COUNTER_FILE, …), so a single shared binary serves every test.
-    sharedBinTempDir = await createTempDir();
-    fakeBinDir = await createFakeClaudeBinary(join(sharedBinTempDir.path, "bin"));
-  });
-
-  afterAll(async () => {
-    await sharedBinTempDir.cleanup();
+    fakeBinDir = inject("fakeClaudeBinDir");
   });
 
   beforeEach(async () => {

--- a/src/renderer/tsconfig.web.json
+++ b/src/renderer/tsconfig.web.json
@@ -12,5 +12,10 @@
     }
   },
   "include": ["../env.d.ts", "./**/*", "../shared/**/*", "../intents/contract.ts", "../test/**/*"],
-  "exclude": ["../../node_modules", "../../app-data", "../test/setup-matchers.ts"]
+  "exclude": [
+    "../../node_modules",
+    "../../app-data",
+    "../test/setup-matchers.ts",
+    "../test/global-setup-boundary.ts"
+  ]
 }

--- a/src/test/global-setup-boundary.ts
+++ b/src/test/global-setup-boundary.ts
@@ -1,0 +1,29 @@
+/**
+ * Global setup for the boundary test project.
+ *
+ * Compiles the fake claude binary once per run, outside any test worker. On
+ * Windows this invokes @yao-pkg/pkg to bundle a real claude.exe; on a cold
+ * pkg cache that first downloads a base Node binary from GitHub, which blew
+ * vitest's 10s hookTimeout when it ran in beforeAll under CI contention (the
+ * dominant Windows flake). globalSetup is awaited by the vitest main process
+ * with no hook timeout, so a slow download can delay the run but never fail
+ * it. Tests read the directory via inject("fakeClaudeBinDir").
+ */
+
+import { join } from "node:path";
+import type { TestProject } from "vitest/node";
+import { createTempDir } from "../utils/testing/test-utils";
+import { createFakeClaudeBinary } from "../modules/agent-module/claude/fake-claude-binary";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    fakeClaudeBinDir: string;
+  }
+}
+
+export default async function setup(project: TestProject): Promise<() => Promise<void>> {
+  const tempDir = await createTempDir();
+  const fakeBinDir = await createFakeClaudeBinary(join(tempDir.path, "bin"));
+  project.provide("fakeClaudeBinDir", fakeBinDir);
+  return () => tempDir.cleanup();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,6 +75,9 @@ export default defineConfig({
           environment: "node",
           include: ["src/**/*.boundary.test.{js,ts}"],
           setupFiles: ["./src/test/setup.ts", "./src/test/setup-matchers.ts"],
+          // Compiles the fake claude binary once per run; on Windows the pkg
+          // download/compile is too slow for a 10s test hook (see the file).
+          globalSetup: ["./src/test/global-setup-boundary.ts"],
           pool: "forks",
         },
       },


### PR DESCRIPTION
- Cache the @yao-pkg/pkg base-binary directory (`PKG_CACHE_PATH`) in the CI setup action on Windows, keyed on OS/arch + host Node major + pkg version, following the existing restore-always/save-only-on-main pattern; a main-gated warmup compile seeds the cache since pkg only populates it at test time
- Move the fake claude.exe compile out of the test's `beforeAll` into a boundary-project vitest `globalSetup` (not subject to `hookTimeout`), handing the binary dir to tests via `provide`/`inject` — so even a cold pkg cache can't hit the 10s hook timeout
- Extract `createFakeClaudeBinary` into its own module so the globalSetup can import it without executing the test file
- Exclude the Node-only globalSetup from the renderer svelte-check project (same precedent as `setup-matchers.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5UfUJmCxqADJHqyeHe8bG