### PR TITLE
fix(build): point vite-plugin-svelte at root svelte.config.js

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -97,7 +97,12 @@ export default defineConfig({
       __APP_VERSION__: JSON.stringify(appVersion),
       __IS_DEV_BUILD__: JSON.stringify(isDevBuild),
     },
-    plugins: [codehydraDefaults(), svelte()],
+    plugins: [
+      codehydraDefaults(),
+      // renderer root is src/renderer, but svelte.config.js lives at the project
+      // root; point the plugin at it so it doesn't warn and fall back to defaults.
+      svelte({ configFile: resolve(__dirname, "svelte.config.js") }),
+    ],
     resolve: {
       alias: {
         $lib: resolve(__dirname, "src/renderer/lib"),


### PR DESCRIPTION
- The renderer's Vite root is `src/renderer`, so vite-plugin-svelte looked for `svelte.config.js` there and, not finding it, warned and fell back to default configuration (dropping `vitePreprocess`)
- Pass `configFile` to the `svelte()` plugin so the root `svelte.config.js` is used
- Verified via `pnpm build`: renderer builds cleanly with no missing-config warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)