### PR TITLE
chore(process): log graceful SIGTERM at info level

### DIFF
--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -188,7 +188,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
     // Unix: Two-phase SIGTERM → SIGKILL
     // 1. Send SIGTERM
     await this.killProcess(pid, false);
-    this.logger.warn("Killed", { command: this.command, pid, signal: "SIGTERM" });
+    this.logger.info("Killed", { command: this.command, pid, signal: "SIGTERM" });
 
     // 2. If termTimeout defined, wait for graceful exit
     if (termTimeout !== undefined) {


### PR DESCRIPTION
- Log a graceful SIGTERM (that the process honors) at `info` instead of `warn`
- Keep `warn` for the forced SIGKILL / Windows TASKKILL fallback, so a process that actually resists termination still stands out in the logs