### PR TITLE
fix: workspace switches are skipped when sidebar is expanded

### DIFF
--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -49,7 +49,11 @@ import {
   EVENT_WORKSPACE_CREATED,
   EVENT_WORKSPACE_LOADING,
   EVENT_WORKSPACE_CREATE_FAILED,
+  INTENT_OPEN_WORKSPACE,
+  type OpenWorkspacePayload,
+  type WorkspaceOpenSource,
 } from "../../intents/open-workspace";
+import type { Intent } from "../../intents/lib/types";
 import {
   EVENT_WORKSPACE_DELETED,
   EVENT_WORKSPACE_DELETION_PROGRESS,
@@ -2171,5 +2175,118 @@ describe("PresentationModule - shortcut navigation", () => {
     await key(module, "z");
 
     expect(dispatched).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Background-focus suppression (the suppress-background-focus interceptor)
+//
+// A workspace an agent opens in the background asks to steal the view with
+// stealFocus. While the sidebar is expanded (mode !== "workspace") that yank is
+// jarring, so the interceptor downgrades the request to stealFocus: false. The
+// open still happens; the arriving row flashes and picks up the "new" tag.
+// =============================================================================
+
+describe("PresentationModule - background-focus suppression", () => {
+  /** The module's sole interceptor. */
+  function interceptor(module: UiPresenter) {
+    const list = module.interceptors ?? [];
+    expect(list).toHaveLength(1);
+    return list[0]!;
+  }
+
+  /** A workspace:open intent from `source`, requesting focus (or as given). */
+  function openIntent(source: WorkspaceOpenSource, stealFocus?: boolean): Intent {
+    const payload: OpenWorkspacePayload = {
+      workspaceName: "feat",
+      projectPath: PROJECT_PATH,
+      source,
+      ...(stealFocus !== undefined && { stealFocus }),
+    };
+    return { type: INTENT_OPEN_WORKSPACE, payload };
+  }
+
+  function stealFocusOf(intent: Intent | null): boolean | undefined {
+    return (intent?.payload as OpenWorkspacePayload | undefined)?.stealFocus;
+  }
+
+  /** Drive the presenter to workspace mode (an active, non-hibernated workspace). */
+  async function toWorkspaceMode(deps: Deps): Promise<UiPresenter> {
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("main", { url: "http://127.0.0.1:1/main" });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
+    await flush();
+    expect(lastSnapshot(deps).mode).toBe("workspace");
+    return module;
+  }
+
+  it("never modifies non-open intents", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const other: Intent = { type: "workspace:switch", payload: { workspacePath: null } };
+    expect(await interceptor(module).before(other)).toBe(other);
+  });
+
+  for (const source of ["mcp", "plugin-server", "auto-workspace"] as const) {
+    it(`downgrades stealFocus for a background ${source} open while the sidebar is expanded`, async () => {
+      const deps = createDeps();
+      // Steady state with no workspace ⇒ creation panel ⇒ hover (expanded).
+      const module = await startModule(deps);
+      expect(lastSnapshot(deps).mode).toBe("hover");
+
+      const result = await interceptor(module).before(openIntent(source, true));
+      expect(stealFocusOf(result)).toBe(false);
+    });
+  }
+
+  it("downgrades an undefined (default-switch) stealFocus too", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const result = await interceptor(module).before(openIntent("mcp"));
+    expect(stealFocusOf(result)).toBe(false);
+  });
+
+  it("leaves the open untouched when the sidebar is not expanded (workspace mode)", async () => {
+    const deps = createDeps();
+    const module = await toWorkspaceMode(deps);
+    const intent = openIntent("mcp", true);
+    const result = await interceptor(module).before(intent);
+    expect(result).toBe(intent);
+    expect(stealFocusOf(result)).toBe(true);
+  });
+
+  it("never touches interactive sources, even while expanded", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    expect(lastSnapshot(deps).mode).toBe("hover");
+
+    for (const source of ["ui-ipc", "creation", "open-project"] as const) {
+      const intent = openIntent(source, true);
+      const result = await interceptor(module).before(intent);
+      expect(result).toBe(intent);
+      expect(stealFocusOf(result)).toBe(true);
+    }
+  });
+
+  it("leaves an already-background open (stealFocus:false) unchanged", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const intent = openIntent("mcp", false);
+    const result = await interceptor(module).before(intent);
+    expect(result).toBe(intent);
+    expect(stealFocusOf(result)).toBe(false);
+  });
+
+  it("suppresses in shortcut mode as well as hover", async () => {
+    const deps = createDeps();
+    const module = await toWorkspaceMode(deps);
+    // Enter shortcut mode.
+    await emit(module, EVENT_SHORTCUT_ACTIVE_CHANGED, { active: true });
+    await flush();
+    expect(lastSnapshot(deps).mode).toBe("shortcut");
+
+    const result = await interceptor(module).before(openIntent("mcp", true));
+    expect(stealFocusOf(result)).toBe(false);
   });
 });

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -28,7 +28,8 @@
  */
 
 import type { IntentModule, EventDeclarations } from "../../intents/lib/module";
-import type { DomainEvent } from "../../intents/lib/types";
+import type { IntentInterceptor } from "../../intents/lib/dispatcher";
+import type { DomainEvent, Intent } from "../../intents/lib/types";
 import type { HookContext, HookOutput } from "../../intents/lib/operation";
 import { ANY_VALUE } from "../../intents/lib/operation";
 import type { IDispatcher } from "../../intents/lib/dispatcher";
@@ -75,6 +76,9 @@ import {
   EVENT_WORKSPACE_CREATED,
   EVENT_WORKSPACE_LOADING,
   EVENT_WORKSPACE_CREATE_FAILED,
+  INTENT_OPEN_WORKSPACE,
+  type OpenWorkspacePayload,
+  type WorkspaceOpenSource,
   type WorkspaceCreatedEvent,
   type WorkspaceLoadingEvent,
   type WorkspaceCreateFailedEvent,
@@ -708,8 +712,12 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * Compute the single UI mode. Priority shortcut > dialog > hover > workspace.
    * The creation panel (no active workspace) maps to hover-level: UI on top but
    * Alt+X still works.
+   *
+   * Takes the creation-panel flag rather than the whole main view so the
+   * focus-suppression interceptor can ask for the current mode without building
+   * a main view (buildMain resolves screenshots, which kicks off a file read).
    */
-  function buildMode(main: UiMainView): UIMode {
+  function buildMode(creationMain: boolean): UIMode {
     // The startup surfaces are modal system dialogs, so isModalOpen() already
     // yields "dialog" for them — no startup special-case needed. The mid-session
     // loading surface is a "panel" (not modal), so it falls through to the
@@ -717,9 +725,59 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     // deletion panel.
     if (shortcutActive) return "shortcut";
     if (dialogs.isModalOpen()) return "dialog";
-    if (main.kind === "creation" || hoverRegion === "sidebar") return "hover";
+    if (creationMain || hoverRegion === "sidebar") return "hover";
     return "workspace";
   }
+
+  /** Whether main is showing the creation panel — buildMain's `creation` condition. */
+  function isCreationMain(): boolean {
+    return startupPhase === "done" && (activeKey === null || findByKey(activeKey) === undefined);
+  }
+
+  /** The mode the next snapshot would carry. */
+  function currentMode(): UIMode {
+    return buildMode(isCreationMain());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Background-focus suppression
+  //
+  // A workspace an agent opens in the background (MCP, the plugin server, an
+  // auto-workspace source with focus: true) asks to steal the view by passing
+  // stealFocus: true. That is jarring while the user is reading the expanded
+  // sidebar — the view yanks out from under the cursor. This interceptor
+  // downgrades such a request to stealFocus: false whenever the sidebar is
+  // expanded (mode !== "workspace"), so the open still happens but the view
+  // stays put; the arriving row flashes (Sidebar's in:arrivalFlash) and picks
+  // up the blue "new" tag (auto-tagging keys off stealFocus === false) instead.
+  //
+  // Interactive sources (ui-ipc, creation, open-project) are never touched, so
+  // clicking a hibernated row or creating from the New workspace panel still
+  // switches even though those happen in hover mode. Wakes count: a background
+  // wake (existingWorkspace set) yanks the view just as much as a fresh open.
+  //
+  // Evaluated when the open STARTS, not when the switch would land — creation
+  // takes seconds, so leaving the sidebar mid-creation still suppresses. That is
+  // the intended bias: err toward not stealing focus.
+  const BACKGROUND_OPEN_SOURCES: ReadonlySet<WorkspaceOpenSource> = new Set([
+    "mcp",
+    "plugin-server",
+    "auto-workspace",
+  ]);
+
+  const suppressBackgroundFocus: IntentInterceptor = {
+    id: "suppress-background-focus",
+    before: async (intent: Intent): Promise<Intent | null> => {
+      if (intent.type !== INTENT_OPEN_WORKSPACE) return intent;
+      const payload = intent.payload as OpenWorkspacePayload;
+      if (payload.stealFocus === false) return intent;
+      if (payload.source === undefined || !BACKGROUND_OPEN_SOURCES.has(payload.source)) {
+        return intent;
+      }
+      if (currentMode() === "workspace") return intent;
+      return { ...intent, payload: { ...payload, stealFocus: false } };
+    },
+  };
 
   // ---------------------------------------------------------------------------
   // System dialog (startup surfaces + mid-session loading)
@@ -936,7 +994,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       theme,
       labelScroll: labelScrollConfig.get(),
       silent: silentConfig.get(),
-      mode: buildMode(main),
+      mode: buildMode(main.kind === "creation"),
       capturing,
       dialogs: dialogs.getSnapshot(),
       notifications: notifications.getSnapshot(),
@@ -1749,6 +1807,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     deletionProgress: (workspacePath: string): DeletionProgress | undefined =>
       deletions.get(workspacePath),
     events,
+    interceptors: [suppressBackgroundFocus],
     hooks: {
       [APP_START_OPERATION_ID]: {
         init: {

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -14,6 +14,7 @@
     getStatusText,
   } from "$lib/utils/sidebar-utils.js";
   import { createLogger } from "$lib/logging";
+  import { arrivalFlash } from "$lib/utils/arrival-flash.js";
   import { clampSidebarWidthMin } from "@shared/ui-state";
 
   const logger = createLogger("ui");
@@ -401,12 +402,17 @@
               {@const showSecondLine = hasTitle || hasTags}
               {@const rowHovered = hoveredRowKey === workspace.key}
               <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
+              <!-- in:arrivalFlash — pulse a row that just entered the list, so
+                   a workspace an agent created in the background announces
+                   itself instead of stealing the view. Keyed each ⇒ fires once
+                   per introduction; see arrival-flash.ts. -->
               <li
                 class="workspace-item"
                 class:active={isActive}
                 class:has-second-line={showSecondLine}
                 class:hibernated
                 aria-current={isActive ? "true" : undefined}
+                in:arrivalFlash
                 onclick={() => {
                   if (status !== "creating") onSwitchWorkspace(workspace.key);
                 }}

--- a/src/renderer/lib/utils/arrival-flash.test.ts
+++ b/src/renderer/lib/utils/arrival-flash.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { arrivalFlash, flashStrength } from "./arrival-flash.js";
+
+describe("arrival-flash", () => {
+  describe("flashStrength (two-pulse envelope)", () => {
+    it("is zero at the endpoints and the midpoint", () => {
+      expect(flashStrength(0, false)).toBeCloseTo(0);
+      expect(flashStrength(0.5, false)).toBeCloseTo(0);
+      expect(flashStrength(1, false)).toBeCloseTo(0);
+    });
+
+    it("peaks twice — at the quarter and three-quarter marks", () => {
+      // |sin(2πt)| tops out at t = 0.25 and t = 0.75.
+      expect(flashStrength(0.25, false)).toBeGreaterThan(flashStrength(0.15, false));
+      expect(flashStrength(0.25, false)).toBeCloseTo(flashStrength(0.75, false));
+      expect(flashStrength(0.5, false)).toBeLessThan(flashStrength(0.25, false));
+    });
+
+    it("never goes negative (absolute value of the wave)", () => {
+      for (let t = 0; t <= 1; t += 0.05) {
+        expect(flashStrength(t, false)).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe("flashStrength (reduced motion — single fade)", () => {
+    it("has exactly one hump, peaking at the midpoint", () => {
+      expect(flashStrength(0, true)).toBeCloseTo(0);
+      expect(flashStrength(1, true)).toBeCloseTo(0);
+      // sin(πt) peaks at t = 0.5, where the two-pulse curve is at a trough.
+      expect(flashStrength(0.5, true)).toBeGreaterThan(flashStrength(0.25, true));
+      expect(flashStrength(0.5, false)).toBeLessThan(flashStrength(0.5, true));
+    });
+  });
+
+  describe("arrivalFlash transition", () => {
+    const node = {} as Element;
+
+    it("runs two pulses over the full duration by default", () => {
+      const config = arrivalFlash(node, { reducedMotion: false });
+      expect(config.duration).toBe(1200);
+    });
+
+    it("shortens to a single fade under reduced motion", () => {
+      const config = arrivalFlash(node, { reducedMotion: true });
+      expect(config.duration).toBe(400);
+    });
+
+    it("emits an inset box-shadow whose tint tracks the envelope", () => {
+      const config = arrivalFlash(node, { reducedMotion: false });
+      const css = config.css!;
+      const atPeak = css(0.25, 0.75);
+      const atTrough = css(0.5, 0.5);
+      expect(atPeak).toContain("box-shadow: inset");
+      expect(atPeak).toContain("color-mix");
+      // Peak carries a higher tint percentage than the trough.
+      const pct = (s: string): number => Number(/([\d.]+)%/.exec(s)![1]);
+      expect(pct(atPeak)).toBeGreaterThan(pct(atTrough));
+    });
+  });
+});

--- a/src/renderer/lib/utils/arrival-flash.ts
+++ b/src/renderer/lib/utils/arrival-flash.ts
@@ -1,0 +1,71 @@
+/**
+ * Arrival flash — the `in:` transition played by a sidebar workspace row when
+ * it enters the DOM.
+ *
+ * It exists because a workspace can appear without the user putting it there:
+ * an agent creates one over MCP, an auto-workspace source polls one in. Those
+ * arrivals are deliberately NOT allowed to steal the view while the sidebar is
+ * expanded (see the presentation module's `suppress-background-focus`
+ * interceptor), so the row itself has to say "something landed here".
+ *
+ * Row introduction is the trigger, which Svelte already tracks for a keyed
+ * `{#each}` — no bookkeeping of seen keys. The flip side is that a row coming
+ * BACK (un-hiding hibernated rows, reopening a closed project) flashes too;
+ * both are actions the user just took, so it reads as confirmation.
+ *
+ * The tint is an inset box-shadow rather than a background, so it layers over
+ * whatever the row already paints (active selection, hover, hibernated dim)
+ * instead of replacing it for the duration.
+ */
+
+import { linear } from "svelte/easing";
+import type { TransitionConfig } from "svelte/transition";
+
+/** Full-strength tint, as a color-mix percentage against transparent. */
+const PEAK_PERCENT = 22;
+/** Two pulses. */
+const PULSE_DURATION_MS = 1200;
+/** One fade in and back out, for prefers-reduced-motion. */
+const REDUCED_DURATION_MS = 400;
+
+export interface ArrivalFlashParams {
+  /**
+   * Override the prefers-reduced-motion probe. Only tests pass this; the
+   * component relies on the media query below.
+   */
+  readonly reducedMotion?: boolean;
+}
+
+/** True when the OS asks for reduced motion. Falls back to false where `matchMedia` is absent. */
+function prefersReducedMotion(): boolean {
+  return globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}
+
+/**
+ * Tint strength at progress `t` (0..1), as a percentage.
+ *
+ * Two humps: |sin(2πt)| is zero at t = 0, 0.5, 1 and peaks at t = 0.25, 0.75.
+ * Reduced motion collapses that to the single hump of sin(πt) — the arrival is
+ * still announced, the throbbing is gone.
+ */
+export function flashStrength(t: number, reducedMotion: boolean): number {
+  const wave = reducedMotion ? Math.sin(Math.PI * t) : Math.abs(Math.sin(2 * Math.PI * t));
+  return PEAK_PERCENT * wave;
+}
+
+/**
+ * Svelte `in:` transition. `node` is unused — the whole animation is expressed
+ * as sampled CSS, which keeps this a pure function of `t`.
+ */
+export function arrivalFlash(_node: Element, params?: ArrivalFlashParams): TransitionConfig {
+  const reducedMotion = params?.reducedMotion ?? prefersReducedMotion();
+  return {
+    duration: reducedMotion ? REDUCED_DURATION_MS : PULSE_DURATION_MS,
+    easing: linear,
+    css: (t: number): string =>
+      `box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--ch-arrival-flash, var(--vscode-focusBorder, #0078d4)) ${flashStrength(
+        t,
+        reducedMotion
+      ).toFixed(2)}%, transparent)`,
+  };
+}

--- a/src/test/setup-renderer.ts
+++ b/src/test/setup-renderer.ts
@@ -43,6 +43,53 @@ import { PropertySymbol } from "happy-dom";
   }
 }
 
+// Mock Element.animate for Svelte 5 transitions in happy-dom. Svelte 5 drives
+// css-based transitions (e.g. the sidebar's in:arrivalFlash) through the Web
+// Animations API, which happy-dom does not implement — an unmocked call throws
+// "element.animate is not a function" and the transitioning element never
+// renders. This returns an inert Animation stub: the element mounts, the
+// (visual-only) animation is a no-op, and nothing under test reads it back.
+if (typeof Element.prototype.animate !== "function") {
+  Element.prototype.animate = function (): Animation {
+    let onfinish: ((this: Animation, ev: AnimationPlaybackEvent) => unknown) | null = null;
+    let oncancel: ((this: Animation, ev: AnimationPlaybackEvent) => unknown) | null = null;
+    const animation = {
+      currentTime: 0,
+      startTime: 0,
+      playbackRate: 1,
+      playState: "finished" as AnimationPlayState,
+      pending: false,
+      effect: null,
+      finished: Promise.resolve(),
+      ready: Promise.resolve(),
+      get onfinish() {
+        return onfinish;
+      },
+      set onfinish(fn) {
+        onfinish = fn;
+      },
+      get oncancel() {
+        return oncancel;
+      },
+      set oncancel(fn) {
+        oncancel = fn;
+      },
+      cancel: () => {},
+      finish: () => {},
+      play: () => {},
+      pause: () => {},
+      reverse: () => {},
+      persist: () => {},
+      commitStyles: () => {},
+      updatePlaybackRate: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    };
+    return animation as unknown as Animation;
+  };
+}
+
 // Mock attachInternals for vscode-elements in happy-dom
 if (typeof HTMLElement.prototype.attachInternals === "undefined") {
   HTMLElement.prototype.attachInternals = function () {


### PR DESCRIPTION
A workspace an agent opens in the background (MCP, plugin server, an auto-workspace source with `focus: true`) asks to steal the view via `stealFocus`. That yank is jarring while the user is reading the expanded sidebar.

- The presentation module now intercepts `workspace:open` and downgrades `stealFocus` to `false` for background sources (`mcp`, `plugin-server`, `auto-workspace`) whenever the sidebar is expanded (UI mode `!== "workspace"`). The open still happens; the view stays put and the arriving row picks up the existing blue "new" tag (auto-tagging keys off `stealFocus === false`).
- Interactive sources (`ui-ipc`, `creation`, `open-project`) are never touched, so clicking a hibernated row or creating from the New workspace panel still switches even though those happen in hover mode. Background wakes count too.
- To replace the lost switch as feedback, a sidebar row flashes when it enters the list: a pure Svelte `in:` transition (two ~1.2s inset-shadow pulses, single fade under `prefers-reduced-motion`) on the keyed each, so it fires once per row introduction with no seen-set bookkeeping.

Known gap: with no workspace active the mode is always hover, so the open-workspace "switch anyway so the user sees something" fallback still wins there. Left as-is for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuJqjuMVZaHmTUi8xkqe5b