### PR TITLE
fix: improved docs for auto workspace config

### DIFF
--- a/src/modules/auto-workspace/template-defaults.ts
+++ b/src/modules/auto-workspace/template-defaults.ts
@@ -2,13 +2,16 @@
  * Reference text shown beside the `auto-workspace.sources` editor in settings.
  *
  * Sources are user-defined, so the reference is source-agnostic: it documents
- * the document shape and the template keys, then shows the migrated github /
- * youtrack sources as copyable starting points. The `template` values render as
+ * the document shape, the template fields (with required/default), how Liquid
+ * renders over the cmd's JSON, and how metadata/tags map — then shows the
+ * github source as a copyable starting point. The `template` values render as
  * Liquid over whatever JSON each source's `cmd` emits.
  */
 
-const FORMAT = `Format — a multi-document YAML stream, one document per source
-(separated by "---"):
+const FORMAT = `=== FORMAT ===
+
+A multi-document YAML stream — one document per source, separated by
+"---":
 
   name       source name (also the state-key prefix); must be unique
   type       cron (default; the only supported type)
@@ -16,23 +19,66 @@ const FORMAT = `Format — a multi-document YAML stream, one document per source
              cmd.exe on Windows). Must print a top-level JSON array of
              objects to stdout. Inherits the app environment; inline any
              secrets (kept out of bug reports).
-             The syntax is the platform shell's own — the examples below
-             are POSIX. On Windows use cmd.exe syntax: "..." rather than
+             The syntax is the platform shell's own — the example below
+             is POSIX. On Windows use cmd.exe syntax: "..." rather than
              '...' for quoting, and ^ rather than \\ to continue a line.
-  template   mapping rendered once per emitted object — every string leaf
-             is a Liquid template over that object's JSON:
-    name                 workspace name (required)
-    key                  dedup identity (defaults to the rendered name)
-    base                 branch to fork the new worktree from
-    tracking             remote branch to check out with upstream set
-    focus                true = switch to the workspace once created
-    project              local project path  (or use git)
-    git                  git URL to clone as the project
-    agent: { type, name, permission-mode, model: { provider, id } }
-    metadata: { title, tags: { <name>: { color } }, <key>: <value> }
-    prompt               agent prompt (empty = no prompt)`;
+  template   mapping rendered once per emitted object into one workspace
+             (see FIELDS)`;
 
-const GITHUB_EXAMPLE = `name: github
+const FIELDS = `=== FIELDS (keys under template) ===
+
+  Key          Required  Default         Meaning
+  name         yes       —               workspace name (also the git branch)
+  key          no        rendered name   dedup identity across polls
+  base         no        —               branch to fork the new worktree from
+  tracking     no        —               remote branch to track (upstream set)
+  project      no        —               local project path (or use git)
+  git          no        —               git URL to clone as the project
+  focus        no        false           true = switch to it once created
+  prompt       no        "" (no prompt)  agent prompt
+  agent        no        —               agent config (see below)
+  metadata     no        —               title / tags / extra keys (see METADATA)
+
+agent: { type, name, permission-mode, model: { provider, id } }
+  type             claude | opencode (required to set any other agent field)
+  name             named agent / subagent
+  permission-mode  claude only; ignored for opencode
+  model            { provider, id } — both required together`;
+
+const LIQUID = `=== LIQUID ===
+
+Every string leaf in template is a Liquid template. The render context
+IS the JSON object your cmd emitted for that item — there is no fixed
+variable list; whatever keys the object has are what you can reference.
+
+  {{ title }}                  a top-level field
+  {{ user.login }}             nested field (dot access)
+  {{ title | truncate: 60 }}   liquidjs filters work
+  {% if draft %}…{% endif %}   tags work too
+
+A referenced field the object doesn't have renders empty.`;
+
+const METADATA = `=== METADATA ===
+
+  metadata:
+    title: "{{ summary }}"           sidebar display title
+    tags:
+      review: { color: "#4b6de8" }   a colored tag named "review"
+    <any-key>: "<any value>"         passed through as-is
+
+- title sets the sidebar display title; when unset the row falls back
+  to the branch name (template.name).
+- each tags.<name> becomes a workspace tag; its { color } object is
+  JSON-encoded for the tag system. Omit color for an uncolored tag.
+
+Three different "names", easy to confuse:
+  name (document)          the source id — unique, prefixes its state keys
+  template.name            the workspace name and git branch
+  template.metadata.title  the sidebar display title (falls back to branch)`;
+
+const GITHUB_EXAMPLE = `=== EXAMPLE — github ===
+
+name: github
 type: cron
 cmd: |
   gh api graphql -f q='is:open is:pr review-requested:@me' \\
@@ -43,6 +89,10 @@ template:
   key: "{{ html_url }}"
   base: "{{ base.ref }}"
   project: "{{ clone_url }}"
+  metadata:
+    title: "PR #{{ number }}: {{ title }}"
+    tags:
+      review: { color: "#4b6de8" }
   prompt: |
     Review pull request #{{ number }} "{{ title }}" opened by {{ user.login }}.
 
@@ -50,19 +100,4 @@ template:
 
     PR: {{ html_url }}`;
 
-const YOUTRACK_EXAMPLE = `name: youtrack
-type: cron
-cmd: |
-  curl -s -G -H "Authorization: Bearer perm:XXXX" \\
-    --data-urlencode "query=for:me State: {In Progress}" \\
-    --data-urlencode "fields=id,idReadable,summary,description,project(name)" \\
-    "https://youtrack.example.com/api/issues"
-template:
-  name: "{{ summary }}"
-  key: "https://youtrack.example.com/api/issues/{{ id }}"
-  prompt: |
-    Work on {{ idReadable }} "{{ summary }}" in {{ project.name }}.
-
-    {{ description }}`;
-
-export const SOURCES_HELP = `${FORMAT}\n\nExample — github:\n${GITHUB_EXAMPLE}\n\nExample — youtrack:\n${YOUTRACK_EXAMPLE}`;
+export const SOURCES_HELP = `${FORMAT}\n\n${FIELDS}\n\n${LIQUID}\n\n${METADATA}\n\n${GITHUB_EXAMPLE}`;

--- a/src/renderer/lib/components/form/InputSection.svelte
+++ b/src/renderer/lib/components/form/InputSection.svelte
@@ -201,7 +201,8 @@
   }
 
   .input-textarea::placeholder {
-    color: var(--ch-foreground-dim, rgba(255, 255, 255, 0.5));
+    color: var(--ch-foreground);
+    opacity: 0.5;
   }
 
   .input-textfield {

--- a/src/renderer/lib/components/form/SettingRow.svelte
+++ b/src/renderer/lib/components/form/SettingRow.svelte
@@ -143,7 +143,8 @@
     gap: 0.3rem;
     padding: 2px 6px;
     font-size: 0.8rem;
-    color: var(--ch-foreground-dim, rgba(255, 255, 255, 0.7));
+    color: var(--ch-foreground);
+    opacity: 0.7;
     background: transparent;
     border: none;
     border-radius: var(--ch-radius-sm, 6px);
@@ -151,7 +152,7 @@
   }
 
   .setting-help-toggle:hover {
-    color: var(--ch-foreground);
+    opacity: 1;
     background: var(--ch-list-hover-bg, rgba(255, 255, 255, 0.08));
   }
 
@@ -168,7 +169,8 @@
     line-height: 1.5;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-    color: var(--ch-foreground-dim, rgba(255, 255, 255, 0.7));
+    color: var(--ch-foreground);
+    opacity: 0.7;
     background: var(--ch-list-hover-bg, rgba(255, 255, 255, 0.04));
     border: 1px solid var(--ch-border);
     border-radius: var(--ch-radius-sm, 6px);
@@ -201,7 +203,8 @@
     line-height: 1.4;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    color: var(--ch-foreground-dim, rgba(255, 255, 255, 0.6));
+    color: var(--ch-foreground);
+    opacity: 0.6;
     background: var(--ch-list-hover-bg, rgba(255, 255, 255, 0.08));
     border-radius: var(--ch-radius-sm, 6px);
   }


### PR DESCRIPTION
Improves the `auto-workspace.sources` settings help, which was hard to use.

- **Fix invisible help text**: `--ch-foreground-dim` was never defined, so four call sites fell back to opaque white — invisible on light themes (the reported "Darstellungsproblem"). Switched them to the `color: var(--ch-foreground); opacity` convention: the reference toggle, reference panel, env/cli badge, and textarea placeholder.
- **Expand the source-format reference** into scannable sections: FORMAT, FIELDS (with required/default columns and the `agent` sub-mapping), LIQUID (the render context is the JSON the `cmd` emits — no fixed variable list), METADATA (title / tags / color, plus the `name` vs `template.name` vs `metadata.title` distinction), and a github EXAMPLE that now shows a title and a colored tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)