### PR TITLE
fix(claude): strip inherited CLAUDE_CODE_CHILD_SESSION before spawning agent

### DIFF
--- a/src/modules/agent-module/claude/fake-claude-binary.ts
+++ b/src/modules/agent-module/claude/fake-claude-binary.ts
@@ -25,6 +25,7 @@ const output = {
   args: process.argv.slice(2),
   env: {
     CLAUDECODE: process.env.CLAUDECODE ?? null,
+    CLAUDE_CODE_CHILD_SESSION: process.env.CLAUDE_CODE_CHILD_SESSION ?? null,
   },
 };
 

--- a/src/modules/agent-module/claude/wrapper.boundary.test.ts
+++ b/src/modules/agent-module/claude/wrapper.boundary.test.ts
@@ -37,6 +37,7 @@ interface FakeClaudeOutput {
   args: string[];
   env: {
     CLAUDECODE: string | null;
+    CLAUDE_CODE_CHILD_SESSION: string | null;
   };
 }
 
@@ -195,6 +196,29 @@ describe("ch-claude.cjs boundary tests", () => {
       const output = parseFakeClaudeOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.env.CLAUDECODE).toBeNull();
+    });
+
+    it("deletes inherited CLAUDE_CODE_CHILD_SESSION env var before spawning", async () => {
+      const result = await executeScript(
+        COMPILED_SCRIPT_PATH,
+        {
+          _CH_CLAUDE_SETTINGS: "/tmp/settings.json",
+          _CH_CLAUDE_MCP_CONFIG: "/tmp/mcp.json",
+          PATH: buildPath(fakeBinDir),
+          CLAUDE_CODE_CHILD_SESSION: "1",
+        },
+        tempDir.path
+      );
+
+      expect(
+        result.status,
+        `wrapper exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      ).toBe(0);
+      const output = parseFakeClaudeOutput(result.stdout);
+      expect(output).not.toBeNull();
+      // A leaked marker would make the workspace agent a "child session" and
+      // disable transcript saving, so the wrapper must strip it.
+      expect(output!.env.CLAUDE_CODE_CHILD_SESSION).toBeNull();
     });
 
     it("propagates exit code from claude binary", async () => {
@@ -470,7 +494,10 @@ if (process.argv.includes("--version")) {
 
 const output = {
   args: process.argv.slice(2),
-  env: { CLAUDECODE: process.env.CLAUDECODE ?? null },
+  env: {
+    CLAUDECODE: process.env.CLAUDECODE ?? null,
+    CLAUDE_CODE_CHILD_SESSION: process.env.CLAUDE_CODE_CHILD_SESSION ?? null,
+  },
 };
 
 const counterFile = process.env.CLAUDE_COUNTER_FILE;

--- a/src/modules/agent-module/claude/wrapper.ts
+++ b/src/modules/agent-module/claude/wrapper.ts
@@ -423,8 +423,13 @@ async function main(): Promise<never> {
     ...getUserArgs(), // Auto-detect user args for both terminal and panel modes
   ];
 
-  // 5. Clear CLAUDECODE to allow nested Claude Code sessions inside CodeHydra
+  // 5. Clear inherited Claude Code session markers so the workspace agent runs
+  //    as a top-level session. CLAUDECODE enables nested sessions;
+  //    CLAUDE_CODE_CHILD_SESSION (set only by Claude Code when it spawns a
+  //    subprocess) would otherwise flag this as a child session and disable
+  //    transcript saving, breaking --resume/--continue in the workspace.
   delete process.env.CLAUDECODE;
+  delete process.env.CLAUDE_CODE_CHILD_SESSION;
 
   // 6. Spawn Claude with automatic session resume.
   // Skip --continue attempt for new workspaces (no prior session to resume).


### PR DESCRIPTION
When CodeHydra is launched from within a Claude Code session, the `CLAUDE_CODE_CHILD_SESSION=1` marker propagates through to every `claude` process spawned for a workspace. Claude Code treats the marker as a nested/child session and disables transcript saving, surfacing the "Transcript saving is off" warning and breaking `--resume`/`--continue` in the workspace.

- `wrapper.ts`: delete `CLAUDE_CODE_CHILD_SESSION` alongside the existing `CLAUDECODE` deletion so each workspace agent runs as a genuine top-level session
- `fake-claude-binary.ts`: report the marker so a leak is observable in boundary tests
- `wrapper.boundary.test.ts`: new test asserting the wrapper strips the inherited marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MbLBDVeNJdxog9Hcd1aym