### PR TITLE
feat: Show number of hibernated workspaces per project

### DIFF
--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -466,6 +466,7 @@ describe("PresentationModule - ui:state snapshots", () => {
                 active: true,
               },
             ],
+            hiddenHibernatedCount: 0,
           },
         ],
         width: SIDEBAR_DEFAULT_WIDTH,
@@ -1004,19 +1005,22 @@ describe("PresentationModule - sidebar resize", () => {
     const asleep = makeWorkspace("b", { metadata: { hibernated: "true" } });
     await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([awake, asleep]) });
 
-    // Default: both rows visible, flag off.
+    // Default: both rows visible, flag off, nothing withheld.
     expect(lastSnapshot(deps).sidebar.hideHibernated).toBe(false);
     expect(lastSnapshot(deps).sidebar.projects[0]!.workspaces.map((w) => w.name)).toEqual([
       "a",
       "b",
     ]);
+    expect(lastSnapshot(deps).sidebar.projects[0]!.hiddenHibernatedCount).toBe(0);
 
     emitUiEvent(deps, { kind: "toggle-hide-hibernated" });
     await flush();
 
-    // Hidden: the hibernated row is dropped and the flag is on.
+    // Hidden: the hibernated row is dropped, the flag is on, and the project
+    // reports the row it swallowed.
     expect(lastSnapshot(deps).sidebar.hideHibernated).toBe(true);
     expect(lastSnapshot(deps).sidebar.projects[0]!.workspaces.map((w) => w.name)).toEqual(["a"]);
+    expect(lastSnapshot(deps).sidebar.projects[0]!.hiddenHibernatedCount).toBe(1);
 
     emitUiEvent(deps, { kind: "toggle-hide-hibernated" });
     await flush();
@@ -1027,6 +1031,27 @@ describe("PresentationModule - sidebar resize", () => {
       "a",
       "b",
     ]);
+    expect(lastSnapshot(deps).sidebar.projects[0]!.hiddenHibernatedCount).toBe(0);
+  });
+
+  it("an all-hibernated project reports its count instead of looking empty", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    await emit(module, EVENT_PROJECT_OPENED, {
+      project: makeProject([
+        makeWorkspace("a", { metadata: { hibernated: "true" } }),
+        makeWorkspace("b", { metadata: { hibernated: "true" } }),
+      ]),
+    });
+
+    emitUiEvent(deps, { kind: "toggle-hide-hibernated" });
+    await flush();
+
+    // Every row is gone, so `workspaces` alone cannot distinguish this from a
+    // project with no workspaces at all — the count is what carries it.
+    const project = lastSnapshot(deps).sidebar.projects[0]!;
+    expect(project.workspaces).toEqual([]);
+    expect(project.hiddenHibernatedCount).toBe(2);
   });
 });
 

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -956,19 +956,25 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     const hideHibernated = hideHibernatedState.get();
     const projectRows: UiProjectRow[] = [...projects.values()]
       .sort((a, b) => compareDisplayNames(a.name, b.name))
-      .map((project) => ({
-        id: project.id,
-        name: project.name,
-        title: project.remoteUrl ?? project.path,
-        remote: project.remoteUrl !== undefined,
-        workspaces: [...project.workspaces.values()]
+      .map((project) => {
+        const rows = [...project.workspaces.values()]
           .sort((a, b) => compareDisplayNames(a.name, b.name))
-          .map((workspace): UiWorkspaceRow => buildRow(project, workspace))
-          // Omit hibernated rows when the visibility toggle is on. An active
-          // hibernated workspace is hidden too (main still shows its hibernated
-          // screen); recover via the bottom toggle, Alt+X+T, or Alt+X+H.
-          .filter((row) => !hideHibernated || !row.hibernated),
-      }));
+          .map((workspace): UiWorkspaceRow => buildRow(project, workspace));
+        // Omit hibernated rows when the visibility toggle is on, but report how
+        // many went missing so the sidebar can say so — an all-asleep project
+        // would otherwise look empty. An active hibernated workspace is hidden
+        // too (main still shows its hibernated screen); recover via the bottom
+        // toggle, Alt+X+T, or Alt+X+H.
+        const visible = hideHibernated ? rows.filter((row) => !row.hibernated) : rows;
+        return {
+          id: project.id,
+          name: project.name,
+          title: project.remoteUrl ?? project.path,
+          remote: project.remoteUrl !== undefined,
+          workspaces: visible,
+          hiddenHibernatedCount: rows.length - visible.length,
+        };
+      });
 
     const frames: Record<string, string> = {};
     for (const project of projects.values()) {

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -371,6 +371,20 @@
               <Icon name={project.remote ? "source-control" : "folder-opened"} size={14} />
             </span>
             <span class="project-name" title={project.title}>{project.name}</span>
+            <!-- How many of this project's rows the hide-hibernated toggle is
+                 swallowing. Present only while something is actually hidden, so
+                 an empty project stays visibly empty. Indicator only — the
+                 bottom toggle / Alt+X+T is how you get the rows back. -->
+            {#if project.hiddenHibernatedCount > 0}
+              {@const hiddenLabel = `${project.hiddenHibernatedCount} hibernated ${
+                project.hiddenHibernatedCount === 1 ? "workspace" : "workspaces"
+              } hidden`}
+              <span class="hibernated-count" title={hiddenLabel}>
+                <Icon name="eye-closed" size={12} />
+                <span aria-hidden="true">{project.hiddenHibernatedCount}</span>
+                <span class="ch-visually-hidden">{hiddenLabel}</span>
+              </span>
+            {/if}
             <div class="project-actions">
               <button
                 type="button"
@@ -853,6 +867,19 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* Hidden-row count in the project header. Dimmed and tabular so a column of
+     projects reads as one list rather than competing with the project names. */
+  .hibernated-count {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.55;
   }
 
   .project-actions {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -122,6 +122,44 @@ describe("Sidebar component", () => {
     });
   });
 
+  describe("hidden hibernated count", () => {
+    // Regression: with hide-hibernated on, a project whose workspaces are all
+    // asleep rendered as a bare header, indistinguishable from an empty one.
+
+    it("shows the count in the project header when rows are hidden", () => {
+      const project = makeUiProjectRow([], { hiddenHibernatedCount: 3 });
+
+      render(Sidebar, {
+        props: { ...defaultProps, projects: [project], hideHibernated: true },
+      });
+
+      expect(screen.getByText("3")).toBeInTheDocument();
+      expect(screen.getByText("3 hibernated workspaces hidden")).toBeInTheDocument();
+    });
+
+    it("uses the singular wording for one hidden workspace", () => {
+      const project = makeUiProjectRow([makeUiWorkspaceRow("awake")], {
+        hiddenHibernatedCount: 1,
+      });
+
+      render(Sidebar, {
+        props: { ...defaultProps, projects: [project], hideHibernated: true },
+      });
+
+      expect(screen.getByText("1 hibernated workspace hidden")).toBeInTheDocument();
+    });
+
+    it("shows nothing when no rows are hidden", () => {
+      const project = makeUiProjectRow([makeUiWorkspaceRow("ws1")]);
+
+      render(Sidebar, {
+        props: { ...defaultProps, projects: [project] },
+      });
+
+      expect(screen.queryByText(/hibernated workspaces? hidden/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe("active row scroll-into-view", () => {
     // Regression: Alt+X arrow/jump navigation switches the active workspace to
     // a row that may be scrolled out of the sidebar's viewport. The sidebar

--- a/src/renderer/lib/test-utils.ts
+++ b/src/renderer/lib/test-utils.ts
@@ -36,6 +36,7 @@ export function makeUiProjectRow(
     id: "test-project-12345678",
     name: "test-project",
     remote: false,
+    hiddenHibernatedCount: 0,
     ...overrides,
     title:
       overrides?.title ?? (overrides?.remote ? "https://example.com/repo.git" : "/test/project"),

--- a/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
+++ b/src/renderer/lib/utils/setup-domain-event-bindings.test.ts
@@ -23,7 +23,9 @@ function row(key: string, agent: AgentStatus): UiWorkspaceRow {
 function makeState(workspaces: UiWorkspaceRow[]): UiState {
   return {
     sidebar: {
-      projects: [{ id: "p", name: "p", title: "/p", remote: false, workspaces }],
+      projects: [
+        { id: "p", name: "p", title: "/p", remote: false, workspaces, hiddenHibernatedCount: 0 },
+      ],
       width: 250,
       hideHibernated: false,
     },

--- a/src/shared/ui-state.ts
+++ b/src/shared/ui-state.ts
@@ -117,6 +117,14 @@ export interface UiProjectRow {
   /** True for projects cloned from a git URL (drives the project icon). */
   readonly remote: boolean;
   readonly workspaces: readonly UiWorkspaceRow[];
+  /**
+   * How many of this project's workspaces the presenter withheld from
+   * `workspaces` because `UiState.sidebar.hideHibernated` is on; always 0 when
+   * it is off. The renderer cannot derive this — the hidden rows never reach it
+   * — and without it a project whose workspaces are all asleep renders exactly
+   * like one that has none.
+   */
+  readonly hiddenHibernatedCount: number;
 }
 
 /**


### PR DESCRIPTION
With the hide-hibernated toggle on, a project whose workspaces were all asleep rendered as a bare header — indistinguishable from a project with no workspaces at all. Reported via bug report: 8 hidden workspaces across 8 projects, 5 of which looked completely empty.

The presenter filters hibernated rows out of the snapshot before it crosses IPC, so the count cannot be derived in the renderer — it has to be carried explicitly.

- `UiProjectRow` gains `hiddenHibernatedCount` (always 0 when the toggle is off)
- `buildSnapshot` materializes the rows once then splits them, so the count falls out as `rows.length - visible.length`
- The sidebar project header renders a dimmed eye-closed icon + count whenever anything is hidden, with a tooltip and visually-hidden text for screen readers
- Indicator only — the bottom toggle / Alt+X+T remains the way to restore the rows