### PR TITLE
chore(intents): make the contract plain serializable data

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,46 @@ const NO_DYNAMIC_IMPORT = {
   message: "Use a top-level `import` declaration instead of an inline dynamic import().",
 };
 
+// ---------------------------------------------------------------------------
+// Intent contract: keep every carrier plain serializable data.
+//
+// The dispatcher validates six carriers with zod (intent payload, hook input context, hook
+// result, provides, event, operation result). Those parse calls ARE the serializability gate
+// for a backend that runs out of process — but only if no schema opts out of validating:
+//
+//   z.instanceof(Path)  does not merely permit a class instance, it *requires* one.
+//   z.custom<T>()       with no validator function performs no validation at all
+//                       (`z.custom().parse({ fn: () => {} })` passes) — an `as T` in a costume.
+//
+// A branded string (`z.string().brand<"WorkspacePath">()`) rejects a class instance, so with
+// the escapes closed the existing parses do the work and no new runtime machinery is needed.
+// ---------------------------------------------------------------------------
+
+const NO_ZOD_INSTANCEOF = {
+  selector: "CallExpression[callee.object.name='z'][callee.property.name='instanceof']",
+  message:
+    "z.instanceof() requires a class instance, which cannot cross a backend tunnel. Model the value as plain data (e.g. a branded path string, or `serializedErrorSchema` for an Error) and construct the class inside the handler.",
+};
+
+const NO_BARE_ZOD_CUSTOM = {
+  selector:
+    "CallExpression[callee.object.name='z'][callee.property.name='custom'][arguments.length=0]",
+  message:
+    "z.custom<T>() without a validator performs no validation — it is an `as T` assertion wearing a zod costume. Declare the shape structurally (z.object/z.enum/…) so the dispatcher's parse actually checks it.",
+};
+
+const NO_INTENT_ASSERTION_IN_DISPATCH = {
+  selector: "CallExpression[callee.property.name='dispatch'] > TSAsExpression",
+  message:
+    "`dispatch({…} as XIntent)` asserts the payload instead of checking it, so a contract change is invisible here. Use the explicit type argument — `dispatch<XIntent>({…})` — which types the result identically and checks the argument.",
+};
+
+const NO_EVENT_ASSERTION_IN_EMIT = {
+  selector: "CallExpression[callee.property.name='emit'] > TSAsExpression",
+  message:
+    "`emit({…} as XEvent)` asserts the payload instead of checking it. Drop the assertion (emit is typed to the events this operation declares) or use `satisfies XEvent`.",
+};
+
 // Files where a dynamic import() is load-bearing and cannot be hoisted:
 // - vite.config.ts: `await import("vite")` inside a plugin hook (importing vite
 //   at module scope would be circular).
@@ -130,6 +170,38 @@ export default tseslint.config(
             },
           ],
         },
+      ],
+    },
+  },
+  // Intent contract hygiene. Scoped to the intent system, which is what a backend tunnel has
+  // to serialize. `linterOptions.noInlineConfig` is on, so there is no per-line escape — an
+  // exemption would have to be a visible `files:` block here, which is the point.
+  {
+    files: ["src/intents/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        NO_DYNAMIC_IMPORT,
+        NO_INLINE_TYPE_IMPORT,
+        NO_ZOD_INSTANCEOF,
+        NO_BARE_ZOD_CUSTOM,
+        NO_INTENT_ASSERTION_IN_DISPATCH,
+        NO_EVENT_ASSERTION_IN_EMIT,
+      ],
+    },
+  },
+  // The dispatch/emit assertion bans apply everywhere intents are dispatched, not just inside
+  // the intent system — modules are where most dispatch sites live.
+  {
+    files: ["src/modules/**/*.ts", "src/main.ts"],
+    ignores: ["**/*.test.ts", "**/*.test-utils.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        NO_DYNAMIC_IMPORT,
+        NO_INLINE_TYPE_IMPORT,
+        NO_INTENT_ASSERTION_IN_DISPATCH,
+        NO_EVENT_ASSERTION_IN_EMIT,
       ],
     },
   },

--- a/src/boundaries/platform/config.ts
+++ b/src/boundaries/platform/config.ts
@@ -47,9 +47,11 @@ const BROKEN_CONFIG_FILENAME = "config.json.broken";
  * Agent types that can be selected by the user. Non-nullable: the default is
  * "claude". First-run onboarding is gated on whether config.json existed at load
  * (Config.wasConfigured()), not on a null agent.
- * Config-specific (not a generic store type), so it lives with the Config service.
+ *
+ * Type-only re-export of the intent contract's `agentTypeSchema` — one definition of the
+ * agent vocabulary, rather than a hand-written union per consumer.
  */
-export type ConfigAgentType = "claude" | "opencode";
+export type { AgentType as ConfigAgentType } from "../../intents/contract";
 
 /**
  * Where a config key's effective value came from, in precedence order.

--- a/src/boundaries/platform/git-worktree-provider.integration.test.ts
+++ b/src/boundaries/platform/git-worktree-provider.integration.test.ts
@@ -20,6 +20,7 @@ import { Path } from "../../utils/path/path";
 import type { IGitClient } from "./git-client";
 import type { FileSystemBoundary } from "./filesystem";
 import type { Logger } from "./logging";
+import { projPath } from "../../shared/test-fixtures";
 
 /** Construct a provider the way production does: new + validateRepository + registerProject. */
 async function createProvider(
@@ -2274,7 +2275,7 @@ describe("GitWorktreeProvider", () => {
             worktrees: [
               {
                 name: "feature-x",
-                path: new Path(WORKSPACES_DIR, "feature-x").toString(),
+                path: projPath(new Path(WORKSPACES_DIR, "feature-x").toString()),
                 branch: "feature-x",
               },
             ],
@@ -2316,7 +2317,7 @@ describe("GitWorktreeProvider", () => {
             worktrees: [
               {
                 name: "feature-x",
-                path: new Path(WORKSPACES_DIR, "feature-x").toString(),
+                path: projPath(new Path(WORKSPACES_DIR, "feature-x").toString()),
                 branch: "feature-x",
               },
             ],

--- a/src/intents/agent-launch-options.ts
+++ b/src/intents/agent-launch-options.ts
@@ -70,7 +70,11 @@ export const launchOptionsHookInputSchema = hookCtxSchema(
   launchOptionsEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_LAUNCH_OPTIONS,
   payload: getLaunchOptionsPayloadSchema,
   result: launchOptionsResultSchema,
@@ -102,12 +106,14 @@ export class AgentLaunchOptionsOperation implements Operation<typeof schemas> {
   readonly id = GET_LAUNCH_OPTIONS_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<GetLaunchOptionsIntent>): Promise<LaunchOptionsResult> {
+  async execute(
+    ctx: OperationContext<GetLaunchOptionsIntent, typeof schemas>
+  ): Promise<LaunchOptionsResult> {
     const hookCtx: LaunchOptionsHookInput = {
       intent: ctx.intent,
       backend: ctx.intent.payload.backend,
     };
-    const { results } = await ctx.hooks.collect<LaunchOptionsHookResult>("launch-options", hookCtx);
+    const { results } = await ctx.hooks.collect("launch-options", hookCtx);
 
     const permissionModes: string[] = [];
     for (const result of results) {

--- a/src/intents/agent-lifecycle.ts
+++ b/src/intents/agent-lifecycle.ts
@@ -20,7 +20,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { hookCtxSchema } from "./contract";
+import { hookCtxSchema, workspacePathSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 export const INTENT_AGENT_LIFECYCLE = "agent:lifecycle" as const;
@@ -40,14 +40,14 @@ const agentLifecycleEventSchema = z.enum(["open", "close"]);
 
 export const agentLifecyclePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     event: agentLifecycleEventSchema,
   })
   .readonly();
 
 /** Operation-added enrichment for the "lifecycle" hook point (beyond the base HookContext). */
 const lifecycleEnrichmentSchema = z.object({
-  workspacePath: z.string(),
+  workspacePath: workspacePathSchema,
   event: agentLifecycleEventSchema,
 });
 
@@ -57,7 +57,11 @@ export const lifecycleHookInputSchema = hookCtxSchema(
   lifecycleEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_AGENT_LIFECYCLE,
   payload: agentLifecyclePayloadSchema,
   hooks: {
@@ -83,7 +87,7 @@ export class AgentLifecycleOperation implements Operation<typeof schemas> {
   readonly id = AGENT_LIFECYCLE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<AgentLifecycleIntent>): Promise<void> {
+  async execute(ctx: OperationContext<AgentLifecycleIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
 
     const lifecycleCtx: AgentLifecycleHookInput = {
@@ -91,7 +95,7 @@ export class AgentLifecycleOperation implements Operation<typeof schemas> {
       workspacePath: payload.workspacePath,
       event: payload.event,
     };
-    const { errors } = await ctx.hooks.collect<void>("lifecycle", lifecycleCtx);
+    const { errors } = await ctx.hooks.collect("lifecycle", lifecycleCtx);
     throwHookErrors(errors, "agent-lifecycle lifecycle hooks failed");
   }
 }

--- a/src/intents/app-ready.integration.test.ts
+++ b/src/intents/app-ready.integration.test.ts
@@ -9,6 +9,7 @@
 
 import { createMockDispatcher } from "./lib/dispatcher.test-utils";
 import { describe, it, expect } from "vitest";
+import { projPath } from "../shared/test-fixtures";
 import { Dispatcher } from "./lib/dispatcher";
 
 import {
@@ -26,6 +27,7 @@ import type { HookOutput, Operation, OperationSchemas } from "./lib/operation";
 import type { Project } from "../shared/api/types";
 import { createMockAccessor } from "../boundaries/platform/config.test-utils";
 import type { ConfigAgentType } from "../boundaries/platform/config";
+import { projectSchema } from "./contract";
 
 // =============================================================================
 // Test Helpers
@@ -50,7 +52,7 @@ function createProjectModule(projectPaths: readonly string[]): IntentModule {
       [APP_READY_OPERATION_ID]: {
         "load-projects": {
           handler: async (): Promise<HookOutput<LoadProjectsResult>> => {
-            return { result: { projectPaths } };
+            return { result: { projectPaths: projectPaths.map(projPath) } };
           },
         },
       },
@@ -61,7 +63,7 @@ function createProjectModule(projectPaths: readonly string[]): IntentModule {
 const openProjectStubSchemas = {
   type: INTENT_OPEN_PROJECT,
   payload: z.unknown(),
-  result: z.custom<Project>(),
+  result: projectSchema,
 } satisfies OperationSchemas;
 
 function createProjectOpenStub(

--- a/src/intents/app-ready.ts
+++ b/src/intents/app-ready.ts
@@ -14,18 +14,18 @@
  *
  * Contract schemas (item 2): zod is the single source of truth. The payload/result/hook/
  * event schemas are declared once and hung on the operation's `schemas` field; the `Intent`
- * and result types are **derived** via `IntentOf`/`z.infer`. `AgentInfo`/`LifecycleAgentType`
- * are shared IPC types modeled with `z.custom` so their exact named types flow through.
+ * and result types are **derived** via `IntentOf`/`z.infer`. The agent vocabulary
+ * (`agentTypeSchema`/`agentInfoSchema`) lives in the contract; `shared/ipc` re-exports those
+ * types, so there is one definition rather than a schema mirroring an interface.
  */
 
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import { INTENT_OPEN_PROJECT, type OpenProjectIntent } from "./open-project";
-import { Path } from "../utils/path/path";
-import type { AgentInfo, LifecycleAgentType } from "../shared/ipc";
+import { agentInfoSchema, agentTypeSchema, projectPathSchema, hookCtxSchema } from "./contract";
+import type { AgentInfo, AgentType, ProjectPath } from "./contract";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
-import type { ConfigAgentType } from "../boundaries/platform/config";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 export const INTENT_APP_READY = "app:ready" as const;
@@ -56,9 +56,9 @@ export const appReadyPayloadSchema = z.object({}).readonly();
 export const appReadyResultSchema = z
   .object({
     /** Global default agent (config.agent). Null when not yet chosen (first-run pending). */
-    defaultAgent: z.custom<LifecycleAgentType>().nullable(),
+    defaultAgent: agentTypeSchema.nullable(),
     /** Agents whose binaries are currently present on disk. */
-    availableAgents: z.array(z.custom<AgentInfo>()).readonly(),
+    availableAgents: z.array(agentInfoSchema).readonly(),
   })
   .readonly();
 
@@ -68,7 +68,7 @@ export const appReadyResultSchema = z
  */
 export const loadProjectsResultSchema = z
   .object({
-    projectPaths: z.array(z.string()).readonly().optional(),
+    projectPaths: z.array(projectPathSchema).readonly().optional(),
   })
   .readonly();
 
@@ -78,20 +78,27 @@ export const loadProjectsResultSchema = z
  */
 export const availableAgentsResultSchema = z
   .object({
-    agent: z.custom<AgentInfo>().optional(),
+    agent: agentInfoSchema.optional(),
   })
   .readonly();
 
 /** Payload emitted by `app:started`. */
 export const appStartedPayloadSchema = z.object({}).readonly();
 
-const schemas = {
+/** Both hook points receive the bare intent — declared so the context type is derived. */
+const appReadyHookInputSchema = hookCtxSchema(appReadyPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_APP_READY,
   payload: appReadyPayloadSchema,
   result: appReadyResultSchema,
   hooks: {
-    "load-projects": { result: loadProjectsResultSchema },
-    "available-agents": { result: availableAgentsResultSchema },
+    "load-projects": { input: appReadyHookInputSchema, result: loadProjectsResultSchema },
+    "available-agents": { input: appReadyHookInputSchema, result: availableAgentsResultSchema },
   },
   events: {
     [EVENT_APP_STARTED]: appStartedPayloadSchema,
@@ -116,15 +123,15 @@ export class AppReadyOperation implements Operation<typeof schemas> {
   readonly id = APP_READY_OPERATION_ID;
   readonly schemas = schemas;
 
-  constructor(private readonly agentConfig: PersistedAccessor<ConfigAgentType>) {}
+  constructor(private readonly agentConfig: PersistedAccessor<AgentType>) {}
 
-  async execute(ctx: OperationContext<AppReadyIntent>): Promise<AppReadyResult> {
+  async execute(ctx: OperationContext<AppReadyIntent, typeof schemas>): Promise<AppReadyResult> {
     const hookCtx: HookContext = { intent: ctx.intent };
 
     // Collect bootstrap data: available agents + saved project paths in parallel.
     const [agentsResult, projectsResult] = await Promise.all([
-      ctx.hooks.collect<AvailableAgentsResult>("available-agents", hookCtx),
-      ctx.hooks.collect<LoadProjectsResult>("load-projects", hookCtx),
+      ctx.hooks.collect("available-agents", hookCtx),
+      ctx.hooks.collect("load-projects", hookCtx),
     ]);
     throwHookErrors(projectsResult.errors, "app:ready load-projects hooks failed");
     // available-agents errors are best-effort: an agent that fails preflight just
@@ -136,10 +143,9 @@ export class AppReadyOperation implements Operation<typeof schemas> {
     }
 
     const defaultAgentRaw = this.agentConfig.get();
-    const defaultAgent: LifecycleAgentType | null =
-      defaultAgentRaw === "claude" || defaultAgentRaw === "opencode" ? defaultAgentRaw : null;
+    const defaultAgent: AgentType | null = agentTypeSchema.safeParse(defaultAgentRaw).data ?? null;
 
-    const projectPaths: string[] = [];
+    const projectPaths: ProjectPath[] = [];
     for (const result of projectsResult.results) {
       if (result.projectPaths) projectPaths.push(...result.projectPaths);
     }
@@ -150,10 +156,10 @@ export class AppReadyOperation implements Operation<typeof schemas> {
     // not git repos, etc.) are silently dropped without aborting the rest.
     await Promise.allSettled(
       projectPaths.map((projectPath) =>
-        ctx.dispatch({
+        ctx.dispatch<OpenProjectIntent>({
           type: INTENT_OPEN_PROJECT,
-          payload: { path: new Path(projectPath) },
-        } as OpenProjectIntent)
+          payload: { path: projectPath },
+        })
       )
     );
 

--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -24,6 +24,7 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
+import { hookCtxSchema } from "./contract";
 
 export const INTENT_APP_RESUME = "app:resume" as const;
 
@@ -73,11 +74,18 @@ export const appResumeFailedPayloadSchema = z.object({ error: z.string() }).read
 /** Payload emitted by `ide-server:restarted`. */
 export const ideServerRestartedPayloadSchema = z.object({}).readonly();
 
-const schemas = {
+/** The resume hook point receives the bare intent. */
+const appResumeHookInputSchema = hookCtxSchema(appResumePayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_APP_RESUME,
   payload: appResumePayloadSchema,
   hooks: {
-    [APP_RESUME_HOOK_RESUME]: { result: resumeHookResultSchema },
+    [APP_RESUME_HOOK_RESUME]: { input: appResumeHookInputSchema, result: resumeHookResultSchema },
   },
   events: {
     [EVENT_APP_RESUMED]: appResumedPayloadSchema,
@@ -124,9 +132,9 @@ export class AppResumeOperation implements Operation<typeof schemas> {
   readonly id = APP_RESUME_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<AppResumeIntent>): Promise<void> {
+  async execute(ctx: OperationContext<AppResumeIntent, typeof schemas>): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
-    const { results } = await ctx.hooks.collect<ResumeHookResult>(APP_RESUME_HOOK_RESUME, hookCtx);
+    const { results } = await ctx.hooks.collect(APP_RESUME_HOOK_RESUME, hookCtx);
 
     // Turn handler outcomes into domain events (operation owns emits).
     for (const result of results) {

--- a/src/intents/app-shutdown.ts
+++ b/src/intents/app-shutdown.ts
@@ -23,6 +23,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
+import { hookCtxSchema } from "./contract";
 
 export const INTENT_APP_SHUTDOWN = "app:shutdown" as const;
 
@@ -43,9 +44,20 @@ export const appShutdownPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/** Both shutdown hook points receive the bare intent. */
+const shutdownHookInputSchema = hookCtxSchema(appShutdownPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_APP_SHUTDOWN,
   payload: appShutdownPayloadSchema,
+  hooks: {
+    stop: { input: shutdownHookInputSchema },
+    quit: { input: shutdownHookInputSchema },
+  },
 } satisfies OperationSchemas;
 
 // =============================================================================
@@ -63,7 +75,7 @@ export class AppShutdownOperation implements Operation<typeof schemas> {
   readonly id = APP_SHUTDOWN_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<AppShutdownIntent>): Promise<void> {
+  async execute(ctx: OperationContext<AppShutdownIntent, typeof schemas>): Promise<void> {
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
@@ -71,10 +83,10 @@ export class AppShutdownOperation implements Operation<typeof schemas> {
     // Hook: "stop" -- All modules dispose (independent, best-effort)
     // collect() catches errors from each handler and continues to the next.
     // The dispatcher logs hook errors centrally.
-    await ctx.hooks.collect<void>("stop", hookCtx);
+    await ctx.hooks.collect("stop", hookCtx);
 
     // Hook: "quit" -- Terminate the process (runs after all cleanup)
-    await ctx.hooks.collect<void>("quit", hookCtx);
+    await ctx.hooks.collect("quit", hookCtx);
 
     // Intentionally ignore both results and errors -- shutdown is best-effort.
     // Individual module errors are logged by the dispatcher.

--- a/src/intents/app-start.integration.test.ts
+++ b/src/intents/app-start.integration.test.ts
@@ -1088,7 +1088,10 @@ describe("AppStart Operation", () => {
 
       expect(captured.ctx).toBeDefined();
       expect(captured.ctx!.phase).toBe("start");
-      expect(captured.ctx!.error).toBeInstanceOf(Error);
+      // The contract carries the failure as plain data — an Error instance could not cross a
+      // backend tunnel. error-report-module rebuilds a real Error for the telemetry boundary.
+      expect(captured.ctx!.error).not.toBeInstanceOf(Error);
+      expect(captured.ctx!.error.name).toBe("Error");
       expect(captured.ctx!.error.message).toBe("IdeServer failed to start");
     });
 

--- a/src/intents/app-start.ts
+++ b/src/intents/app-start.ts
@@ -41,24 +41,30 @@
  * Contract schemas (item 2): zod is the single source of truth. Payload, per-hook-point
  * (result/input) schemas are declared once and hung on the operation's `schemas` field; the
  * `Intent`, result, and hook-input-context types are **derived** via `IntentOf`/`z.infer`.
- * The "start" and "await-retry" hook points return void (no schema). `BinaryType` is a shared
- * binary-resolution type modeled with `z.custom` so its exact named type flows through.
+ * Every hook point declares an input schema, including those whose context is just the
+ * intent ("start", "await-retry"), so a handler's context type is derived rather than
+ * hand-written and nothing undeclared can ride along.
  */
 
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { configAgentTypeSchema, hookCtxSchema } from "./contract";
-import type { ConfigAgentType } from "../shared/api/types";
-import type { LifecycleAgentType } from "../shared/ipc";
+import {
+  agentInfoSchema,
+  agentTypeSchema,
+  binaryTypeSchema,
+  hookCtxSchema,
+  serializedErrorSchema,
+} from "./contract";
+import type { AgentType, BinaryType } from "./contract";
+import { toSerializedError } from "../shared/error-utils";
 import type { PersistedAccessor } from "../boundaries/platform/store-definition";
-import type { BinaryType } from "../utils/binary-resolution/types";
 import { INTENT_SETUP } from "./setup";
 import { INTENT_APP_READY, type AppReadyIntent } from "./app-ready";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 /** Re-exported for use by operation integration tests (avoids direct service import). */
-export type { BinaryType } from "../utils/binary-resolution/types";
+export type { BinaryType } from "./contract";
 
 export const INTENT_APP_START = "app:start" as const;
 
@@ -110,20 +116,11 @@ export const appStartPhaseSchema = z.enum([
   "start",
 ]);
 
-/** Selectable agent backend. Local schema; mirrors shared/ipc's LifecycleAgentType. */
-const lifecycleAgentTypeSchema = z.enum(["opencode", "claude"]);
-
 /**
  * Per-handler result for the "register-agents" hook point.
  * Each per-agent module returns its agent info for the selection UI.
  */
-export const registerAgentResultSchema = z
-  .object({
-    agent: lifecycleAgentTypeSchema,
-    label: z.string(),
-    icon: z.string(),
-  })
-  .readonly();
+export const registerAgentResultSchema = agentInfoSchema;
 
 /**
  * Per-handler result for "before-ready" hook point.
@@ -161,7 +158,7 @@ export const showUIHookResultSchema = z
 /** Per-handler result for "check-deps" hook point. Arrays only -- booleans derived by operation. */
 export const checkDepsResultSchema = z
   .object({
-    missingBinaries: z.array(z.custom<BinaryType>()).readonly().optional(),
+    missingBinaries: z.array(binaryTypeSchema).readonly().optional(),
     extensionInstallPlan: z.array(extensionInstallEntrySchema).readonly().optional(),
   })
   .readonly();
@@ -182,7 +179,7 @@ const agentSelectionInputSchema = hookCtxSchema(
 );
 
 /** Operation-added enrichment for the "save-agent" hook (selectedAgent from agent-selection). */
-const saveAgentEnrichmentSchema = z.object({ selectedAgent: configAgentTypeSchema });
+const saveAgentEnrichmentSchema = z.object({ selectedAgent: agentTypeSchema });
 const saveAgentInputSchema = hookCtxSchema(appStartPayloadSchema, saveAgentEnrichmentSchema.shape);
 
 /**
@@ -190,7 +187,7 @@ const saveAgentInputSchema = hookCtxSchema(appStartPayloadSchema, saveAgentEnric
  * Non-nullable: agent selection runs first, so the agent is always known here.
  */
 const checkDepsEnrichmentSchema = z.object({
-  configuredAgent: configAgentTypeSchema,
+  configuredAgent: agentTypeSchema,
   extensionRequirements: z.array(extensionRequirementSchema).readonly(),
 });
 const checkDepsHookInputSchema = hookCtxSchema(
@@ -199,11 +196,12 @@ const checkDepsHookInputSchema = hookCtxSchema(
 );
 
 /**
- * Operation-added enrichment for the "error" hook point. Carries the live fatal error
- * (a real Error instance — host-only) and the phase it occurred in.
+ * Operation-added enrichment for the "error" hook point. Carries the fatal error as plain
+ * data (with its `cause` chain) and the phase it occurred in. The operation converts with
+ * `toSerializedError()`; a handler that needs a real `Error` rebuilds one.
  */
 const appStartErrorEnrichmentSchema = z.object({
-  error: z.instanceof(Error),
+  error: serializedErrorSchema,
   phase: appStartPhaseSchema,
 });
 const appStartErrorHookInputSchema = hookCtxSchema(
@@ -211,15 +209,27 @@ const appStartErrorHookInputSchema = hookCtxSchema(
   appStartErrorEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * The hook points whose context is just the intent. Declared rather than omitted: a hook
+ * point with no input schema has no contract, and `InputOf` has nothing to derive from.
+ */
+const bareHookInputSchema = hookCtxSchema(appStartPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_APP_START,
   payload: appStartPayloadSchema,
   hooks: {
-    "before-ready": { result: configureResultSchema },
+    "before-ready": { input: bareHookInputSchema, result: configureResultSchema },
     init: { input: initHookInputSchema, result: initResultSchema },
-    "show-ui": { result: showUIHookResultSchema },
-    "register-agents": { result: registerAgentResultSchema },
-    "agent-selection": { input: agentSelectionInputSchema, result: lifecycleAgentTypeSchema },
+    "show-ui": { input: bareHookInputSchema, result: showUIHookResultSchema },
+    "register-agents": { input: bareHookInputSchema, result: registerAgentResultSchema },
+    start: { input: bareHookInputSchema },
+    "await-retry": { input: bareHookInputSchema },
+    "agent-selection": { input: agentSelectionInputSchema, result: agentTypeSchema },
     "save-agent": { input: saveAgentInputSchema },
     "check-deps": { input: checkDepsHookInputSchema, result: checkDepsResultSchema },
     [APP_START_ERROR_HOOK]: { input: appStartErrorHookInputSchema },
@@ -284,12 +294,12 @@ export class AppStartOperation implements Operation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor(
-    private readonly agentConfig: PersistedAccessor<ConfigAgentType>,
+    private readonly agentConfig: PersistedAccessor<AgentType>,
     /** Whether config.json existed at load; false = first run → agent selection. */
     private readonly wasConfigured: () => boolean
   ) {}
 
-  async execute(ctx: OperationContext<AppStartIntent>): Promise<void> {
+  async execute(ctx: OperationContext<AppStartIntent, typeof schemas>): Promise<void> {
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
@@ -303,8 +313,10 @@ export class AppStartOperation implements Operation<typeof schemas> {
       // --- Hook 1: "before-ready" (pre-ready) ---
       // Script declarations, noAsar, data paths, electron flags. All independent.
       phase = "before-ready";
-      const { results: configResults, errors: configErrors } =
-        await ctx.hooks.collect<ConfigureResult>("before-ready", hookCtx);
+      const { results: configResults, errors: configErrors } = await ctx.hooks.collect(
+        "before-ready",
+        hookCtx
+      );
       throwHookErrors(configErrors, "app:start before-ready hooks failed");
       const requiredScripts = configResults.flatMap((r) => r.scripts ?? []);
 
@@ -314,10 +326,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
       // Receives requiredScripts from before-ready results.
       phase = "init";
       const initCtx: InitHookContext = { ...hookCtx, requiredScripts };
-      const { results: initResults, errors: initErrors } = await ctx.hooks.collect<InitResult>(
-        "init",
-        initCtx
-      );
+      const { results: initResults, errors: initErrors } = await ctx.hooks.collect("init", initCtx);
       throwHookErrors(initErrors, "app:start init hooks failed");
 
       // Extract extensionRequirements from init results
@@ -331,20 +340,22 @@ export class AppStartOperation implements Operation<typeof schemas> {
       // null drives the agent-selection hook points below. The `agent` config key is
       // non-nullable (it defaults to "claude"), so file existence — not the value —
       // is what distinguishes "never chosen" from "chose Claude".
-      const configuredAgent: ConfigAgentType | null = this.wasConfigured()
+      const configuredAgent: AgentType | null = this.wasConfigured()
         ? this.agentConfig.get()
         : null;
 
       // Hook 3: "show-ui" -- Show starting screen; learn whether a retry loop is supported.
       phase = "show-ui";
-      const { results: showUiResults, errors: showUiErrors } =
-        await ctx.hooks.collect<ShowUIHookResult>("show-ui", hookCtx);
+      const { results: showUiResults, errors: showUiErrors } = await ctx.hooks.collect(
+        "show-ui",
+        hookCtx
+      );
       throwHookErrors(showUiErrors, "app:start show-ui hooks failed");
       const retrySupported = showUiResults.some((r) => r.retrySupported === true);
 
       // Hook 4: agent selection (first run only) -- register-agents, agent-selection, save-agent.
       // Runs BEFORE check-deps so the deps check knows which agent's binary to look for.
-      let agent: ConfigAgentType;
+      let agent: AgentType;
       if (configuredAgent === null) {
         phase = "agent-selection";
         agent = await this.selectAgent(ctx, hookCtx, retrySupported);
@@ -381,7 +392,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
             // hook point blocks (host-side, in the UI handler) until the user clicks
             // Retry and returns data — no closure crosses the hook contract.
             if (retrySupported) {
-              const { errors: retryErrors } = await ctx.hooks.collect<void>("await-retry", hookCtx);
+              const { errors: retryErrors } = await ctx.hooks.collect("await-retry", hookCtx);
               throwHookErrors(retryErrors, "app:start await-retry hooks failed");
               // Re-run check hooks to get fresh preflight state for retry
               checkResult = await this.runChecks(ctx, agent, extensionRequirements);
@@ -404,7 +415,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
       // read from ctx.capabilities. Capability-based ordering replaces the former
       // separate "activate" hook point.
       phase = "start";
-      const { errors: startErrors } = await ctx.hooks.collect<void>("start", hookCtx);
+      const { errors: startErrors } = await ctx.hooks.collect("start", hookCtx);
       throwHookErrors(startErrors, "app:start start hooks failed");
 
       // After all start handlers (IDE server included) are up, load initial projects.
@@ -426,7 +437,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
       // box + app.quit path unchanged.
       const errorCtx: AppStartErrorHookContext = {
         intent: ctx.intent,
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: toSerializedError(error),
         phase,
       };
       await ctx.hooks.collect(APP_START_ERROR_HOOK, errorCtx);
@@ -443,29 +454,33 @@ export class AppStartOperation implements Operation<typeof schemas> {
    * app:shutdown during selection), save-agent never runs and the next launch re-prompts.
    */
   private async selectAgent(
-    ctx: OperationContext<AppStartIntent>,
+    ctx: OperationContext<AppStartIntent, typeof schemas>,
     hookCtx: HookContext,
     retrySupported: boolean
-  ): Promise<ConfigAgentType> {
+  ): Promise<AgentType> {
     for (;;) {
       try {
-        const { results: agentInfos, errors: registerErrors } =
-          await ctx.hooks.collect<RegisterAgentResult>("register-agents", hookCtx);
+        const { results: agentInfos, errors: registerErrors } = await ctx.hooks.collect(
+          "register-agents",
+          hookCtx
+        );
         throwHookErrors(registerErrors, "app:start register-agents hooks failed");
 
         const selectionCtx: AgentSelectionHookContext = { ...hookCtx, availableAgents: agentInfos };
-        const { results: agentResults, errors: agentErrors } =
-          await ctx.hooks.collect<LifecycleAgentType>("agent-selection", selectionCtx);
+        const { results: agentResults, errors: agentErrors } = await ctx.hooks.collect(
+          "agent-selection",
+          selectionCtx
+        );
         throwHookErrors(agentErrors, "app:start agent-selection hooks failed");
 
         // Single result-producer (the picker); results[0] is the chosen agent.
-        const selectedAgent = agentResults[0] as ConfigAgentType | undefined;
+        const selectedAgent = agentResults[0];
         if (selectedAgent === undefined) {
           throw new Error("app:start agent-selection produced no agent");
         }
 
         const saveAgentInput: SaveAgentHookInput = { intent: ctx.intent, selectedAgent };
-        const { errors: saveErrors } = await ctx.hooks.collect<void>("save-agent", saveAgentInput);
+        const { errors: saveErrors } = await ctx.hooks.collect("save-agent", saveAgentInput);
         throwHookErrors(saveErrors, "app:start save-agent hooks failed");
 
         return selectedAgent;
@@ -475,7 +490,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
             cause: selectionError,
           });
         }
-        const { errors: retryErrors } = await ctx.hooks.collect<void>("await-retry", hookCtx);
+        const { errors: retryErrors } = await ctx.hooks.collect("await-retry", hookCtx);
         throwHookErrors(retryErrors, "app:start await-retry hooks failed");
       }
     }
@@ -490,8 +505,8 @@ export class AppStartOperation implements Operation<typeof schemas> {
    * a null agent would silently produce an empty binary list.
    */
   private async runChecks(
-    ctx: OperationContext<AppStartIntent>,
-    configuredAgent: ConfigAgentType,
+    ctx: OperationContext<AppStartIntent, typeof schemas>,
+    configuredAgent: AgentType,
     extensionRequirements: readonly ExtensionRequirement[]
   ): Promise<CheckResult> {
     // check-deps: binary + extension checks (collect, isolated contexts)
@@ -500,7 +515,7 @@ export class AppStartOperation implements Operation<typeof schemas> {
       configuredAgent,
       extensionRequirements,
     };
-    const { results: depsResults, errors: depsErrors } = await ctx.hooks.collect<CheckDepsResult>(
+    const { results: depsResults, errors: depsErrors } = await ctx.hooks.collect(
       "check-deps",
       depsCtx
     );

--- a/src/intents/close-project.integration.test.ts
+++ b/src/intents/close-project.integration.test.ts
@@ -60,6 +60,7 @@ import type { TestViewManager } from "./operations.test-utils";
 import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
 import type { ProjectId, WorkspaceName, Project } from "../shared/api/types";
 import { Path } from "../utils/path/path";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Helpers
@@ -73,11 +74,11 @@ function testProjectId(path: string): ProjectId {
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/test/project";
+const PROJECT_PATH = projPath("/test/project");
 const PROJECT_ID = testProjectId(PROJECT_PATH);
-const WORKSPACE_A_PATH = "/test/project/workspaces/feature-a";
+const WORKSPACE_A_PATH = wsPath("/test/project/workspaces/feature-a");
 const WORKSPACE_A_NAME = "feature-a" as WorkspaceName;
-const WORKSPACE_B_PATH = "/test/project/workspaces/feature-b";
+const WORKSPACE_B_PATH = wsPath("/test/project/workspaces/feature-b");
 const WORKSPACE_B_NAME = "feature-b" as WorkspaceName;
 
 // =============================================================================
@@ -487,7 +488,7 @@ describe("CloseProjectOperation", () => {
   it("test 13: close with unknown projectPath throws", async () => {
     const harness = createTestHarness({ projectNotFound: true });
     const intent = buildCloseIntent({
-      projectPath: "/nonexistent/project",
+      projectPath: projPath("/nonexistent/project"),
     });
 
     await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Project not found");
@@ -500,10 +501,17 @@ describe("CloseProjectOperation", () => {
     await harness.dispatcher.dispatch(intent);
 
     // The deleteViewModule checks skipSwitch -- no setActiveWorkspace calls from
-    // individual workspace deletes (only from the project close operation itself)
-    // The operation sets active to null since no other projects exist
+    // individual workspace deletes (only from the project close operation itself).
+    //
+    // Deselection happens twice, and both are the same idempotent write. The "close" hook
+    // nulls the active workspace, and the operation then dispatches workspace:switch(null),
+    // whose `activate` hook nulls it again. That mirrors production exactly: view-module
+    // clears `activeWorkspacePath` in both its `activate` handler and its workspace:switched
+    // event handler. The invariant under test is that the workspace is deselected and that no
+    // *intermediate workspace* switch occurred — not how many code paths wrote the null.
     const nullCalls = harness.state.setActiveWorkspaceCalls.filter((c) => c.path === null);
-    expect(nullCalls.length).toBe(1);
+    expect(nullCalls.length).toBeGreaterThanOrEqual(1);
+    expect(harness.viewManager.getActiveWorkspacePath()).toBeNull();
 
     // No intermediate workspace switches (no calls with workspace paths)
     const workspaceSwitchCalls = harness.state.setActiveWorkspaceCalls.filter(
@@ -663,7 +671,9 @@ describe("CloseProjectOperation.interactiveConfirm", () => {
     harness.dispatcher.subscribe(EVENT_PROJECT_CLOSE_FAILED, (e) => closeFailed.push(e));
 
     await expect(
-      harness.dispatcher.dispatch(buildCloseIntent({ projectPath: "/nonexistent/project" }))
+      harness.dispatcher.dispatch(
+        buildCloseIntent({ projectPath: projPath("/nonexistent/project") })
+      )
     ).rejects.toThrow("Project not found");
 
     expect(closeFailed).toHaveLength(1);

--- a/src/intents/close-project.ts
+++ b/src/intents/close-project.ts
@@ -26,9 +26,10 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, hookCtxSchema } from "./contract";
+import { hookCtxSchema, projectIdSchema, projectPathSchema, workspacePathSchema } from "./contract";
+import type { ProjectPath } from "./contract";
 import { INTENT_DELETE_WORKSPACE, type DeleteWorkspaceIntent } from "./delete-workspace";
-import { EVENT_WORKSPACE_SWITCHED, type WorkspaceSwitchedEvent } from "./switch-workspace";
+import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
 
@@ -51,7 +52,7 @@ export const EVENT_PROJECT_CLOSE_FAILED = "project:close-failed" as const;
 
 export const closeProjectPayloadSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     removeLocalRepo: z.boolean().optional(),
     /**
      * The dispatch is user-interactive: the "confirm" hook point runs after
@@ -76,13 +77,13 @@ export const projectClosedPayloadSchema = z
      * project:close-failed. Without it, getKey(payload) is undefined and a
      * successfully-closed-then-reopened project can never be closed again.
      */
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
   })
   .readonly();
 
 export const projectCloseFailedPayloadSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
   })
   .readonly();
 
@@ -95,7 +96,7 @@ export const closeResolveHookResultSchema = z
   .object({
     remoteUrl: z.string().optional(),
     workspaces: z
-      .array(z.object({ path: z.string() }))
+      .array(z.object({ path: workspacePathSchema }))
       .readonly()
       .optional(),
   })
@@ -131,9 +132,9 @@ export const closeHookResultSchema = z
 
 /** Operation-added enrichment for the "confirm" hook point (interactive dispatches only). */
 const closeConfirmEnrichmentSchema = z.object({
-  projectPath: z.string(),
+  projectPath: projectPathSchema,
   remoteUrl: z.string().optional(),
-  workspaces: z.array(z.object({ path: z.string() })).readonly(),
+  workspaces: z.array(z.object({ path: workspacePathSchema })).readonly(),
 });
 
 /** Runtime whole-context validation schema for "confirm". */
@@ -144,7 +145,7 @@ export const closeConfirmHookInputSchema = hookCtxSchema(
 
 /** Operation-added enrichment for the "close" hook point. */
 const closeEnrichmentSchema = z.object({
-  projectPath: z.string(),
+  projectPath: projectPathSchema,
   remoteUrl: z.string().optional(),
   removeLocalRepo: z.boolean(),
 });
@@ -155,11 +156,18 @@ export const closeHookInputSchema = hookCtxSchema(
   closeEnrichmentSchema.shape
 );
 
-const schemas = {
+/** The resolve hook point receives the bare intent. */
+const bareCloseHookInputSchema = hookCtxSchema(closeProjectPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_CLOSE_PROJECT,
   payload: closeProjectPayloadSchema,
   hooks: {
-    resolve: { result: closeResolveHookResultSchema },
+    resolve: { input: bareCloseHookInputSchema, result: closeResolveHookResultSchema },
     confirm: { input: closeConfirmHookInputSchema, result: closeConfirmHookResultSchema },
     close: { input: closeHookInputSchema, result: closeHookResultSchema },
   },
@@ -213,7 +221,7 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
   readonly id = CLOSE_PROJECT_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<CloseProjectIntent>): Promise<void> {
+  async execute(ctx: OperationContext<CloseProjectIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
     const projectPath = payload.projectPath;
 
@@ -226,7 +234,10 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
     }
   }
 
-  private emitCloseFailed(ctx: OperationContext<CloseProjectIntent>, projectPath: string): void {
+  private emitCloseFailed(
+    ctx: OperationContext<CloseProjectIntent, typeof schemas>,
+    projectPath: ProjectPath
+  ): void {
     const event: ProjectCloseFailedEvent = {
       type: EVENT_PROJECT_CLOSE_FAILED,
       payload: { projectPath },
@@ -234,23 +245,25 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
     ctx.emit(event);
   }
 
-  private async run(ctx: OperationContext<CloseProjectIntent>): Promise<void> {
+  private async run(ctx: OperationContext<CloseProjectIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
     const projectPath = payload.projectPath;
 
     // 1. Dispatch project:resolve to get projectId from projectPath
-    const projResolved = await ctx.dispatch({
+    const projResolved = await ctx.dispatch<ResolveProjectIntent>({
       type: INTENT_RESOLVE_PROJECT,
       payload: { projectPath },
-    } as ResolveProjectIntent);
+    });
     const projectId = projResolved.projectId;
 
     // 2. Run "resolve" hook -- returns remoteUrl, workspaces
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
-    const { results: resolveResults, errors: resolveErrors } =
-      await ctx.hooks.collect<CloseResolveHookResult>("resolve", hookCtx);
+    const { results: resolveResults, errors: resolveErrors } = await ctx.hooks.collect(
+      "resolve",
+      hookCtx
+    );
     throwHookErrors(resolveErrors, "close-project resolve hooks failed");
 
     // Merge resolve results — last-write-wins
@@ -269,8 +282,10 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
         ...(remoteUrl !== undefined && { remoteUrl }),
         workspaces,
       };
-      const { results: confirmResults, errors: confirmErrors } =
-        await ctx.hooks.collect<CloseConfirmHookResult>("confirm", confirmCtx);
+      const { results: confirmResults, errors: confirmErrors } = await ctx.hooks.collect(
+        "confirm",
+        confirmCtx
+      );
       throwHookErrors(confirmErrors, "close-project confirm hooks failed");
       if (confirmResults.some((r) => r.canceled)) {
         this.emitCloseFailed(ctx, projectPath);
@@ -318,7 +333,7 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
       removeLocalRepo,
       ...(remoteUrl !== undefined && { remoteUrl }),
     };
-    const { results: closeResults, errors: closeErrors } = await ctx.hooks.collect<CloseHookResult>(
+    const { results: closeResults, errors: closeErrors } = await ctx.hooks.collect(
       "close",
       closeHookInput
     );
@@ -327,13 +342,21 @@ export class CloseProjectOperation implements Operation<typeof schemas> {
     // Merge close results — last-write-wins for otherProjectsExist
     const otherProjectsExist = lastDefined(closeResults, (r) => r.otherProjectsExist);
 
-    // 5. Emit workspace:switched(null) if no other projects remain
+    // 5. Deselect if no other projects remain.
+    //
+    // Dispatches workspace:switch(null) rather than emitting workspace:switched(null)
+    // directly. `workspace:switched` is switch-workspace's event — an operation emits only
+    // events it declares, and the dispatcher rejects a duplicate event-schema registration,
+    // so this operation cannot own it. The switch operation's null path is the proper route
+    // and is documented as idempotent: it runs the `activate` hooks with a null target (so
+    // main-side active-workspace bookkeeping clears) and then announces. The extra handler
+    // that runs is view-module's `activate`, which clears the same state the
+    // `workspace:switched` event handler already clears — so the end state is unchanged.
     if (otherProjectsExist === false) {
-      const nullEvent: WorkspaceSwitchedEvent = {
-        type: EVENT_WORKSPACE_SWITCHED,
-        payload: null,
-      };
-      ctx.emit(nullEvent);
+      await ctx.dispatch<SwitchWorkspaceIntent>({
+        type: INTENT_SWITCH_WORKSPACE,
+        payload: { workspacePath: null },
+      });
     }
 
     // 6. Emit project:closed event

--- a/src/intents/contract.ts
+++ b/src/intents/contract.ts
@@ -84,6 +84,46 @@ export const agentSessionSchema = z
 export type AgentSession = z.infer<typeof agentSessionSchema>;
 
 // =============================================================================
+// Errors
+// =============================================================================
+
+/**
+ * A thrown value reduced to plain, serializable data.
+ *
+ * The intent contract never carries a live `Error`: an `Error` is a class instance, so it
+ * cannot cross a backend tunnel. Producers convert with `toSerializedError()`
+ * (`shared/error-utils`); consumers that need a real `Error` (e.g. the telemetry boundary,
+ * which reads `name`/`message`/`stack` to group issues) rebuild one with
+ * `fromSerializedError()`.
+ *
+ * `cause` is recursive so a wrapped failure keeps its chain — `app:start` wraps setup and
+ * agent-selection failures with `{ cause }`, and that context is worth keeping in a crash
+ * report. The recursion uses a getter, zod v4's form for self-referential object schemas.
+ */
+export const serializedErrorSchema: z.ZodType<SerializedError> = z.object({
+  name: z.string(),
+  message: z.string(),
+  stack: z.string().optional(),
+  get cause() {
+    return serializedErrorSchema.optional();
+  },
+});
+
+/**
+ * Plain-data form of a thrown value. See {@link serializedErrorSchema}.
+ *
+ * The optional members spell `| undefined` explicitly: under `exactOptionalPropertyTypes`
+ * a bare `?` means "may be absent" but not "may be undefined", which is narrower than what
+ * `z.optional()` produces and would not satisfy the schema's annotation.
+ */
+export interface SerializedError {
+  readonly name: string;
+  readonly message: string;
+  readonly stack?: string | undefined;
+  readonly cause?: SerializedError | undefined;
+}
+
+// =============================================================================
 // Domain value objects
 // =============================================================================
 
@@ -96,19 +136,39 @@ export const workspaceSchema = z
     branch: z.string().nullable(),
     /** Workspace metadata stored in git config (always contains `base`). */
     metadata: z.record(z.string(), z.string()).readonly(),
-    path: z.string(),
+    path: workspacePathSchema,
     /** IDE server URL for the iframe. Absent for hibernated workspaces until they wake. */
     url: z.string().optional(),
   })
   .readonly();
 export type Workspace = z.infer<typeof workspaceSchema>;
 
+/**
+ * A workspace as found on disk by a `discover` / `list-workspaces` hook — the internal
+ * git-worktree shape (`boundaries/platform/git-types`) reduced to plain data.
+ *
+ * Distinct from {@link workspaceSchema}, which is the IPC form and additionally carries
+ * `projectId` and the optional IDE `url`. Both `project:open` and `project:list` used to
+ * declare this shape privately, one with `z.instanceof(Path)` and one with `z.custom<Path>()`
+ * — the same type spelled two different ways, both of them opt-outs. Converted from the
+ * internal form by `toDiscoveredWorkspace()`.
+ */
+export const discoveredWorkspaceSchema = z
+  .object({
+    name: workspaceNameSchema,
+    path: workspacePathSchema,
+    branch: z.string().nullable(),
+    metadata: z.record(z.string(), z.string()).readonly(),
+  })
+  .readonly();
+export type DiscoveredWorkspace = z.infer<typeof discoveredWorkspaceSchema>;
+
 /** A project in CodeHydra (represents a git repository). */
 export const projectSchema = z
   .object({
     id: projectIdSchema,
     name: z.string(),
-    path: z.string(),
+    path: projectPathSchema,
     workspaces: z.array(workspaceSchema).readonly(),
     defaultBaseBranch: z.string().optional(),
     /** Original git remote URL if the project was cloned from a URL. */
@@ -122,7 +182,7 @@ export const workspaceRefSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    path: z.string(),
+    path: workspacePathSchema,
   })
   .readonly();
 export type WorkspaceRef = z.infer<typeof workspaceRefSchema>;
@@ -171,9 +231,31 @@ export const baseInfoSchema = z
   .readonly();
 export type BaseInfo = z.infer<typeof baseInfoSchema>;
 
-/** Agent types that can be selected by the user. */
-export const configAgentTypeSchema = z.enum(["claude", "opencode"]);
-export type ConfigAgentType = z.infer<typeof configAgentTypeSchema>;
+/**
+ * The agent backends CodeHydra can run. Single source of truth: `ConfigAgentType`
+ * (the persisted `agent` config value) and `LifecycleAgentType` (the runtime/IPC name)
+ * are the same set and are both derived from this schema — see the type-only re-exports
+ * in `shared/api/types.ts`, `shared/ipc.ts` and `boundaries/platform/config.ts`.
+ */
+export const agentTypeSchema = z.enum(["claude", "opencode"]);
+export type AgentType = z.infer<typeof agentTypeSchema>;
+
+/**
+ * The binaries CodeHydra resolves and downloads. Source of truth for
+ * `utils/binary-resolution`'s `BinaryType`, which re-exports this type.
+ */
+export const binaryTypeSchema = z.enum(["vscodium", "opencode", "claude"]);
+export type BinaryType = z.infer<typeof binaryTypeSchema>;
+
+/** An agent backend plus its presentation fields, as shown in the first-run picker. */
+export const agentInfoSchema = z
+  .object({
+    agent: agentTypeSchema,
+    label: z.string(),
+    icon: z.string(),
+  })
+  .readonly();
+export type AgentInfo = z.infer<typeof agentInfoSchema>;
 
 // =============================================================================
 // Setup screen progress
@@ -268,12 +350,22 @@ export const capabilitiesSchema = z.record(
  * Build the whole-context schema for a hook input point: the base HookContext
  * (`intent` + scalar `capabilities`) extended with the operation-added enrichment fields.
  *
+ * **Strict.** A non-declared field on the context is an error, not something to strip. A
+ * plain `z.object` would silently drop it — and since the dispatcher parses the input for
+ * its throw only (the un-parsed context is what reaches the handler), stripping would let an
+ * undeclared value travel on regardless. Strict makes the declaration the whole truth about
+ * what a hook point receives, which is what a backend tunnel has to serialize.
+ *
+ * Every hook point declares one of these, including those whose context is just the intent
+ * (`hookCtxSchema(payloadSchema, {})`) — a hook point with no schema is a hook point with no
+ * contract, and `InputOf` has nothing to derive its handler's context type from.
+ *
  * @param payload the operation's intent payload schema (re-affirms `ctx.intent.payload`)
  * @param enrichment the extra fields the operation puts on the context for this hook point
  */
 export function hookCtxSchema<E extends z.ZodRawShape>(payload: z.ZodType, enrichment: E) {
-  return z.object({
-    intent: z.object({ type: z.string(), payload }),
+  return z.strictObject({
+    intent: z.strictObject({ type: z.string(), payload }),
     capabilities: capabilitiesSchema.optional(),
     ...enrichment,
   });

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -102,6 +102,8 @@ import {
   INTENT_RESOLVE_PROJECT,
 } from "./resolve-project";
 import type { ResolveHookResult as ResolveProjectHookResult } from "./resolve-project";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import type { WorkspacePath, ProjectPath } from "./contract";
 
 // =============================================================================
 // Test Helpers
@@ -115,12 +117,12 @@ function testProjectId(path: string): ProjectId {
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/test/project";
+const PROJECT_PATH = projPath("/test/project");
 const PROJECT_ID = testProjectId(PROJECT_PATH);
-const WORKSPACE_PATH = "/test/project/workspaces/feature-a";
+const WORKSPACE_PATH = wsPath("/test/project/workspaces/feature-a");
 const WORKSPACE_NAME = "feature-a" as WorkspaceName;
 
-const WORKSPACE_PATH_B = "/test/project/workspaces/feature-b";
+const WORKSPACE_PATH_B = wsPath("/test/project/workspaces/feature-b");
 
 // =============================================================================
 // Helper: Build Intent
@@ -154,7 +156,7 @@ interface TestProject {
 interface TestAppState {
   projects: TestProject[];
   serverStopped: boolean;
-  removedWorkspaces: Array<{ projectPath: string; workspacePath: string }>;
+  removedWorkspaces: Array<{ projectPath: ProjectPath; workspacePath: WorkspacePath }>;
   worktreeRemoved: boolean;
 }
 
@@ -169,7 +171,7 @@ interface MockAppState {
   } | null;
   getAllProjects: () => Promise<TestProject[]>;
   getProject: (path: string) => TestProject | undefined;
-  unregisterWorkspace: (projectPath: string, workspacePath: string) => void;
+  unregisterWorkspace: (projectPath: ProjectPath, workspacePath: WorkspacePath) => void;
   findProjectForWorkspace: (wsPath: string) => TestProject | undefined;
 }
 
@@ -247,7 +249,7 @@ function createTestAppState(initial?: Partial<TestAppState>): {
     }),
     unregisterWorkspace: vi
       .fn()
-      .mockImplementation((projectPath: string, workspacePath: string) => {
+      .mockImplementation((projectPath: ProjectPath, workspacePath: WorkspacePath) => {
         state.removedWorkspaces.push({ projectPath, workspacePath });
         // Actually remove from state
         const project = state.projects.find((p) => p.path === projectPath);
@@ -299,7 +301,7 @@ function createTestHarness(options?: {
     killProcesses: (...args: unknown[]) => Promise<void>;
     closeHandles: (...args: unknown[]) => Promise<void>;
   };
-  killTerminalsCallback?: (workspacePath: string) => Promise<void>;
+  killTerminalsCallback?: (workspacePath: WorkspacePath) => Promise<void>;
   serverStopError?: string;
   worktreeRemoveError?: string;
   initialProjects?: TestAppState["projects"];
@@ -421,14 +423,14 @@ function createTestHarness(options?: {
       [RESOLVE_WORKSPACE_OPERATION_ID]: {
         resolve: {
           handler: async (ctx: HookContext): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
-            const { workspacePath: wsPath } = ctx as { workspacePath: string } & HookContext;
+            const { workspacePath: wsPath } = ctx as { workspacePath: WorkspacePath } & HookContext;
             // Reverse lookup: find which project owns this workspace path
             const project = appState.findProjectForWorkspace(wsPath);
             if (!project) return { result: {} };
             const workspaceName = wsPath.slice(wsPath.lastIndexOf("/") + 1);
             return {
               result: {
-                projectPath: project.path,
+                projectPath: projPath(project.path),
                 workspaceName: workspaceName as WorkspaceName,
                 active: viewManager.getActiveWorkspacePath() === wsPath,
               },
@@ -445,7 +447,7 @@ function createTestHarness(options?: {
       [RESOLVE_PROJECT_OPERATION_ID]: {
         resolve: {
           handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
-            const { projectPath } = ctx as { projectPath: string } & HookContext;
+            const { projectPath } = ctx as { projectPath: ProjectPath } & HookContext;
             const allProjects = await appState.getAllProjects();
             const project = allProjects.find((p) => p.path === projectPath);
             return {
@@ -711,17 +713,17 @@ function createTestHarness(options?: {
           handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
             const allProjects = await appState.getAllProjects();
             const candidates: Array<{
-              projectPath: string;
+              projectPath: ProjectPath;
               projectName: string;
-              workspacePath: string;
+              workspacePath: WorkspacePath;
               workspaceName: string;
             }> = [];
             for (const project of allProjects) {
               for (const ws of project.workspaces) {
                 candidates.push({
-                  projectPath: project.path,
+                  projectPath: projPath(project.path),
                   projectName: project.name,
-                  workspacePath: ws.path,
+                  workspacePath: wsPath(ws.path),
                   workspaceName: ws.path.slice(ws.path.lastIndexOf("/") + 1),
                 });
               }
@@ -746,7 +748,7 @@ function createTestHarness(options?: {
                 workspaceRef: {
                   projectId: PROJECT_ID,
                   workspaceName: path.slice(path.lastIndexOf("/") + 1) as WorkspaceName,
-                  path,
+                  path: wsPath(path),
                 },
               },
             };
@@ -1637,7 +1639,7 @@ describe("DeleteWorkspaceOperation.resolveHooks", () => {
     const intent: DeleteWorkspaceIntent = {
       type: INTENT_DELETE_WORKSPACE,
       payload: {
-        workspacePath: "/unknown/workspace",
+        workspacePath: wsPath("/unknown/workspace"),
         keepBranch: true,
         force: false,
         removeWorktree: true,

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -36,14 +36,16 @@ import type {
   DeletionOperationStatus,
   BlockingProcess,
 } from "../shared/api/types";
-import type { WorkspacePath } from "../shared/ipc";
 import {
-  projectIdSchema,
-  workspaceNameSchema,
   blockingProcessSchema,
   deletionProgressSchema,
   hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
 } from "./contract";
+import type { ProjectPath, WorkspacePath } from "./contract";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { resolveWorkspaceIdentity } from "./lib/workspace-identity";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
@@ -63,7 +65,7 @@ export const EVENT_WORKSPACE_DELETION_PROGRESS = "workspace:deletion-progress" a
 
 export const deleteWorkspacePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     keepBranch: z.boolean(),
     force: z.boolean(),
     /** Whether to remove the git worktree. true = full pipeline, false = shutdown only (runtime teardown). */
@@ -158,8 +160,8 @@ export const flushResultSchema = z.object({ error: z.string().optional() }).read
 
 /** Operation-added enrichment shared by shutdown/release/delete/detect/confirm/preflight hooks. */
 const deletePipelineEnrichmentSchema = z.object({
-  projectPath: z.string(),
-  workspacePath: z.string(),
+  projectPath: projectPathSchema,
+  workspacePath: workspacePathSchema,
   workspaceName: workspaceNameSchema,
   active: z.boolean(),
 });
@@ -182,8 +184,8 @@ const workspaceDeletedSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    workspacePath: z.string(),
-    projectPath: z.string(),
+    workspacePath: workspacePathSchema,
+    projectPath: projectPathSchema,
     /**
      * True when the dispatch removed (or force-abandoned) the git worktree;
      * false for runtime-only teardown (removeWorktree: false — e.g. the
@@ -194,9 +196,13 @@ const workspaceDeletedSchema = z
   })
   .readonly();
 
-const workspaceDeleteFailedSchema = z.object({ workspacePath: z.string() }).readonly();
+const workspaceDeleteFailedSchema = z.object({ workspacePath: workspacePathSchema }).readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_DELETE_WORKSPACE,
   payload: deleteWorkspacePayloadSchema,
   result: deleteWorkspaceResultSchema,
@@ -329,7 +335,8 @@ function mergeDetect(
 // Emit function type (for threading ctx.emit through private methods)
 // =============================================================================
 
-type EmitFn = (event: DomainEvent) => Promise<void>;
+/** The operation's own emit, narrowed to the events it declares. */
+type EmitFn = OperationContext<DeleteWorkspaceIntent, typeof schemas>["emit"];
 
 // =============================================================================
 // Pipeline State (for progress emission)
@@ -351,7 +358,7 @@ interface PipelineState {
 interface ResolvedIdentity {
   readonly projectId: ProjectId;
   readonly workspaceName: WorkspaceName;
-  readonly projectPath: string;
+  readonly projectPath: ProjectPath;
 }
 
 /** Return value of runPipeline, carrying resolved identity for emitEvent. */
@@ -366,7 +373,9 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = DELETE_WORKSPACE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<DeleteWorkspaceIntent>): Promise<{ started: boolean }> {
+  async execute(
+    ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>
+  ): Promise<{ started: boolean }> {
     const { payload } = ctx.intent;
 
     const emitEvent = (identity: ResolvedIdentity): void => {
@@ -437,7 +446,7 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
   }
 
   private async runPipeline(
-    ctx: OperationContext<DeleteWorkspaceIntent>,
+    ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>,
     emit: EmitFn
   ): Promise<PipelineResult> {
     const { payload } = ctx.intent;
@@ -465,8 +474,10 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
         workspaceName,
         active,
       };
-      const { results: confirmResults, errors: confirmErrors } =
-        await ctx.hooks.collect<ConfirmHookResult>("confirm", confirmCtx);
+      const { results: confirmResults, errors: confirmErrors } = await ctx.hooks.collect(
+        "confirm",
+        confirmCtx
+      );
       throwHookErrors(confirmErrors, "workspace:delete confirm hooks failed");
       if (confirmResults.some((r) => r.canceled)) {
         return { hasErrors: false, identity, canceled: true };
@@ -505,7 +516,7 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
   }
 
   private async runPipelineBody(
-    ctx: OperationContext<DeleteWorkspaceIntent>,
+    ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>,
     emit: EmitFn,
     identity: ResolvedIdentity,
     pipelineCtx: DeletePipelineHookInput,
@@ -520,16 +531,18 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
       // unmerged. Best-effort — a fetch failure falls through to the stale-ref read
       // rather than blocking the delete.
       try {
-        await ctx.dispatch({
+        await ctx.dispatch<GetProjectBasesIntent>({
           type: INTENT_GET_PROJECT_BASES,
           payload: { projectPath: identity.projectPath, refresh: true, wait: true },
-        } as GetProjectBasesIntent);
+        });
       } catch {
         // Fall through to the preflight read with possibly-stale refs.
       }
 
-      const { results: preflightResults, errors: preflightCollectErrors } =
-        await ctx.hooks.collect<PreflightHookResult>("preflight", pipelineCtx);
+      const { results: preflightResults, errors: preflightCollectErrors } = await ctx.hooks.collect(
+        "preflight",
+        pipelineCtx
+      );
 
       let isDirty = false;
       let unmergedCommits = 0;
@@ -554,8 +567,10 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
 
     // --- Shutdown ---
     this.emitPipelineProgress(emit, identity, payload, {}, false, false, "kill-terminals");
-    const { results: shutdownResults, errors: shutdownCollectErrors } =
-      await ctx.hooks.collect<ShutdownHookResult>("shutdown", pipelineCtx);
+    const { results: shutdownResults, errors: shutdownCollectErrors } = await ctx.hooks.collect(
+      "shutdown",
+      pipelineCtx
+    );
     const shutdown = mergeShutdown(shutdownResults, shutdownCollectErrors);
     this.emitPipelineProgress(
       emit,
@@ -594,8 +609,10 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
     }
 
     // --- Release (CWD scan + kill) ---
-    const { results: releaseResults, errors: releaseCollectErrors } =
-      await ctx.hooks.collect<ReleaseHookResult>("release", pipelineCtx);
+    const { results: releaseResults, errors: releaseCollectErrors } = await ctx.hooks.collect(
+      "release",
+      pipelineCtx
+    );
     const release = mergeErrors(releaseResults, releaseCollectErrors);
     this.emitPipelineProgress(
       emit,
@@ -623,14 +640,18 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
         ...pipelineCtx,
         blockingPids: payload.blockingPids,
       };
-      const { results: flushResults, errors: flushCollectErrors } =
-        await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);
+      const { results: flushResults, errors: flushCollectErrors } = await ctx.hooks.collect(
+        "flush",
+        flushCtx
+      );
       flush = mergeErrors(flushResults, flushCollectErrors);
     }
 
     // --- Delete ---
-    const { results: deleteResults, errors: deleteCollectErrors } =
-      await ctx.hooks.collect<DeleteHookResult>("delete", pipelineCtx);
+    const { results: deleteResults, errors: deleteCollectErrors } = await ctx.hooks.collect(
+      "delete",
+      pipelineCtx
+    );
     const del = mergeErrors(deleteResults, deleteCollectErrors);
 
     const deleteFailed = del.errors.length > 0;
@@ -671,8 +692,10 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
       false,
       "detecting-blockers"
     );
-    const { results: detectResults, errors: detectCollectErrors } =
-      await ctx.hooks.collect<DetectHookResult>("detect", pipelineCtx);
+    const { results: detectResults, errors: detectCollectErrors } = await ctx.hooks.collect(
+      "detect",
+      pipelineCtx
+    );
     const detect = mergeDetect(detectResults, detectCollectErrors);
 
     // Emit progress with blockers and return failure
@@ -692,19 +715,19 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
    * we must switch again before emitting workspace:deleted.
    */
   private async autoSwitchIfBecameActive(
-    ctx: OperationContext<DeleteWorkspaceIntent>,
-    workspacePath: string
+    ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>,
+    workspacePath: WorkspacePath
   ): Promise<void> {
     try {
-      const activeRef = await ctx.dispatch({
+      const activeRef = await ctx.dispatch<GetActiveWorkspaceIntent>({
         type: INTENT_GET_ACTIVE_WORKSPACE,
         payload: {},
-      } as GetActiveWorkspaceIntent);
+      });
       if (activeRef?.path === workspacePath) {
-        await ctx.dispatch({
+        await ctx.dispatch<SwitchWorkspaceIntent>({
           type: INTENT_SWITCH_WORKSPACE,
           payload: { auto: true, currentPath: workspacePath, focus: true },
-        } as SwitchWorkspaceIntent);
+        });
       }
     } catch {
       // Best-effort

--- a/src/intents/get-active-workspace.integration.test.ts
+++ b/src/intents/get-active-workspace.integration.test.ts
@@ -30,6 +30,7 @@ import type { HookOutput } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceRef } from "../shared/api/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { wsPath } from "../shared/test-fixtures";
 
 const PROJECT_ID = "project-ea0135bc" as ProjectId;
 
@@ -37,7 +38,7 @@ const PROJECT_ID = "project-ea0135bc" as ProjectId;
 // Test Constants
 // =============================================================================
 
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 
 // =============================================================================
 // Test Setup

--- a/src/intents/get-active-workspace.ts
+++ b/src/intents/get-active-workspace.ts
@@ -15,7 +15,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { workspaceRefSchema } from "./contract";
+import { hookCtxSchema, workspaceRefSchema } from "./contract";
 import { throwHookErrors, lastDefined, requireResult } from "./lib/hook-helpers";
 
 export const INTENT_GET_ACTIVE_WORKSPACE = "ui:get-active-workspace" as const;
@@ -40,12 +40,19 @@ export const getActiveWorkspaceHookResultSchema = z
   })
   .readonly();
 
-const schemas = {
+/** The get hook point receives the bare intent. */
+const getActiveHookInputSchema = hookCtxSchema(getActiveWorkspacePayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_ACTIVE_WORKSPACE,
   payload: getActiveWorkspacePayloadSchema,
   result: getActiveWorkspaceResultSchema,
   hooks: {
-    get: { result: getActiveWorkspaceHookResultSchema },
+    get: { input: getActiveHookInputSchema, result: getActiveWorkspaceHookResultSchema },
   },
 } satisfies OperationSchemas;
 
@@ -67,17 +74,14 @@ export class GetActiveWorkspaceOperation implements Operation<typeof schemas> {
   readonly schemas = schemas;
 
   async execute(
-    ctx: OperationContext<GetActiveWorkspaceIntent>
+    ctx: OperationContext<GetActiveWorkspaceIntent, typeof schemas>
   ): Promise<GetActiveWorkspaceResult> {
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
 
     // Run "get" hook -- handler retrieves active workspace ref
-    const { results, errors } = await ctx.hooks.collect<GetActiveWorkspaceHookResult>(
-      "get",
-      hookCtx
-    );
+    const { results, errors } = await ctx.hooks.collect("get", hookCtx);
     throwHookErrors(errors, "get-active-workspace get hooks failed");
 
     // Merge results — last-write-wins for workspaceRef

--- a/src/intents/get-agent-session.integration.test.ts
+++ b/src/intents/get-agent-session.integration.test.ts
@@ -25,13 +25,15 @@ import type { IntentModule } from "./lib/module";
 import type { HookOutput } from "./lib/operation";
 import type { Intent } from "./lib/types";
 import type { WorkspaceName, AgentSession } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "./contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_ROOT = "/project";
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const PROJECT_ROOT = projPath("/project");
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 
 // =============================================================================
 // Behavioral Mocks
@@ -85,7 +87,7 @@ function createTestSetup(opts: { session?: AgentSessionInfo | null }): TestSetup
 // Helpers
 // =============================================================================
 
-function sessionIntent(workspacePath: string): GetAgentSessionIntent {
+function sessionIntent(workspacePath: WorkspacePath): GetAgentSessionIntent {
   return {
     type: INTENT_GET_AGENT_SESSION,
     payload: { workspacePath },
@@ -143,9 +145,9 @@ describe("GetAgentSession Operation", () => {
     it("unknown workspace path throws", async () => {
       const setup = createTestSetup({ session: null });
 
-      await expect(setup.dispatcher.dispatch(sessionIntent("/nonexistent/path"))).rejects.toThrow(
-        "Workspace not found: /nonexistent/path"
-      );
+      await expect(
+        setup.dispatcher.dispatch(sessionIntent(wsPath("/nonexistent/path")))
+      ).rejects.toThrow("Workspace not found: /nonexistent/path");
     });
   });
 

--- a/src/intents/get-agent-session.ts
+++ b/src/intents/get-agent-session.ts
@@ -15,7 +15,7 @@
 import { z } from "zod/v4";
 import type { HookContext, OperationSchemas } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { agentSessionSchema, hookCtxSchema } from "./contract";
+import { agentSessionSchema, hookCtxSchema, workspacePathSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
@@ -28,7 +28,7 @@ export const GET_AGENT_SESSION_OPERATION_ID = "get-agent-session";
 
 export const getAgentSessionPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
   })
   .readonly();
 
@@ -46,7 +46,7 @@ export const getAgentSessionHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
-const getAgentSessionEnrichmentSchema = z.object({ workspacePath: z.string() });
+const getAgentSessionEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "get". */
 export const getAgentSessionHookInputSchema = hookCtxSchema(
@@ -54,7 +54,11 @@ export const getAgentSessionHookInputSchema = hookCtxSchema(
   getAgentSessionEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_AGENT_SESSION,
   payload: getAgentSessionPayloadSchema,
   result: getAgentSessionResultSchema,
@@ -80,15 +84,13 @@ export type GetAgentSessionHookInput = HookContext &
 // Operation
 // =============================================================================
 
-export class GetAgentSessionOperation extends WorkspaceHookOperation<
-  typeof schemas,
-  GetAgentSessionHookResult
-> {
+export class GetAgentSessionOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(GET_AGENT_SESSION_OPERATION_ID, {
       hookPoint: "get",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       errorLabel: "get-agent-session get hooks failed",
       extract: (results) =>
         requireResult(

--- a/src/intents/get-metadata.integration.test.ts
+++ b/src/intents/get-metadata.integration.test.ts
@@ -33,6 +33,8 @@ import { isValidMetadataKey } from "../shared/api/types";
 import type { IntentModule } from "./lib/module";
 import type { Intent } from "./lib/types";
 import type { HookContext, HookOutput } from "./lib/operation";
+import type { WorkspacePath } from "./contract";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Constants
@@ -49,7 +51,7 @@ interface TestSetup {
   dispatcher: Dispatcher;
   projectId: ProjectId;
   workspaceName: WorkspaceName;
-  workspacePath: string;
+  workspacePath: WorkspacePath;
 }
 
 function createTestSetup(): TestSetup {
@@ -71,7 +73,7 @@ function createTestSetup(): TestSetup {
   registerTestInfrastructure(dispatcher, {
     workspaces: {
       [workspacePath.toString()]: {
-        projectPath: PROJECT_ROOT.toString(),
+        projectPath: projPath(PROJECT_ROOT.toString()),
         workspaceName,
       },
     },
@@ -122,7 +124,7 @@ function createTestSetup(): TestSetup {
     dispatcher,
     projectId,
     workspaceName,
-    workspacePath: workspacePath.toString(),
+    workspacePath: wsPath(workspacePath.toString()),
   };
 }
 
@@ -131,7 +133,7 @@ function createTestSetup(): TestSetup {
 // =============================================================================
 
 function setMetadataIntent(
-  workspacePath: string,
+  workspacePath: WorkspacePath,
   key: string,
   value: string | null
 ): SetMetadataIntent {
@@ -141,7 +143,7 @@ function setMetadataIntent(
   };
 }
 
-function getMetadataIntent(workspacePath: string): GetMetadataIntent {
+function getMetadataIntent(workspacePath: WorkspacePath): GetMetadataIntent {
   return {
     type: INTENT_GET_METADATA,
     payload: { workspacePath },

--- a/src/intents/get-metadata.ts
+++ b/src/intents/get-metadata.ts
@@ -15,7 +15,7 @@
 import { z } from "zod/v4";
 import type { HookContext, OperationSchemas } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { hookCtxSchema } from "./contract";
+import { hookCtxSchema, workspacePathSchema } from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
@@ -28,7 +28,7 @@ export const GET_METADATA_OPERATION_ID = "get-metadata";
 
 export const getMetadataPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
   })
   .readonly();
 
@@ -45,7 +45,7 @@ export const getMetadataHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
-const getMetadataEnrichmentSchema = z.object({ workspacePath: z.string() });
+const getMetadataEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "get". */
 export const getMetadataHookInputSchema = hookCtxSchema(
@@ -53,7 +53,11 @@ export const getMetadataHookInputSchema = hookCtxSchema(
   getMetadataEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_METADATA,
   payload: getMetadataPayloadSchema,
   result: getMetadataResultSchema,
@@ -78,15 +82,13 @@ export type GetHookInput = HookContext & z.infer<typeof getMetadataEnrichmentSch
 // Operation
 // =============================================================================
 
-export class GetMetadataOperation extends WorkspaceHookOperation<
-  typeof schemas,
-  GetMetadataHookResult
-> {
+export class GetMetadataOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(GET_METADATA_OPERATION_ID, {
       hookPoint: "get",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       errorLabel: "get-metadata get hooks failed",
       extract: (results) =>
         requireResult(

--- a/src/intents/get-project-bases.integration.test.ts
+++ b/src/intents/get-project-bases.integration.test.ts
@@ -37,13 +37,14 @@ import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent } from "./lib/types";
 import type { ProjectId } from "../shared/api/types";
+import { projPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
 const PROJECT_ID = "project-ea0135bc" as ProjectId;
-const PROJECT_ROOT = "/project";
+const PROJECT_ROOT = projPath("/project");
 const CACHED_BASES = [
   { name: "main", isRemote: false },
   { name: "origin/main", isRemote: true },
@@ -304,9 +305,9 @@ describe("GetProjectBases Operation", () => {
     it("throws for unrecognized project path", async () => {
       const setup = createTestSetup();
 
-      await expect(setup.dispatcher.dispatch(createIntent("/nonexistent/project"))).rejects.toThrow(
-        "Project not found for path: /nonexistent/project"
-      );
+      await expect(
+        setup.dispatcher.dispatch(createIntent(projPath("/nonexistent/project")))
+      ).rejects.toThrow("Project not found for path: /nonexistent/project");
     });
   });
 });

--- a/src/intents/get-project-bases.ts
+++ b/src/intents/get-project-bases.ts
@@ -23,7 +23,7 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, baseInfoSchema, hookCtxSchema } from "./contract";
+import { baseInfoSchema, hookCtxSchema, projectIdSchema, projectPathSchema } from "./contract";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, mergeHookResults } from "./lib/hook-helpers";
 
@@ -37,7 +37,7 @@ export const GET_PROJECT_BASES_OPERATION_ID = "get-project-bases";
 
 export const getProjectBasesPayloadSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     refresh: z.boolean().optional(),
     /** When true (and refresh is true), await the refresh and return fresh data. */
     wait: z.boolean().optional(),
@@ -48,7 +48,7 @@ export const getProjectBasesResultSchema = z
   .object({
     bases: z.array(baseInfoSchema).readonly(),
     defaultBaseBranch: z.string().optional(),
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     projectId: projectIdSchema,
   })
   .readonly();
@@ -56,7 +56,7 @@ export const getProjectBasesResultSchema = z
 export const basesUpdatedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     bases: z.array(baseInfoSchema).readonly(),
     /** Fresh default base branch; absent when detection found none (authoritative). */
     defaultBaseBranch: z.string().optional(),
@@ -71,8 +71,8 @@ export const listBasesHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "list" / "refresh" hook points. */
-const listBasesEnrichmentSchema = z.object({ projectPath: z.string() });
-const refreshBasesEnrichmentSchema = z.object({ projectPath: z.string() });
+const listBasesEnrichmentSchema = z.object({ projectPath: projectPathSchema });
+const refreshBasesEnrichmentSchema = z.object({ projectPath: projectPathSchema });
 
 export const listBasesHookInputSchema = hookCtxSchema(
   getProjectBasesPayloadSchema,
@@ -83,7 +83,11 @@ export const refreshBasesHookInputSchema = hookCtxSchema(
   refreshBasesEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_PROJECT_BASES,
   payload: getProjectBasesPayloadSchema,
   result: getProjectBasesResultSchema,
@@ -124,19 +128,20 @@ export class GetProjectBasesOperation implements Operation<typeof schemas> {
   readonly id = GET_PROJECT_BASES_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<GetProjectBasesIntent>): Promise<GetProjectBasesResult> {
+  async execute(
+    ctx: OperationContext<GetProjectBasesIntent, typeof schemas>
+  ): Promise<GetProjectBasesResult> {
     const { projectPath, refresh } = ctx.intent.payload;
 
     // 1. Dispatch project:resolve to get projectId
-    const { projectId } = await ctx.dispatch({
+    const { projectId } = await ctx.dispatch<ResolveProjectIntent>({
       type: INTENT_RESOLVE_PROJECT,
       payload: { projectPath },
-    } as ResolveProjectIntent);
+    });
 
     // 2. Collect "list" hook — fast local read
     const listCtx: ListBasesHookInput = { intent: ctx.intent, projectPath };
-    const { results: listResults, errors: listErrors } =
-      await ctx.hooks.collect<ListBasesHookResult>("list", listCtx);
+    const { results: listResults, errors: listErrors } = await ctx.hooks.collect("list", listCtx);
 
     throwHookErrors(listErrors, "project:get-bases list hooks failed");
 
@@ -151,10 +156,7 @@ export class GetProjectBasesOperation implements Operation<typeof schemas> {
         const { errors: refreshErrors } = await ctx.hooks.collect("refresh", refreshCtx);
         if (refreshErrors.length > 0) return undefined;
 
-        const { results: freshListResults } = await ctx.hooks.collect<ListBasesHookResult>(
-          "list",
-          listCtx
-        );
+        const { results: freshListResults } = await ctx.hooks.collect("list", listCtx);
         const freshMerged = mergeHookResults(freshListResults, "list");
         const freshBases = freshMerged.bases ?? [];
         return {

--- a/src/intents/get-workspace-status.integration.test.ts
+++ b/src/intents/get-workspace-status.integration.test.ts
@@ -32,13 +32,15 @@ import type { Intent } from "./lib/types";
 import type { WorkspaceName, WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import { Path } from "../utils/path/path";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "./contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_ROOT = "/project";
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const PROJECT_ROOT = projPath("/project");
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 
 // =============================================================================
 // Behavioral Mocks
@@ -125,7 +127,7 @@ function createTestSetup(opts: {
 // Helpers
 // =============================================================================
 
-function statusIntent(workspacePath: string): GetWorkspaceStatusIntent {
+function statusIntent(workspacePath: WorkspacePath): GetWorkspaceStatusIntent {
   return {
     type: INTENT_GET_WORKSPACE_STATUS,
     payload: { workspacePath },
@@ -289,7 +291,7 @@ describe("GetWorkspaceStatus Operation", () => {
       });
 
       const error = await setup.dispatcher
-        .dispatch(statusIntent("/nonexistent/path"))
+        .dispatch(statusIntent(wsPath("/nonexistent/path")))
         .then(() => expect.unreachable("should have thrown"))
         .catch((e: unknown) => e);
 

--- a/src/intents/get-workspace-status.ts
+++ b/src/intents/get-workspace-status.ts
@@ -15,7 +15,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { workspaceStatusSchema, hookCtxSchema } from "./contract";
+import { hookCtxSchema, workspacePathSchema, workspaceStatusSchema } from "./contract";
 import type { WorkspaceStatus } from "../shared/api/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
@@ -31,7 +31,7 @@ export const GET_WORKSPACE_STATUS_OPERATION_ID = "get-workspace-status";
 
 export const getWorkspaceStatusPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     /**
      * If true, fetch remotes (via project:get-bases with refresh+wait) before
      * reading status. Best-effort: fetch failures are swallowed and the status
@@ -66,7 +66,7 @@ export const getStatusHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "get" hook point (beyond the base HookContext). */
-const getStatusEnrichmentSchema = z.object({ workspacePath: z.string() });
+const getStatusEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "get". */
 export const getStatusHookInputSchema = hookCtxSchema(
@@ -74,7 +74,11 @@ export const getStatusHookInputSchema = hookCtxSchema(
   getStatusEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_GET_WORKSPACE_STATUS,
   payload: getWorkspaceStatusPayloadSchema,
   result: workspaceStatusSchema,
@@ -102,23 +106,25 @@ export class GetWorkspaceStatusOperation implements Operation<typeof schemas> {
   readonly id = GET_WORKSPACE_STATUS_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<GetWorkspaceStatusIntent>): Promise<WorkspaceStatus> {
+  async execute(
+    ctx: OperationContext<GetWorkspaceStatusIntent, typeof schemas>
+  ): Promise<WorkspaceStatus> {
     const { payload } = ctx.intent;
 
     // 1. Dispatch shared workspace resolution
-    const { projectPath } = await ctx.dispatch({
+    const { projectPath } = await ctx.dispatch<ResolveWorkspaceIntent>({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
+    });
 
     // 2. Optional refresh — fetch remotes so unmerged-commit counts reflect
     // server-merged branches. Best-effort; errors are swallowed.
     if (payload.refresh) {
       try {
-        await ctx.dispatch({
+        await ctx.dispatch<GetProjectBasesIntent>({
           type: INTENT_GET_PROJECT_BASES,
           payload: { projectPath, refresh: true, wait: true },
-        } as GetProjectBasesIntent);
+        });
       } catch {
         // Fall through to status read with possibly-stale refs.
       }
@@ -129,7 +135,7 @@ export class GetWorkspaceStatusOperation implements Operation<typeof schemas> {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
     };
-    const { results, errors } = await ctx.hooks.collect<GetStatusHookResult>("get", getCtx);
+    const { results, errors } = await ctx.hooks.collect("get", getCtx);
     throwHookErrors(errors, "get-workspace-status get hooks failed");
 
     // Merge results — isDirty uses OR, unmergedCommits uses max

--- a/src/intents/hibernate-workspace.integration.test.ts
+++ b/src/intents/hibernate-workspace.integration.test.ts
@@ -54,10 +54,12 @@ import {
   type OpenWorkspacePayload,
 } from "./open-workspace";
 import type { ProjectId, WorkspaceName, Workspace } from "../shared/api/types";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import { workspaceSchema } from "./contract";
 
-const PROJECT_PATH = "/test/project";
+const PROJECT_PATH = projPath("/test/project");
 const PROJECT_ID = Buffer.from(PROJECT_PATH).toString("base64url") as ProjectId;
-const WORKSPACE_PATH = "/test/project/workspaces/feature-a";
+const WORKSPACE_PATH = wsPath("/test/project/workspaces/feature-a");
 const WORKSPACE_NAME = "feature-a" as WorkspaceName;
 const BRANCH = "feature-a-branch";
 const CLEAN_METADATA: Readonly<Record<string, string>> = { base: "main" };
@@ -73,13 +75,13 @@ const REOPENED_WORKSPACE: Workspace = {
 const getMetadataStubSchemas = {
   type: INTENT_GET_METADATA,
   payload: z.unknown(),
-  result: z.custom<Readonly<Record<string, string>>>(),
+  result: z.record(z.string(), z.string()).readonly(),
 } satisfies OperationSchemas;
 
 const openWorkspaceStubSchemas = {
   type: INTENT_OPEN_WORKSPACE,
   payload: z.unknown(),
-  result: z.custom<Workspace>(),
+  result: workspaceSchema,
 } satisfies OperationSchemas;
 
 interface Recorder {
@@ -361,10 +363,10 @@ describe("workspace:hibernate", () => {
       { active: true }
     );
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
     await waitForBackground();
 
     // Switch happened in foreground, between set-metadata and shutdown.
@@ -387,10 +389,10 @@ describe("workspace:hibernate", () => {
       createHibernateHookModule(r, { shutdownGate }),
     ]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
 
     // Foreground done: metadata flipped, no shutdown yet.
     expect(recorder.callOrder).toEqual(["capture", "set-metadata:true"]);
@@ -425,10 +427,10 @@ describe("workspace:hibernate", () => {
       },
     ]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
     await waitForBackground();
 
     expect(recorder.events.find((e) => e.type === EVENT_WORKSPACE_HIBERNATED)).toBeDefined();
@@ -443,10 +445,10 @@ describe("workspace:hibernate", () => {
       createCaptureBracketModule(r),
     ]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
     await waitForBackground();
 
     // Foreground: the sidebar is collapsed (prepare), the screenshot is taken
@@ -464,10 +466,10 @@ describe("workspace:hibernate", () => {
       createCaptureBracketModule(r, { captureThrows: true }),
     ]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
     await waitForBackground();
 
     // capture threw, but cleanup-capture still ran and hibernation completed —
@@ -487,10 +489,10 @@ describe("workspace:hibernate", () => {
       createHibernateHookModule(r, { releaseThrows: true }),
     ]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<HibernateWorkspaceIntent>({
       type: INTENT_HIBERNATE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as HibernateWorkspaceIntent);
+    });
     await waitForBackground();
 
     expect(recorder.releaseCalled).toBe(true);
@@ -542,10 +544,10 @@ describe("workspace:wake", () => {
   it("forwards stealFocus and source to the internal open", async () => {
     const { dispatcher, recorder } = buildHarness((r) => [createWakeHookModule(r)]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<WakeWorkspaceIntent>({
       type: INTENT_WAKE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH, stealFocus: false, source: "mcp" },
-    } as WakeWorkspaceIntent);
+    });
 
     expect(recorder.openPayload?.stealFocus).toBe(false);
     expect(recorder.openPayload?.source).toBe("mcp");
@@ -554,10 +556,10 @@ describe("workspace:wake", () => {
   it("omits stealFocus/source when the caller does not set them", async () => {
     const { dispatcher, recorder } = buildHarness((r) => [createWakeHookModule(r)]);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<WakeWorkspaceIntent>({
       type: INTENT_WAKE_WORKSPACE,
       payload: { workspacePath: WORKSPACE_PATH },
-    } as WakeWorkspaceIntent);
+    });
 
     expect(recorder.openPayload).toBeDefined();
     expect(recorder.openPayload).not.toHaveProperty("stealFocus");

--- a/src/intents/hibernate-workspace.ts
+++ b/src/intents/hibernate-workspace.ts
@@ -42,10 +42,17 @@ import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
-import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+} from "./contract";
+import type { ProjectPath } from "./contract";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "./set-metadata";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
-import { resolveWorkspaceIdentity, emitWorkspaceFailure } from "./lib/workspace-identity";
+import { resolveWorkspaceIdentity, workspaceFailurePayload } from "./lib/workspace-identity";
 
 export const INTENT_HIBERNATE_WORKSPACE = "workspace:hibernate" as const;
 export const HIBERNATE_WORKSPACE_OPERATION_ID = "hibernate-workspace";
@@ -61,7 +68,7 @@ export const HIBERNATED_METADATA_KEY = "hibernated";
 
 export const hibernateWorkspacePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
   })
   .readonly();
 
@@ -73,22 +80,22 @@ export const workspaceHibernatedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    workspacePath: z.string(),
-    projectPath: z.string(),
+    workspacePath: workspacePathSchema,
+    projectPath: projectPathSchema,
   })
   .readonly();
 
 export const workspaceHibernateFailedPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     error: z.string(),
   })
   .readonly();
 
 /** Operation-added enrichment shared by every hibernate pipeline hook point. */
 const hibernatePipelineEnrichmentSchema = z.object({
-  projectPath: z.string(),
-  workspacePath: z.string(),
+  projectPath: projectPathSchema,
+  workspacePath: workspacePathSchema,
   projectId: projectIdSchema,
   workspaceName: workspaceNameSchema,
   active: z.boolean(),
@@ -110,7 +117,11 @@ export const hibernateReleaseHookResultSchema = z
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_HIBERNATE_WORKSPACE,
   payload: hibernateWorkspacePayloadSchema,
   result: hibernateWorkspaceResultSchema,
@@ -184,13 +195,13 @@ export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
   readonly schemas = schemas;
 
   async execute(
-    ctx: OperationContext<HibernateWorkspaceIntent>
+    ctx: OperationContext<HibernateWorkspaceIntent, typeof schemas>
   ): Promise<HibernateWorkspaceResult> {
     const { payload } = ctx.intent;
 
     let hookCtx: HibernatePipelineHookInput;
     let projectId: ProjectId;
-    let projectPath: string;
+    let projectPath: ProjectPath;
     let workspaceName: WorkspaceName;
 
     try {
@@ -216,25 +227,25 @@ export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
       // owns the sidebar UI state); "cleanup-capture" restores it. Cleanup runs
       // in `finally` so a stuck capturing flag can never leave the sidebar
       // permanently collapsed, even if the capture hook throws.
-      await ctx.hooks.collect<PrepareCaptureHookResult>("prepare-capture", hookCtx);
+      await ctx.hooks.collect("prepare-capture", hookCtx);
       try {
-        await ctx.hooks.collect<CaptureHookResult>("capture", hookCtx);
+        await ctx.hooks.collect("capture", hookCtx);
       } finally {
-        await ctx.hooks.collect<CleanupCaptureHookResult>("cleanup-capture", hookCtx);
+        await ctx.hooks.collect("cleanup-capture", hookCtx);
       }
 
       // Persist hibernated flag via existing set-metadata pipeline. This is
       // what makes the renderer swap in HibernatedOverlay via the
       // workspace:metadata-changed → WORKSPACE_METADATA_CHANGED IPC, and
       // makes switch-workspace's `c.hibernated` filter exclude us.
-      await ctx.dispatch({
+      await ctx.dispatch<SetMetadataIntent>({
         type: INTENT_SET_METADATA,
         payload: {
           workspacePath: payload.workspacePath,
           key: HIBERNATED_METADATA_KEY,
           value: "true",
         },
-      } as SetMetadataIntent);
+      });
 
       // If the hibernated workspace was active, switch to an awake sibling
       // immediately so the user is moved away while the teardown runs in the
@@ -243,7 +254,7 @@ export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
       // pending hibernation overlay over it.
       if (active) {
         try {
-          await ctx.dispatch({
+          await ctx.dispatch<SwitchWorkspaceIntent>({
             type: INTENT_SWITCH_WORKSPACE,
             payload: {
               auto: true,
@@ -251,18 +262,16 @@ export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
               focus: true,
               fallbackToCurrent: true,
             },
-          } as SwitchWorkspaceIntent);
+          });
         } catch {
           // Best-effort: switch failure doesn't fail hibernation.
         }
       }
     } catch (error) {
-      emitWorkspaceFailure(
-        ctx.emit,
-        EVENT_WORKSPACE_HIBERNATE_FAILED,
-        payload.workspacePath,
-        error
-      );
+      ctx.emit({
+        type: EVENT_WORKSPACE_HIBERNATE_FAILED,
+        payload: workspaceFailurePayload(payload.workspacePath, error),
+      });
       throw error;
     }
 
@@ -272,8 +281,8 @@ export class HibernateWorkspaceOperation implements Operation<typeof schemas> {
     // so no wake intent can race the teardown.
     void (async () => {
       try {
-        await ctx.hooks.collect<HibernateShutdownHookResult>("shutdown", hookCtx);
-        await ctx.hooks.collect<HibernateReleaseHookResult>("release", hookCtx);
+        await ctx.hooks.collect("shutdown", hookCtx);
+        await ctx.hooks.collect("release", hookCtx);
       } finally {
         // Always emit so the dispatcher's idempotency interceptor releases
         // the per-workspace lock and the renderer clears its pending entry.

--- a/src/intents/lib/dispatcher.integration.test.ts
+++ b/src/intents/lib/dispatcher.integration.test.ts
@@ -46,7 +46,7 @@ function defineOp(
   const schemas = {
     type: intentType,
     payload: z.unknown(),
-    result: z.custom<unknown>(),
+    result: z.unknown(),
   } satisfies OperationSchemas;
   const op: Operation<typeof schemas> = { id: spec.id, schemas, execute: spec.execute };
   return op;

--- a/src/intents/lib/dispatcher.ts
+++ b/src/intents/lib/dispatcher.ts
@@ -277,19 +277,19 @@ export class Dispatcher implements IDispatcher {
   // Hook collection (capability-based topological sort)
   // ===========================================================================
 
-  private async collectHookResults<T>(
+  private async collectHookResults(
     hookHandlers: HookHandler[],
     inputCtx: HookContext,
     initialCaps: Readonly<Record<string, unknown>>,
     onYield?: (frame: unknown) => void | Promise<void>,
     hookSchemas?: HookPointSchemas
-  ): Promise<CollectResult<T>> {
+  ): Promise<CollectResult> {
     const capabilities: Record<string, unknown> = {
       ...initialCaps,
       ...((inputCtx.capabilities as Record<string, unknown> | undefined) ?? {}),
     };
     let pending = [...hookHandlers];
-    const results: T[] = [];
+    const results: unknown[] = [];
     const errors: Error[] = [];
     const ran: string[] = [];
 
@@ -326,7 +326,7 @@ export class Dispatcher implements IDispatcher {
               const validated = hookSchemas?.result
                 ? hookSchemas.result.parse(output.result)
                 : output.result;
-              results.push(validated as T);
+              results.push(validated);
             }
             // Merge provided capabilities from returned data (no host-side closure).
             // Skip undefined-valued keys: requires/ANY_VALUE test key *presence*, so a
@@ -381,18 +381,21 @@ export class Dispatcher implements IDispatcher {
     const opHooks = this.operationSchemas.get(operationId)?.hooks;
     const initCaps = this.initialCapabilities;
     const logger = this.logger;
+    // Erased: the dispatcher stores handlers without their operation's schema bundle, so it
+    // collects as `unknown` and the typed `ResolvedHooks<S>` view is applied at the operation
+    // boundary (where the bundle is known). The runtime behaviour is identical either way.
     return {
-      collect: async <T>(
+      collect: async (
         hookPointId: string,
         ctx: HookContext,
         options?: CollectOptions
-      ): Promise<HookResult<T>> => {
+      ): Promise<HookResult> => {
         const hookHandlers = opMap?.get(hookPointId);
         if (!hookHandlers) {
           return { results: [], errors: [], capabilities: initCaps };
         }
         const start = performance.now();
-        const { ran, skipped, ...hookResult } = await this.collectHookResults<T>(
+        const { ran, skipped, ...hookResult } = await this.collectHookResults(
           hookHandlers,
           ctx,
           initCaps,

--- a/src/intents/lib/idempotency-module.integration.test.ts
+++ b/src/intents/lib/idempotency-module.integration.test.ts
@@ -28,7 +28,7 @@ function opWithType(
   const schemas = {
     type: intentType,
     payload: z.unknown(),
-    result: z.custom<unknown>(),
+    result: z.unknown(),
   } satisfies OperationSchemas;
   const op: Operation<typeof schemas> = { id: spec.id, schemas, execute: spec.execute };
   return op;

--- a/src/intents/lib/operation.test-utils.ts
+++ b/src/intents/lib/operation.test-utils.ts
@@ -6,9 +6,18 @@
  * optionally throws the first error, and returns the first result.
  *
  * Since operations are parameterized by their schema bundle (`Operation<S>`), a minimal
- * operation carries a permissive schema (payload `z.unknown()`, result `z.custom<TResult>()`)
- * so the dispatcher's validation is a no-op for it while the dispatched result stays typed.
- * `intentType` becomes the operation's `schemas.type` — the dispatcher registration key.
+ * operation carries a permissive schema (`z.unknown()` for payload and result) so the
+ * dispatcher's validation is a no-op for it. `intentType` becomes the operation's
+ * `schemas.type` — the dispatcher registration key.
+ *
+ * The result schema is `z.unknown()` rather than `z.custom<TResult>()`. Both accept anything,
+ * but only one of them says so: `z.custom<T>()` runs no validator at all, so it reads like a
+ * typed schema while behaving as an assertion — the pattern the intent contract now bans. It
+ * was never buying the typing it appeared to, either. A dispatched result is typed by the
+ * *intent's* phantom carrier, not by the registered operation's schema (the dispatcher erases
+ * it at `registerOperation`), and `execute` already narrows to `TResult` on its way out. So
+ * `TResult` stays as a parameter for `defaultResult` and the return type, and the schema
+ * honestly declares that this test double validates nothing.
  */
 
 import { z } from "zod/v4";
@@ -17,7 +26,8 @@ import type { Operation, OperationContext, HookContext, OperationSchemas } from 
 import { DELETE_WORKSPACE_OPERATION_ID, INTENT_DELETE_WORKSPACE } from "../delete-workspace";
 import { EVENT_WORKSPACE_DELETED } from "../delete-workspace";
 import type { DeleteWorkspaceIntent, WorkspaceDeletedEvent } from "../delete-workspace";
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import type { ProjectId, ProjectPath, WorkspaceName } from "../contract";
+import { projectPathSchema } from "../contract";
 
 /** Options for `createMinimalOperation`. */
 export interface MinimalOperationOptions<TResult = void> {
@@ -30,17 +40,17 @@ export interface MinimalOperationOptions<TResult = void> {
 }
 
 /** The permissive schema shape a minimal test operation carries. */
-type MinimalSchemas<TResult> = {
+type MinimalSchemas = {
   readonly type: string;
   readonly payload: z.ZodUnknown;
-  readonly result: z.ZodType<TResult>;
+  readonly result: z.ZodUnknown;
 };
 
 /**
  * Create a minimal test operation that collects a single hook point.
  *
  * Behavior:
- * 1. Calls `ctx.hooks.collect<TResult>(hookPoint, hookContext)`
+ * 1. Calls `ctx.hooks.collect(hookPoint, hookContext)`
  * 2. If `throwOnError !== false` and `errors.length > 0`: throws `errors[0]`
  * 3. Returns `results[0] ?? defaultResult`
  *
@@ -60,11 +70,11 @@ export function createMinimalOperation<TResult = void>(
   intentType: string,
   hookPoint: string,
   options?: MinimalOperationOptions<TResult>
-): Operation<MinimalSchemas<TResult>> {
+): Operation<MinimalSchemas> {
   const schemas = {
     type: intentType,
     payload: z.unknown(),
-    result: z.custom<TResult>(),
+    result: z.unknown(),
   } satisfies OperationSchemas;
   const throwOnError = options?.throwOnError !== false;
   const buildHookContext = options?.hookContext;
@@ -76,7 +86,7 @@ export function createMinimalOperation<TResult = void>(
       const hookCtx = buildHookContext
         ? buildHookContext(ctx)
         : { intent: ctx.intent, capabilities: {} };
-      const { results, errors } = await ctx.hooks.collect<TResult>(hookPoint, hookCtx);
+      const { results, errors } = await ctx.hooks.collect(hookPoint, hookCtx);
       if (throwOnError && errors.length > 0) throw errors[0]!;
       return (results[0] ?? options?.defaultResult) as TResult;
     },
@@ -88,13 +98,15 @@ export function createMinimalOperation<TResult = void>(
 export interface DeleteEventOperationFields {
   readonly projectId?: ProjectId;
   readonly workspaceName?: WorkspaceName;
-  readonly projectPath?: string;
+  readonly projectPath?: ProjectPath;
 }
 
+// This one's result is trivially expressible, so it is a real schema rather than a
+// permissive one — there was never a reason for it to opt out of validation.
 const deleteEventSchemas = {
   type: INTENT_DELETE_WORKSPACE,
   payload: z.unknown(),
-  result: z.custom<{ started: true }>(),
+  result: z.object({ started: z.literal(true) }).readonly(),
 } satisfies OperationSchemas;
 
 /**
@@ -117,7 +129,7 @@ export function createDeleteEventOperation(
           workspaceName: fields.workspaceName ?? ("ws" as WorkspaceName),
           workspacePath: intent.payload.workspacePath,
           worktreeRemoved: intent.payload.removeWorktree,
-          projectPath: fields.projectPath ?? "/projects/test",
+          projectPath: fields.projectPath ?? projectPathSchema.parse("/projects/test"),
         },
       };
       ctx.emit(event);

--- a/src/intents/lib/operation.ts
+++ b/src/intents/lib/operation.ts
@@ -123,18 +123,78 @@ export interface CollectOptions {
 }
 
 /**
+ * The hook-point ids an operation's schema bundle declares.
+ *
+ * Falls back to `string` for the open `OperationSchemas` (whose `hooks` is optional), which is
+ * what the dispatcher holds internally after erasing an operation's concrete bundle.
+ */
+export type HookPointOf<S extends OperationSchemas> = S extends {
+  readonly hooks: infer H;
+}
+  ? keyof H & string
+  : string;
+
+/**
+ * The input-context type for hook point `K`, derived from its declared `input` schema.
+ *
+ * The schema's own `intent` and `capabilities` members are dropped and taken from
+ * {@link HookContext} instead. Those two exist in the schema for its runtime job — re-affirming
+ * the payload and shape-checking the capability bag — and describing them structurally would
+ * force every operation to restate the dispatcher's own bookkeeping. What is worth checking at
+ * compile time is the **enrichment**: the fields the operation itself puts on the context.
+ *
+ * Falls back to the base {@link HookContext} for a hook point that declares no input schema.
+ * Every hook point in this codebase declares one — see `hookCtxSchema` — so the fallback
+ * exists only to keep the type total.
+ */
+export type InputOf<S extends OperationSchemas, K extends HookPointOf<S>> = S extends {
+  readonly hooks: infer H;
+}
+  ? K extends keyof H
+    ? H[K] extends { readonly input: infer I extends z.ZodType }
+      ? Omit<z.infer<I>, "intent" | "capabilities"> & HookContext
+      : HookContext
+    : HookContext
+  : HookContext;
+
+/**
+ * The per-handler result type for hook point `K`, derived from its declared `result` schema.
+ *
+ * `void` when the hook point declares no `result` (a side-effect-only hook point), but
+ * `unknown` when the bundle declares no `hooks` at all — the erased view the dispatcher holds
+ * internally, and the permissive bundle a minimal test operation carries.
+ */
+export type HookResultOf<S extends OperationSchemas, K extends HookPointOf<S>> = S extends {
+  readonly hooks: infer H;
+}
+  ? K extends keyof H
+    ? H[K] extends { readonly result: infer R extends z.ZodType }
+      ? z.infer<R>
+      : void
+    : void
+  : unknown;
+
+/**
  * Resolved hooks for a specific operation.
  *
  * `collect()` provides isolated-context execution: each handler receives a frozen
  * clone of the input context. All handlers always run. Returns typed results + errors.
  * Streaming handlers' yielded frames are delivered to `options.onYield` as they occur.
+ *
+ * Typed off the operation's own schema bundle: the hook-point id must be one the operation
+ * declares, the context is checked against that hook point's `input` schema, and the result
+ * type comes from its `result` schema. Previously all three were free — `hookPointId` was a
+ * bare `string` (so a typo silently collected nothing), `ctx` was widened to the base
+ * `HookContext` (so any enrichment was accepted anywhere), and `T` was supplied by the caller
+ * and applied with an `as T` inside the dispatcher. The schemas were already the source of
+ * truth; this makes the compiler read them.
  */
-export interface ResolvedHooks {
-  collect<T = unknown>(
-    hookPointId: string,
-    ctx: HookContext,
+export interface ResolvedHooks<S extends OperationSchemas = OperationSchemas> {
+  collect<K extends HookPointOf<S>>(
+    hookPointId: K,
+    ctx: InputOf<S, K>,
     options?: CollectOptions
-  ): Promise<HookResult<T>>;
+  ): Promise<HookResult<HookResultOf<S, K>>>;
 }
 
 // =============================================================================
@@ -143,14 +203,41 @@ export interface ResolvedHooks {
 
 /**
  * Context injected into operations by the dispatcher.
+ *
+ * Parameterized by the operation's schema bundle so `hooks` and `emit` are typed against the
+ * hook points and events that operation actually declares. `S` defaults to the open
+ * `OperationSchemas`, which keeps the erased `OperationContext` the dispatcher passes around
+ * internally assignable.
  */
-export interface OperationContext<I extends Intent = Intent> {
+export interface OperationContext<
+  I extends Intent = Intent,
+  S extends OperationSchemas = OperationSchemas,
+> {
   readonly intent: I;
   readonly dispatch: DispatchFn;
-  readonly emit: (event: DomainEvent) => Promise<void>;
-  readonly hooks: ResolvedHooks;
+  readonly emit: (event: EventOf<S>) => Promise<void>;
+  readonly hooks: ResolvedHooks<S>;
   readonly causation: readonly string[];
 }
+
+/**
+ * The domain events an operation may emit: its declared event types, each paired with the
+ * payload its schema describes.
+ *
+ * An operation emits only events it declares — the dispatcher rejects a duplicate event-schema
+ * registration, so a type is owned by exactly one operation. Falls back to the open
+ * `DomainEvent` when a bundle declares no events.
+ */
+export type EventOf<S extends OperationSchemas> = S extends {
+  readonly events: infer E;
+}
+  ? {
+      [K in keyof E]: {
+        readonly type: K;
+        readonly payload: E[K] extends z.ZodType ? z.infer<E[K]> : never;
+      };
+    }[keyof E]
+  : DomainEvent;
 
 /**
  * An operation that handles a specific intent type.
@@ -166,7 +253,7 @@ export interface Operation<S extends OperationSchemas = OperationSchemas> {
    * are **derived** from this bundle via {@link IntentOf} / {@link ResultOf}.
    */
   readonly schemas: S;
-  execute(ctx: OperationContext<IntentOf<S>>): Promise<ResultOf<S>>;
+  execute(ctx: OperationContext<IntentOf<S>, S>): Promise<ResultOf<S>>;
 }
 
 /** Per-hook-point schemas: whole input context, each handler's partial result, provided data. */

--- a/src/intents/lib/serializability.integration.test.ts
+++ b/src/intents/lib/serializability.integration.test.ts
@@ -1,0 +1,322 @@
+// @vitest-environment node
+/**
+ * The dispatcher's contract carriers reject non-serializable values.
+ *
+ * This is T1's thesis as an executable claim. The dispatcher already validates six carriers
+ * with zod — intent payload, hook input context, hook result, provided capabilities, event
+ * payload, and operation result. Those `parse` calls only amount to a serializability gate if
+ * no schema opts out of validating, and two zod forms do exactly that:
+ *
+ *   z.instanceof(Path)  requires a class instance rather than merely permitting one
+ *   z.custom<T>()       with no validator runs no validation at all
+ *
+ * With both closed (and an eslint rule keeping them closed), a branded string rejects a class
+ * instance and a structural object rejects a function — so the parses that were already there
+ * become the gate, with no new runtime machinery. If someone reintroduces an escape, the
+ * carrier it guards stops rejecting and a test here fails.
+ *
+ * Note what this file does NOT assert: that a *live* value is converted. `z.object` accepts an
+ * `Error` instance (it can read `name`/`message`/`stack` off the prototype) and strips it to a
+ * plain object — and the dispatcher discards the hook-input parse result, so stripping alone
+ * would not make the context serializable. That is why `app:start` converts explicitly with
+ * `toSerializedError()`, and why the last test here checks the *operation's* output rather
+ * than the schema's tolerance.
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
+import { Dispatcher } from "./dispatcher";
+import { SILENT_LOGGER } from "../../boundaries/platform/logging";
+import type { Operation, OperationSchemas, HookOutput } from "./operation";
+import { hookCtxSchema, workspacePathSchema, serializedErrorSchema } from "../contract";
+import { toSerializedError } from "../../shared/error-utils";
+
+// =============================================================================
+// Values that must never cross a carrier
+// =============================================================================
+
+class Path {
+  constructor(private readonly value: string) {}
+  toString(): string {
+    return this.value;
+  }
+}
+
+const NON_SERIALIZABLE: ReadonlyArray<readonly [string, unknown]> = [
+  ["a class instance", new Path("/ws/a")],
+  ["a function", () => "/ws/a"],
+];
+
+// =============================================================================
+// A probe operation whose every carrier is declared
+// =============================================================================
+
+const INTENT_PROBE = "probe:run";
+const PROBE_OP_ID = "probe";
+const EVENT_PROBE_DONE = "probe:done";
+
+const probePayloadSchema = z.object({ workspacePath: workspacePathSchema }).readonly();
+const probeResultSchema = z.object({ workspacePath: workspacePathSchema }).readonly();
+const probeHookResultSchema = z.object({ workspacePath: workspacePathSchema }).readonly();
+const probeProvidesSchema = z.object({ ready: z.boolean() });
+const probeEventSchema = z.object({ workspacePath: workspacePathSchema }).readonly();
+const probeInputSchema = hookCtxSchema(probePayloadSchema, {
+  workspacePath: workspacePathSchema,
+});
+
+const schemas = {
+  type: INTENT_PROBE,
+  payload: probePayloadSchema,
+  result: probeResultSchema,
+  hooks: {
+    run: {
+      input: probeInputSchema,
+      result: probeHookResultSchema,
+      provides: probeProvidesSchema,
+    },
+  },
+  events: { [EVENT_PROBE_DONE]: probeEventSchema },
+} satisfies OperationSchemas;
+
+/** Drives whichever carrier a test is exercising, from values the test injects. */
+interface ProbeControls {
+  /** Enrichment the operation puts on the hook input context. */
+  readonly enrichment?: Record<string, unknown>;
+  /** Emit the event with this payload before returning. */
+  readonly eventPayload?: unknown;
+  /** Return this as the operation result instead of the payload. */
+  readonly result?: unknown;
+  /** Receives what `collect()` actually let through, so a test can assert on it directly. */
+  readonly onCollect?: (collected: {
+    readonly results: readonly unknown[];
+    readonly errors: readonly Error[];
+    readonly capabilities: Readonly<Record<string, unknown>>;
+  }) => void;
+}
+
+function createProbeOperation(controls: ProbeControls = {}): Operation<typeof schemas> {
+  return {
+    id: PROBE_OP_ID,
+    schemas,
+    async execute(ctx) {
+      const enrichment = controls.enrichment ?? { workspacePath: ctx.intent.payload.workspacePath };
+      const collected = await ctx.hooks.collect("run", {
+        intent: ctx.intent,
+        ...enrichment,
+      } as Parameters<typeof ctx.hooks.collect>[1]);
+      controls.onCollect?.(collected);
+      if (controls.eventPayload !== undefined) {
+        // Deliberately invalid data: the point is that the carrier rejects it. Built as a
+        // separate value so the assertion is not inside the emit() call expression.
+        const badEvent = {
+          type: EVENT_PROBE_DONE,
+          payload: controls.eventPayload,
+        } as Parameters<typeof ctx.emit>[0];
+        await ctx.emit(badEvent);
+      }
+      return (controls.result ?? ctx.intent.payload) as { workspacePath: never };
+    },
+  };
+}
+
+function createDispatcher(controls?: ProbeControls): Dispatcher {
+  const dispatcher = new Dispatcher({ logger: SILENT_LOGGER });
+  dispatcher.registerOperation(createProbeOperation(controls));
+  return dispatcher;
+}
+
+const GOOD_PATH = workspacePathSchema.parse("/ws/a");
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("the dispatcher's carriers reject non-serializable values", () => {
+  describe("intent payload", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label}`, async () => {
+        const dispatcher = createDispatcher();
+        await expect(
+          dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: value } })
+        ).rejects.toThrow();
+      });
+    }
+
+    it("accepts a branded string", async () => {
+      const dispatcher = createDispatcher();
+      await expect(
+        dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } })
+      ).resolves.toEqual({ workspacePath: GOOD_PATH });
+    });
+  });
+
+  describe("hook input context", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label} in the operation-added enrichment`, async () => {
+        const dispatcher = createDispatcher({ enrichment: { workspacePath: value } });
+        dispatcher.registerModule({
+          name: "probe-handler",
+          hooks: { [PROBE_OP_ID]: { run: { handler: async () => ({}) } } },
+        });
+        await expect(
+          dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } })
+        ).rejects.toThrow();
+      });
+    }
+
+    it("rejects an undeclared enrichment field (strict)", async () => {
+      const dispatcher = createDispatcher({
+        enrichment: { workspacePath: GOOD_PATH, smuggled: new Path("/ws/b") },
+      });
+      dispatcher.registerModule({
+        name: "probe-handler",
+        hooks: { [PROBE_OP_ID]: { run: { handler: async () => ({}) } } },
+      });
+      await expect(
+        dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("hook result", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label}`, async () => {
+        // A bad hook result is isolated to its handler (it becomes a collected error rather
+        // than a rejected dispatch), so assert on what collect() actually admitted.
+        let collected: { results: readonly unknown[]; errors: readonly Error[] } | undefined;
+        const dispatcher = createDispatcher({
+          onCollect: (c) => {
+            collected = c;
+          },
+        });
+        dispatcher.registerModule({
+          name: "probe-handler",
+          hooks: {
+            [PROBE_OP_ID]: {
+              run: {
+                handler: async (): Promise<HookOutput> => ({ result: { workspacePath: value } }),
+              },
+            },
+          },
+        });
+        await dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } });
+        expect(collected?.results).toEqual([]);
+        expect(collected?.errors).toHaveLength(1);
+      });
+    }
+
+    it("admits a branded string", async () => {
+      let collected: { results: readonly unknown[]; errors: readonly Error[] } | undefined;
+      const dispatcher = createDispatcher({
+        onCollect: (c) => {
+          collected = c;
+        },
+      });
+      dispatcher.registerModule({
+        name: "probe-handler",
+        hooks: {
+          [PROBE_OP_ID]: {
+            run: {
+              handler: async (): Promise<HookOutput> => ({
+                result: { workspacePath: GOOD_PATH },
+              }),
+            },
+          },
+        },
+      });
+      await dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } });
+      expect(collected?.errors).toEqual([]);
+      expect(collected?.results).toEqual([{ workspacePath: GOOD_PATH }]);
+    });
+  });
+
+  describe("provided capabilities", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label}`, async () => {
+        let collected: { capabilities: Readonly<Record<string, unknown>> } | undefined;
+        const dispatcher = createDispatcher({
+          onCollect: (c) => {
+            collected = c;
+          },
+        });
+        dispatcher.registerModule({
+          name: "probe-provider",
+          hooks: {
+            [PROBE_OP_ID]: {
+              run: { handler: async (): Promise<HookOutput> => ({ provides: { ready: value } }) },
+            },
+          },
+        });
+        await dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } });
+        // The bad capability was never merged into the bag.
+        expect(collected?.capabilities).not.toHaveProperty("ready");
+      });
+    }
+
+    it("merges a scalar", async () => {
+      let collected: { capabilities: Readonly<Record<string, unknown>> } | undefined;
+      const dispatcher = createDispatcher({
+        onCollect: (c) => {
+          collected = c;
+        },
+      });
+      dispatcher.registerModule({
+        name: "probe-provider",
+        hooks: {
+          [PROBE_OP_ID]: {
+            run: { handler: async (): Promise<HookOutput> => ({ provides: { ready: true } }) },
+          },
+        },
+      });
+      await dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } });
+      expect(collected?.capabilities.ready).toBe(true);
+    });
+  });
+
+  describe("event payload", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label}`, async () => {
+        const dispatcher = createDispatcher({ eventPayload: { workspacePath: value } });
+        await expect(
+          dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } })
+        ).rejects.toThrow();
+      });
+    }
+  });
+
+  describe("operation result", () => {
+    for (const [label, value] of NON_SERIALIZABLE) {
+      it(`rejects ${label}`, async () => {
+        const dispatcher = createDispatcher({ result: { workspacePath: value } });
+        await expect(
+          dispatcher.dispatch({ type: INTENT_PROBE, payload: { workspacePath: GOOD_PATH } })
+        ).rejects.toThrow();
+      });
+    }
+  });
+});
+
+describe("errors cross the contract as plain data", () => {
+  it("serializedErrorSchema keeps the cause chain and survives a JSON round-trip", () => {
+    const inner = new TypeError("inner boom");
+    const outer = new Error("outer boom", { cause: inner });
+
+    const serialized = toSerializedError(outer);
+    expect(serialized.name).toBe("Error");
+    expect(serialized.cause?.name).toBe("TypeError");
+    expect(serialized.cause?.message).toBe("inner boom");
+
+    // The real check: it is data, not an instance.
+    const roundTripped: unknown = JSON.parse(JSON.stringify(serialized));
+    expect(serializedErrorSchema.parse(roundTripped)).toEqual(serialized);
+  });
+
+  it("a converted error carries no prototype identity", () => {
+    const serialized = toSerializedError(new TypeError("boom"));
+    expect(serialized).not.toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
+    // `name` is preserved explicitly — rebuilding without it would regroup a TypeError
+    // under "Error" in the crash reporter.
+    expect(serialized.name).toBe("TypeError");
+  });
+});

--- a/src/intents/lib/workspace-identity.ts
+++ b/src/intents/lib/workspace-identity.ts
@@ -6,15 +6,14 @@
  */
 
 import type { DispatchFn } from "./operation";
-import type { DomainEvent } from "./types";
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import type { ProjectId, WorkspaceName, ProjectPath, WorkspacePath } from "../contract";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "../resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "../resolve-project";
 import { getErrorMessage } from "../../shared/error-utils";
 
 /** A workspace's full identity, resolved from its path. */
 export interface ResolvedWorkspaceIdentity {
-  readonly projectPath: string;
+  readonly projectPath: ProjectPath;
   readonly workspaceName: WorkspaceName;
   readonly projectId: ProjectId;
   readonly active: boolean;
@@ -29,30 +28,32 @@ export interface ResolvedWorkspaceIdentity {
  */
 export async function resolveWorkspaceIdentity(
   dispatch: DispatchFn,
-  workspacePath: string
+  workspacePath: WorkspacePath
 ): Promise<ResolvedWorkspaceIdentity> {
-  const { projectPath, workspaceName, active, branch } = await dispatch({
+  const { projectPath, workspaceName, active, branch } = await dispatch<ResolveWorkspaceIntent>({
     type: INTENT_RESOLVE_WORKSPACE,
     payload: { workspacePath },
-  } as ResolveWorkspaceIntent);
+  });
 
-  const { projectId } = await dispatch({
+  const { projectId } = await dispatch<ResolveProjectIntent>({
     type: INTENT_RESOLVE_PROJECT,
     payload: { projectPath },
-  } as ResolveProjectIntent);
+  });
 
   return { projectPath, workspaceName, projectId, active, branch };
 }
 
 /**
- * Emit a `{workspacePath, error}` failure domain event. Used by the
- * hibernate/wake `catch` blocks before rethrowing.
+ * Build the `{workspacePath, error}` payload the hibernate/wake failure events carry.
+ *
+ * Returns the payload rather than emitting it: `ctx.emit` is now typed to the events its own
+ * operation declares, so a shared helper cannot emit on the operation's behalf without either
+ * a cast or a type parameter that defeats the check. The caller emits, and the event type it
+ * names is validated against its own bundle.
  */
-export function emitWorkspaceFailure(
-  emit: (event: DomainEvent) => void,
-  type: string,
-  workspacePath: string,
+export function workspaceFailurePayload(
+  workspacePath: WorkspacePath,
   error: unknown
-): void {
-  emit({ type, payload: { workspacePath, error: getErrorMessage(error) } });
+): { readonly workspacePath: WorkspacePath; readonly error: string } {
+  return { workspacePath, error: getErrorMessage(error) };
 }

--- a/src/intents/lib/workspace-operation.integration.test.ts
+++ b/src/intents/lib/workspace-operation.integration.test.ts
@@ -25,14 +25,16 @@ import { ResolveProjectOperation, RESOLVE_PROJECT_OPERATION_ID } from "../resolv
 import type { ResolveHookResult as ResolveProjectHookResult } from "../resolve-project";
 import type { IntentModule } from "./module";
 import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import { workspacePathSchema } from "../contract";
+import { projPath, wsPath } from "../../shared/test-fixtures";
 
 // =============================================================================
 // Test operation
 // =============================================================================
 
-const PROJECT_ROOT = "/project";
+const PROJECT_ROOT = projPath("/project");
 const PROJECT_ID = "proj-1" as ProjectId;
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 const WORKSPACE_NAME = "feature-x" as WorkspaceName;
 
 const INTENT_TEST = "test:workspace-hook" as const;
@@ -44,22 +46,22 @@ interface TestIntent extends Intent<string> {
   readonly payload: { readonly workspacePath: string };
 }
 
-interface TestHookResult {
-  readonly value?: string;
-}
+const testHookResultSchema = z.object({ value: z.string().optional() }).readonly();
 
 const testSchemas = {
   type: INTENT_TEST,
-  payload: z.object({ workspacePath: z.string() }).readonly(),
+  payload: z.object({ workspacePath: workspacePathSchema }).readonly(),
   result: z.string(),
+  hooks: { work: { result: testHookResultSchema } },
 } satisfies OperationSchemas;
 
-class TestOperation extends WorkspaceHookOperation<typeof testSchemas, TestHookResult> {
+class TestOperation extends WorkspaceHookOperation<typeof testSchemas> {
   readonly schemas = testSchemas;
 
   constructor(opts?: { resolveProject?: boolean; emitEvent?: boolean }) {
     super(TEST_OPERATION_ID, {
       hookPoint: "work",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       ...(opts?.resolveProject !== undefined && { resolveProject: opts.resolveProject }),
       errorLabel: "test-workspace-hook work hooks failed",
       extract: (results) =>
@@ -106,7 +108,9 @@ function createSetup(opts: {
           handler: async (ctx): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
             const intent = ctx.intent as TestIntent;
             if (intent.payload.workspacePath === WORKSPACE_PATH) {
-              return { result: { projectPath: PROJECT_ROOT, workspaceName: WORKSPACE_NAME } };
+              return {
+                result: { projectPath: projPath(PROJECT_ROOT), workspaceName: WORKSPACE_NAME },
+              };
             }
             return { result: {} };
           },

--- a/src/intents/lib/workspace-operation.ts
+++ b/src/intents/lib/workspace-operation.ts
@@ -19,11 +19,10 @@
  */
 
 import type { z } from "zod/v4";
-import type { Intent, DomainEvent } from "./types";
+import type { Intent } from "./types";
 import type {
   Operation,
   OperationContext,
-  HookContext,
   OperationSchemas,
   IntentOf,
   ResultOf,
@@ -39,71 +38,93 @@ import {
   type ResolveProjectIntent,
   type ResolveProjectResult,
 } from "../resolve-project";
+import type { WorkspacePath } from "../contract";
+import type { HookPointOf, HookResultOf, InputOf, EventOf } from "./operation";
 
 /** An intent whose payload carries the target workspace path. */
 export type WorkspaceScopedIntent<R> = Intent<R> & {
-  readonly payload: { readonly workspacePath: string };
+  readonly payload: { readonly workspacePath: WorkspacePath };
 };
 
 /** Operation schemas whose payload carries the target workspace path. */
 export type WorkspaceScopedSchemas = OperationSchemas & {
-  readonly payload: z.ZodType<{ readonly workspacePath: string }>;
+  readonly payload: z.ZodType<{ readonly workspacePath: WorkspacePath }>;
 };
 
-/** Input context passed to the hook point — matches the per-op input interfaces. */
-interface WorkspaceHookInput extends HookContext {
-  readonly workspacePath: string;
-}
+/**
+ * The per-handler result type of the single hook point these operations collect.
+ *
+ * Derived from the bundle rather than supplied as a type parameter: every
+ * `WorkspaceHookOperation` declares exactly one hook point, so `HookPointOf<S>` is a single
+ * literal and this resolves to that hook point's `result` schema.
+ */
+export type WorkspaceHookResult<S extends WorkspaceScopedSchemas> = HookResultOf<S, HookPointOf<S>>;
 
-export interface WorkspaceHookSpec<I extends WorkspaceScopedIntent<R>, THook, R> {
-  /** Hook point to collect (e.g. "get", "restart"). */
-  readonly hookPoint: string;
+export interface WorkspaceHookSpec<
+  S extends WorkspaceScopedSchemas,
+  I extends WorkspaceScopedIntent<R>,
+  R,
+> {
+  /** Hook point to collect — must be one this operation's bundle declares. */
+  readonly hookPoint: HookPointOf<S> & string;
+  /**
+   * Build the hook input context.
+   *
+   * Supplied by the subclass rather than built here because only the subclass knows the
+   * concrete schema bundle: inside this generic base `InputOf<S, …>` is unresolved, so a
+   * context built here could only be forced into place with an assertion. At the call site
+   * `S` is a literal bundle and the returned object is checked against the hook point's
+   * declared `input` schema.
+   */
+  readonly buildInput: (
+    intent: IntentOf<S>,
+    workspacePath: WorkspacePath
+  ) => InputOf<S, HookPointOf<S> & string>;
   /** Also dispatch project:resolve — needed only when onSuccess wants projectId. */
   readonly resolveProject?: boolean;
   /** AggregateError message when multiple handlers fail. */
   readonly errorLabel: string;
   /** Merge hook results into the operation result. May throw (missing required result). */
-  readonly extract: (results: readonly THook[]) => R;
+  readonly extract: (results: readonly WorkspaceHookResult<S>[]) => R;
   /** Optional post-hook domain event. `project` is set iff `resolveProject` is true. */
   readonly onSuccess?: (args: {
     readonly intent: I;
     readonly resolved: ResolveWorkspaceResult;
     readonly project: ResolveProjectResult | undefined;
     readonly result: R;
-  }) => DomainEvent;
+  }) => EventOf<S>;
 }
 
 export abstract class WorkspaceHookOperation<
   S extends WorkspaceScopedSchemas,
-  THook,
 > implements Operation<S> {
   abstract readonly schemas: S;
 
   protected constructor(
     readonly id: string,
-    private readonly spec: WorkspaceHookSpec<IntentOf<S>, THook, ResultOf<S>>
+    private readonly spec: WorkspaceHookSpec<S, IntentOf<S>, ResultOf<S>>
   ) {}
 
-  async execute(ctx: OperationContext<IntentOf<S>>): Promise<ResultOf<S>> {
+  async execute(ctx: OperationContext<IntentOf<S>, S>): Promise<ResultOf<S>> {
     const { workspacePath } = ctx.intent.payload;
 
     // 1. Dispatch shared workspace resolution
-    const resolved = await ctx.dispatch({
+    const resolved = await ctx.dispatch<ResolveWorkspaceIntent>({
       type: INTENT_RESOLVE_WORKSPACE,
       payload: { workspacePath },
-    } as ResolveWorkspaceIntent);
+    });
 
     // 2. Dispatch shared project resolution (event payloads only)
     const project = this.spec.resolveProject
-      ? await ctx.dispatch({
+      ? await ctx.dispatch<ResolveProjectIntent>({
           type: INTENT_RESOLVE_PROJECT,
           payload: { projectPath: resolved.projectPath },
-        } as ResolveProjectIntent)
+        })
       : undefined;
 
     // 3. Run the hook point — handlers do the actual work
-    const hookCtx: WorkspaceHookInput = { intent: ctx.intent, workspacePath };
-    const { results, errors } = await ctx.hooks.collect<THook>(this.spec.hookPoint, hookCtx);
+    const hookCtx = this.spec.buildInput(ctx.intent, workspacePath);
+    const { results, errors } = await ctx.hooks.collect(this.spec.hookPoint, hookCtx);
     throwHookErrors(errors, this.spec.errorLabel);
 
     // 4. Extract result and emit optional domain event

--- a/src/intents/list-projects.integration.test.ts
+++ b/src/intents/list-projects.integration.test.ts
@@ -23,22 +23,27 @@ import type {
 import type { IntentModule } from "./lib/module";
 import type { HookOutput } from "./lib/operation";
 import type { Project, ProjectId } from "../shared/api/types";
-import type { InternalWorkspace } from "./list-projects";
+import type { DiscoveredWorkspace, ProjectPath, WorkspaceName } from "./contract";
 import { Path } from "../utils/path/path";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
 const PROJECT_A_ID = "project-a-ea0135bc" as ProjectId;
-const PROJECT_A_PATH = "/repos/project-a";
+const PROJECT_A_PATH = projPath("/repos/project-a");
 const PROJECT_B_ID = "project-b-fb1246cd" as ProjectId;
-const PROJECT_B_PATH = "/repos/project-b";
+const PROJECT_B_PATH = projPath("/repos/project-b");
 
-function makeWorkspace(name: string, projectPath: string, branch: string): InternalWorkspace {
+function makeWorkspace(
+  name: string,
+  projectPath: ProjectPath,
+  branch: string
+): DiscoveredWorkspace {
   return {
-    name,
-    path: new Path(`${projectPath}/.codehydra/workspaces/${name}`),
+    name: name as WorkspaceName,
+    path: wsPath(new Path(`${projectPath}/.codehydra/workspaces/${name}`).toString()),
     branch,
     metadata: { base: "main" },
   };
@@ -134,7 +139,7 @@ describe("ListProjects Operation", () => {
           },
         }),
         async () => ({
-          result: { entries: [{ projectPath: PROJECT_A_PATH, workspaces: [ws1, ws2] }] },
+          result: { entries: [{ projectPath: projPath(PROJECT_A_PATH), workspaces: [ws1, ws2] }] },
         })
       );
     });
@@ -227,7 +232,7 @@ describe("ListProjects Operation", () => {
           },
         }),
         async () => ({
-          result: { entries: [{ projectPath: PROJECT_A_PATH, workspaces: [] }] },
+          result: { entries: [{ projectPath: projPath(PROJECT_A_PATH), workspaces: [] }] },
         })
       );
 
@@ -261,7 +266,7 @@ describe("ListProjects Operation", () => {
 
   describe("workspace data for unknown project", () => {
     let setup: TestSetup;
-    const ws = makeWorkspace("orphan", "/repos/unknown", "orphan");
+    const ws = makeWorkspace("orphan", projPath("/repos/unknown"), "orphan");
 
     beforeEach(() => {
       setup = createTestSetup(
@@ -271,7 +276,7 @@ describe("ListProjects Operation", () => {
           },
         }),
         async () => ({
-          result: { entries: [{ projectPath: "/repos/unknown", workspaces: [ws] }] },
+          result: { entries: [{ projectPath: projPath("/repos/unknown"), workspaces: [ws] }] },
         })
       );
     });

--- a/src/intents/list-projects.ts
+++ b/src/intents/list-projects.ts
@@ -16,14 +16,16 @@ import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import type { Project } from "../shared/api/types";
-import type { Path } from "../utils/path/path";
-import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
-import { projectIdSchema, projectSchema } from "./contract";
+import {
+  discoveredWorkspaceSchema,
+  hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  projectSchema,
+} from "./contract";
+import type { DiscoveredWorkspace } from "./contract";
 import { toIpcWorkspaces } from "../utils/workspace-conversion";
 import { throwHookErrors } from "./lib/hook-helpers";
-
-/** Re-exported for use by operation integration tests (avoids direct service import). */
-export type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
 
 export const INTENT_LIST_PROJECTS = "project:list" as const;
 export const LIST_PROJECTS_OPERATION_ID = "list-projects";
@@ -40,7 +42,7 @@ export const listProjectsHookEntrySchema = z
   .object({
     projectId: projectIdSchema,
     name: z.string(),
-    path: z.string(),
+    path: projectPathSchema,
   })
   .readonly();
 
@@ -50,23 +52,10 @@ export const listProjectsHookResultSchema = z
   })
   .readonly();
 
-/**
- * Local schema for the internal Workspace shape (from boundaries/git-types) — not in
- * contract.ts because it carries a `Path` instance (a class), not an IPC string.
- */
-const internalWorkspaceSchema = z
-  .object({
-    name: z.string(),
-    path: z.custom<Path>(),
-    branch: z.string().nullable(),
-    metadata: z.record(z.string(), z.string()).readonly(),
-  })
-  .readonly();
-
 export const listWorkspacesHookEntrySchema = z
   .object({
-    projectPath: z.string(),
-    workspaces: z.array(internalWorkspaceSchema).readonly(),
+    projectPath: projectPathSchema,
+    workspaces: z.array(discoveredWorkspaceSchema).readonly(),
     /**
      * Per-project default base branch, computed once at project:open and cached
      * by the contributing module. Carried here so the creation form can seed the
@@ -82,13 +71,23 @@ export const listWorkspacesHookResultSchema = z
   })
   .readonly();
 
-const schemas = {
+/** Both hook points receive the bare intent — declared so the context type is derived. */
+const listProjectsHookInputSchema = hookCtxSchema(listProjectsPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_LIST_PROJECTS,
   payload: listProjectsPayloadSchema,
   result: listProjectsResultSchema,
   hooks: {
-    "list-projects": { result: listProjectsHookResultSchema },
-    "list-workspaces": { result: listWorkspacesHookResultSchema },
+    "list-projects": { input: listProjectsHookInputSchema, result: listProjectsHookResultSchema },
+    "list-workspaces": {
+      input: listProjectsHookInputSchema,
+      result: listWorkspacesHookResultSchema,
+    },
   },
 } satisfies OperationSchemas;
 
@@ -110,27 +109,21 @@ export class ListProjectsOperation implements Operation<typeof schemas> {
   readonly id = LIST_PROJECTS_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<ListProjectsIntent>): Promise<Project[]> {
+  async execute(ctx: OperationContext<ListProjectsIntent, typeof schemas>): Promise<Project[]> {
     const hookCtx: HookContext = {
       intent: ctx.intent,
     };
 
     // Collect project identity from "list-projects" hook
-    const projectsResult = await ctx.hooks.collect<ListProjectsHookResult>(
-      "list-projects",
-      hookCtx
-    );
+    const projectsResult = await ctx.hooks.collect("list-projects", hookCtx);
     throwHookErrors(projectsResult.errors, "Multiple errors listing projects");
 
     // Collect workspace data from "list-workspaces" hook
-    const workspacesResult = await ctx.hooks.collect<ListWorkspacesHookResult>(
-      "list-workspaces",
-      hookCtx
-    );
+    const workspacesResult = await ctx.hooks.collect("list-workspaces", hookCtx);
     throwHookErrors(workspacesResult.errors, "Multiple errors listing workspaces");
 
     // Build workspace + default-base lookups by projectPath
-    const workspaceMap = new Map<string, InternalWorkspace[]>();
+    const workspaceMap = new Map<string, DiscoveredWorkspace[]>();
     const defaultBaseMap = new Map<string, string>();
     for (const result of workspacesResult.results) {
       if (result.entries) {

--- a/src/intents/open-project.integration.test.ts
+++ b/src/intents/open-project.integration.test.ts
@@ -67,6 +67,8 @@ import {
 import type { TestViewManager } from "./operations.test-utils";
 import { GET_ACTIVE_WORKSPACE_OPERATION_ID } from "./get-active-workspace";
 import type { GetActiveWorkspaceHookResult } from "./get-active-workspace";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { DiscoveredWorkspace, ProjectPath, WorkspacePath } from "./contract";
 
 // =============================================================================
 // Test Helpers
@@ -85,10 +87,10 @@ function testProjectId(path: string): ProjectId {
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/test/project";
+const PROJECT_PATH = projPath("/test/project");
 const PROJECT_ID = testProjectId(PROJECT_PATH);
-const WORKSPACE_A_PATH = "/test/project/workspaces/feature-a";
-const WORKSPACE_B_PATH = "/test/project/workspaces/feature-b";
+const WORKSPACE_A_PATH = wsPath("/test/project/workspaces/feature-a");
+const WORKSPACE_B_PATH = wsPath("/test/project/workspaces/feature-b");
 const WORKSPACE_URL = "http://127.0.0.1:8080/?folder=test";
 
 // =============================================================================
@@ -100,12 +102,16 @@ interface TestProjectState {
   registeredProjects: Array<{
     id: ProjectId;
     name: string;
-    path: string;
-    workspaces: Array<{ path: string; branch: string | null; metadata: Record<string, string> }>;
+    path: ProjectPath;
+    workspaces: Array<{
+      path: WorkspacePath;
+      branch: string | null;
+      metadata: Record<string, string>;
+    }>;
     remoteUrl?: string;
   }>;
   /** Workspaces registered via stateModule event handler */
-  registeredWorkspaces: Array<{ projectPath: string; workspacePath: string }>;
+  registeredWorkspaces: Array<{ projectPath: ProjectPath; workspacePath: WorkspacePath }>;
   /** Whether the project is considered "open" */
   openProjectPaths: Set<string>;
   /** Last base branch cache */
@@ -121,12 +127,7 @@ interface TestHarness {
   preloadedPaths: string[];
   projectState: TestProjectState;
   /** Mock for provider.discover() */
-  discoverResult: Array<{
-    name: string;
-    path: Path;
-    branch: string | null;
-    metadata: Readonly<Record<string, string>>;
-  }>;
+  discoverResult: DiscoveredWorkspace[];
   /** Whether validateRepository should throw */
   validateThrows: boolean;
   /** Mock projectStore state */
@@ -152,14 +153,14 @@ function createTestHarness(options?: {
 
   const discoverResult: TestHarness["discoverResult"] = options?.discoverResult ?? [
     {
-      name: "feature-a",
-      path: new Path(WORKSPACE_A_PATH),
+      name: "feature-a" as WorkspaceName,
+      path: wsPath(new Path(WORKSPACE_A_PATH).toString()),
       branch: "feature-a",
       metadata: { base: "main" },
     },
     {
-      name: "feature-b",
-      path: new Path(WORKSPACE_B_PATH),
+      name: "feature-b" as WorkspaceName,
+      path: wsPath(new Path(WORKSPACE_B_PATH).toString()),
       branch: "feature-b",
       metadata: { base: "main" },
     },
@@ -209,9 +210,9 @@ function createTestHarness(options?: {
         projectState.registeredProjects.push({
           id: project.id,
           name: project.name,
-          path: project.path.toString(),
+          path: projPath(project.path.toString()),
           workspaces: project.workspaces.map((w) => ({
-            path: w.path.toString(),
+            path: wsPath(w.path.toString()),
             branch: w.branch,
             metadata: w.metadata,
           })),
@@ -221,7 +222,7 @@ function createTestHarness(options?: {
     ),
     registerWorkspace: vi.fn().mockImplementation(
       (
-        projectPath: string,
+        projectPath: ProjectPath,
         workspace: {
           path: Path;
           branch: string | null;
@@ -230,7 +231,7 @@ function createTestHarness(options?: {
       ) => {
         projectState.registeredWorkspaces.push({
           projectPath,
-          workspacePath: workspace.path.toString(),
+          workspacePath: wsPath(workspace.path.toString()),
         });
         // Also add to the project's workspaces (matches real behavior)
         const project = projectState.registeredProjects.find(
@@ -238,7 +239,7 @@ function createTestHarness(options?: {
         );
         if (project) {
           project.workspaces.push({
-            path: workspace.path.toString(),
+            path: wsPath(workspace.path.toString()),
             branch: workspace.branch,
             metadata: workspace.metadata,
           });
@@ -321,7 +322,7 @@ function createTestHarness(options?: {
             }
 
             await gitWorktreeProvider.validateRepository(path);
-            return { result: { projectPath: path.toString() } };
+            return { result: { projectPath: projPath(path.toString()) } };
           },
         },
       },
@@ -357,7 +358,7 @@ function createTestHarness(options?: {
             });
             projectStoreState.configs.set(gitPath.toString(), { remoteUrl });
 
-            return { result: { projectPath: gitPath.toString(), remoteUrl } };
+            return { result: { projectPath: projPath(gitPath.toString()), remoteUrl } };
           },
         },
       },
@@ -514,7 +515,7 @@ function createTestHarness(options?: {
         handler: async (event: DomainEvent): Promise<void> => {
           const payload = (event as WorkspaceCreatedEvent).payload;
           appState.registerWorkspace(payload.projectPath, {
-            path: new Path(payload.workspacePath),
+            path: wsPath(new Path(payload.workspacePath).toString()),
             name: payload.workspaceName,
             branch: payload.branch,
             metadata: payload.metadata,
@@ -579,7 +580,7 @@ function createTestHarness(options?: {
                   ? {
                       projectId: testProjectId(project.path),
                       workspaceName: name as WorkspaceName,
-                      path,
+                      path: wsPath(path),
                     }
                   : null,
               },
@@ -619,7 +620,7 @@ function createTestHarness(options?: {
   };
 }
 
-function buildOpenIntent(input: { path: Path } | { git: string }): OpenProjectIntent {
+function buildOpenIntent(input: { path: ProjectPath } | { git: string }): OpenProjectIntent {
   return {
     type: INTENT_OPEN_PROJECT,
     payload: "path" in input ? { path: input.path } : { git: input.git },
@@ -633,7 +634,7 @@ function buildOpenIntent(input: { path: Path } | { git: string }): OpenProjectIn
 describe("OpenProjectOperation", () => {
   it("test 1: opens local project and activates workspaces", async () => {
     const harness = createTestHarness();
-    const intent = buildOpenIntent({ path: new Path(PROJECT_PATH) });
+    const intent = buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) });
 
     const result = await harness.dispatcher.dispatch(intent);
 
@@ -686,7 +687,9 @@ describe("OpenProjectOperation", () => {
     const harness = createTestHarness();
 
     // First open populates state
-    await harness.dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+    await harness.dispatcher.dispatch(
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
+    );
 
     // Reset tracking
     harness.createdViews.length = 0;
@@ -703,7 +706,7 @@ describe("OpenProjectOperation", () => {
     // so we test the operation behavior by adding a module that sets alreadyOpen)
     // Instead, test at operation level: re-dispatch and verify project returned
     const result = await harness.dispatcher.dispatch(
-      buildOpenIntent({ path: new Path(PROJECT_PATH) })
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
     );
 
     expect(result).toBeDefined();
@@ -738,7 +741,7 @@ describe("OpenProjectOperation", () => {
               const intent = ctx.intent as OpenProjectIntent;
               const { path } = intent.payload;
               if (!path) return { result: {} };
-              return { result: { projectPath: path.toString(), alreadyOpen: true } };
+              return { result: { projectPath: projPath(path.toString()), alreadyOpen: true } };
             },
           },
         },
@@ -772,8 +775,8 @@ describe("OpenProjectOperation", () => {
                 result: {
                   workspaces: [
                     {
-                      name: "feature-a",
-                      path: new Path(WORKSPACE_A_PATH),
+                      name: "feature-a" as WorkspaceName,
+                      path: wsPath(new Path(WORKSPACE_A_PATH).toString()),
                       branch: "feature-a",
                       metadata: { base: "main" },
                     },
@@ -796,7 +799,9 @@ describe("OpenProjectOperation", () => {
       receivedEvents.push(event);
     });
 
-    const result = await dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+    const result = await dispatcher.dispatch(
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
+    );
 
     // Returns project data
     expect(result).toBeDefined();
@@ -842,7 +847,9 @@ describe("OpenProjectOperation", () => {
       receivedEvents.push(event);
     });
 
-    await harness.dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+    await harness.dispatcher.dispatch(
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
+    );
 
     expect(receivedEvents).toHaveLength(1);
     const event = receivedEvents[0] as ProjectOpenedEvent;
@@ -861,7 +868,7 @@ describe("OpenProjectOperation", () => {
       workspaceCreateThrowsForPath: WORKSPACE_A_PATH,
     });
 
-    const intent = buildOpenIntent({ path: new Path(PROJECT_PATH) });
+    const intent = buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) });
     const result = await harness.dispatcher.dispatch(intent);
 
     // Operation succeeds despite one workspace failure
@@ -877,7 +884,7 @@ describe("OpenProjectOperation", () => {
   it("test 7: rejects invalid git path", async () => {
     const harness = createTestHarness({ validateThrows: true });
 
-    const intent = buildOpenIntent({ path: new Path("/invalid/path") });
+    const intent = buildOpenIntent({ path: projPath(new Path("/invalid/path").toString()) });
 
     await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Not a valid git repository");
   });
@@ -945,10 +952,10 @@ describe("OpenProjectOperation", () => {
 
     dispatcher.registerModule(selectFolderModule);
 
-    const result = await dispatcher.dispatch({
+    const result = await dispatcher.dispatch<OpenProjectIntent>({
       type: INTENT_OPEN_PROJECT,
       payload: {},
-    } as OpenProjectIntent);
+    });
 
     expect(result).toBeNull();
   });
@@ -965,7 +972,7 @@ describe("OpenProjectOperation", () => {
           "select-folder": {
             handler: async (): Promise<HookOutput<SelectFolderHookResult>> => {
               selectFolderSpy();
-              return { result: { folderPath: "/should-not-be-used" } };
+              return { result: { folderPath: projPath("/should-not-be-used") } };
             },
           },
         },
@@ -974,7 +981,7 @@ describe("OpenProjectOperation", () => {
     harness.dispatcher.registerModule(selectFolderModule);
 
     // Dispatch with a path — should skip select-folder
-    const intent = buildOpenIntent({ path: new Path(PROJECT_PATH) });
+    const intent = buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) });
     await harness.dispatcher.dispatch(intent);
 
     expect(selectFolderSpy).not.toHaveBeenCalled();
@@ -992,14 +999,14 @@ describe("OpenProjectOperation", () => {
       failedEvents.push(event);
     });
 
-    const intent = buildOpenIntent({ path: new Path("/invalid/path") });
+    const intent = buildOpenIntent({ path: projPath(new Path("/invalid/path").toString()) });
     await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow("Not a valid git repository");
 
     expect(failedEvents).toHaveLength(1);
     const event = failedEvents[0] as ProjectOpenFailedEvent;
     expect(event.type).toBe(EVENT_PROJECT_OPEN_FAILED);
     expect(event.payload.reason).toBe("Not a valid git repository");
-    expect(event.payload.path).toEqual(new Path("/invalid/path"));
+    expect(event.payload.path).toEqual(projPath("/invalid/path"));
     expect(event.payload.git).toBeUndefined();
   });
 
@@ -1039,7 +1046,7 @@ describe("OpenProjectOperation", () => {
               const intent = ctx.intent as OpenProjectIntent;
               const { path } = intent.payload;
               if (!path) return { result: {} };
-              return { result: { projectPath: path.toString(), alreadyOpen: true } };
+              return { result: { projectPath: projPath(path.toString()), alreadyOpen: true } };
             },
           },
           register: {
@@ -1068,7 +1075,9 @@ describe("OpenProjectOperation", () => {
       failedEvents.push(event);
     });
 
-    const result = await dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+    const result = await dispatcher.dispatch(
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
+    );
 
     // Returns project data (it's not a hard failure)
     expect(result).toBeDefined();
@@ -1080,7 +1089,7 @@ describe("OpenProjectOperation", () => {
     expect(failedEvents).toHaveLength(1);
     const event = failedEvents[0] as ProjectOpenFailedEvent;
     expect(event.payload.reason).toBe("already-open");
-    expect(event.payload.path).toEqual(new Path(PROJECT_PATH));
+    expect(event.payload.path).toEqual(PROJECT_PATH);
   });
 
   it("project:opened event includes intent-origin fields", async () => {
@@ -1091,12 +1100,14 @@ describe("OpenProjectOperation", () => {
       receivedEvents.push(event);
     });
 
-    await harness.dispatcher.dispatch(buildOpenIntent({ path: new Path(PROJECT_PATH) }));
+    await harness.dispatcher.dispatch(
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
+    );
 
     expect(receivedEvents).toHaveLength(1);
     const event = receivedEvents[0] as ProjectOpenedEvent;
     expect(event.payload.project.id).toBe(PROJECT_ID);
-    expect(event.payload.path).toEqual(new Path(PROJECT_PATH));
+    expect(event.payload.path).toEqual(PROJECT_PATH);
     expect(event.payload.git).toBeUndefined();
   });
 
@@ -1119,7 +1130,7 @@ describe("OpenProjectOperation", () => {
     harness.dispatcher.registerModule(prepareModule);
 
     const result = await harness.dispatcher.dispatch(
-      buildOpenIntent({ path: new Path(PROJECT_PATH) })
+      buildOpenIntent({ path: projPath(new Path(PROJECT_PATH).toString()) })
     );
 
     expect(result).toBeNull();

--- a/src/intents/open-project.ts
+++ b/src/intents/open-project.ts
@@ -23,8 +23,14 @@ import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import type { ProjectId, Project } from "../shared/api/types";
-import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
-import { projectSchema, projectIdSchema, hookCtxSchema } from "./contract";
+import {
+  projectSchema,
+  projectIdSchema,
+  projectPathSchema,
+  discoveredWorkspaceSchema,
+  hookCtxSchema,
+} from "./contract";
+import type { ProjectPath, DiscoveredWorkspace } from "./contract";
 import {
   INTENT_OPEN_WORKSPACE,
   type OpenWorkspaceIntent,
@@ -51,7 +57,7 @@ export const EVENT_CLONE_PROGRESS = "clone:progress" as const;
 export const openProjectPayloadSchema = z
   .object({
     /** Absolute local filesystem path. Set by projects.open. */
-    path: z.instanceof(Path).optional(),
+    path: projectPathSchema.optional(),
     /** Git URL or shorthand (e.g. "org/repo"). Set by the creation module's clone sub-dialog. */
     git: z.string().optional(),
   })
@@ -61,28 +67,13 @@ export const openProjectPayloadSchema = z
 export const openProjectResultSchema = projectSchema.nullable();
 
 // -----------------------------------------------------------------------------
-// Internal (git-types) Workspace — local schema (no contract equivalent: the
-// contract's workspaceSchema is the IPC form with a string path; discover
-// results carry the internal form with a `Path` instance).
-// -----------------------------------------------------------------------------
-
-const internalWorkspaceSchema = z
-  .object({
-    name: z.string(),
-    path: z.instanceof(Path),
-    branch: z.string().nullable(),
-    metadata: z.record(z.string(), z.string()).readonly(),
-  })
-  .readonly();
-
-// -----------------------------------------------------------------------------
 // Hook result schemas
 // -----------------------------------------------------------------------------
 
 /** Result returned by handlers on the "select-folder" hook point. */
 export const selectFolderHookResultSchema = z
   .object({
-    folderPath: z.string().nullable(),
+    folderPath: projectPathSchema.nullable(),
   })
   .readonly();
 
@@ -98,7 +89,7 @@ export const prepareHookResultSchema = z
 export const resolveHookResultSchema = z
   .object({
     /** Optional when using collect() — handler may skip via self-selection. */
-    projectPath: z.string().optional(),
+    projectPath: projectPathSchema.optional(),
     remoteUrl: z.string().optional(),
     /** If true, the project is already open — skip workspace:open and event emission. */
     alreadyOpen: z.boolean().optional(),
@@ -108,7 +99,7 @@ export const resolveHookResultSchema = z
 /** Result returned by handlers on the "discover" hook point. */
 export const discoverHookResultSchema = z
   .object({
-    workspaces: z.array(internalWorkspaceSchema).readonly(),
+    workspaces: z.array(discoveredWorkspaceSchema).readonly(),
     defaultBaseBranch: z.string().optional(),
   })
   .readonly();
@@ -129,7 +120,7 @@ export const registerHookResultSchema = z
 // -----------------------------------------------------------------------------
 
 /** Operation-added enrichment for the "discover" hook point. */
-const discoverEnrichmentSchema = z.object({ projectPath: z.string() });
+const discoverEnrichmentSchema = z.object({ projectPath: projectPathSchema });
 
 /** Runtime whole-context validation schema for "discover". */
 export const discoverHookInputSchema = hookCtxSchema(
@@ -139,7 +130,7 @@ export const discoverHookInputSchema = hookCtxSchema(
 
 /** Operation-added enrichment for the "register" hook point. */
 const registerEnrichmentSchema = z.object({
-  projectPath: z.string(),
+  projectPath: projectPathSchema,
   remoteUrl: z.string().optional(),
 });
 
@@ -157,7 +148,7 @@ export const projectOpenedPayloadSchema = z
   .object({
     project: projectSchema,
     /** Original intent path, for idempotency reset. */
-    path: z.instanceof(Path).optional(),
+    path: projectPathSchema.optional(),
     /** Original intent git URL, for idempotency reset. */
     git: z.string().optional(),
   })
@@ -166,7 +157,7 @@ export const projectOpenedPayloadSchema = z
 export const projectOpenFailedPayloadSchema = z
   .object({
     /** Original intent path, for idempotency reset. */
-    path: z.instanceof(Path).optional(),
+    path: projectPathSchema.optional(),
     /** Original intent git URL, for idempotency reset. */
     git: z.string().optional(),
     /** Reason the open failed (error message or "already-open"). */
@@ -183,14 +174,21 @@ export const cloneProgressPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/** These hook points receive the bare (possibly folder-resolved) intent. */
+const bareOpenHookInputSchema = hookCtxSchema(openProjectPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_OPEN_PROJECT,
   payload: openProjectPayloadSchema,
   result: openProjectResultSchema,
   hooks: {
-    "select-folder": { result: selectFolderHookResultSchema },
-    prepare: { result: prepareHookResultSchema },
-    resolve: { result: resolveHookResultSchema },
+    "select-folder": { input: bareOpenHookInputSchema, result: selectFolderHookResultSchema },
+    prepare: { input: bareOpenHookInputSchema, result: prepareHookResultSchema },
+    resolve: { input: bareOpenHookInputSchema, result: resolveHookResultSchema },
     register: { input: registerHookInputSchema, result: registerHookResultSchema },
     discover: { input: discoverHookInputSchema, result: discoverHookResultSchema },
   },
@@ -276,7 +274,7 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
   readonly id = OPEN_PROJECT_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<OpenProjectIntent>): Promise<Project | null> {
+  async execute(ctx: OperationContext<OpenProjectIntent, typeof schemas>): Promise<Project | null> {
     const { intent } = ctx;
 
     // Intent-origin fields for idempotency reset events
@@ -289,10 +287,12 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
     let effectiveIntent = intent;
     if (!intent.payload.path && !intent.payload.git) {
       const selectCtx: HookContext = { intent };
-      const { results: selectResults, errors: selectErrors } =
-        await ctx.hooks.collect<SelectFolderHookResult>("select-folder", selectCtx);
+      const { results: selectResults, errors: selectErrors } = await ctx.hooks.collect(
+        "select-folder",
+        selectCtx
+      );
       throwHookErrors(selectErrors, "project:open select-folder hooks failed");
-      let folderPath: string | null = null;
+      let folderPath: ProjectPath | null = null;
       for (const r of selectResults) {
         if (r.folderPath) folderPath = r.folderPath;
       }
@@ -302,7 +302,7 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
       // Construct effective intent with the selected path
       effectiveIntent = {
         ...intent,
-        payload: { ...intent.payload, path: new Path(folderPath) },
+        payload: { ...intent.payload, path: folderPath },
       };
     }
 
@@ -310,8 +310,10 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
     // Only runs for local paths, not git URLs
     if (effectiveIntent.payload.path && !effectiveIntent.payload.git) {
       const prepareCtx: HookContext = { intent: effectiveIntent };
-      const { results: prepareResults, errors: prepareErrors } =
-        await ctx.hooks.collect<PrepareHookResult>("prepare", prepareCtx);
+      const { results: prepareResults, errors: prepareErrors } = await ctx.hooks.collect(
+        "prepare",
+        prepareCtx
+      );
       throwHookErrors(prepareErrors, "project:open prepare hooks failed");
       for (const r of prepareResults) {
         if (r.canceled) return null;
@@ -338,12 +340,15 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
 
       // 1. Resolve: clone if URL, validate git, return projectPath + remoteUrl
       const resolveCtx: HookContext = { intent: effectiveIntent };
-      const { results: resolveResults, errors: resolveErrors } =
-        await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx, {
+      const { results: resolveResults, errors: resolveErrors } = await ctx.hooks.collect(
+        "resolve",
+        resolveCtx,
+        {
           onYield: emitCloneProgress,
-        });
+        }
+      );
       throwHookErrors(resolveErrors, "project:open resolve hooks failed");
-      let projectPath: string | undefined;
+      let projectPath: ProjectPath | undefined;
       let resolvedRemoteUrl: string | undefined;
       let alreadyOpen = false;
       for (const r of resolveResults) {
@@ -361,8 +366,10 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
         projectPath,
         ...(resolvedRemoteUrl !== undefined && { remoteUrl: resolvedRemoteUrl }),
       };
-      const { results: registerResults, errors: registerErrors } =
-        await ctx.hooks.collect<RegisterHookResult>("register", registerCtx);
+      const { results: registerResults, errors: registerErrors } = await ctx.hooks.collect(
+        "register",
+        registerCtx
+      );
       throwHookErrors(registerErrors, "project:open register hooks failed");
       let projectId: ProjectId | undefined;
       let name: string | undefined;
@@ -377,10 +384,12 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
 
       // 3. Discover: find existing workspaces
       const discoverCtx: DiscoverHookInput = { intent: effectiveIntent, projectPath };
-      const { results: discoverResults, errors: discoverErrors } =
-        await ctx.hooks.collect<DiscoverHookResult>("discover", discoverCtx);
+      const { results: discoverResults, errors: discoverErrors } = await ctx.hooks.collect(
+        "discover",
+        discoverCtx
+      );
       throwHookErrors(discoverErrors, "project:open discover hooks failed");
-      const workspaces: InternalWorkspace[] = [];
+      const workspaces: DiscoveredWorkspace[] = [];
       let defaultBaseBranch: string | undefined;
       for (const r of discoverResults) {
         if (r.workspaces) workspaces.push(...r.workspaces);
@@ -407,7 +416,7 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
           if (workspace.metadata[HIBERNATED_METADATA_KEY] === "true") continue;
           try {
             const existingWorkspace: ExistingWorkspaceData = {
-              path: workspace.path.toString(),
+              path: workspace.path,
               name: workspace.name,
               branch: workspace.branch,
               metadata: workspace.metadata,
@@ -457,10 +466,10 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
         // During startup, multiple projects open sequentially — only the first
         // should activate a workspace to avoid visual jumping.
         if (project.workspaces.length > 0) {
-          const activeWorkspace = await ctx.dispatch({
+          const activeWorkspace = await ctx.dispatch<GetActiveWorkspaceIntent>({
             type: INTENT_GET_ACTIVE_WORKSPACE,
             payload: {},
-          } as GetActiveWorkspaceIntent);
+          });
 
           if (activeWorkspace === null) {
             // Pick the first non-hibernated workspace; if all are hibernated,
@@ -470,10 +479,10 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
             );
             if (firstAwake) {
               try {
-                await ctx.dispatch({
+                await ctx.dispatch<SwitchWorkspaceIntent>({
                   type: INTENT_SWITCH_WORKSPACE,
                   payload: { workspacePath: firstAwake.path },
-                } as SwitchWorkspaceIntent);
+                });
               } catch {
                 // Best-effort: switch failure doesn't fail the project open
               }
@@ -485,7 +494,7 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
         ctx.emit({
           type: EVENT_PROJECT_OPEN_FAILED,
           payload: { ...origin, reason: "already-open" },
-        } as ProjectOpenFailedEvent);
+        } satisfies ProjectOpenFailedEvent);
       }
 
       return project;
@@ -497,7 +506,7 @@ export class OpenProjectOperation implements Operation<typeof schemas> {
           ...origin,
           reason: e instanceof Error ? e.message : String(e),
         },
-      } as ProjectOpenFailedEvent);
+      } satisfies ProjectOpenFailedEvent);
       throw e;
     }
   }

--- a/src/intents/open-workspace.integration.test.ts
+++ b/src/intents/open-workspace.integration.test.ts
@@ -69,13 +69,14 @@ import { SWITCH_WORKSPACE_OPERATION_ID } from "./switch-workspace";
 import type { SwitchWorkspaceHookResult, ActivateHookInput } from "./switch-workspace";
 import { registerTestInfrastructure } from "./operations.test-utils";
 import type { WorkspaceRef } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_ROOT = "/project";
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const PROJECT_ROOT = projPath("/project");
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 const WORKSPACE_BRANCH = "feature-x";
 const WORKSPACE_METADATA: Readonly<Record<string, string>> = { base: "main" };
 const WORKSPACE_URL = "http://127.0.0.1:8080/?folder=/workspaces/feature-x";
@@ -256,7 +257,7 @@ function createTestSetup(opts?: TestSetupOptions): TestSetup {
 
             return {
               result: {
-                workspacePath: workspace.path.toString(),
+                workspacePath: wsPath(workspace.path.toString()),
                 branch: workspace.branch,
                 metadata: workspace.metadata,
               },
@@ -373,7 +374,7 @@ function createIntent(overrides?: Partial<OpenWorkspacePayload>): OpenWorkspaceI
   return {
     type: INTENT_OPEN_WORKSPACE,
     payload: {
-      projectPath: PROJECT_ROOT,
+      projectPath: projPath(PROJECT_ROOT),
       workspaceName: "feature-x",
       base: "main",
       ...overrides,
@@ -493,7 +494,7 @@ describe("OpenWorkspace Operation", () => {
 
       const intentWithoutBase: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
-        payload: { projectPath: PROJECT_ROOT, workspaceName: "feature-x" },
+        payload: { projectPath: projPath(PROJECT_ROOT), workspaceName: "feature-x" },
       };
       await setup.dispatcher.dispatch(intentWithoutBase);
 
@@ -578,7 +579,7 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectPath: "/nonexistent/project",
+          projectPath: projPath("/nonexistent/project"),
           workspaceName: "feature-x",
           base: "main",
         },
@@ -643,7 +644,7 @@ describe("OpenWorkspace Operation", () => {
         activeWorkspaceRef: {
           projectId: PROJECT_ID,
           workspaceName: "other" as WorkspaceName,
-          path: "/workspaces/other",
+          path: wsPath("/workspaces/other"),
         },
       });
 
@@ -757,7 +758,7 @@ describe("OpenWorkspace Operation", () => {
       const setup = createTestSetup();
 
       const existingWorkspace: ExistingWorkspaceData = {
-        path: "/existing/workspace/feature-y",
+        path: wsPath("/existing/workspace/feature-y"),
         name: "feature-y",
         branch: "feature-y",
         metadata: { base: "main" },
@@ -774,7 +775,7 @@ describe("OpenWorkspace Operation", () => {
           workspaceName: "feature-y",
           base: "main",
           existingWorkspace,
-          projectPath: PROJECT_ROOT,
+          projectPath: projPath(PROJECT_ROOT),
         },
       };
 
@@ -801,7 +802,7 @@ describe("OpenWorkspace Operation", () => {
       setup.knownProjectPaths.add(customProjectPath);
 
       const existingWorkspace: ExistingWorkspaceData = {
-        path: "/custom/workspace/my-ws",
+        path: wsPath("/custom/workspace/my-ws"),
         name: "my-ws",
         branch: null,
         metadata: { base: "develop" },
@@ -818,7 +819,7 @@ describe("OpenWorkspace Operation", () => {
           workspaceName: "my-ws",
           base: "develop",
           existingWorkspace,
-          projectPath: customProjectPath,
+          projectPath: projPath(customProjectPath),
         },
       };
 
@@ -863,7 +864,7 @@ describe("OpenWorkspace Operation", () => {
       const setup = createTestSetup();
 
       const existingWorkspace: ExistingWorkspaceData = {
-        path: "/existing/workspace/sdk-214", // lowercased by Path on Windows
+        path: wsPath("/existing/workspace/sdk-214"), // lowercased by Path on Windows
         name: "SDK-214",
         branch: "SDK-214",
         metadata: { base: "main" },
@@ -880,7 +881,7 @@ describe("OpenWorkspace Operation", () => {
           workspaceName: "SDK-214",
           base: "main",
           existingWorkspace,
-          projectPath: PROJECT_ROOT,
+          projectPath: projPath(PROJECT_ROOT),
         },
       };
 
@@ -901,7 +902,7 @@ describe("OpenWorkspace Operation", () => {
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,
         payload: {
-          projectPath: "/nonexistent/project",
+          projectPath: projPath("/nonexistent/project"),
           workspaceName: "feature-x",
           base: "main",
         },
@@ -1044,7 +1045,7 @@ describe("OpenWorkspace Operation", () => {
         activeWorkspaceRef: {
           projectId: PROJECT_ID,
           workspaceName: "other-ws" as WorkspaceName,
-          path: "/workspaces/other-ws",
+          path: wsPath("/workspaces/other-ws"),
         },
       });
 

--- a/src/intents/open-workspace.ts
+++ b/src/intents/open-workspace.ts
@@ -25,13 +25,15 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import type { WorkspaceName } from "./contract";
+import type { ProjectPath, WorkspaceName } from "./contract";
 import {
-  projectIdSchema,
-  workspaceNameSchema,
-  workspaceSchema,
   agentSpecSchema,
   hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+  workspaceSchema,
 } from "./contract";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
@@ -67,7 +69,7 @@ export type WorkspaceOpenSource = z.infer<typeof workspaceOpenSourceSchema>;
 /** Data for activating an existing (discovered) workspace via workspace:open */
 export const existingWorkspaceDataSchema = z
   .object({
-    path: z.string(),
+    path: workspacePathSchema,
     name: z.string(),
     branch: z.string().nullable(),
     metadata: z.record(z.string(), z.string()).readonly(),
@@ -88,7 +90,7 @@ export const openWorkspacePayloadSchema = z
     /** When set, skip worktree creation and populate context from existing workspace data. */
     existingWorkspace: existingWorkspaceDataSchema.optional(),
     /** Authoritative project path. */
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     /** Which module dispatched this intent. Used by error-notification to skip non-interactive sources. */
     source: workspaceOpenSourceSchema.optional(),
     /**
@@ -107,13 +109,13 @@ export const openWorkspaceResultSchema = workspaceSchema;
 // =============================================================================
 
 /** Operation-added enrichment for the "create" hook point (resolved project path). */
-const createEnrichmentSchema = z.object({ projectPath: z.string() });
+const createEnrichmentSchema = z.object({ projectPath: projectPathSchema });
 const createInputSchema = hookCtxSchema(openWorkspacePayloadSchema, createEnrichmentSchema.shape);
 
 /** Result from the "create" hook point. Fields optional — multiple handlers may each contribute a subset. */
 export const createResultSchema = z
   .object({
-    workspacePath: z.string().optional(),
+    workspacePath: workspacePathSchema.optional(),
     branch: z.string().optional(),
     metadata: z.record(z.string(), z.string()).readonly().optional(),
     /** The resolved base branch (explicit or auto-detected). Used in the event payload. */
@@ -123,8 +125,8 @@ export const createResultSchema = z
 
 /** Operation-added enrichment for the "setup" hook point (merged create results). */
 const setupEnrichmentSchema = z.object({
-  workspacePath: z.string(),
-  projectPath: z.string(),
+  workspacePath: workspacePathSchema,
+  projectPath: projectPathSchema,
 });
 const setupInputSchema = hookCtxSchema(openWorkspacePayloadSchema, setupEnrichmentSchema.shape);
 
@@ -143,7 +145,7 @@ export const setupResultSchema = z
 
 /** Operation-added enrichment for the "finalize" hook point (create+setup results). */
 const finalizeEnrichmentSchema = z.object({
-  workspacePath: z.string(),
+  workspacePath: workspacePathSchema,
   envVars: z.record(z.string(), z.string()),
   agentType: agentTypeSchema.nullable(),
 });
@@ -170,8 +172,8 @@ const workspaceCreatedSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    workspacePath: z.string(),
-    projectPath: z.string(),
+    workspacePath: workspacePathSchema,
+    projectPath: projectPathSchema,
     branch: z.string(),
     base: z.string().optional(),
     tracking: z.string().optional(),
@@ -189,7 +191,7 @@ const workspaceCreatedSchema = z
 const workspaceLoadingSchema = z
   .object({
     workspaceName: z.string(),
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     /** The requested base branch (absent when auto-detected later). */
     base: z.string().optional(),
   })
@@ -198,14 +200,18 @@ const workspaceLoadingSchema = z
 const workspaceCreateFailedSchema = z
   .object({
     workspaceName: z.string(),
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     error: z.string(),
     /** Which module dispatched the original intent. */
     source: workspaceOpenSourceSchema.optional(),
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_OPEN_WORKSPACE,
   payload: openWorkspacePayloadSchema,
   result: openWorkspaceResultSchema,
@@ -280,7 +286,9 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = OPEN_WORKSPACE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<OpenWorkspaceIntent>): Promise<OpenWorkspaceResult> {
+  async execute(
+    ctx: OperationContext<OpenWorkspaceIntent, typeof schemas>
+  ): Promise<OpenWorkspaceResult> {
     const { projectPath } = ctx.intent.payload;
 
     // Show loading dialog for foreground workspace creations.
@@ -297,7 +305,7 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
           projectPath,
           ...(ctx.intent.payload.base !== undefined && { base: ctx.intent.payload.base }),
         },
-      } as WorkspaceLoadingEvent);
+      } satisfies WorkspaceLoadingEvent);
     }
 
     try {
@@ -311,26 +319,28 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
           error: error instanceof Error ? error.message : String(error),
           ...(ctx.intent.payload.source !== undefined && { source: ctx.intent.payload.source }),
         },
-      } as WorkspaceCreateFailedEvent);
+      } satisfies WorkspaceCreateFailedEvent);
       throw error;
     }
   }
 
   private async executeWorkspaceOpen(
-    ctx: OperationContext<OpenWorkspaceIntent>,
-    projectPath: string
+    ctx: OperationContext<OpenWorkspaceIntent, typeof schemas>,
+    projectPath: ProjectPath
   ): Promise<OpenWorkspaceResult> {
     // Dispatch project:resolve to get projectId from projectPath
-    const projResolved = await ctx.dispatch({
+    const projResolved = await ctx.dispatch<ResolveProjectIntent>({
       type: INTENT_RESOLVE_PROJECT,
       payload: { projectPath },
-    } as ResolveProjectIntent);
+    });
     const resolvedProjectId = projResolved.projectId;
 
     // Hook: "create" — worktree creation (fatal on error)
     const createCtx: CreateHookInput = { intent: ctx.intent, projectPath };
-    const { results: createResults, errors: createErrors } =
-      await ctx.hooks.collect<CreateHookResult>("create", createCtx);
+    const { results: createResults, errors: createErrors } = await ctx.hooks.collect(
+      "create",
+      createCtx
+    );
 
     throwHookErrors(createErrors, "workspace:open create hooks failed");
 
@@ -353,7 +363,7 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
       workspacePath,
       projectPath,
     };
-    const setupResult = await ctx.hooks.collect<SetupHookResult>("setup", setupCtx);
+    const setupResult = await ctx.hooks.collect("setup", setupCtx);
 
     throwHookErrors(setupResult.errors, "workspace:open setup hooks failed");
 
@@ -379,8 +389,10 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
       envVars,
       agentType,
     };
-    const { errors: finalizeErrors, results: finalizeResults } =
-      await ctx.hooks.collect<FinalizeHookResult>("finalize", finalizeCtx);
+    const { errors: finalizeErrors, results: finalizeResults } = await ctx.hooks.collect(
+      "finalize",
+      finalizeCtx
+    );
 
     throwHookErrors(finalizeErrors, "workspace:open finalize hooks failed");
 
@@ -447,18 +459,18 @@ export class OpenWorkspaceOperation implements Operation<typeof schemas> {
     if (ctx.intent.payload.stealFocus !== false) {
       shouldSwitch = true;
     } else {
-      const activeWorkspace = await ctx.dispatch({
+      const activeWorkspace = await ctx.dispatch<GetActiveWorkspaceIntent>({
         type: INTENT_GET_ACTIVE_WORKSPACE,
         payload: {},
-      } as GetActiveWorkspaceIntent);
+      });
       shouldSwitch = activeWorkspace === null;
     }
 
     if (shouldSwitch) {
-      await ctx.dispatch({
+      await ctx.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: { workspacePath, focus: true },
-      } as SwitchWorkspaceIntent);
+      });
     }
 
     return workspace;

--- a/src/intents/operations.test-utils.ts
+++ b/src/intents/operations.test-utils.ts
@@ -19,7 +19,7 @@ import type { Dispatcher } from "./lib/dispatcher";
 import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { ProjectId, WorkspaceName, WorkspaceRef } from "../shared/api/types";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { AggregatedAgentStatus } from "../shared/ipc";
 import { INTENT_UPDATE_AGENT_STATUS } from "./update-agent-status";
 import type { UpdateAgentStatusIntent } from "./update-agent-status";
 import { ResolveWorkspaceOperation, RESOLVE_WORKSPACE_OPERATION_ID } from "./resolve-workspace";
@@ -40,13 +40,14 @@ import type {
   SwitchWorkspaceHookResult,
   ActivateHookInput,
 } from "./switch-workspace";
+import type { WorkspacePath, ProjectPath } from "./contract";
 
 // =============================================================================
 // Configuration Types
 // =============================================================================
 
 export interface MockWorkspaceEntry {
-  readonly projectPath: string;
+  readonly projectPath: ProjectPath;
   readonly workspaceName: WorkspaceName;
   readonly branch?: string | null;
   /** Explicit active flag; when omitted, derived from the viewManager (if any). */
@@ -68,12 +69,12 @@ export interface MockViewManager {
 /** Static map or dynamic lookup function for workspace resolution. */
 export type MockWorkspaceLookup =
   | Readonly<Record<string, MockWorkspaceEntry>>
-  | ((workspacePath: string) => MockWorkspaceEntry | undefined);
+  | ((workspacePath: WorkspacePath) => MockWorkspaceEntry | undefined);
 
 /** Static map or dynamic lookup function for project resolution. */
 export type MockProjectLookup =
   | Readonly<Record<string, MockProjectEntry>>
-  | ((projectPath: string) => MockProjectEntry | undefined);
+  | ((projectPath: ProjectPath) => MockProjectEntry | undefined);
 
 export interface TestMockConfig {
   /** Maps workspacePath → resolution data (or dynamic lookup). */
@@ -88,9 +89,9 @@ export interface TestMockConfig {
 
 /** Minimal project shape for {@link workspacesFromProjects}. */
 export interface ProjectWithWorkspaces {
-  readonly path: string;
+  readonly path: ProjectPath;
   readonly workspaces?: ReadonlyArray<{
-    readonly path: string;
+    readonly path: WorkspacePath;
     readonly metadata?: Readonly<Record<string, string>>;
   }>;
 }
@@ -102,7 +103,7 @@ export interface ProjectWithWorkspaces {
  */
 export function workspacesFromProjects(
   getProjects: () => readonly ProjectWithWorkspaces[]
-): (workspacePath: string) => MockWorkspaceEntry | undefined {
+): (workspacePath: WorkspacePath) => MockWorkspaceEntry | undefined {
   return (workspacePath) => {
     for (const project of getProjects()) {
       const workspace = project.workspaces?.find((w) => w.path === workspacePath);
@@ -124,7 +125,7 @@ export function workspacesFromProjects(
 
 /** Build an agent:update-status intent. */
 export function updateStatusIntent(
-  workspacePath: string,
+  workspacePath: WorkspacePath,
   status: AggregatedAgentStatus
 ): UpdateAgentStatusIntent {
   return {
@@ -143,7 +144,7 @@ export function updateStatusIntent(
 /** ViewManager surface used by operation tests, with capture-friendly extras. */
 export interface TestViewManager extends MockViewManager {
   destroyWorkspaceView(path: string): Promise<void>;
-  createWorkspaceView(path: string, url: string, projectPath: string, visible: boolean): void;
+  createWorkspaceView(path: string, url: string, projectPath: ProjectPath, visible: boolean): void;
   preloadWorkspaceUrl(path: string): void;
 }
 
@@ -221,7 +222,7 @@ export function createTestMockModule(config: TestMockConfig): IntentModule {
     hooks[RESOLVE_WORKSPACE_OPERATION_ID] = {
       resolve: {
         handler: async (ctx: HookContext): Promise<HookOutput<ResolveWorkspaceHookResult>> => {
-          const intent = ctx.intent as { payload: { workspacePath: string } };
+          const intent = ctx.intent as { payload: { workspacePath: WorkspacePath } };
           const entry = lookupWorkspace(intent.payload.workspacePath);
           if (!entry) return { result: {} };
           return {

--- a/src/intents/resolve-project.integration.test.ts
+++ b/src/intents/resolve-project.integration.test.ts
@@ -24,12 +24,14 @@ import type { ResolveProjectIntent, ResolveHookResult } from "./resolve-project"
 import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { ProjectId } from "../shared/api/types";
+import { projPath } from "../shared/test-fixtures";
+import type { ProjectPath } from "./contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/projects/my-app";
+const PROJECT_PATH = projPath("/projects/my-app");
 const PROJECT_ID = "my-app-12345678" as ProjectId;
 const PROJECT_NAME = "my-app";
 
@@ -61,7 +63,7 @@ function createTestSetup(
   return { dispatcher };
 }
 
-function resolveIntent(projectPath: string): ResolveProjectIntent {
+function resolveIntent(projectPath: ProjectPath): ResolveProjectIntent {
   return {
     type: INTENT_RESOLVE_PROJECT,
     payload: { projectPath },

--- a/src/intents/resolve-project.ts
+++ b/src/intents/resolve-project.ts
@@ -18,7 +18,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, hookCtxSchema } from "./contract";
+import { hookCtxSchema, projectIdSchema, projectPathSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 export const INTENT_RESOLVE_PROJECT = "project:resolve" as const;
@@ -30,7 +30,7 @@ export const RESOLVE_PROJECT_OPERATION_ID = "resolve-project";
 
 export const resolveProjectPayloadSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
   })
   .readonly();
 
@@ -50,7 +50,7 @@ export const resolveHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "resolve" hook point (beyond the base HookContext). */
-const resolveEnrichmentSchema = z.object({ projectPath: z.string() });
+const resolveEnrichmentSchema = z.object({ projectPath: projectPathSchema });
 
 /** Runtime whole-context validation schema for "resolve" (its inferred type isn't the ctx type). */
 export const resolveHookInputSchema = hookCtxSchema(
@@ -58,7 +58,11 @@ export const resolveHookInputSchema = hookCtxSchema(
   resolveEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_RESOLVE_PROJECT,
   payload: resolveProjectPayloadSchema,
   result: resolveProjectResultSchema,
@@ -87,14 +91,16 @@ export class ResolveProjectOperation implements Operation<typeof schemas> {
   readonly id = RESOLVE_PROJECT_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<ResolveProjectIntent>): Promise<ResolveProjectResult> {
+  async execute(
+    ctx: OperationContext<ResolveProjectIntent, typeof schemas>
+  ): Promise<ResolveProjectResult> {
     const { payload } = ctx.intent;
 
     const resolveCtx: ResolveHookInput = {
       intent: ctx.intent,
       projectPath: payload.projectPath,
     };
-    const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+    const { results, errors } = await ctx.hooks.collect("resolve", resolveCtx);
     throwHookErrors(errors, "project:resolve hooks failed");
 
     let projectId: ResolveProjectResult["projectId"] | undefined;

--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -24,13 +24,15 @@ import type { ResolveWorkspaceIntent, ResolveHookResult } from "./resolve-worksp
 import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { WorkspaceName } from "../shared/api/types";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "./contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/projects/my-app";
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const PROJECT_PATH = projPath("/projects/my-app");
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 const WORKSPACE_NAME = "feature-x" as WorkspaceName;
 
 // =============================================================================
@@ -61,7 +63,7 @@ function createTestSetup(
   return { dispatcher };
 }
 
-function resolveIntent(workspacePath: string): ResolveWorkspaceIntent {
+function resolveIntent(workspacePath: WorkspacePath): ResolveWorkspaceIntent {
   return {
     type: INTENT_RESOLVE_WORKSPACE,
     payload: { workspacePath },

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -18,7 +18,13 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { workspaceNameSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+} from "./contract";
+import type { ProjectPath } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 export const INTENT_RESOLVE_WORKSPACE = "workspace:resolve" as const;
@@ -30,13 +36,13 @@ export const RESOLVE_WORKSPACE_OPERATION_ID = "resolve-workspace";
 
 export const resolveWorkspacePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
   })
   .readonly();
 
 export const resolveWorkspaceResultSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     workspaceName: workspaceNameSchema,
     active: z.boolean(),
     /** Current branch name, or null for detached HEAD. */
@@ -50,7 +56,7 @@ export const resolveWorkspaceResultSchema = z
 /** Per-handler result for "resolve" (fields optional — each handler contributes a subset). */
 export const resolveHookResultSchema = z
   .object({
-    projectPath: z.string().optional(),
+    projectPath: projectPathSchema.optional(),
     workspaceName: workspaceNameSchema.optional(),
     active: z.boolean().optional(),
     branch: z.string().nullable().optional(),
@@ -59,7 +65,7 @@ export const resolveHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "resolve" hook point (beyond the base HookContext). */
-const resolveEnrichmentSchema = z.object({ workspacePath: z.string() });
+const resolveEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "resolve" (its inferred type isn't the ctx type). */
 export const resolveHookInputSchema = hookCtxSchema(
@@ -67,7 +73,11 @@ export const resolveHookInputSchema = hookCtxSchema(
   resolveEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_RESOLVE_WORKSPACE,
   payload: resolveWorkspacePayloadSchema,
   result: resolveWorkspaceResultSchema,
@@ -96,17 +106,19 @@ export class ResolveWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = RESOLVE_WORKSPACE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<ResolveWorkspaceIntent>): Promise<ResolveWorkspaceResult> {
+  async execute(
+    ctx: OperationContext<ResolveWorkspaceIntent, typeof schemas>
+  ): Promise<ResolveWorkspaceResult> {
     const { payload } = ctx.intent;
 
     const resolveCtx: ResolveHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
     };
-    const { results, errors } = await ctx.hooks.collect<ResolveHookResult>("resolve", resolveCtx);
+    const { results, errors } = await ctx.hooks.collect("resolve", resolveCtx);
     throwHookErrors(errors, "workspace:resolve hooks failed");
 
-    let projectPath: string | undefined;
+    let projectPath: ProjectPath | undefined;
     let workspaceName: ResolveWorkspaceResult["workspaceName"] | undefined;
     let active = false;
     // branch can legitimately be null (detached HEAD), so track "provided"

--- a/src/intents/restart-agent.integration.test.ts
+++ b/src/intents/restart-agent.integration.test.ts
@@ -32,13 +32,15 @@ import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "./contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_ROOT = "/project";
-const WORKSPACE_PATH = "/workspaces/feature-x";
+const PROJECT_ROOT = projPath("/project");
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
 
 // =============================================================================
 // Behavioral Mocks
@@ -50,7 +52,7 @@ type RestartServerResult =
 
 interface MockAgentServerManager {
   restartResult: RestartServerResult;
-  restartServer(workspacePath: string): Promise<RestartServerResult>;
+  restartServer(workspacePath: WorkspacePath): Promise<RestartServerResult>;
 }
 
 function createMockAgentServerManager(result: RestartServerResult): MockAgentServerManager {
@@ -112,7 +114,7 @@ function createTestSetup(opts: { serverManager: MockAgentServerManager }): TestS
 // Helpers
 // =============================================================================
 
-function restartIntent(workspacePath: string): RestartAgentIntent {
+function restartIntent(workspacePath: WorkspacePath): RestartAgentIntent {
   return {
     type: INTENT_RESTART_AGENT,
     payload: { workspacePath },
@@ -216,9 +218,9 @@ describe("RestartAgent Operation", () => {
         serverManager: createMockAgentServerManager({ success: true, port: 9090 }),
       });
 
-      await expect(setup.dispatcher.dispatch(restartIntent("/nonexistent/path"))).rejects.toThrow(
-        "Workspace not found: /nonexistent/path"
-      );
+      await expect(
+        setup.dispatcher.dispatch(restartIntent(wsPath("/nonexistent/path")))
+      ).rejects.toThrow("Workspace not found: /nonexistent/path");
     });
   });
 

--- a/src/intents/restart-agent.ts
+++ b/src/intents/restart-agent.ts
@@ -19,7 +19,12 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectIdSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+} from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined, requireResult } from "./lib/hook-helpers";
 
@@ -35,7 +40,7 @@ const EVENT_AGENT_RESTARTED = "agent:restarted" as const;
 
 export const restartAgentPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
   })
   .readonly();
 
@@ -46,7 +51,7 @@ export const agentRestartedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    path: z.string(),
+    path: workspacePathSchema,
     port: z.number(),
   })
   .readonly();
@@ -62,7 +67,7 @@ export const restartAgentHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "restart" hook point (beyond the base HookContext). */
-const restartEnrichmentSchema = z.object({ workspacePath: z.string() });
+const restartEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "restart". */
 export const restartAgentHookInputSchema = hookCtxSchema(
@@ -70,7 +75,11 @@ export const restartAgentHookInputSchema = hookCtxSchema(
   restartEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_RESTART_AGENT,
   payload: restartAgentPayloadSchema,
   result: restartAgentResultSchema,
@@ -103,15 +112,13 @@ export type RestartAgentHookInput = HookContext & z.infer<typeof restartEnrichme
 // Operation
 // =============================================================================
 
-export class RestartAgentOperation extends WorkspaceHookOperation<
-  typeof schemas,
-  RestartAgentHookResult
-> {
+export class RestartAgentOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(RESTART_AGENT_OPERATION_ID, {
       hookPoint: "restart",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       resolveProject: true,
       errorLabel: "restart-agent restart hooks failed",
       extract: (results) =>

--- a/src/intents/set-metadata.integration.test.ts
+++ b/src/intents/set-metadata.integration.test.ts
@@ -34,6 +34,8 @@ import { isValidMetadataKey } from "../shared/api/types";
 import type { IntentModule } from "./lib/module";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { HookContext, HookOutput } from "./lib/operation";
+import type { WorkspacePath } from "./contract";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Constants
@@ -51,7 +53,7 @@ interface TestSetup {
   metadataStore: Map<string, Record<string, string>>;
   projectId: ProjectId;
   workspaceName: WorkspaceName;
-  workspacePath: string;
+  workspacePath: WorkspacePath;
 }
 
 function createTestSetup(): TestSetup {
@@ -73,7 +75,7 @@ function createTestSetup(): TestSetup {
   registerTestInfrastructure(dispatcher, {
     workspaces: {
       [workspacePath.toString()]: {
-        projectPath: PROJECT_ROOT.toString(),
+        projectPath: projPath(PROJECT_ROOT.toString()),
         workspaceName,
       },
     },
@@ -125,7 +127,7 @@ function createTestSetup(): TestSetup {
     metadataStore,
     projectId,
     workspaceName,
-    workspacePath: workspacePath.toString(),
+    workspacePath: wsPath(workspacePath.toString()),
   };
 }
 
@@ -134,7 +136,7 @@ function createTestSetup(): TestSetup {
 // =============================================================================
 
 function setMetadataIntent(
-  workspacePath: string,
+  workspacePath: WorkspacePath,
   key: string,
   value: string | null
 ): SetMetadataIntent {
@@ -236,7 +238,7 @@ describe("SetMetadata Operation", () => {
       const { dispatcher } = setup;
 
       await expect(
-        dispatcher.dispatch(setMetadataIntent("/nonexistent/path", "key", "value"))
+        dispatcher.dispatch(setMetadataIntent(wsPath("/nonexistent/path"), "key", "value"))
       ).rejects.toThrow("Workspace not found: /nonexistent/path");
     });
 

--- a/src/intents/set-metadata.ts
+++ b/src/intents/set-metadata.ts
@@ -13,7 +13,12 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectIdSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+} from "./contract";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 
 export const INTENT_SET_METADATA = "workspace:set-metadata" as const;
@@ -26,7 +31,7 @@ export const SET_METADATA_OPERATION_ID = "set-metadata";
 
 export const setMetadataPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     key: z.string(),
     value: z.string().nullable(),
   })
@@ -36,14 +41,14 @@ export const metadataChangedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     key: z.string(),
     value: z.string().nullable(),
   })
   .readonly();
 
 /** Operation-added enrichment for the "set" hook point (beyond the base HookContext). */
-const setEnrichmentSchema = z.object({ workspacePath: z.string() });
+const setEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for the "set" hook point. */
 export const setHookInputSchema = hookCtxSchema(
@@ -51,7 +56,11 @@ export const setHookInputSchema = hookCtxSchema(
   setEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SET_METADATA,
   payload: setMetadataPayloadSchema,
   hooks: {
@@ -82,12 +91,13 @@ export type SetHookInput = HookContext & z.infer<typeof setEnrichmentSchema>;
 // Operation
 // =============================================================================
 
-export class SetMetadataOperation extends WorkspaceHookOperation<typeof schemas, void> {
+export class SetMetadataOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(SET_METADATA_OPERATION_ID, {
       hookPoint: "set",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       resolveProject: true,
       errorLabel: "set-metadata set hooks failed",
       extract: () => undefined,

--- a/src/intents/set-shortcut-active.ts
+++ b/src/intents/set-shortcut-active.ts
@@ -42,7 +42,11 @@ export const shortcutActiveChangedPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SET_SHORTCUT_ACTIVE,
   payload: setShortcutActivePayloadSchema,
   events: {
@@ -71,7 +75,7 @@ export class SetShortcutActiveOperation implements Operation<typeof schemas> {
   readonly id = SET_SHORTCUT_ACTIVE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<SetShortcutActiveIntent>): Promise<void> {
+  async execute(ctx: OperationContext<SetShortcutActiveIntent, typeof schemas>): Promise<void> {
     const event: ShortcutActiveChangedEvent = {
       type: EVENT_SHORTCUT_ACTIVE_CHANGED,
       payload: { active: ctx.intent.payload.active },

--- a/src/intents/setup.ts
+++ b/src/intents/setup.ts
@@ -24,12 +24,7 @@
 import { z } from "zod/v4";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import {
-  configAgentTypeSchema,
-  setupRowIdSchema,
-  setupRowStatusSchema,
-  hookCtxSchema,
-} from "./contract";
+import { agentTypeSchema, setupRowIdSchema, setupRowStatusSchema, hookCtxSchema } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
 
 export const INTENT_SETUP = "app:setup" as const;
@@ -68,7 +63,7 @@ export const setupPayloadSchema = z
     /** Extensions to install (from check-deps install plan) */
     extensionInstallPlan: z.array(extensionInstallEntrySchema).readonly().optional(),
     /** The agent in effect. Always known: app:start selects it before dispatching setup. */
-    configuredAgent: configAgentTypeSchema,
+    configuredAgent: agentTypeSchema,
   })
   .readonly();
 
@@ -82,7 +77,7 @@ export const setupPayloadSchema = z
  * frames); the operation emits `setup:progress` for each — no `report` closure in the context.
  */
 const binaryEnrichmentSchema = z.object({
-  configuredAgent: configAgentTypeSchema,
+  configuredAgent: agentTypeSchema,
   missingBinaries: z.array(binaryTypeSchema).readonly().optional(),
 });
 const binaryInputSchema = hookCtxSchema(setupPayloadSchema, binaryEnrichmentSchema.shape);
@@ -117,10 +112,19 @@ const setupErrorSchema = z
   })
   .readonly();
 
-const schemas = {
+/** The UI show/hide hook points receive the bare intent. */
+const bareSetupHookInputSchema = hookCtxSchema(setupPayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SETUP,
   payload: setupPayloadSchema,
   hooks: {
+    "show-ui": { input: bareSetupHookInputSchema },
+    "hide-ui": { input: bareSetupHookInputSchema },
     binary: { input: binaryInputSchema },
     extensions: { input: extensionsInputSchema },
   },
@@ -169,7 +173,7 @@ export class SetupOperation implements Operation<typeof schemas> {
   readonly id = SETUP_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<SetupIntent>): Promise<void> {
+  async execute(ctx: OperationContext<SetupIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
     const hookCtx: HookContext = {
       intent: ctx.intent,
@@ -177,14 +181,16 @@ export class SetupOperation implements Operation<typeof schemas> {
 
     try {
       // Hook 1: "show-ui" -- Show setup screen
-      const { errors: showUiErrors } = await ctx.hooks.collect<void>("show-ui", hookCtx);
+      const { errors: showUiErrors } = await ctx.hooks.collect("show-ui", hookCtx);
       throwHookErrors(showUiErrors, "app:setup show-ui hooks failed");
 
-      // Streaming handlers (binary/extensions) yield SetupProgressPayload frames;
-      // the operation emits setup:progress for each. DomainEvent.payload is unknown,
-      // so the frame forwards straight through — the handler owns its typed yields.
+      // Streaming handlers (binary/extensions) yield SetupProgressPayload frames; the
+      // operation emits setup:progress for each. A yielded frame is untyped at the collect
+      // boundary, so it is parsed against the event's own schema before being emitted — the
+      // same schema the dispatcher would apply at emit, applied here so a malformed frame
+      // fails at its source rather than as an opaque emit error.
       const emitProgress = (frame: unknown): void => {
-        void ctx.emit({ type: EVENT_SETUP_PROGRESS, payload: frame });
+        void ctx.emit({ type: EVENT_SETUP_PROGRESS, payload: setupProgressSchema.parse(frame) });
       };
 
       // Hook 2: "binary" -- Update binary progress (downloads if needed)
@@ -193,7 +199,7 @@ export class SetupOperation implements Operation<typeof schemas> {
         configuredAgent: payload.configuredAgent,
         ...(payload.missingBinaries !== undefined && { missingBinaries: payload.missingBinaries }),
       };
-      const { errors: binaryErrors } = await ctx.hooks.collect<void>("binary", binaryInput, {
+      const { errors: binaryErrors } = await ctx.hooks.collect("binary", binaryInput, {
         onYield: emitProgress,
       });
       throwHookErrors(binaryErrors, "app:setup binary hooks failed");
@@ -205,15 +211,13 @@ export class SetupOperation implements Operation<typeof schemas> {
           extensionInstallPlan: payload.extensionInstallPlan,
         }),
       };
-      const { errors: extensionsErrors } = await ctx.hooks.collect<void>(
-        "extensions",
-        extensionsInput,
-        { onYield: emitProgress }
-      );
+      const { errors: extensionsErrors } = await ctx.hooks.collect("extensions", extensionsInput, {
+        onYield: emitProgress,
+      });
       throwHookErrors(extensionsErrors, "app:setup extensions hooks failed");
 
       // Hook 4: "hide-ui" -- Hide setup screen (return to starting screen)
-      const { errors: hideUiErrors } = await ctx.hooks.collect<void>("hide-ui", hookCtx);
+      const { errors: hideUiErrors } = await ctx.hooks.collect("hide-ui", hookCtx);
       throwHookErrors(hideUiErrors, "app:setup hide-ui hooks failed");
 
       // Control returns to AppStartOperation (no dispatch)

--- a/src/intents/shortcut-key.ts
+++ b/src/intents/shortcut-key.ts
@@ -36,7 +36,11 @@ export const shortcutKeyPressedPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SHORTCUT_KEY,
   payload: shortcutKeyPayloadSchema,
   events: {
@@ -65,7 +69,7 @@ export class ShortcutKeyOperation implements Operation<typeof schemas> {
   readonly id = SHORTCUT_KEY_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<ShortcutKeyIntent>): Promise<void> {
+  async execute(ctx: OperationContext<ShortcutKeyIntent, typeof schemas>): Promise<void> {
     const event: ShortcutKeyPressedEvent = {
       type: EVENT_SHORTCUT_KEY_PRESSED,
       payload: { key: ctx.intent.payload.key },

--- a/src/intents/submit-bug-report.ts
+++ b/src/intents/submit-bug-report.ts
@@ -36,7 +36,11 @@ export const bugReportSubmittedPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SUBMIT_BUG_REPORT,
   payload: submitBugReportPayloadSchema,
   events: {
@@ -65,7 +69,7 @@ export class SubmitBugReportOperation implements Operation<typeof schemas> {
   readonly id = SUBMIT_BUG_REPORT_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<SubmitBugReportIntent>): Promise<void> {
+  async execute(ctx: OperationContext<SubmitBugReportIntent, typeof schemas>): Promise<void> {
     const event: BugReportSubmittedEvent = {
       type: EVENT_BUG_REPORT_SUBMITTED,
       payload: {

--- a/src/intents/switch-workspace.integration.test.ts
+++ b/src/intents/switch-workspace.integration.test.ts
@@ -43,6 +43,8 @@ import type { IntentModule } from "./lib/module";
 import type { HookContext, HookOutput } from "./lib/operation";
 import type { DomainEvent, Intent } from "./lib/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import type { WorkspacePath, ProjectPath } from "./contract";
 
 // =============================================================================
 // Behavioral Mocks
@@ -53,13 +55,13 @@ import type { ProjectId, WorkspaceName } from "../shared/api/types";
 // =============================================================================
 
 interface WorkspaceEntry {
-  path: string;
+  path: WorkspacePath;
   branch?: string | null;
   metadata: Readonly<Record<string, string>>;
 }
 
 interface ProjectEntry {
-  path: string;
+  path: ProjectPath;
   name: string;
   workspaces: WorkspaceEntry[];
 }
@@ -68,7 +70,7 @@ interface MockAppState {
   projects: ProjectEntry[];
   getAllProjects(): Promise<ReadonlyArray<{ path: string }>>;
   getProject(
-    projectPath: string
+    projectPath: ProjectPath
   ): { path: string; name: string; workspaces: ReadonlyArray<WorkspaceEntry> } | undefined;
 }
 
@@ -79,7 +81,7 @@ function createMockAppState(projects: ProjectEntry[]): MockAppState {
       return this.projects;
     },
     getProject(
-      projectPath: string
+      projectPath: ProjectPath
     ): { path: string; name: string; workspaces: ReadonlyArray<WorkspaceEntry> } | undefined {
       return this.projects.find((p) => p.path === projectPath);
     },
@@ -90,11 +92,11 @@ function createMockAppState(projects: ProjectEntry[]): MockAppState {
 // Test Constants
 // =============================================================================
 
-const TEST_PROJECT_PATH = "/projects/my-app";
+const TEST_PROJECT_PATH = projPath("/projects/my-app");
 const TEST_PROJECT_NAME = "my-app";
-const TEST_WORKSPACE_PATH = "/projects/my-app/workspaces/feature-login";
+const TEST_WORKSPACE_PATH = wsPath("/projects/my-app/workspaces/feature-login");
 const TEST_WORKSPACE_NAME = "feature-login" as WorkspaceName;
-const TEST_WORKSPACE_PATH_B = "/projects/my-app/workspaces/feature-signup";
+const TEST_WORKSPACE_PATH_B = wsPath("/projects/my-app/workspaces/feature-signup");
 function createTestProject(): ProjectEntry {
   return {
     path: TEST_PROJECT_PATH,
@@ -183,17 +185,17 @@ function createTestSetup(opts?: {
           "find-candidates": {
             handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
               const candidates: Array<{
-                projectPath: string;
+                projectPath: ProjectPath;
                 projectName: string;
-                workspacePath: string;
+                workspacePath: WorkspacePath;
                 workspaceName: string;
               }> = [];
               for (const project of appState.projects) {
                 for (const ws of project.workspaces) {
                   candidates.push({
-                    projectPath: project.path,
+                    projectPath: projPath(project.path),
                     projectName: project.name,
-                    workspacePath: ws.path,
+                    workspacePath: wsPath(ws.path),
                     workspaceName: ws.path.slice(ws.path.lastIndexOf("/") + 1),
                   });
                 }
@@ -241,7 +243,7 @@ function generateProjectId(path: string): ProjectId {
   return Buffer.from(path).toString("base64url") as ProjectId;
 }
 
-function switchIntent(workspacePath?: string, focus?: boolean): SwitchWorkspaceIntent {
+function switchIntent(workspacePath?: WorkspacePath, focus?: boolean): SwitchWorkspaceIntent {
   return {
     type: INTENT_SWITCH_WORKSPACE,
     payload: {
@@ -340,7 +342,7 @@ describe("SwitchWorkspace Operation", () => {
       const { dispatcher, getActivePath } = setup;
 
       await expect(
-        dispatcher.dispatch(switchIntent("/projects/my-app/workspaces/nonexistent"))
+        dispatcher.dispatch(switchIntent(wsPath("/projects/my-app/workspaces/nonexistent")))
       ).rejects.toThrow("Workspace not found: /projects/my-app/workspaces/nonexistent");
 
       expect(getActivePath()).toBeNull();
@@ -351,7 +353,7 @@ describe("SwitchWorkspace Operation", () => {
       const { dispatcher, getActivePath } = setup;
 
       await expect(
-        dispatcher.dispatch(switchIntent("/nonexistent/workspaces/feature-login"))
+        dispatcher.dispatch(switchIntent(wsPath("/nonexistent/workspaces/feature-login")))
       ).rejects.toThrow("Workspace not found: /nonexistent/workspaces/feature-login");
 
       expect(getActivePath()).toBeNull();
@@ -385,10 +387,10 @@ describe("SwitchWorkspace Operation", () => {
         receivedEvents.push(event);
       });
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: { workspacePath: null },
-      } as SwitchWorkspaceIntent);
+      });
 
       expect(getActivePath()).toBeNull();
       expect(receivedEvents).toHaveLength(1);
@@ -404,10 +406,10 @@ describe("SwitchWorkspace Operation", () => {
         receivedEvents.push(event);
       });
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: { workspacePath: null },
-      } as SwitchWorkspaceIntent);
+      });
 
       expect(getActivePath()).toBeNull();
       expect(receivedEvents).toHaveLength(1);
@@ -517,7 +519,7 @@ describe("SwitchWorkspace Operation", () => {
 
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { auto: true, currentPath: "/nonexistent", focus: true },
+        payload: { auto: true, currentPath: wsPath("/nonexistent"), focus: true },
       };
       await dispatcher.dispatch(autoIntent);
 
@@ -538,7 +540,7 @@ describe("SwitchWorkspace Operation", () => {
       // currentPath doesn't match any candidate (workspace already de-registered)
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { auto: true, currentPath: "/nonexistent", focus: true },
+        payload: { auto: true, currentPath: wsPath("/nonexistent"), focus: true },
       };
       await dispatcher.dispatch(autoIntent);
 

--- a/src/intents/switch-workspace.ts
+++ b/src/intents/switch-workspace.ts
@@ -26,8 +26,14 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import type { WorkspacePath } from "../shared/ipc";
-import { projectIdSchema, workspaceNameSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+} from "./contract";
+import type { WorkspacePath } from "./contract";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
 import { throwHookErrors, lastDefined } from "./lib/hook-helpers";
@@ -46,7 +52,7 @@ export const SWITCH_WORKSPACE_OPERATION_ID = "switch-workspace";
  *  ground state when nothing is selected). `focus` is ignored for null. */
 export const switchWorkspaceTargetPayloadSchema = z
   .object({
-    workspacePath: z.string().nullable(),
+    workspacePath: workspacePathSchema.nullable(),
     focus: z.boolean().optional(),
   })
   .readonly();
@@ -55,7 +61,7 @@ export const switchWorkspaceTargetPayloadSchema = z
 export const switchWorkspaceAutoPayloadSchema = z
   .object({
     auto: z.literal(true),
-    currentPath: z.string(),
+    currentPath: workspacePathSchema,
     focus: z.boolean().optional(),
     /** When true, if no other candidate is selectable, switch to currentPath
      *  instead of emitting workspace:switched(null). Used by hibernate so the
@@ -73,9 +79,9 @@ export const switchWorkspacePayloadSchema = z.union([
 /** A workspace candidate returned by the "find-candidates" hook. */
 export const workspaceCandidateSchema = z
   .object({
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     projectName: z.string(),
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     /** Stored workspace name (original case) — used for alphabetical ordering. */
     workspaceName: z.string(),
     /** True when the candidate is hibernated. Hibernated candidates are excluded
@@ -88,9 +94,9 @@ export const workspaceSwitchedPayloadSchema = z
   .object({
     projectId: projectIdSchema,
     projectName: z.string(),
-    projectPath: z.string(),
+    projectPath: projectPathSchema,
     workspaceName: workspaceNameSchema,
-    path: z.string(),
+    path: workspacePathSchema,
     /** The workspace's raw domain metadata, as resolved at switch time. It is
      *  the baseline consumers can't reconstruct from workspace:metadata-changed
      *  alone: metadata persists in git config across restarts, so a title set in
@@ -107,7 +113,7 @@ export const workspaceSwitchedPayloadSchema = z
  */
 export const switchWorkspaceHookResultSchema = z
   .object({
-    resolvedPath: z.string().optional(),
+    resolvedPath: workspacePathSchema.optional(),
   })
   .readonly();
 
@@ -128,7 +134,7 @@ export const selectNextHookResultSchema = z
 /** Operation-added enrichment for the "activate" hook point. `workspacePath: null`
  *  = deselect (clear the active workspace). */
 const activateEnrichmentSchema = z.object({
-  workspacePath: z.string().nullable(),
+  workspacePath: workspacePathSchema.nullable(),
   active: z.boolean(),
 });
 
@@ -140,7 +146,7 @@ export const activateHookInputSchema = hookCtxSchema(
 
 /** Operation-added enrichment for the "select-next" hook point. */
 const selectNextEnrichmentSchema = z.object({
-  currentPath: z.string(),
+  currentPath: workspacePathSchema,
   candidates: z.array(workspaceCandidateSchema).readonly(),
 });
 
@@ -150,12 +156,19 @@ export const selectNextHookInputSchema = hookCtxSchema(
   selectNextEnrichmentSchema.shape
 );
 
-const schemas = {
+/** The find-candidates hook point receives the bare intent. */
+const bareSwitchHookInputSchema = hookCtxSchema(switchWorkspacePayloadSchema, {});
+
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_SWITCH_WORKSPACE,
   payload: switchWorkspacePayloadSchema,
   hooks: {
     activate: { input: activateHookInputSchema, result: switchWorkspaceHookResultSchema },
-    "find-candidates": { result: findCandidatesHookResultSchema },
+    "find-candidates": { input: bareSwitchHookInputSchema, result: findCandidatesHookResultSchema },
     "select-next": { input: selectNextHookInputSchema, result: selectNextHookResultSchema },
   },
   events: {
@@ -286,7 +299,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
   readonly id = SWITCH_WORKSPACE_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<SwitchWorkspaceIntent>): Promise<void> {
+  async execute(ctx: OperationContext<SwitchWorkspaceIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
 
     if (isAutoSwitch(payload)) {
@@ -297,7 +310,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
   }
 
   private async executeSpecificTarget(
-    ctx: OperationContext<SwitchWorkspaceIntent>,
+    ctx: OperationContext<SwitchWorkspaceIntent, typeof schemas>,
     payload: SwitchWorkspaceTargetPayload
   ): Promise<void> {
     // Deselect: no workspace to resolve. Run the activate hooks with a null
@@ -311,10 +324,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
         workspacePath: null,
         active: false,
       };
-      const { errors } = await ctx.hooks.collect<SwitchWorkspaceHookResult>(
-        "activate",
-        deselectCtx
-      );
+      const { errors } = await ctx.hooks.collect("activate", deselectCtx);
       throwHookErrors(errors, "workspace:switch activate hooks failed");
 
       const nullEvent: WorkspaceSwitchedEvent = {
@@ -326,16 +336,17 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
     }
 
     // 1. Dispatch shared workspace resolution
-    const { projectPath, workspaceName, active, metadata } = await ctx.dispatch({
-      type: INTENT_RESOLVE_WORKSPACE,
-      payload: { workspacePath: payload.workspacePath },
-    } as ResolveWorkspaceIntent);
+    const { projectPath, workspaceName, active, metadata } =
+      await ctx.dispatch<ResolveWorkspaceIntent>({
+        type: INTENT_RESOLVE_WORKSPACE,
+        payload: { workspacePath: payload.workspacePath },
+      });
 
     // 2. Dispatch shared project resolution
-    const { projectId, projectName } = await ctx.dispatch({
+    const { projectId, projectName } = await ctx.dispatch<ResolveProjectIntent>({
       type: INTENT_RESOLVE_PROJECT,
       payload: { projectPath },
-    } as ResolveProjectIntent);
+    });
 
     // 3. Activate: call setActiveWorkspace
     const activateCtx: ActivateHookInput = {
@@ -343,8 +354,10 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
       workspacePath: payload.workspacePath,
       active,
     };
-    const { results: activateResults, errors: activateErrors } =
-      await ctx.hooks.collect<SwitchWorkspaceHookResult>("activate", activateCtx);
+    const { results: activateResults, errors: activateErrors } = await ctx.hooks.collect(
+      "activate",
+      activateCtx
+    );
     throwHookErrors(activateErrors, "workspace:switch activate hooks failed");
 
     // Merge results — last-write-wins for resolvedPath
@@ -372,15 +385,12 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
   }
 
   private async executeAutoSelect(
-    ctx: OperationContext<SwitchWorkspaceIntent>,
+    ctx: OperationContext<SwitchWorkspaceIntent, typeof schemas>,
     payload: SwitchWorkspaceAutoPayload
   ): Promise<void> {
     // 1. Find candidates via hook
     const hookCtx: HookContext = { intent: ctx.intent };
-    const { results } = await ctx.hooks.collect<FindCandidatesHookResult>(
-      "find-candidates",
-      hookCtx
-    );
+    const { results } = await ctx.hooks.collect("find-candidates", hookCtx);
     const allCandidates: WorkspaceCandidate[] = [];
     for (const r of results) {
       if (r.candidates) allCandidates.push(...r.candidates);
@@ -392,10 +402,7 @@ export class SwitchWorkspaceOperation implements Operation<typeof schemas> {
       currentPath: payload.currentPath,
       candidates: allCandidates,
     };
-    const { results: selectResults } = await ctx.hooks.collect<SelectNextHookResult>(
-      "select-next",
-      selectCtx
-    );
+    const { results: selectResults } = await ctx.hooks.collect("select-next", selectCtx);
     let best: WorkspaceCandidate | undefined;
     for (const r of selectResults) {
       if (r.selected !== undefined) best = r.selected;

--- a/src/intents/update-agent-status.integration.test.ts
+++ b/src/intents/update-agent-status.integration.test.ts
@@ -18,13 +18,14 @@ import { registerTestInfrastructure, updateStatusIntent } from "./operations.tes
 import type { DomainEvent } from "./lib/types";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Setup
 // =============================================================================
 
 const TEST_PROJECT_ID = "test-project-id" as ProjectId;
-const TEST_PROJECT_PATH = "/projects/test";
+const TEST_PROJECT_PATH = projPath("/projects/test");
 const TEST_WORKSPACE_NAME = "test-workspace" as WorkspaceName;
 
 const TEST_WORKSPACE_ENTRY = {
@@ -60,7 +61,7 @@ describe("UpdateAgentStatus Operation", () => {
       });
 
       const status: AggregatedAgentStatus = { status: "busy", counts: { idle: 0, busy: 2 } };
-      await dispatcher.dispatch(updateStatusIntent("/workspace/test", status));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/test"), status));
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
@@ -80,7 +81,7 @@ describe("UpdateAgentStatus Operation", () => {
       });
 
       const status: AggregatedAgentStatus = { status: "idle", counts: { idle: 3, busy: 0 } };
-      await dispatcher.dispatch(updateStatusIntent("/workspace/idle-test", status));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/idle-test"), status));
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
@@ -96,7 +97,7 @@ describe("UpdateAgentStatus Operation", () => {
       });
 
       const status: AggregatedAgentStatus = { status: "mixed", counts: { idle: 1, busy: 2 } };
-      await dispatcher.dispatch(updateStatusIntent("/workspace/mixed", status));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/mixed"), status));
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
@@ -111,7 +112,7 @@ describe("UpdateAgentStatus Operation", () => {
       });
 
       const status: AggregatedAgentStatus = { status: "none", counts: { idle: 0, busy: 0 } };
-      await dispatcher.dispatch(updateStatusIntent("/workspace/none", status));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/none"), status));
 
       expect(receivedEvents).toHaveLength(1);
       const event = receivedEvents[0] as AgentStatusUpdatedEvent;
@@ -132,7 +133,7 @@ describe("UpdateAgentStatus Operation", () => {
       });
 
       const status: AggregatedAgentStatus = { status: "busy", counts: { idle: 0, busy: 1 } };
-      await dispatcher.dispatch(updateStatusIntent("/unknown/workspace", status));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/unknown/workspace"), status));
 
       expect(receivedEvents).toHaveLength(0);
     });

--- a/src/intents/update-agent-status.ts
+++ b/src/intents/update-agent-status.ts
@@ -17,6 +17,7 @@ import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import { projectIdSchema, workspaceNameSchema, workspacePathSchema } from "./contract";
+import type { ProjectPath } from "./contract";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { INTENT_RESOLVE_WORKSPACE, type ResolveWorkspaceIntent } from "./resolve-workspace";
 import { INTENT_RESOLVE_PROJECT, type ResolveProjectIntent } from "./resolve-project";
@@ -77,7 +78,11 @@ export const agentStatusUpdatedPayloadSchema = z
   })
   .readonly();
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_UPDATE_AGENT_STATUS,
   payload: updateAgentStatusPayloadSchema,
   events: {
@@ -107,23 +112,23 @@ export class UpdateAgentStatusOperation implements Operation<typeof schemas> {
   readonly id = UPDATE_AGENT_STATUS_OPERATION_ID;
   readonly schemas = schemas;
 
-  async execute(ctx: OperationContext<UpdateAgentStatusIntent>): Promise<void> {
+  async execute(ctx: OperationContext<UpdateAgentStatusIntent, typeof schemas>): Promise<void> {
     const { payload } = ctx.intent;
 
     // Resolve workspace + project, silently bail if unknown
-    let projectPath: string;
+    let projectPath: ProjectPath;
     let workspaceName: WorkspaceName;
     let projectId: ProjectId;
     let active: boolean;
     try {
-      ({ projectPath, workspaceName, active } = await ctx.dispatch({
+      ({ projectPath, workspaceName, active } = await ctx.dispatch<ResolveWorkspaceIntent>({
         type: INTENT_RESOLVE_WORKSPACE,
         payload: { workspacePath: payload.workspacePath },
-      } as ResolveWorkspaceIntent));
-      ({ projectId } = await ctx.dispatch({
+      }));
+      ({ projectId } = await ctx.dispatch<ResolveProjectIntent>({
         type: INTENT_RESOLVE_PROJECT,
         payload: { projectPath },
-      } as ResolveProjectIntent));
+      }));
     } catch {
       return; // silently bail — unknown workspace/project
     }

--- a/src/intents/vscode-command.ts
+++ b/src/intents/vscode-command.ts
@@ -18,7 +18,7 @@ import type { HookContext, OperationSchemas } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined } from "./lib/hook-helpers";
-import { hookCtxSchema } from "./contract";
+import { hookCtxSchema, workspacePathSchema } from "./contract";
 
 export const INTENT_VSCODE_COMMAND = "vscode:command" as const;
 export const VSCODE_COMMAND_OPERATION_ID = "vscode-command";
@@ -29,7 +29,7 @@ export const VSCODE_COMMAND_OPERATION_ID = "vscode-command";
 
 export const vscodeCommandPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     command: z.string(),
     args: z.array(z.unknown()).readonly().optional(),
   })
@@ -46,7 +46,7 @@ export const executeHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "execute" hook point (beyond the base HookContext). */
-const executeEnrichmentSchema = z.object({ workspacePath: z.string() });
+const executeEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "execute". */
 export const executeHookInputSchema = hookCtxSchema(
@@ -54,7 +54,11 @@ export const executeHookInputSchema = hookCtxSchema(
   executeEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_VSCODE_COMMAND,
   payload: vscodeCommandPayloadSchema,
   result: vscodeCommandResultSchema,
@@ -78,15 +82,13 @@ export type ExecuteHookInput = HookContext & z.infer<typeof executeEnrichmentSch
 // Operation
 // =============================================================================
 
-export class VscodeCommandOperation extends WorkspaceHookOperation<
-  typeof schemas,
-  ExecuteHookResult
-> {
+export class VscodeCommandOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(VSCODE_COMMAND_OPERATION_ID, {
       hookPoint: "execute",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       errorLabel: "vscode-command execute hooks failed",
       // No required result — a command may legitimately return undefined.
       extract: (results) => lastDefined(results, (r) => r.result),

--- a/src/intents/vscode-show-message.ts
+++ b/src/intents/vscode-show-message.ts
@@ -21,7 +21,7 @@ import type { HookContext, OperationSchemas } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
 import { WorkspaceHookOperation } from "./lib/workspace-operation";
 import { lastDefined } from "./lib/hook-helpers";
-import { hookCtxSchema } from "./contract";
+import { hookCtxSchema, workspacePathSchema } from "./contract";
 
 export const INTENT_VSCODE_SHOW_MESSAGE = "vscode:show-message" as const;
 export const VSCODE_SHOW_MESSAGE_OPERATION_ID = "vscode-show-message";
@@ -34,7 +34,7 @@ export const vscodeShowMessageTypeSchema = z.enum(["info", "warning", "error", "
 
 export const vscodeShowMessagePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     type: vscodeShowMessageTypeSchema,
     /** Display text. null = dismiss (only valid for status). */
     message: z.string().nullable(),
@@ -57,7 +57,7 @@ export const showHookResultSchema = z
   .readonly();
 
 /** Operation-added enrichment for the "show" hook point (beyond the base HookContext). */
-const showEnrichmentSchema = z.object({ workspacePath: z.string() });
+const showEnrichmentSchema = z.object({ workspacePath: workspacePathSchema });
 
 /** Runtime whole-context validation schema for "show". */
 export const showHookInputSchema = hookCtxSchema(
@@ -65,7 +65,11 @@ export const showHookInputSchema = hookCtxSchema(
   showEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_VSCODE_SHOW_MESSAGE,
   payload: vscodeShowMessagePayloadSchema,
   result: vscodeShowMessageResultSchema,
@@ -90,15 +94,13 @@ export type ShowHookInput = HookContext & z.infer<typeof showEnrichmentSchema>;
 // Operation
 // =============================================================================
 
-export class VscodeShowMessageOperation extends WorkspaceHookOperation<
-  typeof schemas,
-  ShowHookResult
-> {
+export class VscodeShowMessageOperation extends WorkspaceHookOperation<typeof schemas> {
   readonly schemas = schemas;
 
   constructor() {
     super(VSCODE_SHOW_MESSAGE_OPERATION_ID, {
       hookPoint: "show",
+      buildInput: (intent, workspacePath) => ({ intent, workspacePath }),
       errorLabel: "vscode-show-message show hooks failed",
       extract: (results) => lastDefined(results, (r) => r.result) ?? null,
     });

--- a/src/intents/wake-workspace.ts
+++ b/src/intents/wake-workspace.ts
@@ -24,12 +24,19 @@ import { z } from "zod/v4";
 import type { DomainEvent } from "./lib/types";
 import type { Operation, OperationContext, OperationSchemas, HookContext } from "./lib/operation";
 import { type IntentOf } from "./lib/operation";
-import { projectIdSchema, workspaceNameSchema, workspaceSchema, hookCtxSchema } from "./contract";
+import {
+  hookCtxSchema,
+  projectIdSchema,
+  projectPathSchema,
+  workspaceNameSchema,
+  workspacePathSchema,
+  workspaceSchema,
+} from "./contract";
 import { INTENT_SET_METADATA, type SetMetadataIntent } from "./set-metadata";
 import { INTENT_GET_METADATA, type GetMetadataIntent } from "./get-metadata";
 import { INTENT_OPEN_WORKSPACE, type OpenWorkspaceIntent } from "./open-workspace";
 import { HIBERNATED_METADATA_KEY } from "./hibernate-workspace";
-import { resolveWorkspaceIdentity, emitWorkspaceFailure } from "./lib/workspace-identity";
+import { resolveWorkspaceIdentity, workspaceFailurePayload } from "./lib/workspace-identity";
 
 export const INTENT_WAKE_WORKSPACE = "workspace:wake" as const;
 export const WAKE_WORKSPACE_OPERATION_ID = "wake-workspace";
@@ -56,7 +63,7 @@ const workspaceOpenSourceSchema = z.enum([
 
 export const wakeWorkspacePayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     /** Forwarded to the internal workspace:open. If true, switch to the woken
      *  workspace; if false, bring it online in the background. Default
      *  (undefined): switch — matching the pre-fold renderer behavior. */
@@ -71,22 +78,22 @@ export const workspaceWokenPayloadSchema = z
   .object({
     projectId: projectIdSchema,
     workspaceName: workspaceNameSchema,
-    workspacePath: z.string(),
-    projectPath: z.string(),
+    workspacePath: workspacePathSchema,
+    projectPath: projectPathSchema,
   })
   .readonly();
 
 export const workspaceWakeFailedPayloadSchema = z
   .object({
-    workspacePath: z.string(),
+    workspacePath: workspacePathSchema,
     error: z.string(),
   })
   .readonly();
 
 /** Operation-added enrichment for the "cleanup" hook point. */
 const wakePipelineEnrichmentSchema = z.object({
-  projectPath: z.string(),
-  workspacePath: z.string(),
+  projectPath: projectPathSchema,
+  workspacePath: workspacePathSchema,
   projectId: projectIdSchema,
   workspaceName: workspaceNameSchema,
 });
@@ -97,7 +104,11 @@ export const wakePipelineHookInputSchema = hookCtxSchema(
   wakePipelineEnrichmentSchema.shape
 );
 
-const schemas = {
+/**
+ * This operation's contract bundle. Exported so consumers (and tests) can take a typed view
+ * of its hook points and events via `ResolvedHooks<typeof schemas>` / `EventOf<typeof schemas>`.
+ */
+export const schemas = {
   type: INTENT_WAKE_WORKSPACE,
   payload: wakeWorkspacePayloadSchema,
   result: workspaceSchema,
@@ -145,7 +156,7 @@ export class WakeWorkspaceOperation implements Operation<typeof schemas> {
   readonly schemas = schemas;
 
   async execute(
-    ctx: OperationContext<WakeWorkspaceIntent>
+    ctx: OperationContext<WakeWorkspaceIntent, typeof schemas>
   ): Promise<z.infer<typeof workspaceSchema>> {
     const { payload } = ctx.intent;
 
@@ -157,14 +168,14 @@ export class WakeWorkspaceOperation implements Operation<typeof schemas> {
 
       // Clear the hibernated metadata flag before re-init so any consumers
       // observing the metadata-changed event see the workspace as awake.
-      await ctx.dispatch({
+      await ctx.dispatch<SetMetadataIntent>({
         type: INTENT_SET_METADATA,
         payload: {
           workspacePath: payload.workspacePath,
           key: HIBERNATED_METADATA_KEY,
           value: null,
         },
-      } as SetMetadataIntent);
+      });
 
       const hookCtx: WakePipelineHookInput = {
         intent: ctx.intent,
@@ -175,19 +186,19 @@ export class WakeWorkspaceOperation implements Operation<typeof schemas> {
       };
 
       // Best-effort screenshot file cleanup.
-      await ctx.hooks.collect<CleanupHookResult>("cleanup", hookCtx);
+      await ctx.hooks.collect("cleanup", hookCtx);
 
       // Read back the now-clean metadata (hibernated flag removed above) so the
       // reopen — and the workspace:created event it emits — carry accurate
       // metadata rather than reintroducing the stale flag.
-      const metadata = await ctx.dispatch({
+      const metadata = await ctx.dispatch<GetMetadataIntent>({
         type: INTENT_GET_METADATA,
         payload: { workspacePath: payload.workspacePath },
-      } as GetMetadataIntent);
+      });
 
       // Re-run the canonical open pipeline against the existing worktree to
       // bring the workspace back online (agent server, workspace URL, view).
-      const workspace = await ctx.dispatch({
+      const workspace = await ctx.dispatch<OpenWorkspaceIntent>({
         type: INTENT_OPEN_WORKSPACE,
         payload: {
           projectPath,
@@ -201,7 +212,7 @@ export class WakeWorkspaceOperation implements Operation<typeof schemas> {
           ...(payload.stealFocus !== undefined && { stealFocus: payload.stealFocus }),
           ...(payload.source !== undefined && { source: payload.source }),
         },
-      } as OpenWorkspaceIntent);
+      });
 
       const event: WorkspaceWokenEvent = {
         type: EVENT_WORKSPACE_WOKEN,
@@ -216,7 +227,10 @@ export class WakeWorkspaceOperation implements Operation<typeof schemas> {
 
       return workspace;
     } catch (error) {
-      emitWorkspaceFailure(ctx.emit, EVENT_WORKSPACE_WAKE_FAILED, payload.workspacePath, error);
+      ctx.emit({
+        type: EVENT_WORKSPACE_WAKE_FAILED,
+        payload: workspaceFailurePayload(payload.workspacePath, error),
+      });
       throw error;
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -845,10 +845,10 @@ dispatcher.subscribe(EVENT_WORKSPACE_SWITCHED, (event) => {
   const path = payload.path;
   if (firstFocused.has(path)) return;
   void dispatcher
-    .dispatch({
+    .dispatch<GetWorkspaceStatusIntent>({
       type: INTENT_GET_WORKSPACE_STATUS,
       payload: { workspacePath: path },
-    } as GetWorkspaceStatusIntent)
+    })
     .then((status) => {
       if (status.agent.type === "idle") focusTerminal(path);
     })
@@ -930,10 +930,10 @@ if (helpConfig.get()) {
 
 // Dispatch app:start — orchestrates the entire startup flow via hook points
 void dispatcher
-  .dispatch({
+  .dispatch<AppStartIntent>({
     type: INTENT_APP_START,
     payload: {},
-  } as AppStartIntent)
+  })
   .catch((error: unknown) => {
     appLogger.error(
       "Startup failed",
@@ -957,16 +957,16 @@ void dispatcher
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
-    void dispatcher.dispatch({
+    void dispatcher.dispatch<AppShutdownIntent>({
       type: INTENT_APP_SHUTDOWN,
       payload: {},
-    } as AppShutdownIntent);
+    });
   }
 });
 
 app.on("before-quit", () => {
-  void dispatcher.dispatch({
+  void dispatcher.dispatch<AppShutdownIntent>({
     type: INTENT_APP_SHUTDOWN,
     payload: {},
-  } as AppShutdownIntent);
+  });
 });

--- a/src/modules/agent-module/agent-module.integration.test.ts
+++ b/src/modules/agent-module/agent-module.integration.test.ts
@@ -18,7 +18,13 @@ import type {
   IntentOf,
 } from "../../intents/lib/operation";
 import { createMinimalOperation } from "../../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID, INTENT_APP_START } from "../../intents/app-start";
+import {
+  APP_START_OPERATION_ID,
+  INTENT_APP_START,
+  configureResultSchema,
+  checkDepsResultSchema,
+  registerAgentResultSchema,
+} from "../../intents/app-start";
 import {
   AgentLaunchOptionsOperation,
   INTENT_GET_LAUNCH_OPTIONS,
@@ -33,12 +39,12 @@ import type {
 import { APP_SHUTDOWN_OPERATION_ID, INTENT_APP_SHUTDOWN } from "../../intents/app-shutdown";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
 import type { BinaryHookInput, SetupProgressPayload } from "../../intents/setup";
-import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../../intents/open-workspace";
-import type {
-  SetupHookResult,
-  SetupHookInput,
-  OpenWorkspaceIntent,
+import {
+  INTENT_OPEN_WORKSPACE,
+  OPEN_WORKSPACE_OPERATION_ID,
+  setupResultSchema,
 } from "../../intents/open-workspace";
+import type { SetupHookInput, OpenWorkspaceIntent } from "../../intents/open-workspace";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
   INTENT_DELETE_WORKSPACE,
@@ -69,11 +75,13 @@ import { createAgentModule, type AgentModuleDeps } from "./agent-module";
 import type { AgentModuleProvider, WorkspaceStartResult } from "./agent-module-provider";
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
 import { SetupError } from "../../shared/errors/service-errors";
-import type { WorkspacePath, AggregatedAgentStatus } from "../../shared/ipc";
+import type { AggregatedAgentStatus } from "../../shared/ipc";
 import type { WorkspaceName } from "../../shared/api/types";
 import type { PersistedAccessor } from "../../boundaries/platform/store-definition";
 import type { ConfigAgentType } from "../../boundaries/platform/config";
 import { createMockAccessor } from "../../boundaries/platform/config.test-utils";
+import { wsPath, projPath } from "../../shared/test-fixtures";
+import type { WorkspacePath } from "../../intents/contract";
 
 // =============================================================================
 // Mock AgentModuleProvider Factory
@@ -130,6 +138,7 @@ const beforeReadySchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<readonly ConfigureResult[]>(),
+  hooks: { "before-ready": { result: configureResultSchema } },
 } satisfies OperationSchemas;
 
 class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas> {
@@ -137,9 +146,9 @@ class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas
   readonly schemas = beforeReadySchemas;
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>, typeof beforeReadySchemas>
   ): Promise<readonly ConfigureResult[]> {
-    const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
+    const { results, errors } = await ctx.hooks.collect("before-ready", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -151,6 +160,7 @@ const checkDepsSchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<CheckDepsResult>(),
+  hooks: { "check-deps": { result: checkDepsResultSchema } },
 } satisfies OperationSchemas;
 
 function minimalCheckDeps(
@@ -165,7 +175,7 @@ function minimalCheckDeps(
         configuredAgent: configuredAgent as CheckDepsHookContext["configuredAgent"],
         extensionRequirements: [],
       };
-      const { results } = await ctx.hooks.collect<CheckDepsResult>("check-deps", hookCtx);
+      const { results } = await ctx.hooks.collect("check-deps", hookCtx);
       const merged: CheckDepsResult = {};
       for (const r of results) {
         if (r.missingBinaries) {
@@ -194,6 +204,7 @@ const registerAgentsSchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<readonly RegisterAgentResult[]>(),
+  hooks: { "register-agents": { result: registerAgentResultSchema } },
 } satisfies OperationSchemas;
 
 class MinimalRegisterAgentsOperation implements Operation<typeof registerAgentsSchemas> {
@@ -201,9 +212,9 @@ class MinimalRegisterAgentsOperation implements Operation<typeof registerAgentsS
   readonly schemas = registerAgentsSchemas;
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof registerAgentsSchemas>>
+    ctx: OperationContext<IntentOf<typeof registerAgentsSchemas>, typeof registerAgentsSchemas>
   ): Promise<readonly RegisterAgentResult[]> {
-    const { results, errors } = await ctx.hooks.collect<RegisterAgentResult>("register-agents", {
+    const { results, errors } = await ctx.hooks.collect("register-agents", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -264,6 +275,7 @@ const setupSchemas = {
   type: INTENT_OPEN_WORKSPACE,
   payload: z.unknown(),
   result: z.custom<SetupOperationResult | undefined>(),
+  hooks: { setup: { result: setupResultSchema } },
 } satisfies OperationSchemas;
 
 function minimalSetup(
@@ -274,7 +286,7 @@ function minimalSetup(
     id: OPEN_WORKSPACE_OPERATION_ID,
     schemas: setupSchemas,
     async execute(ctx): Promise<SetupOperationResult | undefined> {
-      const { results, errors } = await ctx.hooks.collect<SetupHookResult | undefined>("setup", {
+      const { results, errors } = await ctx.hooks.collect("setup", {
         intent: ctx.intent,
         workspacePath: "/test/workspace",
         projectPath: "/test/project",
@@ -305,11 +317,11 @@ function minimalShutdown(agentCapability: string | null = "claude"): Operation<O
     "shutdown",
     {
       hookContext: (ctx): DeletePipelineHookInput => {
-        const payload = ctx.intent.payload as { workspacePath?: string };
+        const payload = ctx.intent.payload as { workspacePath?: WorkspacePath };
         return {
           intent: ctx.intent,
-          projectPath: "/test/project",
-          workspacePath: payload.workspacePath ?? "/test/workspace",
+          projectPath: projPath("/test/project"),
+          workspacePath: payload.workspacePath ?? wsPath("/test/workspace"),
           workspaceName: "test-workspace" as WorkspaceName,
           active: false,
           ...(agentCapability !== null && {
@@ -539,8 +551,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -564,8 +576,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -588,8 +600,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -612,8 +624,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
       await dispatcher.dispatch({
@@ -644,8 +656,8 @@ describe("createAgentModule", () => {
       dispatcher.registerOperation(
         minimalSetup(
           {
-            workspacePath: "/test/workspace",
-            projectPath: "/test/project",
+            workspacePath: wsPath("/test/workspace"),
+            projectPath: projPath("/test/project"),
           },
           "opencode"
         )
@@ -827,8 +839,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -855,8 +867,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -882,8 +894,8 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
 
@@ -913,8 +925,8 @@ describe("createAgentModule", () => {
       dispatcher.registerOperation(
         minimalSetup(
           {
-            workspacePath: "/test/workspace",
-            projectPath: "/test/project",
+            workspacePath: wsPath("/test/workspace"),
+            projectPath: projPath("/test/project"),
           },
           "opencode"
         )
@@ -945,15 +957,15 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(minimalShutdown());
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          workspacePath: "/test/workspace",
+          workspacePath: wsPath("/test/workspace"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as ShutdownHookResult | undefined;
+      })) as ShutdownHookResult | undefined;
 
       expect(mockProvider.stopWorkspace).toHaveBeenCalledWith("/test/workspace");
       expect(result).toBeDefined();
@@ -966,15 +978,15 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(minimalShutdown());
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          workspacePath: "/test/workspace",
+          workspacePath: wsPath("/test/workspace"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent);
+      });
 
       expect(mockProvider.clearWorkspaceTracking).toHaveBeenCalledWith("/test/workspace");
     });
@@ -987,15 +999,15 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(minimalShutdown());
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          workspacePath: "/test/workspace",
+          workspacePath: wsPath("/test/workspace"),
           keepBranch: false,
           force: true,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as ShutdownHookResult | undefined;
+      })) as ShutdownHookResult | undefined;
 
       expect(result).toBeDefined();
       expect(result!.error).toBe("server busy");
@@ -1010,15 +1022,15 @@ describe("createAgentModule", () => {
       dispatcher.registerOperation(minimalShutdown());
 
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<DeleteWorkspaceIntent>({
           type: "workspace:delete",
           payload: {
-            workspacePath: "/test/workspace",
+            workspacePath: wsPath("/test/workspace"),
             keepBranch: false,
             force: false,
             removeWorktree: true,
           },
-        } as DeleteWorkspaceIntent)
+        })
       ).rejects.toThrow("server busy");
     });
 
@@ -1027,15 +1039,15 @@ describe("createAgentModule", () => {
 
       dispatcher.registerOperation(minimalShutdown("opencode"));
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          workspacePath: "/test/workspace",
+          workspacePath: wsPath("/test/workspace"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as ShutdownHookResult | undefined;
+      })) as ShutdownHookResult | undefined;
 
       expect(result).toBeUndefined();
       expect(mockProvider.stopWorkspace).not.toHaveBeenCalled();
@@ -1306,7 +1318,7 @@ describe("createAgentModule", () => {
           {
             hookContext: (ctx) => ({
               intent: ctx.intent,
-              workspacePath: (ctx.intent.payload as { workspacePath: string }).workspacePath,
+              workspacePath: (ctx.intent.payload as { workspacePath: WorkspacePath }).workspacePath,
               event: (ctx.intent.payload as { event: "open" | "close" }).event,
               capabilities: { agent },
             }),
@@ -1369,8 +1381,8 @@ describe("createAgentModule", () => {
       await dispatcher.dispatch({ type: "app:start", payload: {} });
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
       await dispatcher.dispatch({
@@ -1415,8 +1427,8 @@ describe("createAgentModule", () => {
       await dispatcher.dispatch({ type: "app:start", payload: {} });
       dispatcher.registerOperation(
         minimalSetup({
-          workspacePath: "/test/workspace",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/workspace"),
+          projectPath: projPath("/test/project"),
         })
       );
       await dispatcher.dispatch({

--- a/src/modules/agent-module/agent-module.ts
+++ b/src/modules/agent-module/agent-module.ts
@@ -145,10 +145,10 @@ export function createAgentModule(
     if (initialized) return;
     provider.initialize(capturedMcpPort !== null ? { port: capturedMcpPort } : null);
     statusChangeCleanup = provider.onStatusChange((workspacePath, status) => {
-      void deps.dispatcher.dispatch({
+      void deps.dispatcher.dispatch<UpdateAgentStatusIntent>({
         type: INTENT_UPDATE_AGENT_STATUS,
         payload: { workspacePath, status },
-      } as UpdateAgentStatusIntent);
+      });
     });
     initialized = true;
   }

--- a/src/modules/agent-module/opencode/module-provider.integration.test.ts
+++ b/src/modules/agent-module/opencode/module-provider.integration.test.ts
@@ -131,7 +131,7 @@ function createMockServerManager(): OpenCodeServerManager & {
 async function initializeAndStart(
   moduleProvider: AgentModuleProvider,
   serverManager: ReturnType<typeof createMockServerManager>,
-  workspacePath: WorkspacePath = WS_PATH,
+  workspacePath: string = WS_PATH,
   port = 8080,
   pendingPrompt?: unknown
 ): Promise<InstanceType<typeof MockOpenCodeProvider>> {

--- a/src/modules/auto-tagging-module.integration.test.ts
+++ b/src/modules/auto-tagging-module.integration.test.ts
@@ -45,11 +45,13 @@ import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { DomainEvent } from "../intents/lib/types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { createAutoTaggingModule } from "./auto-tagging-module";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "../intents/contract";
 
-const PROJECT_ROOT = "/project";
+const PROJECT_ROOT = projPath("/project");
 const PROJECT_ID = "project-ea0135bc" as ProjectId;
-const WORKSPACE_PATH = "/workspaces/feature-x";
-const OTHER_WORKSPACE_PATH = "/workspaces/feature-y";
+const WORKSPACE_PATH = wsPath("/workspaces/feature-x");
+const OTHER_WORKSPACE_PATH = wsPath("/workspaces/feature-y");
 const WORKSPACE_URL = "http://127.0.0.1:25448/?folder=/workspaces/feature-x";
 const NEW_TAG_KEY = "tags.new";
 const NEW_TAG_VALUE = JSON.stringify({ color: "#3498db" });
@@ -59,12 +61,12 @@ interface TestSetup {
   /** Metadata written through the real SetMetadataOperation's "set" hook. */
   readonly metadata: Map<string, Map<string, string>>;
   /** Every set-metadata intent that reached the operation, in order. */
-  readonly writes: Array<{ workspacePath: string; key: string; value: string | null }>;
+  readonly writes: Array<{ workspacePath: WorkspacePath; key: string; value: string | null }>;
   readonly createdEvents: WorkspaceCreatedEvent[];
   readonly views: TestViewManagerHarness;
 }
 
-function metadataFor(setup: TestSetup, workspacePath: string): Record<string, string> {
+function metadataFor(setup: TestSetup, workspacePath: WorkspacePath): Record<string, string> {
   return Object.fromEntries(setup.metadata.get(workspacePath) ?? new Map());
 }
 
@@ -76,7 +78,7 @@ function createTestSetup(options?: { enabled?: boolean; activeWorkspace?: string
   const views = createTestViewManager(options?.activeWorkspace ?? null);
 
   registerTestInfrastructure(dispatcher, {
-    workspaces: (workspacePath: string) => ({
+    workspaces: (workspacePath: WorkspacePath) => ({
       projectPath: PROJECT_ROOT,
       workspaceName: workspacePath.slice(workspacePath.lastIndexOf("/") + 1) as WorkspaceName,
     }),
@@ -104,7 +106,7 @@ function createTestSetup(options?: { enabled?: boolean; activeWorkspace?: string
                     : {
                         projectId: PROJECT_ID,
                         workspaceName: path.slice(path.lastIndexOf("/") + 1) as WorkspaceName,
-                        path,
+                        path: wsPath(path),
                       },
               },
             };
@@ -196,11 +198,11 @@ async function flushEvents(): Promise<void> {
 }
 
 /** Switches, then lets the workspace:switched subscribers run. */
-async function switchTo(setup: TestSetup, workspacePath: string | null): Promise<void> {
-  await setup.dispatcher.dispatch({
+async function switchTo(setup: TestSetup, workspacePath: WorkspacePath | null): Promise<void> {
+  await setup.dispatcher.dispatch<SwitchWorkspaceIntent>({
     type: INTENT_SWITCH_WORKSPACE,
     payload: { workspacePath },
-  } as SwitchWorkspaceIntent);
+  });
   await flushEvents();
 }
 
@@ -382,10 +384,10 @@ describe("AutoTaggingModule", () => {
       const setup = createTestSetup({ activeWorkspace: WORKSPACE_PATH });
 
       await expect(
-        setup.dispatcher.dispatch({
+        setup.dispatcher.dispatch<SwitchWorkspaceIntent>({
           type: INTENT_SWITCH_WORKSPACE,
           payload: { workspacePath: null },
-        } as SwitchWorkspaceIntent)
+        })
       ).resolves.not.toThrow();
     });
   });
@@ -396,10 +398,10 @@ describe("AutoTaggingModule", () => {
       await setup.dispatcher.dispatch(openIntent({ stealFocus: false }));
 
       // Simulates sidekick/MCP deleting the tag.
-      await setup.dispatcher.dispatch({
+      await setup.dispatcher.dispatch<SetMetadataIntent>({
         type: INTENT_SET_METADATA,
         payload: { workspacePath: WORKSPACE_PATH, key: NEW_TAG_KEY, value: null },
-      } as SetMetadataIntent);
+      });
       await flushEvents();
       const writesBeforeSwitch = setup.writes.length;
 
@@ -411,10 +413,10 @@ describe("AutoTaggingModule", () => {
     it("clears a tag the user added by hand", async () => {
       const setup = createTestSetup({ activeWorkspace: OTHER_WORKSPACE_PATH });
 
-      await setup.dispatcher.dispatch({
+      await setup.dispatcher.dispatch<SetMetadataIntent>({
         type: INTENT_SET_METADATA,
         payload: { workspacePath: WORKSPACE_PATH, key: NEW_TAG_KEY, value: NEW_TAG_VALUE },
-      } as SetMetadataIntent);
+      });
       await flushEvents();
 
       await switchTo(setup, WORKSPACE_PATH);

--- a/src/modules/auto-tagging-module.ts
+++ b/src/modules/auto-tagging-module.ts
@@ -80,10 +80,10 @@ export function createAutoTaggingModule(deps: AutoTaggingModuleDeps): IntentModu
 
             const { workspacePath } = ctx as SetupHookInput;
             try {
-              await deps.dispatcher.dispatch({
+              await deps.dispatcher.dispatch<SetMetadataIntent>({
                 type: INTENT_SET_METADATA,
                 payload: { workspacePath, key: NEW_TAG_KEY, value: NEW_TAG_VALUE },
-              } as SetMetadataIntent);
+              });
             } catch (error) {
               // Cosmetic — never fail a workspace creation over a tag.
               deps.logger.warn("Failed to tag background workspace", {
@@ -128,10 +128,10 @@ export function createAutoTaggingModule(deps: AutoTaggingModuleDeps): IntentModu
           if (!tagged.has(payload.path)) return;
 
           try {
-            await deps.dispatcher.dispatch({
+            await deps.dispatcher.dispatch<SetMetadataIntent>({
               type: INTENT_SET_METADATA,
               payload: { workspacePath: payload.path, key: NEW_TAG_KEY, value: null },
-            } as SetMetadataIntent);
+            });
           } catch (error) {
             // Leave it in the set — the next switch retries.
             deps.logger.warn("Failed to clear new tag", {

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -48,6 +48,7 @@ import { createMockProcessRunner } from "../../boundaries/platform/process.state
 import { createAutoWorkspaceModule } from "./module";
 import { createMockConfig } from "../../boundaries/platform/config.test-utils";
 import { createMockState, type MockStateService } from "../../boundaries/platform/state.test-utils";
+import { projPath } from "../../shared/test-fixtures";
 
 const HEARTBEAT_MS = 60 * 1000;
 
@@ -62,9 +63,11 @@ const activateSchemas = { type: INTENT_APP_START, payload: z.unknown() } satisfi
 class MinimalActivateOperation implements Operation<typeof activateSchemas> {
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = activateSchemas;
-  async execute(ctx: OperationContext<IntentOf<typeof activateSchemas>>): Promise<void> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof activateSchemas>, typeof activateSchemas>
+  ): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
-    const { errors } = await ctx.hooks.collect<void>("start", hookCtx);
+    const { errors } = await ctx.hooks.collect("start", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     await ctx.emit({ type: EVENT_APP_STARTED, payload: {} });
   }
@@ -79,10 +82,12 @@ class OpenProjectOp implements Operation<typeof openProjectSchemas> {
   readonly id = "open-project";
   readonly schemas = openProjectSchemas;
   readonly dispatched: IntentOf<typeof openProjectSchemas>[] = [];
-  async execute(ctx: OperationContext<IntentOf<typeof openProjectSchemas>>): Promise<Project> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof openProjectSchemas>, typeof openProjectSchemas>
+  ): Promise<Project> {
     this.dispatched.push(ctx.intent);
     const pathStr = ctx.intent.payload.path?.toString() ?? "/home/user/projects/repo";
-    return { id: "project-1" as ProjectId, name: "repo", path: pathStr, workspaces: [] };
+    return { id: "project-1" as ProjectId, name: "repo", path: projPath(pathStr), workspaces: [] };
   }
 }
 
@@ -103,7 +108,9 @@ class OpenWorkspaceOp implements Operation<typeof openWorkspaceSchemas> {
   readonly schemas = openWorkspaceSchemas;
   readonly dispatched: IntentOf<typeof openWorkspaceSchemas>[] = [];
   readonly failFor = new Set<string>();
-  async execute(ctx: OperationContext<IntentOf<typeof openWorkspaceSchemas>>): Promise<WsResult> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof openWorkspaceSchemas>, typeof openWorkspaceSchemas>
+  ): Promise<WsResult> {
     this.dispatched.push(ctx.intent);
     const name = ctx.intent.payload.workspaceName ?? "ws";
     if (this.failFor.has(name)) throw new Error(`open failed for ${name}`);
@@ -126,7 +133,7 @@ class GetBasesOp implements Operation<typeof getBasesSchemas> {
   readonly id = "get-project-bases";
   readonly schemas = getBasesSchemas;
   async execute(
-    ctx: OperationContext<IntentOf<typeof getBasesSchemas>>
+    ctx: OperationContext<IntentOf<typeof getBasesSchemas>, typeof getBasesSchemas>
   ): Promise<GetProjectBasesResult> {
     return {
       bases: [],
@@ -144,7 +151,9 @@ class SetMetaOp implements Operation<typeof setMetaSchemas> {
   readonly id = "set-metadata";
   readonly schemas = setMetaSchemas;
   readonly dispatched: IntentOf<typeof setMetaSchemas>[] = [];
-  async execute(ctx: OperationContext<IntentOf<typeof setMetaSchemas>>): Promise<void> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof setMetaSchemas>, typeof setMetaSchemas>
+  ): Promise<void> {
     this.dispatched.push(ctx.intent);
   }
 }

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -58,6 +58,7 @@ import { parseSources, validateSourcesConfig, type ParsedSource } from "./source
 import { renderDefinition } from "./template-render";
 import { runCmd } from "./cmd-runner";
 import { buildSeededSources, DEFAULT_GITHUB_QUERY } from "./migration";
+import { projectPathSchema } from "../../intents/contract";
 
 // =============================================================================
 // State
@@ -339,33 +340,35 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
       }
 
       let projectPayload: OpenProjectIntent["payload"] | null = null;
-      if (definition.project) projectPayload = { path: new Path(definition.project) };
+      if (definition.project)
+        // A user-authored template value: normalize, then mint the brand by parsing.
+        projectPayload = { path: projectPathSchema.parse(new Path(definition.project).toString()) };
       else if (definition.git) projectPayload = { git: definition.git };
       if (!projectPayload) {
         deps.logger.warn("Skipping auto-workspace (no project/git in template)", { key });
         return null;
       }
 
-      const project = await deps.dispatcher.dispatch({
+      const project = await deps.dispatcher.dispatch<OpenProjectIntent>({
         type: INTENT_OPEN_PROJECT,
         payload: projectPayload,
-      } as OpenProjectIntent);
+      });
       if (!project) {
         deps.logger.warn("project:open returned null for auto-workspace", { key });
         return null;
       }
 
-      await deps.dispatcher.dispatch({
+      await deps.dispatcher.dispatch<GetProjectBasesIntent>({
         type: INTENT_GET_PROJECT_BASES,
         payload: { projectPath: project.path, refresh: true, wait: true },
-      } as GetProjectBasesIntent);
+      });
 
       const agent: AgentSpec = definition.agent ?? {
         type: "default",
         ...(definition.prompt !== "" && { prompt: definition.prompt }),
       };
 
-      const wsResult = await deps.dispatcher.dispatch({
+      const wsResult = await deps.dispatcher.dispatch<OpenWorkspaceIntent>({
         type: INTENT_OPEN_WORKSPACE,
         payload: {
           workspaceName: definition.name,
@@ -376,7 +379,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
           agent,
           source: "auto-workspace",
         },
-      } as OpenWorkspaceIntent);
+      });
 
       const allMetadata: Record<string, string> = {
         [METADATA_SOURCE_KEY]: source.name,
@@ -384,10 +387,10 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
       };
       for (const [metaKey, value] of Object.entries(allMetadata)) {
         try {
-          await deps.dispatcher.dispatch({
+          await deps.dispatcher.dispatch<SetMetadataIntent>({
             type: INTENT_SET_METADATA,
             payload: { workspacePath: wsResult.path, key: metaKey, value },
-          } as SetMetadataIntent);
+          });
         } catch (error) {
           deps.logger.warn("Failed to set workspace metadata", {
             key: metaKey,

--- a/src/modules/badge-module.integration.test.ts
+++ b/src/modules/badge-module.integration.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../boundaries/shell/window-manager.test-utils";
 import type { ImageHandle } from "../boundaries/shell/image-types";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // BadgeManager Direct Tests
@@ -441,7 +442,7 @@ function createModuleTestSetup(): ModuleTestSetup {
   // Every workspace path resolves; workspaceName derives from the path basename.
   registerTestInfrastructure(dispatcher, {
     workspaces: (workspacePath) => ({
-      projectPath: "/projects/test",
+      projectPath: projPath("/projects/test"),
       workspaceName: workspacePath.split("/").pop() as WorkspaceName,
     }),
     projects: () => ({ projectId: "test-project" as ProjectId }),
@@ -470,7 +471,7 @@ describe("BadgeModule Integration", () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
 
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 2 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 2 } })
       );
 
       expect(appLayer).toHaveDockBadge("\u25CF"); // ●
@@ -481,13 +482,13 @@ describe("BadgeModule Integration", () => {
 
       // First make busy
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25CF");
 
       // Then become idle
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "idle", counts: { idle: 1, busy: 0 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "idle", counts: { idle: 1, busy: 0 } })
       );
       expect(appLayer).toHaveDockBadge("");
     });
@@ -498,10 +499,10 @@ describe("BadgeModule Integration", () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
 
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "idle", counts: { idle: 2, busy: 0 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "idle", counts: { idle: 2, busy: 0 } })
       );
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/2", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/2"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
 
       expect(appLayer).toHaveDockBadge("\u25D0"); // ◐
@@ -512,16 +513,16 @@ describe("BadgeModule Integration", () => {
 
       // Mixed state
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "idle", counts: { idle: 1, busy: 0 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "idle", counts: { idle: 1, busy: 0 } })
       );
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/2", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/2"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25D0");
 
       // Workspace 1 becomes busy
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25CF");
     });
@@ -531,16 +532,16 @@ describe("BadgeModule Integration", () => {
 
       // All working
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/2", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/2"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25CF");
 
       // Workspace 1 becomes idle
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "idle", counts: { idle: 1, busy: 0 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "idle", counts: { idle: 1, busy: 0 } })
       );
       expect(appLayer).toHaveDockBadge("\u25D0");
     });
@@ -552,7 +553,7 @@ describe("BadgeModule Integration", () => {
 
       // One busy workspace
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25CF");
 
@@ -560,7 +561,7 @@ describe("BadgeModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspace/1",
+          workspacePath: wsPath("/workspace/1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -576,10 +577,10 @@ describe("BadgeModule Integration", () => {
 
       // Mixed state: one idle, one busy
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "idle", counts: { idle: 1, busy: 0 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "idle", counts: { idle: 1, busy: 0 } })
       );
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/2", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/2"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25D0");
 
@@ -587,7 +588,7 @@ describe("BadgeModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspace/2",
+          workspacePath: wsPath("/workspace/2"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -606,7 +607,7 @@ describe("BadgeModule Integration", () => {
 
       // Set a busy badge first
       await dispatcher.dispatch(
-        updateStatusIntent("/workspace/1", { status: "busy", counts: { idle: 0, busy: 1 } })
+        updateStatusIntent(wsPath("/workspace/1"), { status: "busy", counts: { idle: 0, busy: 1 } })
       );
       expect(appLayer).toHaveDockBadge("\u25CF");
 
@@ -616,7 +617,7 @@ describe("BadgeModule Integration", () => {
           throwOnError: false,
         })
       );
-      await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
+      await dispatcher.dispatch<AppShutdownIntent>({ type: INTENT_APP_SHUTDOWN, payload: {} });
 
       // Badge should be cleared by dispose()
       expect(appLayer).toHaveDockBadge("");
@@ -641,7 +642,7 @@ describe("BadgeModule Integration", () => {
 
       // Should not throw - collect() catches the error
       await expect(
-        dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent)
+        dispatcher.dispatch<AppShutdownIntent>({ type: INTENT_APP_SHUTDOWN, payload: {} })
       ).resolves.not.toThrow();
 
       disposeSpy.mockRestore();

--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -34,6 +34,7 @@ import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import { INTENT_LIST_PROJECTS } from "../intents/list-projects";
 import { INTENT_GET_LAUNCH_OPTIONS } from "../intents/agent-launch-options";
+import { wsPath, projPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Fixtures
@@ -42,14 +43,14 @@ import { INTENT_GET_LAUNCH_OPTIONS } from "../intents/agent-launch-options";
 const PROJECT_A: Project = {
   id: "project-a-12345678" as ProjectId,
   name: "project-a",
-  path: "/projects/a",
+  path: projPath("/projects/a"),
   workspaces: [
     {
       projectId: "project-a-12345678" as ProjectId,
       name: "existing" as WorkspaceName,
       branch: "existing",
       metadata: {},
-      path: "/projects/a/.worktrees/existing",
+      path: wsPath("/projects/a/.worktrees/existing"),
     },
   ],
 };
@@ -57,7 +58,7 @@ const PROJECT_A: Project = {
 const PROJECT_B: Project = {
   id: "project-b-12345678" as ProjectId,
   name: "project-b",
-  path: "/projects/b",
+  path: projPath("/projects/b"),
   workspaces: [],
 };
 

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -70,6 +70,7 @@ import {
   type GetLaunchOptionsIntent,
   type LaunchOptionsResult,
 } from "../intents/agent-launch-options";
+import type { ProjectPath } from "../intents/contract";
 
 // =============================================================================
 // Dependencies
@@ -152,7 +153,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   let launchOptions: LaunchOptionsResult | null = null;
   /** The backend whose launch options are currently being fetched (if any). */
   let loadingLaunchOptionsFor: LifecycleAgentType | null = null;
-  let selectedProjectPath: string | null = null;
+  let selectedProjectPath: ProjectPath | null = null;
   let branches: readonly BaseInfo[] = [];
   let branchesLoading = false;
   let branchesError: string | null = null;
@@ -164,7 +165,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   /** Form-level error (e.g. folder-open failure), shown above the footer. */
   let formError: string | null = null;
   /** Project to seed the next reset with (most recently opened project). */
-  let pendingSeedProjectPath: string | null = null;
+  let pendingSeedProjectPath: ProjectPath | null = null;
   /**
    * Project path of the workspace the app last made active. Recorded from
    * non-null workspace:switched events so it survives the deselect
@@ -522,7 +523,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
    * even when it already carried the flag — used by the folder-open and
    * git-clone flows.
    */
-  function selectProject(projectPath: string, options?: { refocusName?: boolean }): void {
+  function selectProject(projectPath: ProjectPath, options?: { refocusName?: boolean }): void {
     selectedProjectPath = projectPath;
     branches = [];
     branchesLoading = true;
@@ -565,7 +566,7 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   // ---- Session lifecycle ----
 
   /** Seed rule: pending opened project > last active workspace's project > first. */
-  function computeSeedProject(): string | null {
+  function computeSeedProject(): ProjectPath | null {
     if (pendingSeedProjectPath !== null) {
       const seed = pendingSeedProjectPath;
       pendingSeedProjectPath = null;
@@ -638,9 +639,12 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       if (handle !== sessionHandle) return;
       const data = event.data;
       if (event.fieldId === FIELD_PROJECT) {
-        const path = data[FIELD_PROJECT] ?? "";
-        if (path !== "" && path !== selectedProjectPath) {
-          selectProject(path);
+        // The dialog hands back a raw string; resolve it against the module's own
+        // project list rather than minting a brand from unvalidated UI input.
+        const raw = data[FIELD_PROJECT] ?? "";
+        const picked = projects.find((p) => p.path === raw)?.path;
+        if (picked !== undefined && picked !== selectedProjectPath) {
+          selectProject(picked);
         }
       } else if (event.fieldId === FIELD_NAME) {
         nameValue = data[FIELD_NAME] ?? "";

--- a/src/modules/debug-module.ts
+++ b/src/modules/debug-module.ts
@@ -33,6 +33,7 @@ import { SETUP_OPERATION_ID, type SetupProgressPayload } from "../intents/setup"
 import type { NotificationHandle } from "./presentation/sessions";
 import type { UiPresenter } from "./presentation/presentation-module";
 import type { NotificationConfig } from "../shared/notification-types";
+import type { ProjectPath } from "../intents/contract";
 
 interface DebugModuleDeps {
   readonly configService: Config;
@@ -77,7 +78,10 @@ export function createDebugModule(deps: DebugModuleDeps): IntentModule {
   }
 
   // Workspaces kept alive by debug.blocking-pids after deletion
-  const debugWorkspaces = new Map<string, { projectPath: string; workspaceName: WorkspaceName }>();
+  const debugWorkspaces = new Map<
+    string,
+    { projectPath: ProjectPath; workspaceName: WorkspaceName }
+  >();
 
   return {
     name: "debug",

--- a/src/modules/deletion-dialog-module.ts
+++ b/src/modules/deletion-dialog-module.ts
@@ -48,6 +48,7 @@ import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import type { WorkspaceSwitchedEvent } from "../intents/switch-workspace";
 import type { Logger } from "../boundaries/platform/logging";
 import { getErrorMessage } from "../shared/error-utils";
+import type { WorkspacePath } from "../intents/contract";
 
 /**
  * Dependencies for the deletion dialog module.
@@ -240,7 +241,7 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
   let activeWorkspacePath: string | null = null;
 
   /** Wire retry/dismiss event handlers on a dialog handle. */
-  function wireEvents(handle: DialogHandle, workspacePath: string): void {
+  function wireEvents(handle: DialogHandle, workspacePath: WorkspacePath): void {
     function dismiss(): void {
       deps.logger.debug("Deletion dismiss", { workspace: workspacePath });
       handle.close();
@@ -280,7 +281,7 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
   }
 
   /** Open the deletion dialog for a workspace from its current progress. */
-  function showDialog(path: string, progress: DeletionProgress): void {
+  function showDialog(path: WorkspacePath, progress: DeletionProgress): void {
     const handle = deps.ui.dialog(buildConfig(progress), { kind: "panel" });
     activeDialog = { path, handle };
     wireEvents(handle, path);
@@ -372,14 +373,14 @@ export function createDeletionDialogModule(deps: DeletionDialogModuleDeps): Inte
     void (async (): Promise<void> => {
       try {
         const [status, metadata] = await Promise.all([
-          deps.dispatcher.dispatch({
+          deps.dispatcher.dispatch<GetWorkspaceStatusIntent>({
             type: INTENT_GET_WORKSPACE_STATUS,
             payload: { workspacePath: input.workspacePath, refresh: true },
-          } as GetWorkspaceStatusIntent),
-          deps.dispatcher.dispatch({
+          }),
+          deps.dispatcher.dispatch<GetMetadataIntent>({
             type: INTENT_GET_METADATA,
             payload: { workspacePath: input.workspacePath },
-          } as GetMetadataIntent),
+          }),
         ]);
         state = {
           ...state,

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -19,7 +19,11 @@ import type {
   IntentOf,
 } from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
-import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
+import {
+  INTENT_APP_START,
+  APP_START_OPERATION_ID,
+  configureResultSchema,
+} from "../intents/app-start";
 import type { AppStartIntent, ConfigureResult } from "../intents/app-start";
 import { AppShutdownOperation, INTENT_APP_SHUTDOWN } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
@@ -38,6 +42,7 @@ const beforeReadySchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<ConfigureResult>(),
+  hooks: { "before-ready": { result: configureResultSchema } },
 } satisfies OperationSchemas;
 
 /** Runs "before-ready" hook point only. */
@@ -45,9 +50,9 @@ class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = beforeReadySchemas;
   async execute(
-    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>, typeof beforeReadySchemas>
   ): Promise<ConfigureResult> {
-    const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
+    const { results, errors } = await ctx.hooks.collect("before-ready", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -112,10 +117,10 @@ describe("ElectronLifecycleModule Integration", () => {
     );
     dispatcher.registerModule(module);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     expect(mockApp.whenReady).toHaveBeenCalledOnce();
   });
@@ -138,10 +143,10 @@ describe("ElectronLifecycleModule Integration", () => {
     dispatcher.registerModule(module);
 
     await expect(
-      dispatcher.dispatch({
+      dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent)
+      })
     ).rejects.toThrow("app failed to initialize");
   });
 
@@ -159,10 +164,10 @@ describe("ElectronLifecycleModule Integration", () => {
     );
     dispatcher.registerModule(module);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppShutdownIntent>({
       type: INTENT_APP_SHUTDOWN,
       payload: {},
-    } as AppShutdownIntent);
+    });
 
     expect(mockApp.quit).toHaveBeenCalledOnce();
   });
@@ -188,10 +193,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       const originalNoAsar = process.noAsar;
       try {
-        await dispatcher.dispatch({
+        await dispatcher.dispatch<AppStartIntent>({
           type: INTENT_APP_START,
           payload: {},
-        } as AppStartIntent);
+        });
 
         expect(process.noAsar).toBe(true);
       } finally {
@@ -218,10 +223,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(mockApp.setPath).toHaveBeenCalledWith(
         "userData",
@@ -259,10 +264,10 @@ describe("ElectronLifecycleModule Integration", () => {
       const originalNoAsar = process.noAsar;
       try {
         process.noAsar = false;
-        await dispatcher.dispatch({
+        await dispatcher.dispatch<AppStartIntent>({
           type: INTENT_APP_START,
           payload: {},
-        } as AppStartIntent);
+        });
 
         expect(process.noAsar).toBe(false);
       } finally {
@@ -287,10 +292,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("disable-gpu");
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("use-gl", "swiftshader");
@@ -311,10 +316,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("no-proxy-server");
     });
@@ -333,10 +338,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       const expected = DEFAULT_DISABLED_FEATURES.join(",");
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("disable-features", expected);
@@ -359,10 +364,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith(
         "disable-features",
@@ -391,10 +396,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       const disableFeaturesCalls = (
         mockApp.commandLine.appendSwitch as ReturnType<typeof vi.fn>
@@ -417,10 +422,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       const expected = DEFAULT_DISABLED_FEATURES.join(",");
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("disable-features", expected);
@@ -445,10 +450,10 @@ describe("ElectronLifecycleModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(logger.info).toHaveBeenCalledWith(
         "Disabled Chromium features",
@@ -486,10 +491,10 @@ describe("ElectronLifecycleModule Integration", () => {
       );
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       // Simulate resume
       expect(resumeCallbacks.length).toBe(1);

--- a/src/modules/error-notification-module.integration.test.ts
+++ b/src/modules/error-notification-module.integration.test.ts
@@ -16,6 +16,7 @@ import {
   createMockNotificationManager,
   type MockNotificationManager,
 } from "./presentation/notification-manager.state-mock";
+import { projPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Tests
@@ -41,7 +42,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "my-workspace",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Worktree already exists",
       },
     };
@@ -62,7 +63,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "test-ws",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Some error",
       },
     };
@@ -82,7 +83,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "mcp-workspace",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Some MCP error",
         source: "mcp",
       },
@@ -98,7 +99,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "plugin-workspace",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Some plugin error",
         source: "plugin-server",
       },
@@ -114,7 +115,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "unknown-workspace",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Some error",
       },
     };
@@ -159,7 +160,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "ws-1",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Error 1",
       },
     };
@@ -167,7 +168,7 @@ describe("ErrorNotificationModule", () => {
       type: EVENT_WORKSPACE_CREATE_FAILED,
       payload: {
         workspaceName: "ws-2",
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         error: "Error 2",
       },
     };

--- a/src/modules/error-report-module.integration.test.ts
+++ b/src/modules/error-report-module.integration.test.ts
@@ -39,6 +39,8 @@ import type { DialogMessageBoxOptions } from "../boundaries/shell/dialog";
 import type { HookContext } from "../intents/lib/operation";
 import { createMockDialogHandle } from "./presentation/dialog-manager.state-mock";
 import type { DialogConfig } from "../shared/dialog-types";
+import type { SerializedError } from "../intents/contract";
+import { toSerializedError } from "../shared/error-utils";
 
 // =============================================================================
 // Helpers
@@ -149,7 +151,7 @@ async function registerCrashHandlers(
 /** Run the app:start "error" hook with a fatal error + phase (as the operation does). */
 async function runStartupErrorHook(
   module: ReturnType<typeof setup>["module"],
-  error: Error,
+  error: SerializedError,
   phase: AppStartPhase
 ): Promise<void> {
   const ctx: AppStartErrorHookContext = {
@@ -526,7 +528,11 @@ describe("ErrorReportModule — startup failure report", () => {
       configOverrides: { "log.level": "debug" },
     });
 
-    await runStartupErrorHook(module, new Error("Failed to start IDE server"), "start");
+    await runStartupErrorHook(
+      module,
+      toSerializedError(new Error("Failed to start IDE server")),
+      "start"
+    );
 
     const captured = boundary.$.capturedEvents.find((e) => e.event === "$exception");
     expect(captured).toBeDefined();
@@ -544,7 +550,7 @@ describe("ErrorReportModule — startup failure report", () => {
   it("does NOT report when telemetry is off", async () => {
     const { module, boundary } = setup({ telemetryEnabled: false });
 
-    await runStartupErrorHook(module, new Error("boom"), "start");
+    await runStartupErrorHook(module, toSerializedError(new Error("boom")), "start");
 
     expect(boundary.$.capturedEvents).toHaveLength(0);
     expect(boundary.$.shutdownCalled).toBe(false);

--- a/src/modules/error-report-module.ts
+++ b/src/modules/error-report-module.ts
@@ -73,6 +73,7 @@ import {
   EVENT_BUG_REPORT_SUBMITTED,
   type BugReportSubmittedEvent,
 } from "../intents/submit-bug-report";
+import { fromSerializedError } from "../shared/error-utils";
 
 // =============================================================================
 // Constants
@@ -324,10 +325,10 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
         defaultId: 0,
       })
       .then(() =>
-        deps.dispatcher.dispatch({
+        deps.dispatcher.dispatch<AppShutdownIntent>({
           type: INTENT_APP_SHUTDOWN,
           payload: {},
-        } as AppShutdownIntent)
+        })
       )
       .catch(() => {
         // Dialog failure must not mask the crash; log + report already happened.
@@ -394,10 +395,10 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
         // Log-gathering lives in the bug-report:submitted handler, so the
         // dialog only forwards the description. Fire-and-forget: the dialog
         // closes immediately (the awaited flush happens in the subscriber).
-        void deps.dispatcher.dispatch({
+        void deps.dispatcher.dispatch<SubmitBugReportIntent>({
           type: INTENT_SUBMIT_BUG_REPORT,
           payload: { description },
-        } as SubmitBugReportIntent);
+        });
 
         handle.close();
         activeHandle = null;
@@ -443,7 +444,9 @@ export function createErrorReportModule(deps: ErrorReportModuleDeps): IntentModu
             const { error, phase } = ctx as AppStartErrorHookContext;
             if (deps.telemetryEnabled.get()) {
               try {
-                await captureCrash(error, { crash_source: "startup", phase });
+                // The contract carries the failure as plain data; PostHog groups issues by
+                // reading `name`/`message`/`stack` off a real Error, so rebuild one here.
+                await captureCrash(fromSerializedError(error), { crash_source: "startup", phase });
                 await flushWithTimeout();
               } catch {
                 // Best-effort: reporting must never block or alter the fatal path.

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -37,21 +37,24 @@ import {
   GET_PROJECT_BASES_OPERATION_ID,
   INTENT_GET_PROJECT_BASES,
 } from "../intents/get-project-bases";
-import type { ListBasesHookResult } from "../intents/get-project-bases";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
   INTENT_DELETE_WORKSPACE,
+  preflightResultSchema,
+  deleteResultSchema,
 } from "../intents/delete-workspace";
 import type { DeleteWorkspaceIntent, DeletePipelineHookInput } from "../intents/delete-workspace";
-import type { DeleteHookResult, PreflightHookResult } from "../intents/delete-workspace";
+import type { DeleteHookResult } from "../intents/delete-workspace";
 import {
   GET_WORKSPACE_STATUS_OPERATION_ID,
   INTENT_GET_WORKSPACE_STATUS,
+  getStatusHookResultSchema,
 } from "../intents/get-workspace-status";
-import type { GetStatusHookInput, GetStatusHookResult } from "../intents/get-workspace-status";
+import type { GetStatusHookInput } from "../intents/get-workspace-status";
 import {
   RESOLVE_WORKSPACE_OPERATION_ID,
   INTENT_RESOLVE_WORKSPACE,
+  resolveHookResultSchema,
 } from "../intents/resolve-workspace";
 import {
   SWITCH_WORKSPACE_OPERATION_ID,
@@ -68,6 +71,8 @@ import type { ProjectId, WorkspaceName } from "../shared/api/types";
 import { createGitWorktreeWorkspaceModule } from "./git-worktree-workspace-module";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import type { WorkspacePath, ProjectPath } from "../intents/contract";
 
 // =============================================================================
 // Mock Dependencies
@@ -102,7 +107,7 @@ const openProjectOperation = createMinimalOperation<DiscoverHookResult>(
   {
     hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
+      projectPath: (ctx.intent.payload as { projectPath: ProjectPath }).projectPath,
     }),
   }
 );
@@ -114,7 +119,7 @@ const closeProjectOperation = createMinimalOperation<Record<string, never>>(
   {
     hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: (ctx.intent.payload as { projectPath: string }).projectPath,
+      projectPath: (ctx.intent.payload as { projectPath: ProjectPath }).projectPath,
       removeLocalRepo: false,
     }),
   }
@@ -127,7 +132,7 @@ const openWorkspaceOperation = createMinimalOperation<CreateHookResult>(
   {
     hookContext: (ctx) => ({
       intent: ctx.intent,
-      projectPath: (ctx.intent.payload as { projectPath?: string }).projectPath ?? "",
+      projectPath: (ctx.intent.payload as { projectPath?: ProjectPath }).projectPath ?? "",
     }),
   }
 );
@@ -146,6 +151,7 @@ const preflightSchemas = {
   type: INTENT_DELETE_WORKSPACE,
   payload: z.custom<DeleteWorkspaceIntent["payload"]>(),
   result: z.custom<PreflightResult>(),
+  hooks: { preflight: { result: preflightResultSchema } },
 } satisfies OperationSchemas;
 
 const minimalPreflightOperation: Operation<typeof preflightSchemas> = {
@@ -167,15 +173,12 @@ const minimalPreflightOperation: Operation<typeof preflightSchemas> = {
 
     const preflightInput: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: resolvedProjectPath,
+      projectPath: projPath(resolvedProjectPath),
       workspacePath: payload.workspacePath,
       workspaceName: "test-workspace" as WorkspaceName,
       active: false,
     };
-    const { results, errors } = await ctx.hooks.collect<PreflightHookResult>(
-      "preflight",
-      preflightInput
-    );
+    const { results, errors } = await ctx.hooks.collect("preflight", preflightInput);
     if (errors.length > 0) return { error: errors[0]!.message };
     return results[0] ?? {};
   },
@@ -193,6 +196,7 @@ const deleteWorkspaceSchemas = {
   type: INTENT_DELETE_WORKSPACE,
   payload: z.custom<DeleteWorkspaceIntent["payload"]>(),
   result: z.custom<DeleteResult>(),
+  hooks: { delete: { result: deleteResultSchema } },
 } satisfies OperationSchemas;
 
 const minimalDeleteWorkspaceOperation: Operation<typeof deleteWorkspaceSchemas> = {
@@ -216,13 +220,15 @@ const minimalDeleteWorkspaceOperation: Operation<typeof deleteWorkspaceSchemas> 
     // delete (enriched with both paths, matching real operation's DeletePipelineHookInput)
     const deleteInput: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: resolvedProjectPath,
+      projectPath: projPath(resolvedProjectPath),
       workspacePath: payload.workspacePath,
       workspaceName: "test-workspace" as WorkspaceName,
       active: false,
     };
-    const { results: deleteResults, errors: deleteErrors } =
-      await ctx.hooks.collect<DeleteHookResult>("delete", deleteInput);
+    const { results: deleteResults, errors: deleteErrors } = await ctx.hooks.collect(
+      "delete",
+      deleteInput
+    );
     if (deleteErrors.length > 0 && !payload.force) throw deleteErrors[0]!;
 
     return {
@@ -234,7 +240,7 @@ const minimalDeleteWorkspaceOperation: Operation<typeof deleteWorkspaceSchemas> 
 
 /** Result from workspace path resolution (reverse lookup: workspacePath → projectPath + workspaceName). */
 interface ResolveResult {
-  readonly projectPath?: string | undefined;
+  readonly projectPath?: ProjectPath | undefined;
   readonly workspaceName?: string | undefined;
 }
 
@@ -249,21 +255,19 @@ const resolveWorkspaceSchemas = {
   type: INTENT_RESOLVE_WORKSPACE,
   payload: z.unknown(),
   result: z.custom<ResolveResult>(),
+  hooks: { resolve: { result: resolveHookResultSchema } },
 } satisfies OperationSchemas;
 
 const minimalResolveWorkspaceOperation: Operation<typeof resolveWorkspaceSchemas> = {
   id: RESOLVE_WORKSPACE_OPERATION_ID,
   schemas: resolveWorkspaceSchemas,
   async execute(ctx): Promise<ResolveResult> {
-    const payload = ctx.intent.payload as { workspacePath: string };
+    const payload = ctx.intent.payload as { workspacePath: WorkspacePath };
     const resolveInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
     };
-    const { results: resolveResults } = await ctx.hooks.collect<{
-      projectPath?: string;
-      workspaceName?: string;
-    }>("resolve", resolveInput);
+    const { results: resolveResults } = await ctx.hooks.collect("resolve", resolveInput);
     const projectPath = resolveResults[0]?.projectPath;
     const workspaceName = resolveResults[0]?.workspaceName;
     return projectPath ? { projectPath, workspaceName } : {};
@@ -292,7 +296,7 @@ const minimalGetProjectBasesOperation: Operation<typeof getProjectBasesSchemas> 
   schemas: getProjectBasesSchemas,
   async execute(ctx): Promise<GetProjectBasesTestResult> {
     const payload = ctx.intent.payload as {
-      projectPath: string;
+      projectPath: ProjectPath;
       hookPoint?: "list" | "refresh";
     };
     const hookCtx = { intent: ctx.intent, projectPath: payload.projectPath };
@@ -304,7 +308,7 @@ const minimalGetProjectBasesOperation: Operation<typeof getProjectBasesSchemas> 
     }
 
     // Default: list
-    const { results, errors } = await ctx.hooks.collect<ListBasesHookResult>("list", hookCtx);
+    const { results, errors } = await ctx.hooks.collect("list", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
   },
@@ -324,13 +328,14 @@ const getStatusSchemas = {
   type: INTENT_GET_WORKSPACE_STATUS,
   payload: z.unknown(),
   result: z.custom<GetStatusResult>(),
+  hooks: { get: { result: getStatusHookResultSchema } },
 } satisfies OperationSchemas;
 
 const minimalGetStatusOperation: Operation<typeof getStatusSchemas> = {
   id: GET_WORKSPACE_STATUS_OPERATION_ID,
   schemas: getStatusSchemas,
   async execute(ctx): Promise<GetStatusResult> {
-    const payload = ctx.intent.payload as { workspacePath: string };
+    const payload = ctx.intent.payload as { workspacePath: WorkspacePath };
 
     // Dispatch workspace:resolve (matching real operation)
     const resolved = (await ctx.dispatch({
@@ -344,9 +349,9 @@ const minimalGetStatusOperation: Operation<typeof getStatusSchemas> = {
     // get
     const getInput: GetStatusHookInput = {
       intent: ctx.intent,
-      workspacePath: payload.workspacePath,
+      workspacePath: wsPath(payload.workspacePath),
     };
-    const { results, errors } = await ctx.hooks.collect<GetStatusHookResult>("get", getInput);
+    const { results, errors } = await ctx.hooks.collect("get", getInput);
     if (errors.length > 0) throw errors[0]!;
 
     let isDirty = false;
@@ -459,7 +464,7 @@ function createPreflightTestSetup(): Omit<TestSetup, "module"> {
 // Test Helpers
 // =============================================================================
 
-function makeWorkspace(name: string, projectPath: string): Workspace {
+function makeWorkspace(name: string, projectPath: ProjectPath): Workspace {
   return {
     name,
     path: new Path(`${projectPath}/.worktrees/${name}`),
@@ -472,7 +477,7 @@ function makeWorkspace(name: string, projectPath: string): Workspace {
 
 async function dispatchOpenProject(
   dispatcher: Dispatcher,
-  projectPath: string
+  projectPath: ProjectPath
 ): Promise<DiscoverHookResult> {
   return (await dispatcher.dispatch({
     type: "project:open",
@@ -480,7 +485,10 @@ async function dispatchOpenProject(
   } as Intent)) as DiscoverHookResult;
 }
 
-async function dispatchCloseProject(dispatcher: Dispatcher, projectPath: string): Promise<void> {
+async function dispatchCloseProject(
+  dispatcher: Dispatcher,
+  projectPath: ProjectPath
+): Promise<void> {
   await dispatcher.dispatch({
     type: "project:close",
     payload: { projectPath },
@@ -489,7 +497,7 @@ async function dispatchCloseProject(dispatcher: Dispatcher, projectPath: string)
 
 async function dispatchResolveWorkspace(
   dispatcher: Dispatcher,
-  workspacePath: string
+  workspacePath: WorkspacePath
 ): Promise<ResolveResult> {
   return (await dispatcher.dispatch({
     type: "workspace:resolve",
@@ -499,7 +507,7 @@ async function dispatchResolveWorkspace(
 
 async function dispatchListBases(
   dispatcher: Dispatcher,
-  projectPath: string
+  projectPath: ProjectPath
 ): Promise<GetProjectBasesTestResult> {
   return (await dispatcher.dispatch({
     type: "project:get-bases",
@@ -507,7 +515,10 @@ async function dispatchListBases(
   } as Intent)) as GetProjectBasesTestResult;
 }
 
-async function dispatchRefreshBases(dispatcher: Dispatcher, projectPath: string): Promise<void> {
+async function dispatchRefreshBases(
+  dispatcher: Dispatcher,
+  projectPath: ProjectPath
+): Promise<void> {
   await dispatcher.dispatch({
     type: "project:get-bases",
     payload: { projectPath, hookPoint: "refresh" },
@@ -516,7 +527,7 @@ async function dispatchRefreshBases(dispatcher: Dispatcher, projectPath: string)
 
 async function dispatchGetStatus(
   dispatcher: Dispatcher,
-  workspacePath: string
+  workspacePath: WorkspacePath
 ): Promise<GetStatusResult> {
   return (await dispatcher.dispatch({
     type: "workspace:get-status",
@@ -556,7 +567,7 @@ async function dispatchListWorkspaces(dispatcher: Dispatcher): Promise<ListWorks
 
 async function dispatchPreflight(
   dispatcher: Dispatcher,
-  workspacePath: string
+  workspacePath: WorkspacePath
 ): Promise<PreflightResult> {
   const intent: DeleteWorkspaceIntent = {
     type: "workspace:delete",
@@ -583,13 +594,13 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("open-project -> discover", () => {
     it("registers project, discovers workspaces, returns them", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws1 = makeWorkspace("feature-1", projectPath);
-      const ws2 = makeWorkspace("feature-2", projectPath);
+      const ws1 = makeWorkspace("feature-1", projPath(projectPath));
+      const ws2 = makeWorkspace("feature-2", projPath(projectPath));
       provider.discover.mockResolvedValue([ws1, ws2]);
 
-      const result = await dispatchOpenProject(dispatcher, projectPath);
+      const result = await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       expect(provider.registerProject).toHaveBeenCalledWith(
         new Path(projectPath),
@@ -604,18 +615,18 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
     it("calls fire-and-forget cleanupOrphanedWorkspaces", async () => {
       const { dispatcher, provider } = setup;
 
-      await dispatchOpenProject(dispatcher, "/projects/my-app");
+      await dispatchOpenProject(dispatcher, projPath("/projects/my-app"));
 
       expect(provider.cleanupOrphanedWorkspaces).toHaveBeenCalledWith(new Path("/projects/my-app"));
     });
 
     it("caches the default base from discover and surfaces it via list-workspaces", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
       provider.discover.mockResolvedValue([]);
       provider.defaultBase.mockResolvedValue("origin/main");
 
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
       const listed = await dispatchListWorkspaces(dispatcher);
 
       const entry = listed.entries!.find((e) => e.projectPath === new Path(projectPath).toString());
@@ -630,34 +641,34 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("close-project -> close", () => {
     it("unregisters project and clears state", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
       // Open first
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // Close
-      await dispatchCloseProject(dispatcher, projectPath);
+      await dispatchCloseProject(dispatcher, projPath(projectPath));
 
       expect(provider.unregisterProject).toHaveBeenCalledWith(new Path(projectPath));
 
       // Subsequent resolve should return empty (no projectPath)
       const resolveResult = await dispatchResolveWorkspace(
         dispatcher,
-        `${projectPath}/.worktrees/feature-1`
+        wsPath(`${projectPath}/.worktrees/feature-1`)
       );
       expect(resolveResult.projectPath).toBeUndefined();
     });
 
     it("contributes the project's workspaces to the close resolve hook", async () => {
       const { dispatcher, provider, module } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
       provider.discover.mockResolvedValue([
-        makeWorkspace("feature-1", projectPath),
-        makeWorkspace("feature-2", projectPath),
+        makeWorkspace("feature-1", projPath(projectPath)),
+        makeWorkspace("feature-2", projPath(projectPath)),
       ]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // The CloseProjectOperation collects this hook to drive its
       // per-workspace teardown (and the close confirm dialog's count).
@@ -682,11 +693,11 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
     describe("new workspace", () => {
       it("calls createWorkspace and updates state", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         // Open project first
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         // Mock createWorkspace
         const createdWs: Workspace = {
@@ -718,7 +729,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         expect(result.branch).toBe("new-feature");
 
         // Verify state was updated (resolve should find it)
-        const resolveResult = await dispatchResolveWorkspace(dispatcher, "/workspaces/new-feature");
+        const resolveResult = await dispatchResolveWorkspace(
+          dispatcher,
+          wsPath("/workspaces/new-feature")
+        );
         expect(resolveResult.projectPath).toBe(projectPath);
       });
     });
@@ -726,11 +740,11 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
     describe("existing workspace", () => {
       it("skips provider call and updates state", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         // Open project first
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         const createIntent: OpenWorkspaceIntent = {
           type: "workspace:open",
@@ -739,7 +753,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
             base: "origin/main",
             projectPath,
             existingWorkspace: {
-              path: "/workspaces/existing-ws",
+              path: wsPath("/workspaces/existing-ws"),
               name: "existing-ws",
               branch: "existing-ws",
               metadata: { base: "origin/main" },
@@ -754,7 +768,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         expect(result.branch).toBe("existing-ws");
 
         // Verify state was updated
-        const resolveResult = await dispatchResolveWorkspace(dispatcher, "/workspaces/existing-ws");
+        const resolveResult = await dispatchResolveWorkspace(
+          dispatcher,
+          wsPath("/workspaces/existing-ws")
+        );
         expect(resolveResult.projectPath).toBe(projectPath);
       });
     });
@@ -762,10 +779,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
     describe("base resolution", () => {
       it("resolves default base via defaultBase() when base is omitted", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         provider.defaultBase.mockResolvedValue("origin/main");
 
@@ -799,10 +816,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       it("throws when base is omitted and no default branch exists", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         provider.defaultBase.mockResolvedValue(undefined);
 
@@ -821,10 +838,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       it("includes base branch in error when createWorkspace fails", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         provider.createWorkspace.mockRejectedValue(
           new Error("Failed to create branch focus-test-1: fatal: not a valid object name: 'main'")
@@ -846,10 +863,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       it("uses explicit base without calling defaultBase()", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         const createdWs: Workspace = {
           name: "explicit-base",
@@ -883,10 +900,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       it("returns resolvedBase for existing workspace path", async () => {
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
 
         provider.discover.mockResolvedValue([]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         const createIntent: OpenWorkspaceIntent = {
           type: "workspace:open",
@@ -895,7 +912,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
             base: "origin/main",
             projectPath,
             existingWorkspace: {
-              path: "/workspaces/existing-ws",
+              path: wsPath("/workspaces/existing-ws"),
               name: "existing-ws",
               branch: "existing-ws",
               metadata: { base: "origin/main" },
@@ -918,11 +935,11 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       d: Dispatcher,
       p: ReturnType<typeof createMockGitWorktreeProvider>
     ) {
-      const projectPath = "/projects/my-app";
-      const ws = makeWorkspace("feature-1", projectPath);
+      const projectPath = projPath("/projects/my-app");
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       p.discover.mockResolvedValue([ws]);
 
-      await dispatchOpenProject(d, projectPath);
+      await dispatchOpenProject(d, projPath(projectPath));
 
       return { projectPath, ws };
     }
@@ -934,7 +951,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
         const result = await dispatchResolveWorkspace(
           dispatcher,
-          `${projectPath}/.worktrees/feature-1`
+          wsPath(`${projectPath}/.worktrees/feature-1`)
         );
         expect(result.projectPath).toBe(projectPath);
       });
@@ -943,7 +960,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const { dispatcher, provider } = setup;
         await setupWithWorkspace(dispatcher, provider);
 
-        const result = await dispatchResolveWorkspace(dispatcher, "/nonexistent/path");
+        const result = await dispatchResolveWorkspace(dispatcher, wsPath("/nonexistent/path"));
         expect(result.projectPath).toBeUndefined();
       });
 
@@ -953,7 +970,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         // branch-cased name ("SDK-214") and breaks the renderer's
         // case-sensitive name matching for metadata updates.
         const { dispatcher, provider } = setup;
-        const projectPath = "/projects/my-app";
+        const projectPath = projPath("/projects/my-app");
         const ws: Workspace = {
           name: "SDK-214",
           path: new Path(`${projectPath}/.worktrees/sdk-214`),
@@ -961,11 +978,11 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
           metadata: { base: "origin/main" },
         };
         provider.discover.mockResolvedValue([ws]);
-        await dispatchOpenProject(dispatcher, projectPath);
+        await dispatchOpenProject(dispatcher, projPath(projectPath));
 
         const result = await dispatchResolveWorkspace(
           dispatcher,
-          `${projectPath}/.worktrees/sdk-214`
+          wsPath(`${projectPath}/.worktrees/sdk-214`)
         );
         expect(result.workspaceName).toBe("SDK-214");
       });
@@ -979,7 +996,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const deleteIntent: DeleteWorkspaceIntent = {
           type: "workspace:delete",
           payload: {
-            workspacePath: ws.path.toString(),
+            workspacePath: wsPath(ws.path.toString()),
             keepBranch: false,
             force: false,
             removeWorktree: true,
@@ -998,7 +1015,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const deleteIntent: DeleteWorkspaceIntent = {
           type: "workspace:delete",
           payload: {
-            workspacePath: ws.path.toString(),
+            workspacePath: wsPath(ws.path.toString()),
             keepBranch: true,
             force: false,
             removeWorktree: false,
@@ -1017,7 +1034,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const deleteIntent: DeleteWorkspaceIntent = {
           type: "workspace:delete",
           payload: {
-            workspacePath: ws.path.toString(),
+            workspacePath: wsPath(ws.path.toString()),
             keepBranch: false,
             force: false,
             removeWorktree: true,
@@ -1029,7 +1046,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         // Workspace should no longer be resolvable
         const resolveResult = await dispatchResolveWorkspace(
           dispatcher,
-          `${projectPath}/.worktrees/feature-1`
+          wsPath(`${projectPath}/.worktrees/feature-1`)
         );
         expect(resolveResult.projectPath).toBeUndefined();
       });
@@ -1045,7 +1062,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         const deleteIntent: DeleteWorkspaceIntent = {
           type: "workspace:delete",
           payload: {
-            workspacePath: ws.path.toString(),
+            workspacePath: wsPath(ws.path.toString()),
             keepBranch: false,
             force: true,
             removeWorktree: true,
@@ -1059,7 +1076,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         // Workspace should still be unregistered from state
         const resolveResult = await dispatchResolveWorkspace(
           dispatcher,
-          `${projectPath}/.worktrees/feature-1`
+          wsPath(`${projectPath}/.worktrees/feature-1`)
         );
         expect(resolveResult.projectPath).toBeUndefined();
       });
@@ -1073,7 +1090,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("get-project-bases -> list", () => {
     it("returns bases and defaultBaseBranch from provider", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
       const bases = [
         { name: "origin/main", isRemote: true, base: "origin/main" },
@@ -1082,7 +1099,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       provider.listBases.mockResolvedValue(bases);
       provider.defaultBase.mockResolvedValue("origin/main");
 
-      const result = await dispatchListBases(dispatcher, projectPath);
+      const result = await dispatchListBases(dispatcher, projPath(projectPath));
 
       expect(provider.listBases).toHaveBeenCalledWith(new Path(projectPath));
       // defaultBase reuses the already-enumerated bases (no second listBases).
@@ -1099,9 +1116,9 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("get-project-bases -> refresh", () => {
     it("calls updateBases on provider", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      await dispatchRefreshBases(dispatcher, projectPath);
+      await dispatchRefreshBases(dispatcher, projPath(projectPath));
 
       expect(provider.updateBases).toHaveBeenCalledWith(new Path(projectPath));
     });
@@ -1114,15 +1131,15 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("get-workspace-status -> get", () => {
     it("calls isDirty and returns result", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       provider.isDirty.mockResolvedValue(true);
 
-      const result = await dispatchGetStatus(dispatcher, ws.path.toString());
+      const result = await dispatchGetStatus(dispatcher, wsPath(ws.path.toString()));
 
       expect(provider.isDirty).toHaveBeenCalledWith(ws.path);
       expect(result.isDirty).toBe(true);
@@ -1130,15 +1147,15 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
     it("returns isDirty=false when workspace is clean", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       provider.isDirty.mockResolvedValue(false);
 
-      const result = await dispatchGetStatus(dispatcher, ws.path.toString());
+      const result = await dispatchGetStatus(dispatcher, wsPath(ws.path.toString()));
 
       expect(result.isDirty).toBe(false);
     });
@@ -1151,16 +1168,16 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   describe("delete-workspace -> preflight", () => {
     it("returns isDirty and unmergedCommits from provider", async () => {
       const preflightSetup = createPreflightTestSetup();
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       preflightSetup.provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(preflightSetup.dispatcher, projectPath);
+      await dispatchOpenProject(preflightSetup.dispatcher, projPath(projectPath));
 
       preflightSetup.provider.isDirty.mockResolvedValue(true);
       preflightSetup.provider.countUnmergedCommits.mockResolvedValue(3);
 
-      const result = await dispatchPreflight(preflightSetup.dispatcher, ws.path.toString());
+      const result = await dispatchPreflight(preflightSetup.dispatcher, wsPath(ws.path.toString()));
 
       expect(result.isDirty).toBe(true);
       expect(result.unmergedCommits).toBe(3);
@@ -1168,15 +1185,15 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
     it("returns error when provider throws", async () => {
       const preflightSetup = createPreflightTestSetup();
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       preflightSetup.provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(preflightSetup.dispatcher, projectPath);
+      await dispatchOpenProject(preflightSetup.dispatcher, projPath(projectPath));
 
       preflightSetup.provider.isDirty.mockRejectedValue(new Error("git failed"));
 
-      const result = await dispatchPreflight(preflightSetup.dispatcher, ws.path.toString());
+      const result = await dispatchPreflight(preflightSetup.dispatcher, wsPath(ws.path.toString()));
 
       expect(result.error).toBe("git failed");
     });
@@ -1191,10 +1208,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       d: Dispatcher,
       p: ReturnType<typeof createMockGitWorktreeProvider>
     ) {
-      const projectPath = "/projects/my-app";
-      const ws = makeWorkspace("feature-1", projectPath);
+      const projectPath = projPath("/projects/my-app");
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       p.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(d, projectPath);
+      await dispatchOpenProject(d, projPath(projectPath));
       return { projectPath, ws };
     }
 
@@ -1207,7 +1224,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -1218,10 +1235,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       // Re-discover project — git no longer lists the workspace
       provider.discover.mockResolvedValue([]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // Workspace should still be resolvable via deletionPending
-      const resolveResult = await dispatchResolveWorkspace(dispatcher, ws.path.toString());
+      const resolveResult = await dispatchResolveWorkspace(dispatcher, wsPath(ws.path.toString()));
       expect(resolveResult.projectPath).toBe(projectPath);
     });
 
@@ -1234,7 +1251,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -1243,7 +1260,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       await dispatchDeleteWorkspace(dispatcher, deleteIntent);
 
       // Workspace should not be resolvable
-      const resolveResult = await dispatchResolveWorkspace(dispatcher, ws.path.toString());
+      const resolveResult = await dispatchResolveWorkspace(dispatcher, wsPath(ws.path.toString()));
       expect(resolveResult.projectPath).toBeUndefined();
     });
 
@@ -1256,7 +1273,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: true,
           removeWorktree: true,
@@ -1266,10 +1283,10 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       // Re-discover with empty list
       provider.discover.mockResolvedValue([]);
-      await dispatchOpenProject(dispatcher, "/projects/my-app");
+      await dispatchOpenProject(dispatcher, projPath("/projects/my-app"));
 
       // Workspace should not be resolvable (force cleared deletionPending)
-      const resolveResult = await dispatchResolveWorkspace(dispatcher, ws.path.toString());
+      const resolveResult = await dispatchResolveWorkspace(dispatcher, wsPath(ws.path.toString()));
       expect(resolveResult.projectPath).toBeUndefined();
     });
 
@@ -1282,7 +1299,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -1291,9 +1308,9 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       await dispatchDeleteWorkspace(dispatcher, deleteIntent);
 
       // Re-discover — git no longer lists the workspace, but a new one exists
-      const ws2 = makeWorkspace("feature-2", projectPath);
+      const ws2 = makeWorkspace("feature-2", projPath(projectPath));
       provider.discover.mockResolvedValue([ws2]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // list-workspaces should include both: feature-2 from git + feature-1 from deletionPending
       const listResult = await dispatchListWorkspaces(dispatcher);
@@ -1312,7 +1329,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -1322,7 +1339,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
       // Re-discover without the deleted workspace
       provider.discover.mockResolvedValue([]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // find-candidates should still include the deletion-pending workspace
       const result = await dispatchFindCandidates(dispatcher);
@@ -1339,7 +1356,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       const deleteIntent: DeleteWorkspaceIntent = {
         type: "workspace:delete",
         payload: {
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -1348,14 +1365,14 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       await dispatchDeleteWorkspace(dispatcher, deleteIntent);
 
       // Close project — should clear deletionPending too
-      await dispatchCloseProject(dispatcher, projectPath);
+      await dispatchCloseProject(dispatcher, projPath(projectPath));
 
       // Re-open with empty list
       provider.discover.mockResolvedValue([]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       // Workspace should not be resolvable (close cleared deletionPending)
-      const resolveResult = await dispatchResolveWorkspace(dispatcher, ws.path.toString());
+      const resolveResult = await dispatchResolveWorkspace(dispatcher, wsPath(ws.path.toString()));
       expect(resolveResult.projectPath).toBeUndefined();
     });
   });
@@ -1386,18 +1403,18 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
     it("updates metadata when a key is set", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       const event: MetadataChangedEvent = {
         type: EVENT_METADATA_CHANGED,
         payload: {
           projectId: "test-project" as ProjectId,
           workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           key: "auto-workspace.tracked",
           value: "true",
         },
@@ -1415,7 +1432,7 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
     it("removes metadata key when value is null", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
       const ws: Workspace = {
         name: "feature-1",
@@ -1424,14 +1441,14 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
         metadata: { base: "origin/main", "auto-workspace.tracked": "true" },
       };
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       const event: MetadataChangedEvent = {
         type: EVENT_METADATA_CHANGED,
         payload: {
           projectId: "test-project" as ProjectId,
           workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: ws.path.toString(),
+          workspacePath: wsPath(ws.path.toString()),
           key: "auto-workspace.tracked",
           value: null,
         },
@@ -1446,18 +1463,18 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
 
     it("ignores event for unknown workspace path", async () => {
       const { dispatcher, provider } = setup;
-      const projectPath = "/projects/my-app";
+      const projectPath = projPath("/projects/my-app");
 
-      const ws = makeWorkspace("feature-1", projectPath);
+      const ws = makeWorkspace("feature-1", projPath(projectPath));
       provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(dispatcher, projectPath);
+      await dispatchOpenProject(dispatcher, projPath(projectPath));
 
       const event: MetadataChangedEvent = {
         type: EVENT_METADATA_CHANGED,
         payload: {
           projectId: "test-project" as ProjectId,
           workspaceName: "unknown" as WorkspaceName,
-          workspacePath: "/nonexistent/workspace",
+          workspacePath: wsPath("/nonexistent/workspace"),
           key: "auto-workspace.tracked",
           value: "true",
         },

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -72,6 +72,9 @@ import { Path } from "../utils/path/path";
 import { getErrorMessage, WorkspaceError } from "../shared/errors/service-errors";
 import type { DomainEvent } from "../intents/lib/types";
 import { EVENT_METADATA_CHANGED, type MetadataChangedEvent } from "../intents/set-metadata";
+import { projectPathSchema, workspacePathSchema } from "../intents/contract";
+import type { ProjectPath, WorkspacePath } from "../intents/contract";
+import { toDiscoveredWorkspaces } from "../utils/workspace-conversion";
 
 // =============================================================================
 // Module Factory
@@ -91,24 +94,38 @@ export function createGitWorktreeWorkspaceModule(
   logger: Logger
 ): IntentModule {
   // Internal state
-  const workspaces = new Map<string, Workspace[]>();
-  const deletionPending = new Map<string, { projectPath: string; workspace: Workspace }>();
+  // Keyed by branded paths: these maps feed hook results directly, so keeping the brand on
+  // the key means a project/workspace path never has to be re-minted on the way out.
+  const workspaces = new Map<ProjectPath, Workspace[]>();
+  const deletionPending = new Map<
+    WorkspacePath,
+    { projectPath: ProjectPath; workspace: Workspace }
+  >();
   // Per-project default base branch, computed at project:open (discover) and
   // refreshed by the get-project-bases list hook. Surfaced via list-workspaces
   // so the creation form can seed the base field without a git round-trip.
-  const projectDefaults = new Map<string, string>();
+  const projectDefaults = new Map<ProjectPath, string>();
 
   // ---------------------------------------------------------------------------
   // Private Helpers
   // ---------------------------------------------------------------------------
 
   /**
+   * Normalize a path and keep its brand. `new Path(p).toString()` is how this module
+   * canonicalizes its map keys, but it returns a plain string — parsing re-mints the brand so
+   * a key can go straight back onto a hook result without a cast.
+   */
+  const projectKey = (p: string): ProjectPath => projectPathSchema.parse(new Path(p).toString());
+  const workspaceKey = (p: string): WorkspacePath =>
+    workspacePathSchema.parse(new Path(p).toString());
+
+  /**
    * Shared reverse-lookup: workspacePath → (projectPath, workspaceName).
    * Used by the resolve-workspace operation.
    */
-  function resolveFromWorkspacePath(workspacePath: string):
+  function resolveFromWorkspacePath(workspacePath: WorkspacePath):
     | {
-        projectPath: string;
+        projectPath: ProjectPath;
         workspaceName: WorkspaceName;
         branch: string | null;
         metadata: Readonly<Record<string, string>>;
@@ -135,8 +152,11 @@ export function createGitWorktreeWorkspaceModule(
     return undefined;
   }
 
-  function unregisterWorkspaceFromState(projectPath: string, workspacePath: string): void {
-    const key = new Path(projectPath).toString();
+  function unregisterWorkspaceFromState(
+    projectPath: ProjectPath,
+    workspacePath: WorkspacePath
+  ): void {
+    const key = projectKey(projectPath);
     const projectWorkspaces = workspaces.get(key);
     if (!projectWorkspaces) return;
 
@@ -147,9 +167,9 @@ export function createGitWorktreeWorkspaceModule(
     }
   }
 
-  function addToDeletionPending(projectPath: string, workspacePath: string): void {
-    const key = new Path(projectPath).toString();
-    const normalizedWsPath = new Path(workspacePath).toString();
+  function addToDeletionPending(projectPath: ProjectPath, workspacePath: WorkspacePath): void {
+    const key = projectKey(projectPath);
+    const normalizedWsPath = workspaceKey(workspacePath);
     const wsList = workspaces.get(key);
     if (!wsList) return;
     const ws = wsList.find((w) => w.path.toString() === normalizedWsPath);
@@ -157,8 +177,8 @@ export function createGitWorktreeWorkspaceModule(
     deletionPending.set(normalizedWsPath, { projectPath: key, workspace: ws });
   }
 
-  function removeFromDeletionPending(workspacePath: string): void {
-    const normalizedWsPath = new Path(workspacePath).toString();
+  function removeFromDeletionPending(workspacePath: WorkspacePath): void {
+    const normalizedWsPath = workspaceKey(workspacePath);
     deletionPending.delete(normalizedWsPath);
   }
 
@@ -166,8 +186,8 @@ export function createGitWorktreeWorkspaceModule(
    * Returns the full workspace list: git cache merged with deletion-pending entries.
    * This is the single source of truth for resolve/list/find-candidates consumers.
    */
-  function getMergedWorkspaces(): Map<string, Workspace[]> {
-    const merged = new Map<string, Workspace[]>();
+  function getMergedWorkspaces(): Map<ProjectPath, Workspace[]> {
+    const merged = new Map<ProjectPath, Workspace[]>();
     const seen = new Set<string>();
 
     for (const [key, wsList] of workspaces) {
@@ -212,7 +232,7 @@ export function createGitWorktreeWorkspaceModule(
             const workspacesDir = pathProvider.getProjectWorkspacesDir(projectPathObj);
 
             gitWorktreeProvider.registerProject(projectPathObj, workspacesDir);
-            const key = projectPathObj.toString();
+            const key = projectKey(projectPathObj.toString());
 
             const discovered = await gitWorktreeProvider.discover(projectPathObj);
             workspaces.set(key, [...discovered]);
@@ -234,7 +254,7 @@ export function createGitWorktreeWorkspaceModule(
 
             return {
               result: {
-                workspaces: discovered,
+                workspaces: toDiscoveredWorkspaces(discovered),
                 ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
               },
             };
@@ -250,12 +270,14 @@ export function createGitWorktreeWorkspaceModule(
         resolve: {
           handler: async (ctx: HookContext): Promise<HookOutput<CloseResolveHookResult>> => {
             const intent = ctx.intent as CloseProjectIntent;
-            const key = new Path(intent.payload.projectPath).toString();
+            const key = projectKey(intent.payload.projectPath);
             const list = workspaces.get(key) ?? [];
-            // IPC-shaped contract: paths cross the hook boundary as strings.
+            // The contract carries paths as plain branded data, not `Path` instances.
             return {
               result: {
-                workspaces: list.map((workspace) => ({ path: workspace.path.toString() })),
+                workspaces: list.map((workspace) => ({
+                  path: workspaceKey(workspace.path.toString()),
+                })),
               },
             };
           },
@@ -266,7 +288,7 @@ export function createGitWorktreeWorkspaceModule(
             const projectPathObj = new Path(projectPath);
 
             gitWorktreeProvider.unregisterProject(projectPathObj);
-            const key = projectPathObj.toString();
+            const key = projectKey(projectPathObj.toString());
             workspaces.delete(key);
             projectDefaults.delete(key);
 
@@ -297,7 +319,7 @@ export function createGitWorktreeWorkspaceModule(
               const branch = existing.branch ?? existing.name;
               const metadata = existing.metadata;
 
-              const key = new Path(projectPath).toString();
+              const key = projectKey(projectPath);
               const projectWorkspaces = workspaces.get(key) ?? [];
 
               // Avoid duplicates
@@ -352,7 +374,7 @@ export function createGitWorktreeWorkspaceModule(
             }
 
             // Update state
-            const key = projectPathObj.toString();
+            const key = projectKey(projectPathObj.toString());
             const projectWorkspaces = workspaces.get(key) ?? [];
 
             const normalizedPath = internalWorkspace.path.toString();
@@ -367,7 +389,7 @@ export function createGitWorktreeWorkspaceModule(
 
             return {
               result: {
-                workspacePath: internalWorkspace.path.toString(),
+                workspacePath: workspaceKey(internalWorkspace.path.toString()),
                 branch: internalWorkspace.branch ?? internalWorkspace.name,
                 metadata: internalWorkspace.metadata,
                 resolvedBase: base,
@@ -389,7 +411,7 @@ export function createGitWorktreeWorkspaceModule(
             const bases = await gitWorktreeProvider.listBases(projectPathObj);
             const defaultBaseBranch = await gitWorktreeProvider.defaultBase(projectPathObj, bases);
             if (defaultBaseBranch !== undefined) {
-              projectDefaults.set(projectPathObj.toString(), defaultBaseBranch);
+              projectDefaults.set(projectKey(projectPathObj.toString()), defaultBaseBranch);
             }
 
             return {
@@ -467,9 +489,9 @@ export function createGitWorktreeWorkspaceModule(
         "find-candidates": {
           handler: async (): Promise<HookOutput<FindCandidatesHookResult>> => {
             const candidates: Array<{
-              projectPath: string;
+              projectPath: ProjectPath;
               projectName: string;
-              workspacePath: string;
+              workspacePath: WorkspacePath;
               workspaceName: string;
               hibernated?: boolean;
             }> = [];
@@ -480,7 +502,7 @@ export function createGitWorktreeWorkspaceModule(
                 candidates.push({
                   projectPath: key,
                   projectName,
-                  workspacePath: ws.path.toString(),
+                  workspacePath: workspaceKey(ws.path.toString()),
                   workspaceName: ws.name,
                   ...(hibernated && { hibernated: true }),
                 });
@@ -514,7 +536,7 @@ export function createGitWorktreeWorkspaceModule(
               const defaultBaseBranch = projectDefaults.get(key);
               entries.push({
                 projectPath: key,
-                workspaces: wsList,
+                workspaces: toDiscoveredWorkspaces(wsList),
                 ...(defaultBaseBranch !== undefined && { defaultBaseBranch }),
               });
             }

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -31,7 +31,12 @@ import type {
 } from "../../intents/lib/operation";
 import type { IntentModule } from "../../intents/lib/module";
 import { createMinimalOperation } from "../../intents/lib/operation.test-utils";
-import { APP_START_OPERATION_ID, INTENT_APP_START } from "../../intents/app-start";
+import {
+  APP_START_OPERATION_ID,
+  INTENT_APP_START,
+  configureResultSchema,
+  checkDepsResultSchema,
+} from "../../intents/app-start";
 import type {
   CheckDepsHookContext,
   CheckDepsResult,
@@ -52,12 +57,12 @@ import type {
   ExtensionsHookInput,
   SetupProgressPayload,
 } from "../../intents/setup";
-import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../../intents/open-workspace";
-import type {
-  FinalizeHookInput,
-  FinalizeHookResult,
-  OpenWorkspaceIntent,
+import {
+  OPEN_WORKSPACE_OPERATION_ID,
+  INTENT_OPEN_WORKSPACE,
+  finalizeResultSchema,
 } from "../../intents/open-workspace";
+import type { FinalizeHookInput, OpenWorkspaceIntent } from "../../intents/open-workspace";
 import {
   DELETE_WORKSPACE_OPERATION_ID,
   INTENT_DELETE_WORKSPACE,
@@ -81,7 +86,8 @@ import { createArchiveExtractorMock } from "../../boundaries/platform/archive-ex
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
 import { Path } from "../../utils/path/path";
 import { FileSystemError, SetupError } from "../../shared/errors/service-errors";
-import type { ProjectId, WorkspaceName } from "../../shared/api/types";
+import type { WorkspaceName } from "../../shared/api/types";
+import { wsPath, projPath } from "../../shared/test-fixtures";
 
 // =============================================================================
 // Minimal Test Operations
@@ -91,6 +97,7 @@ const beforeReadySchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<readonly ConfigureResult[]>(),
+  hooks: { "before-ready": { result: configureResultSchema } },
 } satisfies OperationSchemas;
 
 class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas> {
@@ -98,9 +105,9 @@ class MinimalBeforeReadyOperation implements Operation<typeof beforeReadySchemas
   readonly schemas = beforeReadySchemas;
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>>
+    ctx: OperationContext<IntentOf<typeof beforeReadySchemas>, typeof beforeReadySchemas>
   ): Promise<readonly ConfigureResult[]> {
-    const { results, errors } = await ctx.hooks.collect<ConfigureResult>("before-ready", {
+    const { results, errors } = await ctx.hooks.collect("before-ready", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -112,6 +119,7 @@ const checkDepsSchemas = {
   type: INTENT_APP_START,
   payload: z.unknown(),
   result: z.custom<CheckDepsResult>(),
+  hooks: { "check-deps": { result: checkDepsResultSchema } },
 } satisfies OperationSchemas;
 
 class MinimalCheckDepsOperation implements Operation<typeof checkDepsSchemas> {
@@ -124,14 +132,14 @@ class MinimalCheckDepsOperation implements Operation<typeof checkDepsSchemas> {
   }
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof checkDepsSchemas>>
+    ctx: OperationContext<IntentOf<typeof checkDepsSchemas>, typeof checkDepsSchemas>
   ): Promise<CheckDepsResult> {
     const hookCtx: CheckDepsHookContext = {
       intent: ctx.intent,
       configuredAgent: "claude",
       extensionRequirements: this.extensionRequirements,
     };
-    const { results } = await ctx.hooks.collect<CheckDepsResult>("check-deps", hookCtx);
+    const { results } = await ctx.hooks.collect("check-deps", hookCtx);
     // Merge all results
     const merged: CheckDepsResult = {};
     for (const r of results) {
@@ -162,8 +170,10 @@ class MinimalStartOperation implements Operation<typeof startSchemas> {
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = startSchemas;
 
-  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | undefined> {
-    const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof startSchemas>, typeof startSchemas>
+  ): Promise<number | undefined> {
+    const { errors, capabilities } = await ctx.hooks.collect("start", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -188,7 +198,9 @@ class MinimalBinaryOperation implements Operation<typeof binarySchemas> {
     this.hookInput = hookInput;
   }
 
-  async execute(ctx: OperationContext<IntentOf<typeof binarySchemas>>): Promise<void> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof binarySchemas>, typeof binarySchemas>
+  ): Promise<void> {
     const { errors } = await ctx.hooks.collect(
       "binary",
       { intent: ctx.intent, ...this.hookInput },
@@ -219,7 +231,9 @@ class MinimalExtensionsOperation implements Operation<typeof extensionsSchemas> 
     this.hookInput = hookInput;
   }
 
-  async execute(ctx: OperationContext<IntentOf<typeof extensionsSchemas>>): Promise<void> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof extensionsSchemas>, typeof extensionsSchemas>
+  ): Promise<void> {
     const { errors } = await ctx.hooks.collect(
       "extensions",
       { intent: ctx.intent, ...this.hookInput },
@@ -237,6 +251,7 @@ const finalizeSchemas = {
   type: INTENT_OPEN_WORKSPACE,
   payload: z.unknown(),
   result: z.custom<string | undefined>(),
+  hooks: { finalize: { result: finalizeResultSchema } },
 } satisfies OperationSchemas;
 
 class MinimalFinalizeOperation implements Operation<typeof finalizeSchemas> {
@@ -249,9 +264,9 @@ class MinimalFinalizeOperation implements Operation<typeof finalizeSchemas> {
   }
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof finalizeSchemas>>
+    ctx: OperationContext<IntentOf<typeof finalizeSchemas>, typeof finalizeSchemas>
   ): Promise<string | undefined> {
-    const { errors, results } = await ctx.hooks.collect<FinalizeHookResult>("finalize", {
+    const { errors, results } = await ctx.hooks.collect("finalize", {
       intent: ctx.intent,
       workspacePath: "/test/project/.worktrees/feature-1",
       envVars: { OPENCODE_PORT: "8080" },
@@ -272,9 +287,9 @@ function createMinimalDeleteOperation() {
     {
       hookContext: (ctx): DeletePipelineHookInput => ({
         intent: ctx.intent,
-        projectPath: "/projects/test",
-        workspacePath: (ctx.intent as DeleteWorkspaceIntent).payload.workspacePath ?? "",
-        workspaceName: "test-workspace" as WorkspaceName,
+        projectPath: projPath("/test/project"),
+        workspaceName: "feature-1" as WorkspaceName,
+        workspacePath: (ctx.intent as DeleteWorkspaceIntent).payload.workspacePath,
         active: false,
       }),
       defaultResult: {},
@@ -1088,19 +1103,19 @@ describe("IdeServerModule", () => {
       // Now register finalize operation and test it
       dispatcher.registerOperation(
         new MinimalFinalizeOperation({
-          workspacePath: "/test/project/.worktrees/feature-1",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           envVars: { OPENCODE_PORT: "8080" },
         })
       );
 
-      const workspaceUrl = (await dispatcher.dispatch({
+      const workspaceUrl = (await dispatcher.dispatch<OpenWorkspaceIntent>({
         type: "workspace:open",
         payload: {
-          projectPath: "/test/project",
           workspaceName: "feature-1",
+          projectPath: projPath("/test/project"),
           base: "main",
         },
-      } as OpenWorkspaceIntent)) as unknown as string | undefined;
+      })) as unknown as string | undefined;
 
       expect(workspaceUrl).toContain("25448");
       expect(workspaceUrl).toContain("workspace=");
@@ -1146,19 +1161,19 @@ describe("IdeServerModule", () => {
       // Finalize
       dispatcher.registerOperation(
         new MinimalFinalizeOperation({
-          workspacePath: "/test/project/.worktrees/feature-1",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           envVars: {},
         })
       );
 
-      const workspaceUrl = (await dispatcher.dispatch({
+      const workspaceUrl = (await dispatcher.dispatch<OpenWorkspaceIntent>({
         type: "workspace:open",
         payload: {
-          projectPath: "/test/project",
           workspaceName: "feature-1",
+          projectPath: projPath("/test/project"),
           base: "main",
         },
-      } as OpenWorkspaceIntent)) as unknown as string | undefined;
+      })) as unknown as string | undefined;
 
       expect(workspaceUrl).toContain("25448");
       expect(workspaceUrl).toContain("folder=");
@@ -1175,18 +1190,15 @@ describe("IdeServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: "/test/project/.worktrees/feature-1",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent);
+      });
 
       expect(deps.fileSystemLayer.rm).toHaveBeenCalledWith(
         new Path("/test/project/.worktrees/feature-1.code-workspace"),
@@ -1213,18 +1225,15 @@ describe("IdeServerModule", () => {
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
       // Should not throw
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: "/test/project/.worktrees/feature-1",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           keepBranch: false,
           force: true,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as DeleteHookResult;
+      })) as DeleteHookResult;
 
       expect(result).toEqual({});
     });
@@ -1248,18 +1257,15 @@ describe("IdeServerModule", () => {
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<DeleteWorkspaceIntent>({
           type: "workspace:delete",
           payload: {
-            projectId: "test-12345678" as ProjectId,
-            workspaceName: "feature-1" as WorkspaceName,
-            workspacePath: "/test/project/.worktrees/feature-1",
-            projectPath: "/test/project",
+            workspacePath: wsPath("/test/project/.worktrees/feature-1"),
             keepBranch: false,
             force: false,
             removeWorktree: true,
           },
-        } as DeleteWorkspaceIntent)
+        })
       ).rejects.toThrow("permission denied");
     });
   });

--- a/src/modules/local-project-module.integration.test.ts
+++ b/src/modules/local-project-module.integration.test.ts
@@ -31,36 +31,42 @@ import { createLocalProjectModule, type LocalProjectModuleDeps } from "./local-p
 import {
   OPEN_PROJECT_OPERATION_ID,
   INTENT_OPEN_PROJECT,
-  type PrepareHookResult,
-  type ResolveHookResult,
-  type RegisterHookResult,
   type RegisterHookInput,
 } from "../intents/open-project";
 import type { OpenProjectIntent } from "../intents/open-project";
+import type { schemas as openProjectSchemas } from "../intents/open-project";
 import {
   CLOSE_PROJECT_OPERATION_ID,
   INTENT_CLOSE_PROJECT,
-  type CloseResolveHookResult,
-  type CloseHookResult,
   type CloseHookInput,
 } from "../intents/close-project";
 import type { CloseProjectIntent } from "../intents/close-project";
-import { APP_READY_OPERATION_ID, type LoadProjectsResult } from "../intents/app-ready";
+import type { schemas as closeProjectSchemas } from "../intents/close-project";
+import type { schemas as appReadySchemas } from "../intents/app-ready";
+import { APP_READY_OPERATION_ID } from "../intents/app-ready";
 import type { AppReadyIntent } from "../intents/app-ready";
 import { Path } from "../utils/path/path";
 import type { ProjectId } from "../shared/api/types";
-import type { HookContext, ResolvedHooks, HookResult, HookOutput } from "../intents/lib/operation";
+import type {
+  HookContext,
+  ResolvedHooks,
+  HookResult,
+  HookOutput,
+  OperationSchemas,
+} from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 import { createFileSystemMock, directory } from "../boundaries/platform/filesystem.state-mock";
 import { createMockDialogManager } from "./presentation/dialog-manager.state-mock";
 import { projectDirName } from "../boundaries/platform/paths";
 import nodePath from "path";
+import { projPath } from "../shared/test-fixtures";
+import type { ProjectPath } from "../intents/contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/test/local-project";
+const PROJECT_PATH = projPath("/test/local-project");
 const PROJECT_ID = "local-project-40b89393" as ProjectId;
 const PROJECTS_DIR = "/test/app-data/projects";
 
@@ -116,7 +122,10 @@ function createMockDeps(fsOverrides?: Parameters<typeof createFileSystemMock>[0]
  * Build a ResolvedHooks from a module's hook declarations for a given operation.
  * Calls the single handler registered for the hook point and wraps the result.
  */
-function resolveHooksFromModule(module: IntentModule, operationId: string): ResolvedHooks {
+function resolveHooksFromModule<S extends OperationSchemas>(
+  module: IntentModule,
+  operationId: string
+): ResolvedHooks<S> {
   const opHooks = module.hooks?.[operationId] ?? {};
   return {
     collect: async <T>(hookPointId: string, ctx: HookContext): Promise<HookResult<T>> => {
@@ -137,9 +146,9 @@ function resolveHooksFromModule(module: IntentModule, operationId: string): Reso
 }
 
 interface TestSetup {
-  openHooks: ResolvedHooks;
-  closeHooks: ResolvedHooks;
-  readyHooks: ResolvedHooks;
+  openHooks: ResolvedHooks<typeof openProjectSchemas>;
+  closeHooks: ResolvedHooks<typeof closeProjectSchemas>;
+  readyHooks: ResolvedHooks<typeof appReadySchemas>;
   fs: ReturnType<typeof createFileSystemMock>;
   gitWorktreeProvider: LocalProjectModuleDeps["gitWorktreeProvider"];
   dialogManager: ReturnType<typeof createMockDialogManager>;
@@ -152,8 +161,11 @@ function createTestSetup(fsOverrides?: Parameters<typeof createFileSystemMock>[0
   const module = createLocalProjectModule(deps);
 
   return {
-    openHooks: resolveHooksFromModule(module, OPEN_PROJECT_OPERATION_ID),
-    closeHooks: resolveHooksFromModule(module, CLOSE_PROJECT_OPERATION_ID),
+    openHooks: resolveHooksFromModule<typeof openProjectSchemas>(module, OPEN_PROJECT_OPERATION_ID),
+    closeHooks: resolveHooksFromModule<typeof closeProjectSchemas>(
+      module,
+      CLOSE_PROJECT_OPERATION_ID
+    ),
     readyHooks: resolveHooksFromModule(module, APP_READY_OPERATION_ID),
     fs,
     gitWorktreeProvider,
@@ -169,7 +181,7 @@ function createTestSetup(fsOverrides?: Parameters<typeof createFileSystemMock>[0
 /** Write a project config to the mock filesystem */
 function writeConfig(
   fs: ReturnType<typeof createFileSystemMock>,
-  projectPath: string,
+  projectPath: ProjectPath,
   remoteUrl?: string
 ): void {
   const dirName = projectDirName(new Path(projectPath).toString());
@@ -177,7 +189,7 @@ function writeConfig(
   const configPath = nodePath.join(configDir, "config.json");
 
   const config = {
-    path: new Path(projectPath).toString(),
+    path: projPath(new Path(projectPath).toString()),
     ...(remoteUrl !== undefined && { remoteUrl }),
   };
 
@@ -192,7 +204,7 @@ function writeConfig(
 function openLocalIntent(path: string): OpenProjectIntent {
   return {
     type: INTENT_OPEN_PROJECT,
-    payload: { path: new Path(path) },
+    payload: { path: projPath(new Path(path).toString()) },
   };
 }
 
@@ -203,7 +215,7 @@ function openGitIntent(url: string): OpenProjectIntent {
   };
 }
 
-function closeIntent(projectPath: string): CloseProjectIntent {
+function closeIntent(projectPath: ProjectPath): CloseProjectIntent {
   return {
     type: INTENT_CLOSE_PROJECT,
     payload: { projectPath },
@@ -230,20 +242,20 @@ describe("LocalProjectModule Integration", () => {
     it("validates local path and returns projectPath (#1)", async () => {
       const { openHooks, gitWorktreeProvider } = createTestSetup();
 
-      const { results, errors } = await openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await openHooks.collect("resolve", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
-      expect(results[0]).toEqual({ projectPath: new Path(PROJECT_PATH).toString() });
+      expect(results[0]).toEqual({ projectPath: projPath(new Path(PROJECT_PATH).toString()) });
       expect(gitWorktreeProvider.validateRepository).toHaveBeenCalledWith(new Path(PROJECT_PATH));
     });
 
     it("skips for git URL payloads (#2)", async () => {
       const { openHooks, gitWorktreeProvider } = createTestSetup();
 
-      const { results, errors } = await openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await openHooks.collect("resolve", {
         intent: openGitIntent("https://github.com/user/repo.git"),
       });
 
@@ -259,7 +271,7 @@ describe("LocalProjectModule Integration", () => {
         new Error("Not a git repository")
       );
 
-      const { results, errors } = await openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await openHooks.collect("resolve", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -275,14 +287,14 @@ describe("LocalProjectModule Integration", () => {
       writeConfig(setup.fs, PROJECT_PATH, "https://github.com/user/repo.git");
 
       // Resolve with local path only (no git URL) — like app startup
-      const { results, errors } = await setup.openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await setup.openHooks.collect("resolve", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       });
     });
@@ -296,20 +308,20 @@ describe("LocalProjectModule Integration", () => {
       // Register so project is in internal state
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Resolve again — should return alreadyOpen AND remoteUrl
-      const { results, errors } = await setup.openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await setup.openHooks.collect("resolve", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         alreadyOpen: true,
         remoteUrl: "https://github.com/user/repo.git",
       });
@@ -322,19 +334,19 @@ describe("LocalProjectModule Integration", () => {
       // Register a project so it's in internal state
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Resolve again — should return alreadyOpen and skip validation
-      const { results, errors } = await setup.openHooks.collect<ResolveHookResult>("resolve", {
+      const { results, errors } = await setup.openHooks.collect("resolve", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         alreadyOpen: true,
       });
       expect(setup.gitWorktreeProvider.validateRepository).not.toHaveBeenCalled();
@@ -351,10 +363,10 @@ describe("LocalProjectModule Integration", () => {
 
       const ctx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
 
-      const { results, errors } = await openHooks.collect<RegisterHookResult>("register", ctx);
+      const { results, errors } = await openHooks.collect("register", ctx);
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -376,11 +388,11 @@ describe("LocalProjectModule Integration", () => {
 
       const ctx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       };
 
-      const { results, errors } = await openHooks.collect<RegisterHookResult>("register", ctx);
+      const { results, errors } = await openHooks.collect("register", ctx);
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -404,13 +416,10 @@ describe("LocalProjectModule Integration", () => {
 
       const ctx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
 
-      const { results, errors } = await setup.openHooks.collect<RegisterHookResult>(
-        "register",
-        ctx
-      );
+      const { results, errors } = await setup.openHooks.collect("register", ctx);
 
       expect(errors).toHaveLength(0);
       expect(results[0]!.projectId).toBe(PROJECT_ID);
@@ -421,14 +430,11 @@ describe("LocalProjectModule Integration", () => {
 
       const ctx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
 
       // First registration — should persist
-      const { results: first, errors: firstErrors } = await openHooks.collect<RegisterHookResult>(
-        "register",
-        ctx
-      );
+      const { results: first, errors: firstErrors } = await openHooks.collect("register", ctx);
 
       expect(firstErrors).toHaveLength(0);
       expect(first[0]!.projectId).toBe(PROJECT_ID);
@@ -440,10 +446,7 @@ describe("LocalProjectModule Integration", () => {
       expect(fs.$.entries.has(new Path(configPath).toString())).toBe(true);
 
       // Second registration — should return alreadyOpen without re-persisting
-      const { results: second, errors: secondErrors } = await openHooks.collect<RegisterHookResult>(
-        "register",
-        ctx
-      );
+      const { results: second, errors: secondErrors } = await openHooks.collect("register", ctx);
 
       expect(secondErrors).toHaveLength(0);
       expect(second[0]!.projectId).toBe(PROJECT_ID);
@@ -463,15 +466,14 @@ describe("LocalProjectModule Integration", () => {
       // Register a project so config is written to disk
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Now resolve by projectPath - should return config data (empty for local projects without remoteUrl)
-      const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve",
-        { intent: closeIntent(PROJECT_PATH) }
-      );
+      const { results, errors } = await setup.closeHooks.collect("resolve", {
+        intent: closeIntent(PROJECT_PATH),
+      });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -482,8 +484,8 @@ describe("LocalProjectModule Integration", () => {
     it("returns empty for unknown project path (#8)", async () => {
       const { closeHooks } = createTestSetup();
 
-      const { results, errors } = await closeHooks.collect<CloseResolveHookResult>("resolve", {
-        intent: closeIntent("/unknown/project"),
+      const { results, errors } = await closeHooks.collect("resolve", {
+        intent: closeIntent(projPath("/unknown/project")),
       });
 
       expect(errors).toHaveLength(0);
@@ -500,16 +502,15 @@ describe("LocalProjectModule Integration", () => {
       // Register project so it's in internal state
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Resolve — should include remoteUrl from config
-      const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve",
-        { intent: closeIntent(PROJECT_PATH) }
-      );
+      const { results, errors } = await setup.closeHooks.collect("resolve", {
+        intent: closeIntent(PROJECT_PATH),
+      });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -528,25 +529,24 @@ describe("LocalProjectModule Integration", () => {
       // Register a project first
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Close the project
       const closeCtx: CloseHookInput = {
         intent: closeIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         removeLocalRepo: false,
       };
-      const { errors } = await setup.closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { errors } = await setup.closeHooks.collect("close", closeCtx);
 
       expect(errors).toHaveLength(0);
 
       // Verify it's gone from internal state (close resolve should return empty)
-      const { results: resolveResults } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve",
-        { intent: closeIntent(PROJECT_PATH) }
-      );
+      const { results: resolveResults } = await setup.closeHooks.collect("resolve", {
+        intent: closeIntent(PROJECT_PATH),
+      });
       expect(resolveResults[0]).toEqual({});
     });
 
@@ -559,27 +559,26 @@ describe("LocalProjectModule Integration", () => {
       // Register a remote project first so it's in internal state
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Close with remoteUrl present
       const closeCtx: CloseHookInput = {
         intent: closeIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
         removeLocalRepo: false,
       };
-      const { errors } = await setup.closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { errors } = await setup.closeHooks.collect("close", closeCtx);
 
       expect(errors).toHaveLength(0);
 
       // Verify it's gone from internal state
-      const { results: resolveResults } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve",
-        { intent: closeIntent(PROJECT_PATH) }
-      );
+      const { results: resolveResults } = await setup.closeHooks.collect("resolve", {
+        intent: closeIntent(PROJECT_PATH),
+      });
       expect(resolveResults[0]).toEqual({});
     });
 
@@ -592,19 +591,19 @@ describe("LocalProjectModule Integration", () => {
       // Register project
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
       // Close with removeLocalRepo=true and remoteUrl
       const closeCtx: CloseHookInput = {
         intent: closeIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
         remoteUrl: "https://github.com/user/repo.git",
         removeLocalRepo: true,
       };
-      const { errors } = await setup.closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { errors } = await setup.closeHooks.collect("close", closeCtx);
       expect(errors).toHaveLength(0);
 
       // Verify config dir was force-deleted (recursive rm)
@@ -625,15 +624,12 @@ describe("LocalProjectModule Integration", () => {
       const setup = createTestSetup();
 
       // Pre-populate configs
-      writeConfig(setup.fs, localPath);
-      writeConfig(setup.fs, remotePath, "https://github.com/org/repo.git");
+      writeConfig(setup.fs, projPath(localPath));
+      writeConfig(setup.fs, projPath(remotePath), "https://github.com/org/repo.git");
 
-      const { results, errors } = await setup.readyHooks.collect<LoadProjectsResult>(
-        "load-projects",
-        {
-          intent: appReadyIntent(),
-        }
-      );
+      const { results, errors } = await setup.readyHooks.collect("load-projects", {
+        intent: appReadyIntent(),
+      });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -644,7 +640,7 @@ describe("LocalProjectModule Integration", () => {
     it("returns empty when no projects saved (#12)", async () => {
       const { readyHooks } = createTestSetup();
 
-      const { results, errors } = await readyHooks.collect<LoadProjectsResult>("load-projects", {
+      const { results, errors } = await readyHooks.collect("load-projects", {
         intent: appReadyIntent(),
       });
 
@@ -659,16 +655,15 @@ describe("LocalProjectModule Integration", () => {
       // Pre-populate config
       writeConfig(setup.fs, PROJECT_PATH);
 
-      await setup.readyHooks.collect<LoadProjectsResult>("load-projects", {
+      await setup.readyHooks.collect("load-projects", {
         intent: appReadyIntent(),
       });
 
       // load-projects should NOT populate internal state — resolve reads config from disk,
       // so it returns {} for a local project (no remoteUrl)
-      const { results, errors } = await setup.closeHooks.collect<CloseResolveHookResult>(
-        "resolve",
-        { intent: closeIntent(PROJECT_PATH) }
-      );
+      const { results, errors } = await setup.closeHooks.collect("resolve", {
+        intent: closeIntent(PROJECT_PATH),
+      });
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -685,7 +680,7 @@ describe("LocalProjectModule Integration", () => {
     it("skips for git URL payloads", async () => {
       const { openHooks, gitClient } = createTestSetup();
 
-      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+      const { results, errors } = await openHooks.collect("prepare", {
         intent: openGitIntent("https://github.com/user/repo.git"),
       });
 
@@ -699,7 +694,7 @@ describe("LocalProjectModule Integration", () => {
       const { openHooks, dialogManager, gitClient } = createTestSetup();
       vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(true);
 
-      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+      const { results, errors } = await openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -715,11 +710,11 @@ describe("LocalProjectModule Integration", () => {
       // Register project first so it's in internal state
       const registerCtx: RegisterHookInput = {
         intent: openLocalIntent(PROJECT_PATH),
-        projectPath: new Path(PROJECT_PATH).toString(),
+        projectPath: projPath(new Path(PROJECT_PATH).toString()),
       };
-      await setup.openHooks.collect<RegisterHookResult>("register", registerCtx);
+      await setup.openHooks.collect("register", registerCtx);
 
-      const { results, errors } = await setup.openHooks.collect<PrepareHookResult>("prepare", {
+      const { results, errors } = await setup.openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -734,7 +729,7 @@ describe("LocalProjectModule Integration", () => {
       vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
 
       // Start the prepare hook (will block on dialog.nextEvent())
-      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+      const preparePromise = openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -761,7 +756,7 @@ describe("LocalProjectModule Integration", () => {
       vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
 
       // Start the prepare hook (will block on dialog.nextEvent())
-      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+      const preparePromise = openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -786,7 +781,7 @@ describe("LocalProjectModule Integration", () => {
       vi.mocked(gitClient.isRepositoryRoot).mockResolvedValue(false);
 
       // Start the prepare hook (will block on the dialog)
-      const preparePromise = openHooks.collect<PrepareHookResult>("prepare", {
+      const preparePromise = openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 
@@ -807,7 +802,7 @@ describe("LocalProjectModule Integration", () => {
       const { openHooks, dialogManager, gitClient } = createTestSetup();
       vi.mocked(gitClient.isRepositoryRoot).mockRejectedValue(new Error("Path not found"));
 
-      const { results, errors } = await openHooks.collect<PrepareHookResult>("prepare", {
+      const { results, errors } = await openHooks.collect("prepare", {
         intent: openLocalIntent(PROJECT_PATH),
       });
 

--- a/src/modules/local-project-module.ts
+++ b/src/modules/local-project-module.ts
@@ -18,6 +18,8 @@ import nodePath from "path";
 import type { IntentModule } from "../intents/lib/module";
 import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { ProjectId } from "../shared/api/types";
+import { projectPathSchema } from "../intents/contract";
+import type { ProjectPath } from "../intents/contract";
 import { Path } from "../utils/path/path";
 import { projectDirName } from "../boundaries/platform/paths";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
@@ -119,10 +121,10 @@ type ProjectFs = LocalProjectModuleDeps["fs"];
 async function saveProject(
   fs: ProjectFs,
   projectsDir: string,
-  projectPath: string,
+  projectPath: ProjectPath,
   remoteUrl?: string
 ): Promise<void> {
-  const normalizedPath = new Path(projectPath).toString();
+  const normalizedPath = projectPathSchema.parse(new Path(projectPath).toString());
   const projectDir = nodePath.join(projectsDir, projectDirName(normalizedPath));
   const configPath = nodePath.join(projectDir, "config.json");
 
@@ -167,7 +169,7 @@ async function loadAllProjectConfigs(
         ) {
           const rawPath = (parsed as { path: string }).path;
           try {
-            const normalizedPath = new Path(rawPath).toString();
+            const normalizedPath = projectPathSchema.parse(new Path(rawPath).toString());
             const rawRemoteUrl = (parsed as { remoteUrl?: string }).remoteUrl;
 
             const config: ProjectConfig = {
@@ -219,7 +221,7 @@ async function getProjectConfig(
       const rawRemoteUrl = (parsed as { remoteUrl?: string }).remoteUrl;
 
       const config: ProjectConfig = {
-        path: new Path(rawPath).toString(),
+        path: projectPathSchema.parse(new Path(rawPath).toString()),
         ...(rawRemoteUrl !== undefined && { remoteUrl: rawRemoteUrl }),
       };
       return config;
@@ -286,7 +288,9 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
   const { projectsDir, fs, gitWorktreeProvider, ui, gitClient } = deps;
 
   /** Internal state: all projects keyed by normalized path string. */
-  const projects = new Map<string, LocalProject>();
+  // Keyed by the branded project path, so a key can be handed straight back to the
+  // contract (e.g. the list-projects hook result) without re-minting the brand.
+  const projects = new Map<ProjectPath, LocalProject>();
 
   return {
     name: "local-project",
@@ -296,7 +300,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
         resolve: {
           handler: async (ctx: HookContext): Promise<HookOutput<ResolveProjectHookResult>> => {
             const { projectPath } = ctx as ResolveProjectHookInput;
-            const normalizedKey = new Path(projectPath).toString();
+            const normalizedKey = projectPathSchema.parse(new Path(projectPath).toString());
             const project = projects.get(normalizedKey);
             if (!project) return { result: {} };
             return { result: { projectId: project.id, projectName: project.name } };
@@ -315,12 +319,15 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             if (git || !path) return { result: {} };
 
             // Already open — skip
-            if (projects.has(path.toString())) return { result: {} };
+            if (projects.has(path)) return { result: {} };
+
+            // The contract carries the path as plain data; git operations take a `Path`.
+            const pathObj = new Path(path);
 
             // Check if it's already a git repo
             let isRepo: boolean;
             try {
-              isRepo = await gitClient.isRepositoryRoot(path);
+              isRepo = await gitClient.isRepositoryRoot(pathObj);
             } catch {
               // Path doesn't exist or inaccessible — let resolve handle the error
               return { result: {} };
@@ -356,7 +363,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
               return { result: { canceled: true } };
             }
 
-            await gitClient.init(path, { initialCommit: "Initial commit" });
+            await gitClient.init(pathObj, { initialCommit: "Initial commit" });
             return { result: {} };
           },
         },
@@ -373,25 +380,25 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             }
 
             // Check persisted config for remoteUrl (restores icon on startup)
-            const config = await getProjectConfig(fs, projectsDir, path.toString());
+            const config = await getProjectConfig(fs, projectsDir, path);
             const remoteUrl = config?.remoteUrl;
 
             // Already open — skip validation, signal short-circuit
-            if (projects.has(path.toString())) {
+            if (projects.has(path)) {
               return {
                 result: {
-                  projectPath: path.toString(),
+                  projectPath: path,
                   alreadyOpen: true,
                   ...(remoteUrl !== undefined && { remoteUrl }),
                 },
               };
             }
 
-            await gitWorktreeProvider.validateRepository(path);
+            await gitWorktreeProvider.validateRepository(new Path(path));
 
             return {
               result: {
-                projectPath: path.toString(),
+                projectPath: path,
                 ...(remoteUrl !== undefined && { remoteUrl }),
               },
             };
@@ -404,7 +411,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             const { projectPath: projectPathStr, remoteUrl } = ctx as RegisterHookInput;
 
             const projectPath = new Path(projectPathStr);
-            const normalizedKey = projectPath.toString();
+            const normalizedKey = projectPathSchema.parse(projectPath.toString());
             const projectId = generateProjectId(projectPathStr);
 
             // Already in state — return alreadyOpen without re-persisting
@@ -454,7 +461,7 @@ export function createLocalProjectModule(deps: LocalProjectModuleDeps): IntentMo
             const { projectPath, removeLocalRepo, remoteUrl } = ctx as CloseHookInput;
 
             // Remove from internal state
-            const normalizedKey = new Path(projectPath).toString();
+            const normalizedKey = projectPathSchema.parse(new Path(projectPath).toString());
             projects.delete(normalizedKey);
 
             if (removeLocalRepo && remoteUrl) {

--- a/src/modules/logging-module.integration.test.ts
+++ b/src/modules/logging-module.integration.test.ts
@@ -17,7 +17,7 @@ import type {
   IntentOf,
 } from "../intents/lib/operation";
 import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
-import type { AppStartIntent, InitHookContext, ConfigureResult } from "../intents/app-start";
+import type { AppStartIntent, InitHookContext } from "../intents/app-start";
 import { createMockLogger } from "../boundaries/platform/logging";
 import { createLoggingModule } from "./logging-module";
 import { createMockConfig } from "../boundaries/platform/config.test-utils";
@@ -35,13 +35,12 @@ const appStartSchemas = {
 class MinimalAppStartOperation implements Operation<typeof appStartSchemas> {
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = appStartSchemas;
-  async execute(ctx: OperationContext<IntentOf<typeof appStartSchemas>>): Promise<void> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof appStartSchemas>, typeof appStartSchemas>
+  ): Promise<void> {
     const hookCtx: HookContext = { intent: ctx.intent };
 
-    const { errors: beforeReadyErrors } = await ctx.hooks.collect<ConfigureResult>(
-      "before-ready",
-      hookCtx
-    );
+    const { errors: beforeReadyErrors } = await ctx.hooks.collect("before-ready", hookCtx);
     if (beforeReadyErrors.length > 0) throw beforeReadyErrors[0]!;
 
     const initCtx: InitHookContext = {
@@ -49,7 +48,7 @@ class MinimalAppStartOperation implements Operation<typeof appStartSchemas> {
       requiredScripts: [],
       capabilities: { "app-ready": true },
     };
-    const { errors: initErrors } = await ctx.hooks.collect<void>("init", initCtx);
+    const { errors: initErrors } = await ctx.hooks.collect("init", initCtx);
     if (initErrors.length > 0) throw initErrors[0]!;
   }
 }
@@ -103,10 +102,10 @@ describe("LoggingModule Integration", () => {
     dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     expect(deps.logger.info).toHaveBeenCalledWith("App starting", {
       version: "2026.2.0-test",
@@ -124,10 +123,10 @@ describe("LoggingModule Integration", () => {
     dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     expect(deps.loggingService.initialize).toHaveBeenCalledOnce();
   });
@@ -139,10 +138,10 @@ describe("LoggingModule Integration", () => {
     dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     const logOrder = deps.logger.info.mock.invocationCallOrder[0]!;
     const initOrder = deps.loggingService.initialize.mock.invocationCallOrder[0]!;
@@ -160,10 +159,10 @@ describe("LoggingModule Integration", () => {
     dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     expect(deps.loggingService.configure).toHaveBeenCalledWith({
       logLevel: "debug",
@@ -185,10 +184,10 @@ describe("LoggingModule Integration", () => {
     dispatcher.registerOperation(new MinimalAppStartOperation());
     dispatcher.registerModule(createLoggingModule(deps));
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     expect(deps.loggingService.configure).toHaveBeenCalledWith({
       logLevel: "warn",

--- a/src/modules/mcp-module.integration.test.ts
+++ b/src/modules/mcp-module.integration.test.ts
@@ -193,10 +193,10 @@ describe("McpModule Integration", () => {
 
       dispatcher.registerModule(mcpModule);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(portManager.$.allocatedPorts).toHaveLength(1);
       expect(portManager.$.allocatedPorts[0]).toBeGreaterThan(0);
@@ -237,16 +237,16 @@ describe("McpModule Integration", () => {
       shutdownDispatcher.registerModule(quitModule);
 
       // Start to wire callbacks
-      await shutdownDispatcher.dispatch({
+      await shutdownDispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       // Shutdown
-      await shutdownDispatcher.dispatch({
+      await shutdownDispatcher.dispatch<AppShutdownIntent>({
         type: INTENT_APP_SHUTDOWN,
         payload: {},
-      } as AppShutdownIntent);
+      });
 
       // After dispose, starting again should allocate the next port
       // (This verifies the manager was properly stopped/disposed)

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -70,14 +70,15 @@ import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import type { VscodeCommandIntent } from "../intents/vscode-command";
 import { INTENT_SUBMIT_BUG_REPORT } from "../intents/submit-bug-report";
 import type { SubmitBugReportIntent } from "../intents/submit-bug-report";
+import { workspacePathSchema, projectPathSchema } from "../intents/contract";
+import type { WorkspacePath } from "../intents/contract";
 
 /**
  * Optional target workspace path for tools that can act on a workspace other
  * than the session's own (hibernate/wake/delete). Omit to target the current
  * workspace; use project_list to discover other workspaces' paths.
  */
-const targetWorkspacePathSchema = z
-  .string()
+const targetWorkspacePathSchema = workspacePathSchema
   .min(1)
   .optional()
   .describe(
@@ -177,7 +178,7 @@ export function createDefaultMcpServer(): McpServerSdk {
 interface McpSession {
   mcpServer: McpServerSdk;
   transport: StreamableHTTPServerTransport;
-  workspacePath: string;
+  workspacePath: WorkspacePath;
 }
 
 /**
@@ -440,10 +441,11 @@ export class McpServer {
   /**
    * Get workspace path from request header.
    */
-  private getWorkspacePath(req: IncomingMessage): string | null {
+  private getWorkspacePath(req: IncomingMessage): WorkspacePath | null {
     const header = req.headers[WORKSPACE_PATH_HEADER];
     if (typeof header === "string" && header.length > 0) {
-      return header;
+      // An HTTP header is raw input from outside the app: mint the brand by parsing.
+      return workspacePathSchema.parse(header);
     }
     return null;
   }
@@ -453,7 +455,7 @@ export class McpServer {
    * The MCP SDK's StreamableHTTPServerTransport.handleRequest() accepts req.auth of type AuthInfo
    * which has an extra field for custom data that gets passed to tool handlers.
    */
-  private attachAuth(req: IncomingMessage, workspacePath: string): void {
+  private attachAuth(req: IncomingMessage, workspacePath: WorkspacePath): void {
     const reqWithAuth = req as IncomingMessage & {
       auth?: { token: string; clientId: string; scopes: string[]; extra?: Record<string, unknown> };
     };
@@ -479,7 +481,7 @@ export class McpServer {
    * Create a workspace tool handler that passes workspacePath and handles errors.
    */
   private createWorkspaceHandler<TArgs, TResult>(
-    fn: (workspacePath: string, args: TArgs) => Promise<TResult>
+    fn: (workspacePath: WorkspacePath, args: TArgs) => Promise<TResult>
   ): (
     args: TArgs,
     extra: unknown
@@ -512,13 +514,13 @@ export class McpServer {
       },
       this.createWorkspaceHandler(
         async (workspacePath, args: { refresh?: boolean | undefined }) => {
-          const result = await this.dispatcher.dispatch({
+          const result = await this.dispatcher.dispatch<GetWorkspaceStatusIntent>({
             type: INTENT_GET_WORKSPACE_STATUS,
             payload: {
               workspacePath,
               ...(typeof args.refresh === "boolean" && { refresh: args.refresh }),
             },
-          } as GetWorkspaceStatusIntent);
+          });
           if (!result) throw new Error("Get workspace status dispatch returned no result");
           return result;
         }
@@ -534,10 +536,10 @@ export class McpServer {
         inputSchema: z.object({}),
       },
       this.createWorkspaceHandler(async (workspacePath) => {
-        const result = await this.dispatcher.dispatch({
+        const result = await this.dispatcher.dispatch<GetMetadataIntent>({
           type: INTENT_GET_METADATA,
           payload: { workspacePath },
-        } as GetMetadataIntent);
+        });
         if (!result) throw new Error("Get metadata dispatch returned no result");
         return result;
       })
@@ -564,10 +566,10 @@ export class McpServer {
       },
       this.createWorkspaceHandler(
         async (workspacePath, args: { key: string; value: string | null }) => {
-          await this.dispatcher.dispatch({
+          await this.dispatcher.dispatch<SetMetadataIntent>({
             type: INTENT_SET_METADATA,
             payload: { workspacePath, key: args.key, value: args.value },
-          } as SetMetadataIntent);
+          });
           return null;
         }
       )
@@ -581,10 +583,10 @@ export class McpServer {
         inputSchema: z.object({}),
       },
       this.createWorkspaceHandler(async (workspacePath) => {
-        return this.dispatcher.dispatch({
+        return this.dispatcher.dispatch<GetAgentSessionIntent>({
           type: INTENT_GET_AGENT_SESSION,
           payload: { workspacePath },
-        } as GetAgentSessionIntent);
+        });
       })
     );
 
@@ -596,10 +598,10 @@ export class McpServer {
         inputSchema: z.object({}),
       },
       this.createWorkspaceHandler(async (workspacePath) => {
-        const result = await this.dispatcher.dispatch({
+        const result = await this.dispatcher.dispatch<RestartAgentIntent>({
           type: INTENT_RESTART_AGENT,
           payload: { workspacePath },
-        } as RestartAgentIntent);
+        });
         if (result === undefined) throw new Error("Restart agent dispatch returned no result");
         return result;
       })
@@ -620,7 +622,7 @@ export class McpServer {
         }),
       },
       this.createWorkspaceHandler(
-        async (sessionWorkspacePath, args: { workspacePath?: string | undefined }) => {
+        async (sessionWorkspacePath, args: { workspacePath?: WorkspacePath | undefined }) => {
           const workspacePath = args.workspacePath ?? sessionWorkspacePath;
           const intent: HibernateWorkspaceIntent = {
             type: INTENT_HIBERNATE_WORKSPACE,
@@ -650,16 +652,16 @@ export class McpServer {
         }),
       },
       this.createWorkspaceHandler(
-        async (sessionWorkspacePath, args: { workspacePath?: string | undefined }) => {
+        async (sessionWorkspacePath, args: { workspacePath?: WorkspacePath | undefined }) => {
           const workspacePath = args.workspacePath ?? sessionWorkspacePath;
           // The wake operation clears the hibernated flag AND reopens the
           // workspace (restarts the agent server, rebuilds the view) in one step.
           // stealFocus:false keeps it in the background for API callers; source
           // "mcp" suppresses interactive error notifications.
-          const result = await this.dispatcher.dispatch({
+          const result = await this.dispatcher.dispatch<WakeWorkspaceIntent>({
             type: INTENT_WAKE_WORKSPACE,
             payload: { workspacePath, stealFocus: false, source: "mcp" },
-          } as WakeWorkspaceIntent);
+          });
           if (!result) throw new Error("Wake workspace dispatch returned no result");
           return result as Workspace;
         }
@@ -677,10 +679,10 @@ export class McpServer {
       },
       async () => {
         try {
-          const result = await this.dispatcher.dispatch({
+          const result = await this.dispatcher.dispatch<ListProjectsIntent>({
             type: INTENT_LIST_PROJECTS,
             payload: {} as Record<string, never>,
-          } as ListProjectsIntent);
+          });
           if (!result) throw new Error("List projects dispatch returned no result");
           return this.successResult(result);
         } catch (error) {
@@ -733,7 +735,8 @@ export class McpServer {
       },
       async (args) => {
         try {
-          const projectPath = args.projectPath as string;
+          // MCP tool arguments arrive from an external client: mint the brand by parsing.
+          const projectPath = projectPathSchema.parse(args.projectPath);
           const name = args.name as string;
           const base = args.base as string;
           const tracking = args.tracking as string | undefined;
@@ -795,7 +798,7 @@ export class McpServer {
         async (
           sessionWorkspacePath,
           args: {
-            workspacePath?: string | undefined;
+            workspacePath?: WorkspacePath | undefined;
             keepBranch: boolean;
             ignoreWarnings: boolean;
           }
@@ -873,10 +876,10 @@ export class McpServer {
       },
       this.createWorkspaceHandler(
         async (workspacePath, args: { command: string; args?: unknown[] | undefined }) => {
-          return this.dispatcher.dispatch({
+          return this.dispatcher.dispatch<VscodeCommandIntent>({
             type: INTENT_VSCODE_COMMAND,
             payload: { workspacePath, command: args.command, args: args.args },
-          } as VscodeCommandIntent);
+          });
         }
       )
     );
@@ -946,7 +949,7 @@ export class McpServer {
           }
         ) => {
           const timeoutMs = args.timeout ? args.timeout * 1000 : undefined;
-          const result = await this.dispatcher.dispatch({
+          const result = await this.dispatcher.dispatch<VscodeShowMessageIntent>({
             type: INTENT_VSCODE_SHOW_MESSAGE,
             payload: {
               workspacePath,
@@ -956,7 +959,7 @@ export class McpServer {
               ...(args.options !== undefined && { options: args.options }),
               ...(timeoutMs !== undefined && { timeoutMs }),
             },
-          } as VscodeShowMessageIntent);
+          });
           return { result };
         }
       )
@@ -1014,10 +1017,10 @@ export class McpServer {
       },
       async (args: { description: string }) => {
         try {
-          await this.dispatcher.dispatch({
+          await this.dispatcher.dispatch<SubmitBugReportIntent>({
             type: INTENT_SUBMIT_BUG_REPORT,
             payload: { description: args.description },
-          } as SubmitBugReportIntent);
+          });
           return this.successResult({ submitted: true });
         } catch (error) {
           return this.handleError(error);
@@ -1033,17 +1036,19 @@ export class McpServer {
    * The workspace path is passed via req.auth.extra.workspacePath which becomes
    * extra.authInfo.extra.workspacePath in tool handlers.
    */
-  private getWorkspacePathFromExtra(extra: unknown): string {
+  private getWorkspacePathFromExtra(extra: unknown): WorkspacePath {
     if (extra && typeof extra === "object" && "authInfo" in extra) {
       const authInfo = (extra as { authInfo?: unknown }).authInfo;
       if (authInfo && typeof authInfo === "object" && "extra" in authInfo) {
         const authExtra = (authInfo as { extra?: unknown }).extra;
         if (authExtra && typeof authExtra === "object" && "workspacePath" in authExtra) {
-          return String((authExtra as { workspacePath: unknown }).workspacePath);
+          return workspacePathSchema.parse(
+            String((authExtra as { workspacePath: unknown }).workspacePath)
+          );
         }
       }
     }
-    return "";
+    return workspacePathSchema.parse("");
   }
 
   /**

--- a/src/modules/metadata-module.integration.test.ts
+++ b/src/modules/metadata-module.integration.test.ts
@@ -25,6 +25,8 @@ import { GitWorktreeProvider } from "../boundaries/platform/git-worktree-provide
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "../intents/contract";
 
 // =============================================================================
 // Test Constants
@@ -42,7 +44,7 @@ interface TestSetup {
   mockClient: ReturnType<typeof createMockGitClient>;
   projectId: ProjectId;
   workspaceName: WorkspaceName;
-  workspacePath: string;
+  workspacePath: WorkspacePath;
 }
 
 function createTestSetup(): TestSetup {
@@ -54,7 +56,7 @@ function createTestSetup(): TestSetup {
         worktrees: [
           {
             name: "feature-x",
-            path: new Path(WORKSPACES_DIR, "feature-x").toString(),
+            path: projPath(new Path(WORKSPACES_DIR, "feature-x").toString()),
             branch: "feature-x",
           },
         ],
@@ -84,7 +86,7 @@ function createTestSetup(): TestSetup {
 
   registerTestInfrastructure(dispatcher, {
     workspaces: {
-      [workspacePath.toString()]: { projectPath: PROJECT_ROOT.toString(), workspaceName },
+      [workspacePath.toString()]: { projectPath: projPath(PROJECT_ROOT.toString()), workspaceName },
     },
     projects: { [PROJECT_ROOT.toString()]: { projectId } },
   });
@@ -98,7 +100,7 @@ function createTestSetup(): TestSetup {
     mockClient,
     projectId,
     workspaceName,
-    workspacePath: workspacePath.toString(),
+    workspacePath: wsPath(workspacePath.toString()),
   };
 }
 

--- a/src/modules/plugin-server-module.integration.test.ts
+++ b/src/modules/plugin-server-module.integration.test.ts
@@ -36,8 +36,11 @@ import type {
 import { createPluginServerModule, type PluginServerModuleDeps } from "./plugin-server-module";
 import { createPortManagerMock } from "../boundaries/platform/port-manager.state-mock";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
-import type { ProjectId, WorkspaceName } from "../shared/api/types";
+
 import { COMMAND_TIMEOUT_MS } from "../shared/plugin-protocol";
+import { wsPath } from "../shared/test-fixtures";
+import { projPath } from "../shared/test-fixtures";
+import type { WorkspaceName } from "../intents/contract";
 
 // =============================================================================
 // Minimal Test Operations
@@ -53,8 +56,10 @@ class MinimalStartOperation implements Operation<typeof startSchemas> {
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = startSchemas;
 
-  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | null> {
-    const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof startSchemas>, typeof startSchemas>
+  ): Promise<number | null> {
+    const { errors, capabilities } = await ctx.hooks.collect("start", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -78,8 +83,10 @@ function createMinimalFinalizeOperation(
   return {
     id: OPEN_WORKSPACE_OPERATION_ID,
     schemas: finalizeSchemas,
-    async execute(ctx: OperationContext<IntentOf<typeof finalizeSchemas>>): Promise<void> {
-      const { errors } = await ctx.hooks.collect<void>("finalize", {
+    async execute(
+      ctx: OperationContext<IntentOf<typeof finalizeSchemas>, typeof finalizeSchemas>
+    ): Promise<void> {
+      const { errors } = await ctx.hooks.collect("finalize", {
         intent: ctx.intent,
         workspacePath: "/test/project/.worktrees/feature-1",
         envVars: { OPENCODE_PORT: "8080" },
@@ -100,9 +107,9 @@ function createMinimalDeleteOperation() {
     {
       hookContext: (ctx): DeletePipelineHookInput => ({
         intent: ctx.intent,
-        projectPath: "/projects/test",
-        workspacePath: (ctx.intent.payload as DeleteWorkspaceIntent["payload"]).workspacePath ?? "",
-        workspaceName: "test-workspace" as WorkspaceName,
+        projectPath: projPath("/test/project"),
+        workspaceName: "feature-1" as WorkspaceName,
+        workspacePath: (ctx.intent.payload as DeleteWorkspaceIntent["payload"]).workspacePath,
         active: false,
       }),
       defaultResult: {},
@@ -214,21 +221,21 @@ describe("PluginServerModule", () => {
 
       dispatcher.registerOperation(
         createMinimalFinalizeOperation({
-          workspacePath: "/test/project/.worktrees/feature-1",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
         })
       );
 
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<OpenWorkspaceIntent>({
           type: "workspace:open",
           payload: {
-            projectPath: "/test/project",
             workspaceName: "feature-1",
+            projectPath: projPath("/test/project"),
             base: "main",
           },
-        } as OpenWorkspaceIntent)
+        })
       ).resolves.not.toThrow();
     });
 
@@ -239,7 +246,7 @@ describe("PluginServerModule", () => {
       // Do NOT start the server
       dispatcher.registerOperation(
         createMinimalFinalizeOperation({
-          workspacePath: "/test/project/.worktrees/feature-1",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
         })
@@ -247,14 +254,14 @@ describe("PluginServerModule", () => {
 
       // Should resolve without error (no-op when io is null)
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<OpenWorkspaceIntent>({
           type: "workspace:open",
           payload: {
-            projectPath: "/test/project",
             workspaceName: "feature-1",
+            projectPath: projPath("/test/project"),
             base: "main",
           },
-        } as OpenWorkspaceIntent)
+        })
       ).resolves.not.toThrow();
     });
 
@@ -264,21 +271,21 @@ describe("PluginServerModule", () => {
 
       dispatcher.registerOperation(
         createMinimalFinalizeOperation({
-          workspacePath: "/test/project/.worktrees/feature-1",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           envVars: { OPENCODE_PORT: "8080" },
           agentType: "opencode",
         })
       );
 
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<OpenWorkspaceIntent>({
           type: "workspace:open",
           payload: {
-            projectPath: "/test/project",
             workspaceName: "feature-1",
+            projectPath: projPath("/test/project"),
             base: "main",
           },
-        } as OpenWorkspaceIntent)
+        })
       ).resolves.not.toThrow();
     });
   });
@@ -298,18 +305,15 @@ describe("PluginServerModule", () => {
 
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: "/test/project/.worktrees/feature-1",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as DeleteHookResult;
+      })) as DeleteHookResult;
 
       expect(result).toEqual({});
     });
@@ -319,18 +323,15 @@ describe("PluginServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: "/test/project/.worktrees/feature-1",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as DeleteHookResult;
+      })) as DeleteHookResult;
 
       expect(result).toEqual({});
     });
@@ -341,18 +342,15 @@ describe("PluginServerModule", () => {
       const { dispatcher } = createTestSetup(deps);
       dispatcher.registerOperation(createMinimalDeleteOperation());
 
-      const result = (await dispatcher.dispatch({
+      const result = (await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: "workspace:delete",
         payload: {
-          projectId: "test-12345678" as ProjectId,
-          workspaceName: "feature-1" as WorkspaceName,
-          workspacePath: "/test/project/.worktrees/feature-1",
-          projectPath: "/test/project",
+          workspacePath: wsPath("/test/project/.worktrees/feature-1"),
           keepBranch: false,
           force: true,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent)) as DeleteHookResult;
+      })) as DeleteHookResult;
 
       expect(result).toEqual({});
     });

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -106,6 +106,8 @@ import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import type { AppBoundary } from "../boundaries/shell/app";
 import { getErrorMessage } from "../shared/errors/service-errors";
 import { Path } from "../utils/path/path";
+import { workspacePathSchema } from "../intents/contract";
+import type { WorkspacePath } from "../intents/contract";
 
 // =============================================================================
 // Types
@@ -249,7 +251,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // ---------------------------------------------------------------------------
 
   async function sendCommand(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     command: string,
     args?: readonly unknown[],
     timeoutMs: number = COMMAND_TIMEOUT_MS
@@ -291,7 +293,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // ---------------------------------------------------------------------------
 
   async function sendUiEvent<TReq, TRes>(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     event: keyof ServerToClientEvents,
     request: TReq,
     timeoutMs: number = COMMAND_TIMEOUT_MS
@@ -332,7 +334,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   }
 
   async function showNotification(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     request: ShowNotificationRequest,
     timeoutMs: number = COMMAND_TIMEOUT_MS
   ): Promise<PluginResult<ShowNotificationResponse>> {
@@ -340,21 +342,21 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   }
 
   async function updateStatusBar(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     request: StatusBarUpdateRequest
   ): Promise<PluginResult<void>> {
     return sendUiEvent(workspacePath, "ui:statusBarUpdate", request);
   }
 
   async function disposeStatusBar(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     request: StatusBarDisposeRequest
   ): Promise<PluginResult<void>> {
     return sendUiEvent(workspacePath, "ui:statusBarDispose", request);
   }
 
   async function showQuickPick(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     request: ShowQuickPickRequest,
     timeoutMs: number = 0
   ): Promise<PluginResult<ShowQuickPickResponse>> {
@@ -362,7 +364,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   }
 
   async function showInputBox(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     request: ShowInputBoxRequest,
     timeoutMs: number = 0
   ): Promise<PluginResult<ShowInputBoxResponse>> {
@@ -374,7 +376,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // ---------------------------------------------------------------------------
 
   function setWorkspaceConfig(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     env: Record<string, string>,
     agentType: AgentType,
     resetWorkspace: boolean
@@ -383,7 +385,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
     workspaceConfigs.set(normalized, { env, agentType, resetWorkspace });
   }
 
-  function removeWorkspaceConfig(workspacePath: string): void {
+  function removeWorkspaceConfig(workspacePath: WorkspacePath): void {
     const normalized = new Path(workspacePath).toString();
     workspaceConfigs.delete(normalized);
   }
@@ -392,7 +394,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // Auth validation
   // ---------------------------------------------------------------------------
 
-  function isValidAuth(auth: unknown): auth is { workspacePath: string } {
+  function isValidAuth(auth: unknown): auth is { workspacePath: WorkspacePath } {
     return (
       typeof auth === "object" &&
       auth !== null &&
@@ -418,9 +420,11 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
         return;
       }
 
-      let workspacePath: string;
+      // The extension's handshake carries a raw string over a socket — the external edge
+      // where this module mints the workspace-path brand. Every handler below flows from here.
+      let workspacePath: WorkspacePath;
       try {
-        workspacePath = new Path(auth.workspacePath).toString();
+        workspacePath = workspacePathSchema.parse(new Path(auth.workspacePath).toString());
       } catch {
         logger.warn("Connection rejected: invalid path", {
           socketId: socket.id,
@@ -501,7 +505,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
    * Wrap a dispatcher call with error handling, returning a PluginResult.
    */
   async function handlePluginApiCall<T>(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     operation: string,
     fn: () => Promise<T>,
     logContext?: Record<string, unknown>
@@ -526,7 +530,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
    */
   function createNoArgHandler<R>(
     eventName: string,
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     dispatchFn: () => Promise<R>
   ): (ack: (result: PluginResult<R>) => void) => void {
     return (ack) => {
@@ -545,7 +549,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
    */
   function createValidatedHandler<TReq, TValidated, R>(
     eventName: string,
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     validator: (
       payload: unknown
     ) => { valid: true; request?: TValidated } | { valid: false; error: string },
@@ -583,7 +587,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // API event handlers (dispatch intents directly)
   // ---------------------------------------------------------------------------
 
-  function setupApiHandlers(socket: TypedSocket, workspacePath: string): void {
+  function setupApiHandlers(socket: TypedSocket, workspacePath: WorkspacePath): void {
     // No-arg handlers
     socket.on(
       "api:workspace:getStatus",
@@ -756,10 +760,10 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
         validateWorkspaceCreateRequest,
         (req) =>
           handlePluginApiCall(workspacePath, "create", async () => {
-            const resolved = await dispatcher.dispatch({
+            const resolved = await dispatcher.dispatch<ResolveWorkspaceIntent>({
               type: INTENT_RESOLVE_WORKSPACE,
               payload: { workspacePath },
-            } as ResolveWorkspaceIntent);
+            });
 
             const intent: OpenWorkspaceIntent = {
               type: INTENT_OPEN_WORKSPACE,
@@ -825,7 +829,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
   // ---------------------------------------------------------------------------
 
   async function handleShowMessage(
-    workspacePath: string,
+    workspacePath: WorkspacePath,
     type: string,
     message: string | null,
     hint: string | undefined,
@@ -953,7 +957,7 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
         shutdown: {
           handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
             const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
-            const normalized = new Path(wsPath).toString();
+            const normalized = workspacePathSchema.parse(new Path(wsPath).toString());
 
             deletingWorkspaces.add(normalized);
             removeWorkspaceConfig(normalized);

--- a/src/modules/plugin-server.boundary.test.ts
+++ b/src/modules/plugin-server.boundary.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { io as ioClient } from "socket.io-client";
 import { IntentHandle } from "../intents/lib/dispatcher";
 import type { Intent } from "../intents/lib/types";
-import { delay } from "@shared/test-fixtures";
+import { delay, projPath, wsPath } from "../shared/test-fixtures";
 import {
   createTestClient,
   createPluginServerEnv,
@@ -38,6 +38,7 @@ import { z } from "zod/v4";
 import { INTENT_VSCODE_COMMAND } from "../intents/vscode-command";
 import { INTENT_RESOLVE_WORKSPACE } from "../intents/resolve-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
+import type { WorkspacePath } from "../intents/contract";
 
 /**
  * A delete-workspace operation reduced to what this file needs: run the "shutdown"
@@ -51,11 +52,11 @@ function createDeleteShutdownOperation(
     id: DELETE_WORKSPACE_OPERATION_ID,
     schemas: deleteShutdownSchemas,
     async execute(ctx): Promise<void> {
-      const { workspacePath } = ctx.intent.payload as { workspacePath: string };
+      const { workspacePath } = ctx.intent.payload as { workspacePath: WorkspacePath };
       const hookCtx: DeletePipelineHookInput = {
         // The minimal schema types the payload as `unknown`, so widen before narrowing.
         intent: ctx.intent as unknown as DeleteWorkspaceIntent,
-        projectPath: "/projects/test",
+        projectPath: projPath("/projects/test"),
         workspacePath,
         workspaceName: "ws" as WorkspaceName,
         active: false,
@@ -97,7 +98,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     env = await createPluginServerEnv();
   });
   afterEach(() => env.cleanup());
-  function createClient(workspacePath: string) {
+  function createClient(workspacePath: WorkspacePath) {
     return env.createClient(workspacePath);
   }
 
@@ -110,7 +111,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
   describe("client connection", () => {
     it("accepts client with valid auth", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       expect(client.connected).toBe(true);
@@ -118,7 +119,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("rejects client with invalid auth", async () => {
       // Client with empty workspace path
-      const client = createTestClient(env.port, { workspacePath: "" });
+      const client = createTestClient(env.port, { workspacePath: wsPath("") });
 
       let rejected = false;
       client.on("disconnect", () => {
@@ -167,7 +168,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
   describe("command round-trip", () => {
     it("sends command and receives acknowledgment", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Set up command handler on client
@@ -177,14 +178,18 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       client.on("command", handler);
 
       // Send command from server via vscode-command hook
-      const result = await env.sendCommand("/test/workspace", "workbench.action.closeSidebar", []);
+      const result = await env.sendCommand(
+        wsPath("/test/workspace"),
+        "workbench.action.closeSidebar",
+        []
+      );
 
       expect(result).toBe("command executed");
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("throws when client acks with error", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Set up handler that returns an error
@@ -193,13 +198,13 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       });
       client.on("command", handler);
 
-      await expect(env.sendCommand("/test/workspace", "unknown.command", [])).rejects.toThrow(
-        "Command failed"
-      );
+      await expect(
+        env.sendCommand(wsPath("/test/workspace"), "unknown.command", [])
+      ).rejects.toThrow("Command failed");
     });
 
     it("times out when client does not ack", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Handler that never acks
@@ -208,7 +213,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       });
 
       const start = Date.now();
-      await expect(env.sendCommand("/test/workspace", "test.command", [])).rejects.toThrow(
+      await expect(env.sendCommand(wsPath("/test/workspace"), "test.command", [])).rejects.toThrow(
         "Command timed out"
       );
       const elapsed = Date.now() - start;
@@ -220,7 +225,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
   describe("reconnection behavior", () => {
     it("client reconnects after server restart", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
 
       // Configure for fast reconnection
       (client.io.opts as { reconnectionDelay: number }).reconnectionDelay = 100;
@@ -241,7 +246,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
   describe("multiple clients", () => {
     it("handles multiple workspace connections simultaneously", async () => {
       const workspaces = ["/workspace/a", "/workspace/b", "/workspace/c"];
-      const clientsToTest = workspaces.map((ws) => createClient(ws));
+      const clientsToTest = workspaces.map((ws) => createClient(wsPath(ws)));
 
       // Connect all clients
       await Promise.all(clientsToTest.map((c) => waitForConnect(c)));
@@ -253,7 +258,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
       // Send commands to each workspace via hooks
       const results = await Promise.all(
-        workspaces.map((ws) => env.sendCommand(ws, "test.command", []))
+        workspaces.map((ws) => env.sendCommand(wsPath(ws), "test.command", []))
       );
 
       // All should succeed (return undefined from default handler)
@@ -262,7 +267,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("handles 10 concurrent workspace connections (stress test)", async () => {
       const workspaces = Array.from({ length: 10 }, (_, i) => `/workspace/${i}`);
-      const clientsToTest = workspaces.map((ws) => createClient(ws));
+      const clientsToTest = workspaces.map((ws) => createClient(wsPath(ws)));
 
       // Connect all clients in parallel
       await Promise.all(clientsToTest.map((c) => waitForConnect(c)));
@@ -274,7 +279,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
       // Send commands to all workspaces in parallel
       const results = await Promise.allSettled(
-        workspaces.map((ws) => env.sendCommand(ws, "test.command", []))
+        workspaces.map((ws) => env.sendCommand(wsPath(ws), "test.command", []))
       );
 
       // All should succeed
@@ -292,7 +297,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       expect(env.port).toBeLessThan(65536);
 
       // Verify we can connect
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
     });
   });
@@ -311,7 +316,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Emit API call and wait for response
@@ -344,7 +349,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -368,7 +373,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -397,7 +402,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -420,7 +425,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -443,7 +448,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{ success: boolean; error?: string }>((resolve) => {
@@ -469,7 +474,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Fire-and-forget: no ack callback.
@@ -493,7 +498,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.emit("api:workspace:agentLifecycle", { event: "close" });
@@ -509,7 +514,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("agentLifecycle ignores invalid event (no dispatch)", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Invalid event value — handler validates and drops it.
@@ -525,7 +530,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("setMetadata validates request before calling handler", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Send invalid request (empty key)
@@ -548,7 +553,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       });
 
       // Connect with specific workspace path
-      const client = createClient("/my/special/workspace");
+      const client = createClient(wsPath("/my/special/workspace"));
       await waitForConnect(client);
 
       await new Promise<{ success: boolean }>((resolve) => {
@@ -573,8 +578,8 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client1 = createClient("/workspace/one");
-      const client2 = createClient("/workspace/two");
+      const client1 = createClient(wsPath("/workspace/one"));
+      const client2 = createClient(wsPath("/workspace/two"));
 
       await Promise.all([waitForConnect(client1), waitForConnect(client2)]);
 
@@ -607,7 +612,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Make rapid sequential calls
@@ -641,7 +646,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{ success: boolean; error?: string }>((resolve) => {
@@ -662,7 +667,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -698,7 +703,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -718,7 +723,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("executeCommand validates request before calling handler", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Send invalid request (empty command)
@@ -740,7 +745,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -765,7 +770,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -801,7 +806,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -838,7 +843,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         return handle;
       });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       const result = await new Promise<{
@@ -882,7 +887,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       await env.cleanup();
       env = await createPluginServerEnv({ isDevelopment: true });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
 
       const configPromise = new Promise<{ isDevelopment: boolean }>((resolve) => {
         client.on("config", (config) => {
@@ -900,7 +905,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       await env.cleanup();
       env = await createPluginServerEnv({ isDevelopment: false });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
 
       const configPromise = new Promise<{ isDevelopment: boolean }>((resolve) => {
         client.on("config", (config) => {
@@ -915,7 +920,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("sends config with isDevelopment: false by default", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
 
       const configPromise = new Promise<{ isDevelopment: boolean }>((resolve) => {
         client.on("config", (config) => {
@@ -933,7 +938,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       await env.cleanup();
       env = await createPluginServerEnv({ isDevelopment: true });
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
 
       let configCount = 0;
       const firstConfigPromise = new Promise<void>((resolve) => {
@@ -966,9 +971,9 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("sends config with agent type when client connects", async () => {
       // Store workspace config via the finalize hook
-      await env.setWorkspaceConfig("/test/workspace", {}, "opencode", true);
+      await env.setWorkspaceConfig(wsPath("/test/workspace"), {}, "opencode", true);
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       const configPromise = new Promise<PluginConfig>((resolve) => {
         client.on("config", (config) => resolve(config));
       });
@@ -982,13 +987,13 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("sends config with environment variables", async () => {
       await env.setWorkspaceConfig(
-        "/test/workspace",
+        wsPath("/test/workspace"),
         { TEST_VAR: "test-value", ANOTHER_VAR: "another" },
         "opencode",
         true
       );
 
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       const configPromise = new Promise<PluginConfig>((resolve) => {
         client.on("config", (config) => resolve(config));
       });
@@ -1000,7 +1005,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("sends config with null env when no config stored", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       const configPromise = new Promise<PluginConfig>((resolve) => {
         client.on("config", (config) => resolve(config));
       });
@@ -1013,20 +1018,20 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("handles concurrent workspace connections independently", async () => {
       await env.setWorkspaceConfig(
-        "/workspace/one",
+        wsPath("/workspace/one"),
         { WORKSPACE: "/workspace/one" },
         "opencode",
         true
       );
       await env.setWorkspaceConfig(
-        "/workspace/two",
+        wsPath("/workspace/two"),
         { WORKSPACE: "/workspace/two" },
         "opencode",
         true
       );
 
-      const client1 = createClient("/workspace/one");
-      const client2 = createClient("/workspace/two");
+      const client1 = createClient(wsPath("/workspace/one"));
+      const client2 = createClient(wsPath("/workspace/two"));
 
       const config1Promise = new Promise<PluginConfig>((resolve) => {
         client1.on("config", (config) => resolve(config));
@@ -1045,7 +1050,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
   describe("UI events", () => {
     it("showNotification round-trip with action", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:showNotification", (request, ack) => {
@@ -1055,7 +1060,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: { action: "Yes" } });
       });
 
-      const result = await env.showNotification("/test/workspace", {
+      const result = await env.showNotification(wsPath("/test/workspace"), {
         severity: "info",
         message: "Continue?",
         actions: ["Yes", "No"],
@@ -1065,7 +1070,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("showNotification fire-and-forget without actions", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:showNotification", (request, ack) => {
@@ -1075,7 +1080,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: { action: null } });
       });
 
-      const result = await env.showNotification("/test/workspace", {
+      const result = await env.showNotification(wsPath("/test/workspace"), {
         severity: "warning",
         message: "Something happened",
       });
@@ -1085,7 +1090,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
     it("showNotification throws when workspace not connected", async () => {
       await expect(
-        env.showNotification("/nonexistent", {
+        env.showNotification(wsPath("/nonexistent"), {
           severity: "info",
           message: "test",
         })
@@ -1093,7 +1098,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("updateStatusBar round-trip", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:statusBarUpdate", (request, ack) => {
@@ -1103,7 +1108,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: undefined });
       });
 
-      const result = await env.updateStatusBar("/test/workspace", {
+      const result = await env.updateStatusBar(wsPath("/test/workspace"), {
         text: "$(sync~spin) Building...",
         tooltip: "Build in progress",
       });
@@ -1112,7 +1117,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("disposeStatusBar round-trip", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:statusBarDispose", (request, ack) => {
@@ -1120,13 +1125,13 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: undefined });
       });
 
-      const result = await env.disposeStatusBar("/test/workspace");
+      const result = await env.disposeStatusBar(wsPath("/test/workspace"));
 
       expect(result).toBeNull();
     });
 
     it("showQuickPick round-trip with selection", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:showQuickPick", (request, ack) => {
@@ -1135,7 +1140,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: { selected: "Option A" } });
       });
 
-      const result = await env.showQuickPick("/test/workspace", {
+      const result = await env.showQuickPick(wsPath("/test/workspace"), {
         items: [{ label: "Option A" }, { label: "Option B" }],
         placeholder: "Select an option...",
       });
@@ -1144,7 +1149,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("showInputBox round-trip with value", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       client.on("ui:showInputBox", (request, ack) => {
@@ -1153,7 +1158,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
         ack({ success: true, data: { value: "user-input" } });
       });
 
-      const result = await env.showInputBox("/test/workspace", {
+      const result = await env.showInputBox(wsPath("/test/workspace"), {
         prompt: "Workspace name",
         placeholder: "my-workspace",
       });
@@ -1162,7 +1167,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("showNotification times out when client does not ack", async () => {
-      const client = createClient("/test/workspace");
+      const client = createClient(wsPath("/test/workspace"));
       await waitForConnect(client);
 
       // Handler that never acks
@@ -1173,7 +1178,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
       const start = Date.now();
       await expect(
         env.showNotification(
-          "/test/workspace",
+          wsPath("/test/workspace"),
           { severity: "info", message: "test", actions: ["OK"] },
           500
         )
@@ -1207,7 +1212,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
 
       // The server hangs up rather than refusing the handshake, so connect() may
       // briefly succeed. `disconnect(true)` stops the client from reconnecting.
-      const client = createClient(WS);
+      const client = createClient(wsPath(WS));
       client.connect();
       await delay(500);
 
@@ -1217,7 +1222,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     it("sends no config to a client that connects after deletion has begun", async () => {
       await startDeleting();
 
-      const client = createClient(WS);
+      const client = createClient(wsPath(WS));
       const config = vi.fn();
       client.on("config", config);
       client.connect();
@@ -1228,7 +1233,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     });
 
     it("disconnects a client that was already connected", async () => {
-      const client = createClient(WS);
+      const client = createClient(wsPath(WS));
       await waitForConnect(client);
 
       await startDeleting();
@@ -1240,7 +1245,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     it("leaves other workspaces connectable", async () => {
       await startDeleting();
 
-      const other = createClient("/test/other");
+      const other = createClient(wsPath("/test/other"));
       await waitForConnect(other);
 
       expect(other.connected).toBe(true);
@@ -1249,7 +1254,7 @@ describe("PluginServer (boundary)", { timeout: TEST_TIMEOUT }, () => {
     it("accepts clients again once deletion fails, since the workspace survives", async () => {
       await startDeleting(EVENT_WORKSPACE_DELETE_FAILED);
 
-      const client = createClient(WS);
+      const client = createClient(wsPath(WS));
       await waitForConnect(client);
 
       expect(client.connected).toBe(true);

--- a/src/modules/plugin-server.test-utils.ts
+++ b/src/modules/plugin-server.test-utils.ts
@@ -36,6 +36,7 @@ import {
   OPEN_WORKSPACE_OPERATION_ID,
   INTENT_OPEN_WORKSPACE,
   type OpenWorkspaceIntent,
+  finalizeResultSchema,
 } from "../intents/open-workspace";
 import type { FinalizeHookInput } from "../intents/open-workspace";
 import {
@@ -43,15 +44,18 @@ import {
   INTENT_VSCODE_COMMAND,
   type VscodeCommandIntent,
 } from "../intents/vscode-command";
-import type { ExecuteHookInput, ExecuteHookResult } from "../intents/vscode-command";
+import { executeHookResultSchema } from "../intents/vscode-command";
+import type { ExecuteHookInput } from "../intents/vscode-command";
 import {
   VSCODE_SHOW_MESSAGE_OPERATION_ID,
   INTENT_VSCODE_SHOW_MESSAGE,
   type VscodeShowMessageIntent,
   type VscodeShowMessageType,
+  showHookResultSchema,
 } from "../intents/vscode-show-message";
-import type { ShowHookInput, ShowHookResult } from "../intents/vscode-show-message";
+import type { ShowHookInput } from "../intents/vscode-show-message";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
+import type { WorkspacePath } from "../intents/contract";
 
 // ============================================================================
 // Mock Socket Types
@@ -71,7 +75,7 @@ export type TestClientSocket = ClientSocket<ServerToClientEvents, ClientToServer
  */
 export interface TestClientOptions {
   /** Workspace path to send in auth */
-  readonly workspacePath: string;
+  readonly workspacePath: WorkspacePath;
   /** Whether to connect immediately. Default: false */
   readonly autoConnect?: boolean;
 }
@@ -209,8 +213,10 @@ class MinimalStartOperation implements Operation<typeof startSchemas> {
   readonly id = APP_START_OPERATION_ID;
   readonly schemas = startSchemas;
 
-  async execute(ctx: OperationContext<IntentOf<typeof startSchemas>>): Promise<number | null> {
-    const { errors, capabilities } = await ctx.hooks.collect<void>("start", {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof startSchemas>, typeof startSchemas>
+  ): Promise<number | null> {
+    const { errors, capabilities } = await ctx.hooks.collect("start", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
@@ -221,6 +227,7 @@ class MinimalStartOperation implements Operation<typeof startSchemas> {
 const finalizeSchemas = {
   type: INTENT_OPEN_WORKSPACE,
   payload: z.unknown(),
+  hooks: { finalize: { result: finalizeResultSchema } },
 } satisfies OperationSchemas;
 
 /**
@@ -235,8 +242,10 @@ function createMinimalFinalizeOperation(): Operation<typeof finalizeSchemas> & {
     id: OPEN_WORKSPACE_OPERATION_ID,
     schemas: finalizeSchemas,
     hookInput: {} as Partial<FinalizeHookInput>,
-    async execute(ctx: OperationContext<IntentOf<typeof finalizeSchemas>>): Promise<void> {
-      const { errors } = await ctx.hooks.collect<void>("finalize", {
+    async execute(
+      ctx: OperationContext<IntentOf<typeof finalizeSchemas>, typeof finalizeSchemas>
+    ): Promise<void> {
+      const { errors } = await ctx.hooks.collect("finalize", {
         intent: ctx.intent,
         workspacePath: "/test/workspace",
         envVars: {},
@@ -253,6 +262,7 @@ const commandSchemas = {
   type: INTENT_VSCODE_COMMAND,
   payload: z.unknown(),
   result: z.custom<unknown>(),
+  hooks: { execute: { result: executeHookResultSchema } },
 } satisfies OperationSchemas;
 
 /** Minimal vscode-command operation that skips workspace resolution. */
@@ -260,13 +270,15 @@ class MinimalCommandOperation implements Operation<typeof commandSchemas> {
   readonly id = VSCODE_COMMAND_OPERATION_ID;
   readonly schemas = commandSchemas;
 
-  async execute(ctx: OperationContext<IntentOf<typeof commandSchemas>>): Promise<unknown> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof commandSchemas>, typeof commandSchemas>
+  ): Promise<unknown> {
     const payload = ctx.intent.payload as VscodeCommandIntent["payload"];
     const executeCtx: ExecuteHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
     };
-    const { results, errors } = await ctx.hooks.collect<ExecuteHookResult>("execute", executeCtx);
+    const { results, errors } = await ctx.hooks.collect("execute", executeCtx);
     if (errors.length > 0) throw errors[0]!;
 
     let result: unknown;
@@ -281,6 +293,7 @@ const showMessageSchemas = {
   type: INTENT_VSCODE_SHOW_MESSAGE,
   payload: z.unknown(),
   result: z.custom<string | null>(),
+  hooks: { show: { result: showHookResultSchema } },
 } satisfies OperationSchemas;
 
 /** Minimal vscode-show-message operation that skips workspace resolution. */
@@ -289,14 +302,14 @@ class MinimalShowMessageOperation implements Operation<typeof showMessageSchemas
   readonly schemas = showMessageSchemas;
 
   async execute(
-    ctx: OperationContext<IntentOf<typeof showMessageSchemas>>
+    ctx: OperationContext<IntentOf<typeof showMessageSchemas>, typeof showMessageSchemas>
   ): Promise<string | null> {
     const payload = ctx.intent.payload as VscodeShowMessageIntent["payload"];
     const showCtx: ShowHookInput = {
       intent: ctx.intent,
       workspacePath: payload.workspacePath,
     };
-    const { results, errors } = await ctx.hooks.collect<ShowHookResult>("show", showCtx);
+    const { results, errors } = await ctx.hooks.collect("show", showCtx);
     if (errors.length > 0) throw errors[0]!;
 
     let result: string | null | undefined;
@@ -370,7 +383,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
     networkLayer,
     testDispatcher,
 
-    createClient(workspacePath: string): TestClientSocket {
+    createClient(workspacePath: WorkspacePath): TestClientSocket {
       const client = createTestClient(this.port, { workspacePath });
       clients.push(client);
       return client;
@@ -380,7 +393,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
      * Set workspace config by dispatching workspace:open finalize hook.
      */
     async setWorkspaceConfig(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       env: Record<string, string>,
       agentType: AgentType,
       resetWorkspace: boolean
@@ -416,25 +429,25 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
      * Send a VS Code command to a workspace via the vscode-command hook.
      */
     async sendCommand(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       command: string,
       args?: readonly unknown[]
     ): Promise<unknown> {
-      return testDispatcher.dispatch({
+      return testDispatcher.dispatch<VscodeCommandIntent>({
         type: INTENT_VSCODE_COMMAND,
         payload: { workspacePath, command, args },
-      } as VscodeCommandIntent);
+      });
     },
 
     /**
      * Show a notification in a workspace via the vscode-show-message hook.
      */
     async showNotification(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       request: { severity: "info" | "warning" | "error"; message: string; actions?: string[] },
       timeoutMs?: number
     ): Promise<string | null> {
-      const result = await testDispatcher.dispatch({
+      const result = await testDispatcher.dispatch<VscodeShowMessageIntent>({
         type: INTENT_VSCODE_SHOW_MESSAGE,
         payload: {
           workspacePath,
@@ -443,7 +456,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
           options: request.actions,
           timeoutMs,
         },
-      } as VscodeShowMessageIntent);
+      });
       return result as string | null;
     },
 
@@ -451,10 +464,10 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
      * Update a status bar item via the vscode-show-message hook.
      */
     async updateStatusBar(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       request: { text: string; tooltip?: string }
     ): Promise<string | null> {
-      const result = await testDispatcher.dispatch({
+      const result = await testDispatcher.dispatch<VscodeShowMessageIntent>({
         type: INTENT_VSCODE_SHOW_MESSAGE,
         payload: {
           workspacePath,
@@ -462,22 +475,22 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
           message: request.text,
           hint: request.tooltip,
         },
-      } as VscodeShowMessageIntent);
+      });
       return result as string | null;
     },
 
     /**
      * Dispose a status bar item via the vscode-show-message hook.
      */
-    async disposeStatusBar(workspacePath: string): Promise<string | null> {
-      const result = await testDispatcher.dispatch({
+    async disposeStatusBar(workspacePath: WorkspacePath): Promise<string | null> {
+      const result = await testDispatcher.dispatch<VscodeShowMessageIntent>({
         type: INTENT_VSCODE_SHOW_MESSAGE,
         payload: {
           workspacePath,
           type: "status" as VscodeShowMessageType,
           message: null,
         },
-      } as VscodeShowMessageIntent);
+      });
       return result as string | null;
     },
 
@@ -485,7 +498,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
      * Show a quick pick via the vscode-show-message hook.
      */
     async showQuickPick(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       request: {
         items: readonly { label: string; description?: string; detail?: string }[];
         title?: string;
@@ -493,7 +506,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
       },
       timeoutMs?: number
     ): Promise<string | null> {
-      const result = await testDispatcher.dispatch({
+      const result = await testDispatcher.dispatch<VscodeShowMessageIntent>({
         type: INTENT_VSCODE_SHOW_MESSAGE,
         payload: {
           workspacePath,
@@ -503,7 +516,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
           options: request.items.map((i) => i.label),
           timeoutMs,
         },
-      } as VscodeShowMessageIntent);
+      });
       return result as string | null;
     },
 
@@ -511,11 +524,11 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
      * Show an input box via the vscode-show-message hook.
      */
     async showInputBox(
-      workspacePath: string,
+      workspacePath: WorkspacePath,
       request: { title?: string; prompt?: string; placeholder?: string; value?: string },
       timeoutMs?: number
     ): Promise<string | null> {
-      const result = await testDispatcher.dispatch({
+      const result = await testDispatcher.dispatch<VscodeShowMessageIntent>({
         type: INTENT_VSCODE_SHOW_MESSAGE,
         payload: {
           workspacePath,
@@ -524,7 +537,7 @@ export async function createPluginServerEnv(options?: PluginServerOptions) {
           hint: request.placeholder,
           timeoutMs,
         },
-      } as VscodeShowMessageIntent);
+      });
       return result as string | null;
     },
 

--- a/src/modules/power-module.integration.test.ts
+++ b/src/modules/power-module.integration.test.ts
@@ -29,6 +29,7 @@ import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createAppBoundaryMock, type MockAppBoundary } from "../boundaries/shell/app.state-mock";
 import type { AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Helpers
@@ -49,7 +50,7 @@ function createModuleTestSetup(): ModuleTestSetup {
   // Every workspace path resolves; workspaceName derives from the path basename.
   registerTestInfrastructure(dispatcher, {
     workspaces: (workspacePath) => ({
-      projectPath: "/projects/test",
+      projectPath: projPath("/projects/test"),
       workspaceName: workspacePath.split("/").pop() as WorkspaceName,
     }),
     projects: () => ({ projectId: "test-project" as ProjectId }),
@@ -74,43 +75,43 @@ describe("PowerModule Integration", () => {
   describe("blocks sleep while a workspace is busy", () => {
     it("does not prevent sleep when a workspace is idle", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), idle()));
       expect(appLayer).not.toBePreventingSleep();
     });
 
     it("prevents sleep when a workspace becomes busy", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy(2)));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy(2)));
       expect(appLayer).toBePreventingSleep();
     });
 
     it("prevents sleep for a mixed workspace", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", mixed()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), mixed()));
       expect(appLayer).toBePreventingSleep();
     });
 
     it("releases the blocker when the busy workspace becomes idle", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
       expect(appLayer).toBePreventingSleep();
 
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), idle()));
       expect(appLayer).not.toBePreventingSleep();
     });
 
     it("keeps blocking while at least one of several workspaces is busy", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
-      await dispatcher.dispatch(updateStatusIntent("/workspace/2", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/2"), busy()));
       expect(appLayer).toBePreventingSleep();
 
       // One goes idle - the other is still busy.
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", idle()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), idle()));
       expect(appLayer).toBePreventingSleep();
 
       // Both idle now - release.
-      await dispatcher.dispatch(updateStatusIntent("/workspace/2", idle()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/2"), idle()));
       expect(appLayer).not.toBePreventingSleep();
     });
   });
@@ -118,23 +119,23 @@ describe("PowerModule Integration", () => {
   describe("offline workspaces allow sleep", () => {
     it("releases when the only busy workspace goes to status none (hibernation teardown)", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
       expect(appLayer).toBePreventingSleep();
 
       // Hibernation stops the agent server, which fires status "none".
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", none()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), none()));
       expect(appLayer).not.toBePreventingSleep();
     });
 
     it("releases when the only busy workspace is deleted", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
       expect(appLayer).toBePreventingSleep();
 
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspace/1",
+          workspacePath: wsPath("/workspace/1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -146,15 +147,15 @@ describe("PowerModule Integration", () => {
 
     it("keeps blocking when a busy workspace remains after another is deleted", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
-      await dispatcher.dispatch(updateStatusIntent("/workspace/2", idle()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/2"), idle()));
       expect(appLayer).toBePreventingSleep();
 
       // Delete the idle one - the busy one remains.
       const deleteIntent: DeleteWorkspaceIntent = {
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspace/2",
+          workspacePath: wsPath("/workspace/2"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
@@ -168,9 +169,9 @@ describe("PowerModule Integration", () => {
   describe("idempotency", () => {
     it("does not start a second blocker on repeated busy updates", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy(3)));
-      await dispatcher.dispatch(updateStatusIntent("/workspace/2", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy(3)));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/2"), busy()));
 
       expect(appLayer).toBePreventingSleep();
       expect(appLayer).toHaveSleepBlockerStartCount(1);
@@ -180,7 +181,7 @@ describe("PowerModule Integration", () => {
   describe("shutdown", () => {
     it("releases the blocker on app shutdown", async () => {
       const { dispatcher, appLayer } = createModuleTestSetup();
-      await dispatcher.dispatch(updateStatusIntent("/workspace/1", busy()));
+      await dispatcher.dispatch(updateStatusIntent(wsPath("/workspace/1"), busy()));
       expect(appLayer).toBePreventingSleep();
 
       dispatcher.registerOperation(
@@ -188,7 +189,7 @@ describe("PowerModule Integration", () => {
           throwOnError: false,
         })
       );
-      await dispatcher.dispatch({ type: INTENT_APP_SHUTDOWN, payload: {} } as AppShutdownIntent);
+      await dispatcher.dispatch<AppShutdownIntent>({ type: INTENT_APP_SHUTDOWN, payload: {} });
 
       expect(appLayer).not.toBePreventingSleep();
     });

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -64,13 +64,14 @@ import { EVENT_METADATA_CHANGED } from "../../intents/set-metadata";
 import { EVENT_SHORTCUT_ACTIVE_CHANGED } from "../../intents/set-shortcut-active";
 import { EVENT_SHORTCUT_KEY_PRESSED } from "../../intents/shortcut-key";
 import { createPresentationModule, type UiPresenter } from "./presentation-module";
+import { projPath, wsPath } from "../../shared/test-fixtures";
 
 // =============================================================================
 // Test setup helpers
 // =============================================================================
 
 const PROJECT_ID = "alpha-12345678" as ProjectId;
-const PROJECT_PATH = "/projects/alpha";
+const PROJECT_PATH = projPath("/projects/alpha");
 // Local copies of the sidebar-width default/floor (the source constants are no
 // longer exported; the tests only need values that match main.ts's inlined
 // 250, which is stable).
@@ -203,7 +204,7 @@ function makeWorkspace(
     name: name as WorkspaceName,
     branch: name,
     metadata: options?.metadata ?? {},
-    path: `${PROJECT_PATH}/.worktrees/${name}`,
+    path: wsPath(`${PROJECT_PATH}/.worktrees/${name}`),
     ...(options?.url !== undefined && { url: options.url }),
   };
 }
@@ -914,7 +915,7 @@ describe("PresentationModule - ui:state snapshots", () => {
       name: "b" as WorkspaceName,
       branch: "b",
       metadata: {},
-      path: "/projects/beta/.worktrees/b",
+      path: wsPath("/projects/beta/.worktrees/b"),
       url: "http://127.0.0.1:1/b",
     };
     await emit(module, EVENT_PROJECT_OPENED, {
@@ -1057,10 +1058,10 @@ describe("PresentationModule - shutdown", () => {
     const pushesBefore = snapshots(deps).length;
     expect(pushesBefore).toBeGreaterThan(0);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppShutdownIntent>({
       type: INTENT_APP_SHUTDOWN,
       payload: {},
-    } as AppShutdownIntent);
+    });
 
     // After shutdown the ui:event listener is removed: further events do nothing.
     emitUiEvent(deps, { kind: "hover", region: null });

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -147,6 +147,7 @@ import {
 } from "./sessions";
 import type { NotificationConfig } from "../../shared/notification-types";
 import { getErrorMessage } from "../../shared/error-utils";
+import type { ProjectPath, WorkspacePath } from "../../intents/contract";
 
 export interface PresentationModuleDeps {
   readonly loggingService: Pick<Logging, "createLogger">;
@@ -231,7 +232,7 @@ interface WorkspaceModel {
    */
   title: string | undefined;
   /** Real worktree path; null while the workspace is still being created. */
-  path: string | null;
+  path: WorkspacePath | null;
   hibernated: boolean;
   tags: WorkspaceTag[];
   url: string | undefined;
@@ -271,7 +272,7 @@ function toUiDeletionProgress(progress: DeletionProgress): UiDeletionProgress {
 interface ProjectModel {
   readonly id: string;
   readonly name: string;
-  readonly path: string;
+  readonly path: ProjectPath;
   readonly remoteUrl: string | undefined;
   /** Keyed by workspace name (unique per project); insertion-ordered. */
   readonly workspaces: Map<string, WorkspaceModel>;
@@ -851,10 +852,10 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
         }
         return;
       case "quit": {
-        const handle = deps.dispatcher.dispatch({
+        const handle = deps.dispatcher.dispatch<AppShutdownIntent>({
           type: INTENT_APP_SHUTDOWN,
           payload: {},
-        } as AppShutdownIntent);
+        });
         void handle.catch((error: unknown) => {
           logger.debug("app:shutdown dispatch rejected", { error: getErrorMessage(error) });
         });
@@ -988,7 +989,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   }
 
   /** The interactive remove flow (shared by the ui:event and shortcut delete). */
-  function dispatchInteractiveDelete(workspacePath: string): void {
+  function dispatchInteractiveDelete(workspacePath: WorkspacePath): void {
     dispatchDetached({
       type: INTENT_DELETE_WORKSPACE,
       payload: {
@@ -1164,7 +1165,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
   }
 
   /** Switch to a workspace by its real path (placeholders are skipped upstream). */
-  function navigateSwitch(workspacePath: string): void {
+  function navigateSwitch(workspacePath: WorkspacePath): void {
     dispatchDetached({
       type: INTENT_SWITCH_WORKSPACE,
       payload: { workspacePath, focus: false },

--- a/src/modules/remote-project-module.integration.test.ts
+++ b/src/modules/remote-project-module.integration.test.ts
@@ -8,11 +8,12 @@
 
 import { describe, it, expect } from "vitest";
 import type {
-  HookContext,
-  ResolvedHooks,
-  HookResult,
-  HookOutput,
   CollectOptions,
+  HookContext,
+  HookOutput,
+  HookResult,
+  OperationSchemas,
+  ResolvedHooks,
 } from "../intents/lib/operation";
 import type { IntentModule } from "../intents/lib/module";
 
@@ -25,16 +26,16 @@ import { createMockPathProvider } from "../boundaries/platform/path-provider.tes
 import { createFileSystemMock } from "../boundaries/platform/filesystem.state-mock";
 import { createRemoteProjectModule } from "./remote-project-module";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
-import type {
-  ResolveHookResult,
-  OpenProjectIntent,
-  CloneProgressFrame,
-} from "../intents/open-project";
+import type { OpenProjectIntent, CloneProgressFrame } from "../intents/open-project";
 import { CLOSE_PROJECT_OPERATION_ID } from "../intents/close-project";
-import type { CloseHookInput, CloseHookResult, CloseProjectIntent } from "../intents/close-project";
+import type { CloseHookInput, CloseProjectIntent } from "../intents/close-project";
 import { Path } from "../utils/path/path";
 import { extractRepoName } from "../utils/url-utils";
 import type { ProjectId } from "../shared/api/types";
+import type { schemas as openProjectSchemas } from "../intents/open-project";
+import type { schemas as closeProjectSchemas } from "../intents/close-project";
+import type { ProjectPath } from "../intents/contract";
+import { projPath } from "../shared/test-fixtures";
 
 // Pre-computed: generateProjectIdFromUrl("https://github.com/org/repo.git")
 const URL_PROJECT_ID = "repo-4c06e3f1" as ProjectId;
@@ -46,11 +47,14 @@ expect.extend(gitClientMatchers);
 // =============================================================================
 
 /**
- * Build a ResolvedHooks from a module's hook declarations for a given operation.
+ * Build a ResolvedHooks view from a module's hook declarations for a given operation.
  * Mirrors the Dispatcher: awaits a plain handler, or drains a streaming
  * (async-generator) handler, forwarding yielded frames to options.onYield.
  */
-function resolveHooksFromModule(module: IntentModule, operationId: string): ResolvedHooks {
+function resolveHooksFromModule<S extends OperationSchemas>(
+  module: IntentModule,
+  operationId: string
+): ResolvedHooks<S> {
   const opHooks = module.hooks?.[operationId] ?? {};
   return {
     collect: async <T>(
@@ -101,7 +105,10 @@ function createTestSetup() {
   });
 
   const hookRegistry = {
-    resolve: (operationId: string) => resolveHooksFromModule(module, operationId),
+    // Generic over the operation's bundle so each caller gets that operation's hook points
+    // and result types — project:open and project:close have different ones.
+    resolve: <S extends OperationSchemas>(operationId: string) =>
+      resolveHooksFromModule<S>(module, operationId),
   };
 
   return { hookRegistry, fs, gitClient, pathProvider };
@@ -111,7 +118,7 @@ function createTestSetup() {
 // Intent Helpers
 // =============================================================================
 
-function openProjectIntent(payload: { git?: string; path?: Path }): OpenProjectIntent {
+function openProjectIntent(payload: { git?: string; path?: ProjectPath }): OpenProjectIntent {
   return {
     type: "project:open",
     payload,
@@ -123,7 +130,7 @@ function resolveContext(intent: OpenProjectIntent): HookContext {
 }
 
 function closeProjectIntent(payload: {
-  projectPath: string;
+  projectPath: ProjectPath;
   removeLocalRepo?: boolean;
 }): CloseProjectIntent {
   return {
@@ -145,13 +152,10 @@ describe("RemoteProjectModule Integration", () => {
     it("clones new repo when URL provided and no existing clone", async () => {
       const { hookRegistry, gitClient } = createTestSetup();
 
-      const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
+      const hooks = hookRegistry.resolve<typeof openProjectSchemas>(OPEN_PROJECT_OPERATION_ID);
       const intent = openProjectIntent({ git: "https://github.com/org/repo.git" });
 
-      const { results, errors } = await hooks.collect<ResolveHookResult | undefined>(
-        "resolve",
-        resolveContext(intent)
-      );
+      const { results, errors } = await hooks.collect("resolve", resolveContext(intent));
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -177,13 +181,10 @@ describe("RemoteProjectModule Integration", () => {
       // Pre-populate filesystem so readdir succeeds
       fs.$.setEntry(gitPath.toString(), { type: "directory" });
 
-      const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
+      const hooks = hookRegistry.resolve<typeof openProjectSchemas>(OPEN_PROJECT_OPERATION_ID);
       const intent = openProjectIntent({ git: url });
 
-      const { results, errors } = await hooks.collect<ResolveHookResult | undefined>(
-        "resolve",
-        resolveContext(intent)
-      );
+      const { results, errors } = await hooks.collect("resolve", resolveContext(intent));
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -200,13 +201,10 @@ describe("RemoteProjectModule Integration", () => {
     it("returns undefined for local path (no git URL)", async () => {
       const { hookRegistry } = createTestSetup();
 
-      const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
-      const intent = openProjectIntent({ path: new Path("/local/project") });
+      const hooks = hookRegistry.resolve<typeof openProjectSchemas>(OPEN_PROJECT_OPERATION_ID);
+      const intent = openProjectIntent({ path: projPath(new Path("/local/project").toString()) });
 
-      const { results, errors } = await hooks.collect<ResolveHookResult | undefined>(
-        "resolve",
-        resolveContext(intent)
-      );
+      const { results, errors } = await hooks.collect("resolve", resolveContext(intent));
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(0);
@@ -220,13 +218,10 @@ describe("RemoteProjectModule Integration", () => {
         throw new Error("Network error: connection refused");
       };
 
-      const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
+      const hooks = hookRegistry.resolve<typeof openProjectSchemas>(OPEN_PROJECT_OPERATION_ID);
       const intent = openProjectIntent({ git: "https://github.com/org/repo.git" });
 
-      const { results, errors } = await hooks.collect<ResolveHookResult | undefined>(
-        "resolve",
-        resolveContext(intent)
-      );
+      const { results, errors } = await hooks.collect("resolve", resolveContext(intent));
 
       expect(errors).toHaveLength(1);
       expect(errors[0]!.message).toBe("Network error: connection refused");
@@ -253,10 +248,10 @@ describe("RemoteProjectModule Integration", () => {
         return originalClone(url, targetPath);
       };
 
-      const hooks = hookRegistry.resolve(OPEN_PROJECT_OPERATION_ID);
+      const hooks = hookRegistry.resolve<typeof openProjectSchemas>(OPEN_PROJECT_OPERATION_ID);
       const intent = openProjectIntent({ git: "https://github.com/org/repo.git" });
 
-      await hooks.collect<ResolveHookResult | undefined>("resolve", resolveContext(intent), {
+      await hooks.collect("resolve", resolveContext(intent), {
         onYield: (frame) => {
           progressFrames.push(frame as CloneProgressFrame);
         },
@@ -280,15 +275,17 @@ describe("RemoteProjectModule Integration", () => {
     it("deletes clone directory when removeLocalRepo=true and remoteUrl in context", async () => {
       const { hookRegistry, fs } = createTestSetup();
 
-      const projectPath = "/test/app-data/remotes/abc12345/repo";
+      const projectPath = projPath("/test/app-data/remotes/abc12345/repo");
 
       // Pre-populate clone directory
       fs.$.setEntry("/test/app-data/remotes/abc12345", { type: "directory" });
       fs.$.setEntry(projectPath, { type: "directory" });
 
-      const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
+      const closeHooks = hookRegistry.resolve<typeof closeProjectSchemas>(
+        CLOSE_PROJECT_OPERATION_ID
+      );
       const closeIntnt = closeProjectIntent({
-        projectPath: "/test/project",
+        projectPath: projPath("/test/project"),
         removeLocalRepo: true,
       });
 
@@ -298,7 +295,7 @@ describe("RemoteProjectModule Integration", () => {
         removeLocalRepo: true,
         remoteUrl: "https://github.com/org/repo.git",
       };
-      const { results, errors } = await closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { results, errors } = await closeHooks.collect("close", closeCtx);
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -310,13 +307,15 @@ describe("RemoteProjectModule Integration", () => {
     it("no-op when removeLocalRepo=false", async () => {
       const { hookRegistry, fs } = createTestSetup();
 
-      const projectPath = "/test/app-data/remotes/abc12345/repo";
+      const projectPath = projPath("/test/app-data/remotes/abc12345/repo");
       fs.$.setEntry("/test/app-data/remotes/abc12345", { type: "directory" });
       fs.$.setEntry(projectPath, { type: "directory" });
 
-      const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
+      const closeHooks = hookRegistry.resolve<typeof closeProjectSchemas>(
+        CLOSE_PROJECT_OPERATION_ID
+      );
       const closeIntnt = closeProjectIntent({
-        projectPath: "/test/project",
+        projectPath: projPath("/test/project"),
         removeLocalRepo: false,
       });
 
@@ -326,7 +325,7 @@ describe("RemoteProjectModule Integration", () => {
         removeLocalRepo: false,
         remoteUrl: "https://github.com/org/repo.git",
       };
-      const { results, errors } = await closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { results, errors } = await closeHooks.collect("close", closeCtx);
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);
@@ -339,11 +338,13 @@ describe("RemoteProjectModule Integration", () => {
     it("no-op when no remoteUrl in context (local project)", async () => {
       const { hookRegistry } = createTestSetup();
 
-      const projectPath = "/home/user/projects/local";
+      const projectPath = projPath("/home/user/projects/local");
 
-      const closeHooks = hookRegistry.resolve(CLOSE_PROJECT_OPERATION_ID);
+      const closeHooks = hookRegistry.resolve<typeof closeProjectSchemas>(
+        CLOSE_PROJECT_OPERATION_ID
+      );
       const closeIntnt = closeProjectIntent({
-        projectPath: "/test/project",
+        projectPath: projPath("/test/project"),
         removeLocalRepo: true,
       });
 
@@ -353,7 +354,7 @@ describe("RemoteProjectModule Integration", () => {
         removeLocalRepo: true,
         // No remoteUrl — local project
       };
-      const { results, errors } = await closeHooks.collect<CloseHookResult>("close", closeCtx);
+      const { results, errors } = await closeHooks.collect("close", closeCtx);
 
       expect(errors).toHaveLength(0);
       expect(results).toHaveLength(1);

--- a/src/modules/remote-project-module.ts
+++ b/src/modules/remote-project-module.ts
@@ -19,6 +19,7 @@ import type { PathProvider } from "../boundaries/platform/path-provider";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { Logger } from "../boundaries/platform/logging";
 import { Path } from "../utils/path/path";
+import { projectPathSchema } from "../intents/contract";
 import type { ProjectId } from "../shared/api/types";
 import { expandGitUrl, normalizeGitUrl, extractRepoName } from "../utils/url-utils";
 import type {
@@ -100,7 +101,7 @@ export function createRemoteProjectModule(deps: {
               });
               return {
                 result: {
-                  projectPath: gitPath.toString(),
+                  projectPath: projectPathSchema.parse(gitPath.toString()),
                   remoteUrl: expanded,
                 },
               };
@@ -122,7 +123,12 @@ export function createRemoteProjectModule(deps: {
             // No saveProject call — LocalProjectModule.register handles persistence
             // with remoteUrl from context
 
-            return { result: { projectPath: gitPath.toString(), remoteUrl: expanded } };
+            return {
+              result: {
+                projectPath: projectPathSchema.parse(gitPath.toString()),
+                remoteUrl: expanded,
+              },
+            };
           },
         },
       },

--- a/src/modules/script-module.integration.test.ts
+++ b/src/modules/script-module.integration.test.ts
@@ -64,10 +64,10 @@ describe("ScriptModule Integration", () => {
     });
     dispatcher.registerModule(module);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     // Should clean and recreate bin dir
     expect(fileSystem.rm).toHaveBeenCalledWith(
@@ -124,10 +124,10 @@ describe("ScriptModule Integration", () => {
     });
     dispatcher.registerModule(module);
 
-    await dispatcher.dispatch({
+    await dispatcher.dispatch<AppStartIntent>({
       type: INTENT_APP_START,
       payload: {},
-    } as AppStartIntent);
+    });
 
     // Should still clean and recreate bin dir
     expect(fileSystem.rm).toHaveBeenCalled();

--- a/src/modules/shortcut-module.integration.test.ts
+++ b/src/modules/shortcut-module.integration.test.ts
@@ -189,7 +189,7 @@ async function createHarness(
 
   dispatcher.registerModule(module);
 
-  await dispatcher.dispatch({ type: INTENT_APP_START, payload: {} } as AppStartIntent);
+  await dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} });
 
   const emitSwitched = (): Promise<void> =>
     module.events![EVENT_WORKSPACE_SWITCHED]!.handler({
@@ -580,10 +580,10 @@ describe("ShortcutModule integration", () => {
 
     it("dispose unregisters all views and window blur handler on shutdown", async () => {
       const { callbacks, dispatcher } = await createHarness();
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppShutdownIntent>({
         type: INTENT_APP_SHUTDOWN,
         payload: {},
-      } as AppShutdownIntent);
+      });
       expect(callbacks.inputUnsubscribes.get("ui-view")).toHaveBeenCalled();
       expect(callbacks.destroyedUnsubscribes.get("ui-view")).toHaveBeenCalled();
       expect(callbacks.blurUnsubscribe).toHaveBeenCalled();

--- a/src/modules/shortcut-module.ts
+++ b/src/modules/shortcut-module.ts
@@ -156,10 +156,10 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     shortcutActive = true;
     if (restricted) return;
     broadcasted = true;
-    void deps.dispatcher.dispatch({
+    void deps.dispatcher.dispatch<SetShortcutActiveIntent>({
       type: INTENT_SET_SHORTCUT_ACTIVE,
       payload: { active: true },
-    } as SetShortcutActiveIntent);
+    });
   }
 
   /** Exit shortcut mode. Broadcasts active:false only if entry broadcast true. */
@@ -168,17 +168,17 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     shortcutActive = false;
     if (!broadcasted) return;
     broadcasted = false;
-    void deps.dispatcher.dispatch({
+    void deps.dispatcher.dispatch<SetShortcutActiveIntent>({
       type: INTENT_SET_SHORTCUT_ACTIVE,
       payload: { active: false },
-    } as SetShortcutActiveIntent);
+    });
   }
 
   function dispatchShortcutKey(key: string): void {
-    void deps.dispatcher.dispatch({
+    void deps.dispatcher.dispatch<ShortcutKeyIntent>({
       type: INTENT_SHORTCUT_KEY,
       payload: { key },
-    } as ShortcutKeyIntent);
+    });
   }
 
   function registerView(target: KeyboardTarget): void {
@@ -242,10 +242,10 @@ export function createShortcutModule(deps: ShortcutModuleDeps): IntentModule {
     // the Alt+X state machine, so it fires in any state (including shortcut mode).
     if (deps.platform === "linux" && input.key === QUIT_KEY && input.alt) {
       deps.logger.info("Alt+F4 pressed — dispatching app:shutdown");
-      void deps.dispatcher.dispatch({
+      void deps.dispatcher.dispatch<AppShutdownIntent>({
         type: INTENT_APP_SHUTDOWN,
         payload: {},
-      } as AppShutdownIntent);
+      });
       return;
     }
 

--- a/src/modules/telemetry-module.integration.test.ts
+++ b/src/modules/telemetry-module.integration.test.ts
@@ -40,6 +40,7 @@ import { createMockState, type MockStateService } from "../boundaries/platform/s
 import { createStateMigrationRegistry } from "./state-module";
 import { z } from "zod/v4";
 import type { Operation, OperationSchemas } from "../intents/lib/operation";
+import { wsPath, projPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Helpers
@@ -66,8 +67,8 @@ function createMinimalOpenWorkspaceOperation(
 const NEW_WORKSPACE_PAYLOAD: WorkspaceCreatedPayload = {
   projectId: "project-1" as WorkspaceCreatedPayload["projectId"],
   workspaceName: "ws-1" as WorkspaceCreatedPayload["workspaceName"],
-  workspacePath: "/ws",
-  projectPath: "/proj",
+  workspacePath: wsPath("/ws"),
+  projectPath: projPath("/proj"),
   branch: "ws-1",
   metadata: {},
   workspaceUrl: "http://127.0.0.1:8080",

--- a/src/modules/temp-dir-module.integration.test.ts
+++ b/src/modules/temp-dir-module.integration.test.ts
@@ -68,10 +68,10 @@ describe("TempDirModule Integration", () => {
     it("creates the temp directory", async () => {
       const { dispatcher, fileSystem } = createTestSetup();
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       expect(fileSystem.mkdir).toHaveBeenCalledWith(
         expect.objectContaining({ toString: expect.any(Function) })
@@ -81,10 +81,10 @@ describe("TempDirModule Integration", () => {
     it("uses the temp path under data root", async () => {
       const { dispatcher, fileSystem } = createTestSetup();
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       const mkdirPath = fileSystem.mkdir.mock.calls[0]![0];
       expect(mkdirPath.toString()).toBe("/test/app-data/temp");

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -38,10 +38,10 @@ import {
   INTENT_SWITCH_WORKSPACE,
   SWITCH_WORKSPACE_OPERATION_ID,
   EVENT_WORKSPACE_SWITCHED,
+  switchWorkspaceHookResultSchema,
 } from "../intents/switch-workspace";
 import type {
   SwitchWorkspaceIntent,
-  SwitchWorkspaceHookResult,
   ActivateHookInput,
   WorkspaceSwitchedEvent,
 } from "../intents/switch-workspace";
@@ -50,13 +50,18 @@ import type { IdeServerRestartedEvent } from "../intents/app-resume";
 import {
   INTENT_DELETE_WORKSPACE,
   DELETE_WORKSPACE_OPERATION_ID,
+  shutdownResultSchema,
 } from "../intents/delete-workspace";
 import type {
   DeleteWorkspaceIntent,
   DeletePipelineHookInput,
   ShutdownHookResult,
 } from "../intents/delete-workspace";
-import { INTENT_OPEN_PROJECT, OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
+import {
+  INTENT_OPEN_PROJECT,
+  OPEN_PROJECT_OPERATION_ID,
+  selectFolderHookResultSchema,
+} from "../intents/open-project";
 import type { SelectFolderHookResult } from "../intents/open-project";
 import {
   RESOLVE_WORKSPACE_OPERATION_ID,
@@ -67,6 +72,9 @@ import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createMockViewManager } from "../boundaries/shell/view-manager.test-utils";
 import { createViewModule, type ViewModuleDeps } from "./view-module";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { wsPath, projPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "../intents/contract";
+import type { ProjectPath } from "../intents/contract";
 
 // =============================================================================
 // Mock IViewManager
@@ -90,6 +98,7 @@ function createMockShellLayers() {
 const switchOpSchemas = {
   type: INTENT_SWITCH_WORKSPACE,
   payload: z.unknown(),
+  hooks: { activate: { result: switchWorkspaceHookResultSchema } },
 } satisfies OperationSchemas;
 
 /** Runs "activate" hook point + emits workspace:switched event. */
@@ -97,17 +106,16 @@ class MinimalSwitchOperation implements Operation<typeof switchOpSchemas> {
   readonly id = SWITCH_WORKSPACE_OPERATION_ID;
   readonly schemas = switchOpSchemas;
   constructor(private readonly active: boolean = false) {}
-  async execute(ctx: OperationContext<IntentOf<typeof switchOpSchemas>>): Promise<void> {
-    const workspacePath = (ctx.intent.payload as { workspacePath: string }).workspacePath;
+  async execute(
+    ctx: OperationContext<IntentOf<typeof switchOpSchemas>, typeof switchOpSchemas>
+  ): Promise<void> {
+    const workspacePath = (ctx.intent.payload as { workspacePath: WorkspacePath }).workspacePath;
     const activateCtx: ActivateHookInput = {
       intent: ctx.intent,
       workspacePath,
       active: this.active,
     };
-    const { results, errors } = await ctx.hooks.collect<SwitchWorkspaceHookResult>(
-      "activate",
-      activateCtx
-    );
+    const { results, errors } = await ctx.hooks.collect("activate", activateCtx);
     if (errors.length > 0) throw errors[0]!;
     let resolvedPath: string | undefined;
     for (const r of results) {
@@ -121,9 +129,9 @@ class MinimalSwitchOperation implements Operation<typeof switchOpSchemas> {
         payload: {
           projectId: "test-project" as ProjectId,
           projectName: "test",
-          projectPath: "/projects/test",
+          projectPath: projPath("/projects/test"),
           workspaceName: workspaceName as WorkspaceName,
-          path: resolvedPath,
+          path: wsPath(resolvedPath),
           metadata: {},
         },
       };
@@ -136,6 +144,7 @@ const deleteOpSchemas = {
   type: INTENT_DELETE_WORKSPACE,
   payload: z.unknown(),
   result: z.custom<ShutdownHookResult>(),
+  hooks: { shutdown: { result: shutdownResultSchema } },
 } satisfies OperationSchemas;
 
 /** Runs "shutdown" hook point only. */
@@ -144,17 +153,17 @@ class MinimalDeleteOperation implements Operation<typeof deleteOpSchemas> {
   readonly schemas = deleteOpSchemas;
   constructor(private readonly active: boolean = false) {}
   async execute(
-    ctx: OperationContext<IntentOf<typeof deleteOpSchemas>>
+    ctx: OperationContext<IntentOf<typeof deleteOpSchemas>, typeof deleteOpSchemas>
   ): Promise<ShutdownHookResult> {
     const payload = ctx.intent.payload as DeleteWorkspaceIntent["payload"];
     const hookCtx: DeletePipelineHookInput = {
       intent: ctx.intent,
-      projectPath: "/projects/test",
+      projectPath: projPath("/projects/test"),
       workspacePath: payload.workspacePath,
       workspaceName: "test-workspace" as WorkspaceName,
       active: this.active,
     };
-    const { results, errors } = await ctx.hooks.collect<ShutdownHookResult>("shutdown", hookCtx);
+    const { results, errors } = await ctx.hooks.collect("shutdown", hookCtx);
     if (errors.length > 0) throw errors[0]!;
     const merged: ShutdownHookResult = {};
     for (const r of results) {
@@ -169,6 +178,7 @@ const selectFolderOpSchemas = {
   type: INTENT_OPEN_PROJECT,
   payload: z.unknown(),
   result: z.custom<SelectFolderHookResult | null>(),
+  hooks: { "select-folder": { result: selectFolderHookResultSchema } },
 } satisfies OperationSchemas;
 
 /** Runs "select-folder" hook point (matches OpenProjectOperation's conditional hook). */
@@ -176,13 +186,13 @@ class MinimalSelectFolderOperation implements Operation<typeof selectFolderOpSch
   readonly id = OPEN_PROJECT_OPERATION_ID;
   readonly schemas = selectFolderOpSchemas;
   async execute(
-    ctx: OperationContext<IntentOf<typeof selectFolderOpSchemas>>
+    ctx: OperationContext<IntentOf<typeof selectFolderOpSchemas>, typeof selectFolderOpSchemas>
   ): Promise<SelectFolderHookResult | null> {
-    const { results, errors } = await ctx.hooks.collect<SelectFolderHookResult>("select-folder", {
+    const { results, errors } = await ctx.hooks.collect("select-folder", {
       intent: ctx.intent,
     });
     if (errors.length > 0) throw errors[0]!;
-    let folderPath: string | null = null;
+    let folderPath: ProjectPath | null = null;
     for (const r of results) {
       if (r.folderPath) folderPath = r.folderPath;
     }
@@ -240,7 +250,7 @@ function createTestSetup<S extends OperationSchemas = OperationSchemas>(
 }
 
 /** Run the module's resolve-workspace hook and return the `active` flag. */
-async function resolveActive(module: IntentModule, workspacePath: string): Promise<boolean> {
+async function resolveActive(module: IntentModule, workspacePath: WorkspacePath): Promise<boolean> {
   const hookCtx = {
     intent: { type: "workspace:resolve", payload: { workspacePath } },
     workspacePath,
@@ -285,15 +295,15 @@ describe("ViewModule Integration", () => {
         operation: new MinimalDeleteOperation(true),
       });
 
-      const result = await dispatcher.dispatch({
+      const result = await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent);
+      });
 
       expect(result).toEqual(expect.objectContaining({ wasActive: true }));
     });
@@ -305,23 +315,23 @@ describe("ViewModule Integration", () => {
       });
       dispatcher.registerOperation(new MinimalDeleteOperation(true));
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { workspacePath: "/workspaces/ws1" },
-      } as SwitchWorkspaceIntent);
-      expect(await resolveActive(module, "/workspaces/ws1")).toBe(true);
+        payload: { workspacePath: wsPath("/workspaces/ws1") },
+      });
+      expect(await resolveActive(module, wsPath("/workspaces/ws1"))).toBe(true);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<DeleteWorkspaceIntent>({
         type: INTENT_DELETE_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
           keepBranch: false,
           force: false,
           removeWorktree: true,
         },
-      } as DeleteWorkspaceIntent);
+      });
 
-      expect(await resolveActive(module, "/workspaces/ws1")).toBe(false);
+      expect(await resolveActive(module, wsPath("/workspaces/ws1"))).toBe(false);
     });
   });
 
@@ -335,15 +345,15 @@ describe("ViewModule Integration", () => {
         operation: new MinimalSwitchOperation(),
       });
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
         },
-      } as SwitchWorkspaceIntent);
+      });
 
-      expect(await resolveActive(module, "/workspaces/ws1")).toBe(true);
-      expect(await resolveActive(module, "/workspaces/ws2")).toBe(false);
+      expect(await resolveActive(module, wsPath("/workspaces/ws1"))).toBe(true);
+      expect(await resolveActive(module, wsPath("/workspaces/ws2"))).toBe(false);
     });
 
     it("does not record anything when already active (short-circuit)", async () => {
@@ -352,16 +362,16 @@ describe("ViewModule Integration", () => {
         operation: new MinimalSwitchOperation(true),
       });
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
         },
-      } as SwitchWorkspaceIntent);
+      });
 
       // The hook short-circuited: module state was not updated by activate
       // (the switched event also isn't emitted in this minimal operation).
-      expect(await resolveActive(module, "/workspaces/ws1")).toBe(false);
+      expect(await resolveActive(module, wsPath("/workspaces/ws1"))).toBe(false);
     });
   });
 
@@ -380,18 +390,18 @@ describe("ViewModule Integration", () => {
       dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
       // Switch to ws1 first to populate cache
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
         },
-      } as SwitchWorkspaceIntent);
+      });
 
       // Verify cache is populated
-      const refBefore = await dispatcher.dispatch({
+      const refBefore = await dispatcher.dispatch<GetActiveWorkspaceIntent>({
         type: INTENT_GET_ACTIVE_WORKSPACE,
         payload: {} as Record<string, never>,
-      } as GetActiveWorkspaceIntent);
+      });
       expect(refBefore).toEqual(expect.objectContaining({ path: "/workspaces/ws1" }));
 
       // Now emit workspace:switched with null payload by dispatching delete
@@ -419,14 +429,14 @@ describe("ViewModule Integration", () => {
       });
 
       // Verify cache is cleared
-      const refAfter = await dispatcher.dispatch({
+      const refAfter = await dispatcher.dispatch<GetActiveWorkspaceIntent>({
         type: INTENT_GET_ACTIVE_WORKSPACE,
         payload: {} as Record<string, never>,
-      } as GetActiveWorkspaceIntent);
+      });
       expect(refAfter).toBeNull();
 
       // Verify the active surface was cleared too
-      expect(await resolveActive(module, "/workspaces/ws1")).toBe(false);
+      expect(await resolveActive(module, wsPath("/workspaces/ws1"))).toBe(false);
     });
   });
 
@@ -442,17 +452,17 @@ describe("ViewModule Integration", () => {
 
       dispatcher.registerOperation(new GetActiveWorkspaceOperation());
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<SwitchWorkspaceIntent>({
         type: INTENT_SWITCH_WORKSPACE,
         payload: {
-          workspacePath: "/workspaces/ws1",
+          workspacePath: wsPath("/workspaces/ws1"),
         },
-      } as SwitchWorkspaceIntent);
+      });
 
-      const ref = await dispatcher.dispatch({
+      const ref = await dispatcher.dispatch<GetActiveWorkspaceIntent>({
         type: INTENT_GET_ACTIVE_WORKSPACE,
         payload: {} as Record<string, never>,
-      } as GetActiveWorkspaceIntent);
+      });
 
       expect(ref).toEqual({
         projectId: "test-project",
@@ -494,10 +504,10 @@ describe("ViewModule Integration", () => {
       dispatcher.registerModule(module);
       dispatcher.registerModule(quitModule);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppShutdownIntent>({
         type: INTENT_APP_SHUTDOWN,
         payload: {},
-      } as AppShutdownIntent);
+      });
 
       expect(viewManager.destroy).toHaveBeenCalled();
       expect(layers.viewLayer.dispose).toHaveBeenCalled();
@@ -537,10 +547,10 @@ describe("ViewModule Integration", () => {
       dispatcher.registerModule(quitModule);
 
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<AppShutdownIntent>({
           type: INTENT_APP_SHUTDOWN,
           payload: {},
-        } as AppShutdownIntent)
+        })
       ).resolves.not.toThrow();
     });
   });
@@ -579,10 +589,10 @@ describe("ViewModule Integration", () => {
 
       dispatcher.registerModule(module);
 
-      await dispatcher.dispatch({
+      await dispatcher.dispatch<AppStartIntent>({
         type: INTENT_APP_START,
         payload: {},
-      } as AppStartIntent);
+      });
 
       // Verify call sequence
       expect(menuLayer.setApplicationMenu).toHaveBeenCalledWith(null);
@@ -616,10 +626,10 @@ describe("ViewModule Integration", () => {
 
       // Should not throw when optional deps are omitted
       await expect(
-        dispatcher.dispatch({
+        dispatcher.dispatch<AppStartIntent>({
           type: INTENT_APP_START,
           payload: {},
-        } as AppStartIntent)
+        })
       ).resolves.not.toThrow();
 
       // viewManager.create() and focus() are always called

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -53,6 +53,7 @@ import {
 } from "../intents/resolve-workspace";
 import { EVENT_WORKSPACE_SWITCHED } from "../intents/switch-workspace";
 import { EVENT_IDE_SERVER_RESTARTED } from "../intents/app-resume";
+import { projectPathSchema } from "../intents/contract";
 
 // =============================================================================
 // Types
@@ -272,7 +273,11 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             if (result.canceled || result.filePaths.length === 0) {
               return { result: { folderPath: null } };
             }
-            return { result: { folderPath: result.filePaths[0]!.toString() } };
+            // The OS dialog hands back a raw string — one of the few genuine external
+            // edges, so the project-path brand is minted here by parsing.
+            return {
+              result: { folderPath: projectPathSchema.parse(result.filePaths[0]!.toString()) },
+            };
           },
         },
       },

--- a/src/modules/window-title-module.integration.test.ts
+++ b/src/modules/window-title-module.integration.test.ts
@@ -20,6 +20,7 @@ import type { MetadataChangedEvent } from "../intents/set-metadata";
 import type { Operation, OperationSchemas } from "../intents/lib/operation";
 import { createMinimalOperation } from "../intents/lib/operation.test-utils";
 import type { Intent } from "../intents/lib/types";
+import { projPath } from "../shared/test-fixtures";
 import {
   APP_START_OPERATION_ID,
   INTENT_APP_START,
@@ -27,6 +28,8 @@ import {
 } from "../intents/app-start";
 import { createWindowTitleModule } from "./window-title-module";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "../intents/contract";
 
 // =============================================================================
 // Minimal switch operation that emits workspace:switched
@@ -64,9 +67,9 @@ const minimalSwitchOperation: Operation<typeof minimalSwitchSchemas> = {
         ? {
             projectId: payload.projectId,
             projectName: payload.projectName,
-            projectPath: "/projects/test",
+            projectPath: projPath("/projects/test"),
             workspaceName: payload.workspaceName,
-            path: payload.path,
+            path: wsPath(payload.path),
             metadata: payload.metadata ?? {},
           }
         : null,
@@ -84,7 +87,7 @@ const INTENT_MINIMAL_SET_METADATA = "workspace:set-metadata" as const;
 interface MinimalSetMetadataPayload {
   readonly projectId: ProjectId;
   readonly workspaceName: WorkspaceName;
-  readonly workspacePath: string;
+  readonly workspacePath: WorkspacePath;
   readonly key: string;
   readonly value: string | null;
 }
@@ -110,7 +113,7 @@ const minimalSetMetadataOperation: Operation<typeof minimalSetMetadataSchemas> =
       payload: {
         projectId: payload.projectId,
         workspaceName: payload.workspaceName,
-        workspacePath: payload.workspacePath,
+        workspacePath: wsPath(payload.workspacePath),
         key: payload.key,
         value: payload.value,
       },
@@ -286,7 +289,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: ACTIVE.projectId,
           workspaceName: ACTIVE.workspaceName,
-          workspacePath: ACTIVE.path,
+          workspacePath: wsPath(ACTIVE.path),
           key: "title",
           value: "Fix login bug",
         })
@@ -305,7 +308,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: ACTIVE.projectId,
           workspaceName: ACTIVE.workspaceName,
-          workspacePath: ACTIVE.path,
+          workspacePath: wsPath(ACTIVE.path),
           key: "title",
           value: null,
         })
@@ -323,7 +326,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: ACTIVE.projectId,
           workspaceName: "other-branch" as WorkspaceName,
-          workspacePath: "/workspaces/other-branch",
+          workspacePath: wsPath("/workspaces/other-branch"),
           key: "title",
           value: "Someone else",
         })
@@ -341,7 +344,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: "other-project" as ProjectId,
           workspaceName: ACTIVE.workspaceName,
-          workspacePath: "/other/feature-branch",
+          workspacePath: wsPath("/other/feature-branch"),
           key: "title",
           value: "Someone else",
         })
@@ -359,7 +362,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: ACTIVE.projectId,
           workspaceName: ACTIVE.workspaceName,
-          workspacePath: ACTIVE.path,
+          workspacePath: wsPath(ACTIVE.path),
           key: "tags.wip",
           value: "{}",
         })
@@ -377,7 +380,7 @@ describe("WindowTitleModule Integration", () => {
         setMetadataIntent({
           projectId: ACTIVE.projectId,
           workspaceName: ACTIVE.workspaceName,
-          workspacePath: ACTIVE.path,
+          workspacePath: wsPath(ACTIVE.path),
           key: "title",
           value: "Fix login bug",
         })

--- a/src/modules/windows-file-lock-module.integration.test.ts
+++ b/src/modules/windows-file-lock-module.integration.test.ts
@@ -38,6 +38,7 @@ import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createBehavioralLogger } from "../boundaries/platform/logging.test-utils";
 import { createMockProcessRunner } from "../boundaries/platform/process.state-mock";
 import type { MockProcessRunner } from "../boundaries/platform/process.state-mock";
+import { wsPath, projPath } from "../shared/test-fixtures";
 
 // =============================================================================
 // Test Helpers
@@ -128,16 +129,18 @@ class FlushOperation implements Operation<typeof flushOpSchemas> {
 
   constructor(private readonly blockingPids: readonly number[]) {}
 
-  async execute(ctx: OperationContext<IntentOf<typeof flushOpSchemas>>): Promise<FlushHookResult> {
+  async execute(
+    ctx: OperationContext<IntentOf<typeof flushOpSchemas>, typeof flushOpSchemas>
+  ): Promise<FlushHookResult> {
     const flushCtx: FlushHookInput = {
       intent: ctx.intent,
-      projectPath: "/projects/my-app",
-      workspacePath: "/workspaces/feature-1",
+      projectPath: projPath("/projects/my-app"),
+      workspacePath: wsPath("/workspaces/feature-1"),
       workspaceName: "feature-1" as WorkspaceName,
       active: false,
       blockingPids: this.blockingPids,
     };
-    const { results, errors } = await ctx.hooks.collect<FlushHookResult>("flush", flushCtx);
+    const { results, errors } = await ctx.hooks.collect("flush", flushCtx);
     if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
   }

--- a/src/modules/workspace-selection-module.integration.test.ts
+++ b/src/modules/workspace-selection-module.integration.test.ts
@@ -32,20 +32,22 @@ import type { DomainEvent } from "../intents/lib/types";
 import { createWorkspaceSelectionModule } from "./workspace-selection-module";
 import { EVENT_AGENT_STATUS_UPDATED } from "../intents/update-agent-status";
 import type { AgentStatusUpdatedEvent } from "../intents/update-agent-status";
-import type { WorkspacePath, AggregatedAgentStatus } from "../shared/ipc";
+import type { AggregatedAgentStatus } from "../shared/ipc";
 import type { ProjectId, WorkspaceName } from "../shared/api/types";
+import { projPath, wsPath } from "../shared/test-fixtures";
+import type { WorkspacePath } from "../intents/contract";
 
 // =============================================================================
 // Test Constants
 // =============================================================================
 
-const PROJECT_PATH = "/projects/app";
+const PROJECT_PATH = projPath("/projects/app");
 const PROJECT_NAME = "app";
 const WS_A = "/projects/app/workspaces/alpha";
 const WS_B = "/projects/app/workspaces/beta";
 const WS_C = "/projects/app/workspaces/gamma";
 
-function candidate(workspacePath: string): WorkspaceCandidate {
+function candidate(workspacePath: WorkspacePath): WorkspaceCandidate {
   return {
     projectPath: PROJECT_PATH,
     projectName: PROJECT_NAME,
@@ -133,12 +135,12 @@ describe("WorkspaceSelectionModule", () => {
   describe("selects nearest candidate (#1)", () => {
     it("picks the next workspace in alphabetical order", async () => {
       const setup = createTestSetup({
-        candidates: [candidate(WS_A), candidate(WS_B), candidate(WS_C)],
+        candidates: [candidate(wsPath(WS_A)), candidate(wsPath(WS_B)), candidate(wsPath(WS_C))],
       });
 
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { auto: true, currentPath: WS_A },
+        payload: { auto: true, currentPath: wsPath(WS_A) },
       };
       await setup.dispatcher.dispatch(autoIntent);
 
@@ -149,7 +151,7 @@ describe("WorkspaceSelectionModule", () => {
   describe("prefers idle over busy (#2)", () => {
     it("selects idle workspace even when busy workspace is closer", async () => {
       const setup = createTestSetup({
-        candidates: [candidate(WS_A), candidate(WS_B), candidate(WS_C)],
+        candidates: [candidate(wsPath(WS_A)), candidate(wsPath(WS_B)), candidate(wsPath(WS_C))],
       });
 
       // Populate the module's internal status cache via its event handler
@@ -177,7 +179,7 @@ describe("WorkspaceSelectionModule", () => {
 
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { auto: true, currentPath: WS_A },
+        payload: { auto: true, currentPath: wsPath(WS_A) },
       };
       await setup.dispatcher.dispatch(autoIntent);
 
@@ -197,7 +199,7 @@ describe("WorkspaceSelectionModule", () => {
 
       const autoIntent: SwitchWorkspaceIntent = {
         type: INTENT_SWITCH_WORKSPACE,
-        payload: { auto: true, currentPath: "/nonexistent" },
+        payload: { auto: true, currentPath: wsPath("/nonexistent") },
       };
       await setup.dispatcher.dispatch(autoIntent);
 

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -182,7 +182,7 @@ export type {
   AgentStatus,
   AgentStatusCounts,
   BaseInfo,
-  ConfigAgentType,
+  AgentType as ConfigAgentType,
   SetupRowId,
   SetupRowStatus,
   BlockingProcess,

--- a/src/shared/error-utils.ts
+++ b/src/shared/error-utils.ts
@@ -3,6 +3,11 @@
  * Used by both main process (services) and renderer process.
  */
 
+import type { SerializedError } from "../intents/contract";
+
+/** Guard against a self-referential `cause` chain looping forever. */
+const MAX_CAUSE_DEPTH = 8;
+
 /**
  * Extract a message string from an unknown error.
  * Handles Error instances, strings, and other types.
@@ -25,4 +30,47 @@ export function getErrorMessage(error: unknown, fallback?: string): string {
  */
 export function isEnoent(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+/**
+ * Reduce a thrown value to plain, serializable data.
+ *
+ * An `Error` is a class instance and cannot cross a backend tunnel, so nothing on the intent
+ * contract carries one. This is the conversion producers apply before putting a failure on a
+ * hook context or event payload.
+ *
+ * Non-Error values are coerced (`String(value)` as the message) rather than rejected — a
+ * `throw "boom"` still has to be reportable. The `cause` chain is followed to a bounded depth
+ * so a cyclic cause can't hang the conversion.
+ */
+export function toSerializedError(error: unknown, depth = 0): SerializedError {
+  if (!(error instanceof Error)) {
+    return { name: "Error", message: String(error) };
+  }
+  const cause =
+    depth < MAX_CAUSE_DEPTH && error.cause !== undefined && error.cause !== null
+      ? toSerializedError(error.cause, depth + 1)
+      : undefined;
+  return {
+    name: error.name,
+    message: error.message,
+    ...(error.stack !== undefined && { stack: error.stack }),
+    ...(cause !== undefined && { cause }),
+  };
+}
+
+/**
+ * Rebuild an `Error` from its serialized form, for consumers that need a real one — the
+ * telemetry boundary reads `name`/`message`/`stack` off the instance to group issues.
+ *
+ * `name` is assigned explicitly: `new Error()` would report `"Error"`, which would file a
+ * `TypeError` under a different issue than it lands in today.
+ */
+export function fromSerializedError(error: SerializedError): Error {
+  const rebuilt = new Error(error.message, {
+    ...(error.cause !== undefined && { cause: fromSerializedError(error.cause) }),
+  });
+  rebuilt.name = error.name;
+  if (error.stack !== undefined) rebuilt.stack = error.stack;
+  return rebuilt;
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -76,20 +76,16 @@ export const ApiIpcChannels = {
 // ============ Lifecycle Event Payload Types ============
 
 /**
- * Agent types for agent selection.
- * Mirrors ConfigAgentType from api/types.ts but defined here to avoid circular imports.
+ * Agent types for agent selection, and the agent info the selection dialog renders
+ * (provided by per-agent modules via the register-agents hook).
+ *
+ * Type-only re-exports of the intent contract's `agentTypeSchema` / `agentInfoSchema`. zod is
+ * the single source of truth and stays confined to the intent system; these re-exports are
+ * erased at build, so renderer/preload keep importing from here without pulling zod in. There
+ * used to be four hand-written declarations of this two-member union (here, api/types.ts,
+ * config.ts, app-start.ts) — two of them sharing the name `ConfigAgentType`.
  */
-export type LifecycleAgentType = "opencode" | "claude";
-
-/**
- * Agent info for the selection dialog.
- * Provided by per-agent modules via the register-agents hook.
- */
-export interface AgentInfo {
-  readonly agent: LifecycleAgentType;
-  readonly label: string;
-  readonly icon: string;
-}
+export type { AgentType as LifecycleAgentType, AgentInfo } from "../intents/contract";
 
 // ============ Log API Types ============
 

--- a/src/shared/test-fixtures.ts
+++ b/src/shared/test-fixtures.ts
@@ -6,6 +6,8 @@
  */
 
 import type { Project, Workspace, ProjectId, WorkspaceName } from "./api/types";
+import { workspacePathSchema, projectPathSchema } from "../intents/contract";
+import type { ProjectPath, WorkspacePath } from "../intents/contract";
 
 /**
  * Default project ID used in test fixtures.
@@ -47,9 +49,27 @@ export function createMockWorkspace(overrides: WorkspaceOverrides = {}): Workspa
     name: name as WorkspaceName,
     branch,
     metadata: { base: branch ?? "main", ...overrides.metadata },
-    path: overrides.path ?? `/test/project/.worktrees/${name}`,
+    path: workspacePathSchema.parse(overrides.path ?? `/test/project/.worktrees/${name}`),
     ...(overrides.url !== undefined ? { url: overrides.url } : {}),
   };
+}
+
+// =============================================================================
+// Branded path helpers (tests)
+// =============================================================================
+
+/**
+ * Mint a branded project/workspace path for a fixture.
+ *
+ * Tests are producers of contract data like any other caller, so they mint brands the same
+ * way production edges do — by parsing — rather than with an `as` cast.
+ */
+export function projPath(p: string): ProjectPath {
+  return projectPathSchema.parse(p);
+}
+
+export function wsPath(p: string): WorkspacePath {
+  return workspacePathSchema.parse(p);
 }
 
 // =============================================================================
@@ -112,7 +132,7 @@ export function createMockProject(
   return {
     id: projectId,
     name: overrides.name ?? "test-project",
-    path: overrides.path ?? "/test/project",
+    path: projectPathSchema.parse(overrides.path ?? "/test/project"),
     workspaces,
     ...(overrides.defaultBaseBranch !== undefined
       ? { defaultBaseBranch: overrides.defaultBaseBranch }

--- a/src/shared/types/project.ts
+++ b/src/shared/types/project.ts
@@ -3,12 +3,19 @@
  * All properties are readonly for immutability.
  */
 
+import type { ProjectPath } from "../../intents/contract";
+
 /**
  * Configuration stored for a project.
  */
 export interface ProjectConfig {
-  /** Absolute path to the project directory */
-  readonly path: string;
+  /**
+   * Absolute path to the project directory.
+   *
+   * Branded: this config is read back from JSON on disk, which is one of the few places an
+   * unvalidated string genuinely enters the system, so the loader mints the brand by parsing.
+   */
+  readonly path: ProjectPath;
   /** Original git remote URL if project was cloned from URL */
   readonly remoteUrl?: string;
 }

--- a/src/utils/binary-resolution/types.ts
+++ b/src/utils/binary-resolution/types.ts
@@ -4,5 +4,9 @@
 
 /**
  * Binary types that can be resolved.
+ *
+ * Type-only re-export of the intent contract's `binaryTypeSchema` (zod is the single source
+ * of truth, and stays confined to the intent system — the erased re-export keeps it out of
+ * this module's imports).
  */
-export type BinaryType = "vscodium" | "opencode" | "claude";
+export type { BinaryType } from "../../intents/contract";

--- a/src/utils/workspace-conversion.ts
+++ b/src/utils/workspace-conversion.ts
@@ -1,44 +1,72 @@
 /**
  * Type conversion utilities for workspace types.
  *
- * Two Workspace types exist in the codebase:
- * - Internal Workspace (git/types.ts): { name, path: Path, branch, metadata } - no projectId
- * - IPC Workspace (shared/api/types.ts): { projectId, name, path: string, branch, metadata } - has projectId
+ * Three Workspace shapes exist, and this module is the boundary between them:
+ * - Internal (`boundaries/platform/git-types`): `{ name, path: Path, branch, metadata }` —
+ *   a `Path` instance, so it is backend-local and cannot cross a tunnel.
+ * - Discovered (`intents/contract`): the same fields with a branded `WorkspacePath` string.
+ *   This is what a `discover` / `list-workspaces` hook contributes.
+ * - IPC (`intents/contract`): adds `projectId` and the optional IDE `url`.
  *
- * These utilities bridge the gap by converting between internal Path-based types
- * and IPC string-based types at the boundary.
+ * `toDiscoveredWorkspace` is the single place a `Path` becomes contract data.
  */
 
 import type { Workspace as InternalWorkspace } from "../boundaries/platform/git-types";
-import type { Workspace as IpcWorkspace, ProjectId, WorkspaceName } from "../shared/api/types";
+import type {
+  DiscoveredWorkspace,
+  Workspace as IpcWorkspace,
+  ProjectId,
+} from "../intents/contract";
+import { discoveredWorkspaceSchema } from "../intents/contract";
 
 /**
- * Convert internal Workspace to IPC Workspace for sending to renderer.
+ * Convert an internal workspace to its plain-data contract form.
  *
- * @param internal - Internal workspace with Path-based path
- * @param projectId - Project ID to include in IPC workspace
- * @returns IPC workspace with string-based path
+ * Parses rather than asserts: this is where a `Path` instance leaves the backend, so the
+ * brands are minted by validation instead of by a cast.
  */
-function toIpcWorkspace(internal: InternalWorkspace, projectId: ProjectId): IpcWorkspace {
-  return {
-    projectId,
-    name: internal.name as WorkspaceName,
+export function toDiscoveredWorkspace(internal: InternalWorkspace): DiscoveredWorkspace {
+  return discoveredWorkspaceSchema.parse({
+    name: internal.name,
     path: internal.path.toString(),
     branch: internal.branch,
     metadata: internal.metadata,
+  });
+}
+
+/** Convert an array of internal workspaces to their plain-data contract form. */
+export function toDiscoveredWorkspaces(
+  internals: readonly InternalWorkspace[]
+): DiscoveredWorkspace[] {
+  return internals.map(toDiscoveredWorkspace);
+}
+
+/**
+ * Convert a discovered Workspace to an IPC Workspace for sending to the renderer.
+ *
+ * @param discovered - Discovered workspace (already plain data)
+ * @param projectId - Project ID to include in IPC workspace
+ */
+function toIpcWorkspace(discovered: DiscoveredWorkspace, projectId: ProjectId): IpcWorkspace {
+  return {
+    projectId,
+    name: discovered.name,
+    path: discovered.path,
+    branch: discovered.branch,
+    metadata: discovered.metadata,
   };
 }
 
 /**
- * Convert an array of internal Workspaces to IPC Workspaces.
+ * Convert an array of discovered Workspaces to IPC Workspaces.
  *
- * @param internals - Array of internal workspaces
+ * @param discovered - Array of discovered workspaces
  * @param projectId - Project ID to include in all IPC workspaces
  * @returns Array of IPC workspaces
  */
 export function toIpcWorkspaces(
-  internals: readonly InternalWorkspace[],
+  discovered: readonly DiscoveredWorkspace[],
   projectId: ProjectId
 ): IpcWorkspace[] {
-  return internals.map((internal) => toIpcWorkspace(internal, projectId));
+  return discovered.map((w) => toIpcWorkspace(w, projectId));
 }


### PR DESCRIPTION
Prerequisite for running a backend out of process: everything crossing the dispatcher has to be serializable before a tunnel can exist.

The dispatcher already validates six carriers with zod, so the contract *looks* like plain data. It isn't — two zod forms are opt-outs:

- `z.instanceof(Path)` doesn't merely permit a class instance, it **requires** one
- `z.custom<T>()` with no validator performs **no validation at all** (`z.custom().parse({ fn: () => {} })` passes)

Both are the `as T` assertions the zod work was introduced to remove. A branded string rejects a class instance, so once the escapes are closed the parses that were already there **become** the serializability gate — no new runtime machinery.

Closing them exposed the same defect one level up: the dispatcher's own signatures threw away the schema bundle they had in hand, and humans patched it by hand.

## Changes

- **Error → `{ name, message, stack, cause? }`**, recursive so `app:start`'s two deliberate `{ cause }` wraps survive. `error-report-module` rebuilds a real `Error` for PostHog and sets `.name` — otherwise a `TypeError` regroups as `Error`.
- **`Path` → branded strings.** `project:open` and `project:list` each declared the same internal-workspace shape privately (one `z.instanceof`, one `z.custom`); they now share `discoveredWorkspaceSchema`, with `toDiscoveredWorkspace()` the single place a `Path` becomes contract data.
- **Agent vocabulary: five declarations → one** (two of them shared the name `ConfigAgentType`), which drops a cast in `app-start`.
- **79 bare `z.string()` path fields → branded.** The brands existed and enforced nothing: 3 uses before, 124 after. Minted by parsing at the genuine external edges (folder picker, MCP tool args, plugin socket handshake, project config on disk) and flowing by type inside — which deletes the 13 `as WorkspacePath` casts that existed only to bridge the gap.
- **`hookCtxSchema` is strict** and every hook point declares an input schema, including the six that declared nothing at all. A plain `z.object` strips an undeclared field, and the dispatcher parses the input for its throw only, so stripping would have let it travel on regardless.
- **`collect()` / `emit()` typed off the operation's bundle.** A typo'd hook point id used to collect nothing, silently; it's now a compile error. Removes the `as T` inside the dispatcher and most of the 30 hand-written context aliases.
- **57 `as XIntent` → `dispatch<XIntent>()`**, which types the result identically but *checks* the argument. This caught real test bugs — payloads carrying fields the contract never had.
- **eslint** bans the two zod escapes under `src/intents`, and assertions in `dispatch`/`emit` argument position anywhere. `noInlineConfig` is on, so an exemption would have to be a visible `files:` block.

`close-project` emitted `workspace:switched(null)` directly. That event belongs to `switch-workspace` and an operation may only emit what it declares, so it now dispatches `workspace:switch(null)` — which additionally runs the `activate` hooks that clear main-side bookkeeping, reaching the same state by the proper route.

## Verification

- New gate test states the thesis as an executable claim: each carrier rejects a class instance and a function. Reintroducing the escapes on its probe **fails 12 of its 18 tests**.
- `pnpm validate` clean: 3544 tests, 0 type errors, 0 lint errors.
- Ran the packaged app: every hook point reported `errors=0`, including the newly-strict ones and the first-run agent picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XusbQr21aoRZPgA7eTaiuN