### PR TITLE
fix: Fix crash when a workspace iframe closes while another loads

### DIFF
--- a/src/boundaries/shell/view.test.ts
+++ b/src/boundaries/shell/view.test.ts
@@ -3,13 +3,22 @@
  *
  * The view boundary adopts the window's own webContents; these tests drive the
  * real installChildFrameScript did-frame-finish-load injection path through a
- * fake webContents supplied by a stub WindowBoundary.
+ * fake webContents supplied by a stub WindowBoundary, with frame lookups going
+ * through the shared `electron` fake's `webFrameMain.fromId`.
+ *
+ * The handler runs on a native Electron emit, so nothing it does may throw:
+ * an escaping error lands in process.on("uncaughtException"), which
+ * error-report-module answers with exit(1). Most cases below are that guard.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createMockLogger } from "../platform/logging";
+import { webFrameMain, webFrameMainState, resetElectronFake } from "../../test/mocks/electron";
+import type { MockLogger } from "../platform/logging.test-utils";
 import type { WindowBoundary } from "./window";
 import type { WindowHandle } from "./types";
+
+vi.mock("electron");
 
 type FrameLoadListener = (
   event: unknown,
@@ -19,13 +28,10 @@ type FrameLoadListener = (
 ) => void;
 
 interface FakeFrame {
-  processId: number;
-  routingId: number;
   executeJavaScript: ReturnType<typeof vi.fn>;
 }
 
 const listeners = new Map<string, FrameLoadListener[]>();
-let frames: FakeFrame[] = [];
 
 const fakeWebContents = {
   isDestroyed: () => false,
@@ -34,8 +40,12 @@ const fakeWebContents = {
     list.push(listener);
     listeners.set(event, list);
   },
-  get mainFrame() {
-    return { framesInSubtree: frames };
+  // Poisoned on purpose. Scanning `mainFrame.framesInSubtree` to find the
+  // loaded frame is what crashed the app: that getter returns `undefined`
+  // (silently, no throw) whenever any frame in the subtree is mid-deletion,
+  // so `.find()` blew up on undefined. Reintroducing the scan must fail here.
+  get mainFrame(): never {
+    throw new Error("mainFrame must not be touched by installChildFrameScript");
   },
 };
 
@@ -53,43 +63,101 @@ function emitFrameFinishLoad(isMainFrame: boolean, processId: number, routingId:
   }
 }
 
+function createFrame(): FakeFrame {
+  return { executeJavaScript: vi.fn().mockResolvedValue(undefined) };
+}
+
 describe("DefaultViewBoundary installChildFrameScript", () => {
   let boundary: DefaultViewBoundary;
+  let logger: MockLogger;
 
   beforeEach(() => {
     listeners.clear();
-    frames = [];
-    boundary = new DefaultViewBoundary(windowLayer, createMockLogger());
+    resetElectronFake();
+    logger = createMockLogger();
+    boundary = new DefaultViewBoundary(windowLayer, logger);
   });
 
-  it("injects the script into matching child frames", () => {
-    const frame: FakeFrame = {
-      processId: 1,
-      routingId: 7,
-      executeJavaScript: vi.fn().mockResolvedValue(undefined),
-    };
-    frames = [frame];
+  it("injects the script into the frame identified by the event", () => {
+    const frame = createFrame();
+    webFrameMainState.lookup = (processId, routingId) =>
+      processId === 1 && routingId === 7 ? frame : undefined;
     const handle = boundary.adoptWindowWebContents(windowHandle);
 
     boundary.installChildFrameScript(handle, "tracker()");
     emitFrameFinishLoad(false, 1, 7);
 
+    expect(webFrameMain.fromId).toHaveBeenCalledWith(1, 7);
     expect(frame.executeJavaScript).toHaveBeenCalledWith("tracker()");
   });
 
   it("ignores main-frame loads", () => {
-    const frame: FakeFrame = {
-      processId: 1,
-      routingId: 7,
-      executeJavaScript: vi.fn().mockResolvedValue(undefined),
-    };
-    frames = [frame];
+    const frame = createFrame();
+    webFrameMainState.lookup = () => frame;
     const handle = boundary.adoptWindowWebContents(windowHandle);
 
     boundary.installChildFrameScript(handle, "tracker()");
     emitFrameFinishLoad(true, 1, 7);
 
+    expect(webFrameMain.fromId).not.toHaveBeenCalled();
     expect(frame.executeJavaScript).not.toHaveBeenCalled();
+  });
+
+  it("skips frames that are already gone", () => {
+    // fromId returns undefined once the frame has been deleted.
+    webFrameMainState.lookup = () => undefined;
+    const handle = boundary.adoptWindowWebContents(windowHandle);
+
+    boundary.installChildFrameScript(handle, "tracker()");
+
+    expect(() => emitFrameFinishLoad(false, 1, 7)).not.toThrow();
+  });
+
+  it("survives a frame lookup that throws", () => {
+    // Electron throws this when the render frame is disposed mid-lookup.
+    webFrameMainState.lookup = () => {
+      throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+    };
+    const handle = boundary.adoptWindowWebContents(windowHandle);
+
+    boundary.installChildFrameScript(handle, "tracker()");
+
+    expect(() => emitFrameFinishLoad(false, 1, 7)).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Child frame script injection skipped",
+      expect.objectContaining({
+        error: "Render frame was disposed before WebFrameMain could be accessed",
+      })
+    );
+  });
+
+  it("survives a frame lookup that returns a malformed frame", () => {
+    // Guards the whole handler body, not just the lookup: whatever shape a
+    // teardown race hands back, the emit must not carry an error out.
+    webFrameMainState.lookup = () => ({}) as unknown;
+    const handle = boundary.adoptWindowWebContents(windowHandle);
+
+    boundary.installChildFrameScript(handle, "tracker()");
+
+    expect(() => emitFrameFinishLoad(false, 1, 7)).not.toThrow();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Child frame script injection skipped",
+      expect.objectContaining({ id: handle.id })
+    );
+  });
+
+  it("survives executeJavaScript throwing synchronously", () => {
+    const frame = {
+      executeJavaScript: vi.fn(() => {
+        throw new Error("Object has been destroyed");
+      }),
+    };
+    webFrameMainState.lookup = () => frame;
+    const handle = boundary.adoptWindowWebContents(windowHandle);
+
+    boundary.installChildFrameScript(handle, "tracker()");
+
+    expect(() => emitFrameFinishLoad(false, 1, 7)).not.toThrow();
   });
 
   it("attaches a rejection handler to the injection promise", () => {
@@ -107,12 +175,8 @@ describe("DefaultViewBoundary installChildFrameScript", () => {
         return Promise.resolve();
       },
     };
-    const frame: FakeFrame = {
-      processId: 1,
-      routingId: 7,
-      executeJavaScript: vi.fn().mockReturnValue(trackedPromise),
-    };
-    frames = [frame];
+    const frame = { executeJavaScript: vi.fn().mockReturnValue(trackedPromise) };
+    webFrameMainState.lookup = () => frame;
     const handle = boundary.adoptWindowWebContents(windowHandle);
 
     boundary.installChildFrameScript(handle, "tracker()");

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -331,7 +331,7 @@ export interface ViewBoundary {
 // Default Implementation
 // ============================================================================
 
-import type { WebContents } from "electron";
+import { webFrameMain, type WebContents } from "electron";
 
 interface ViewState {
   webContents: WebContents;
@@ -668,13 +668,29 @@ export class DefaultViewBoundary implements ViewBoundary {
     const wc = state.webContents;
     wc.on("did-frame-finish-load", (_event, isMainFrame, frameProcessId, frameRoutingId) => {
       if (isMainFrame) return;
-      const frame = wc.mainFrame.framesInSubtree.find(
-        (f) => f.processId === frameProcessId && f.routingId === frameRoutingId
-      );
-      if (!frame) return;
-      frame.executeJavaScript(script).catch(() => {
-        // Frame may be gone before the script runs ("Script not run")
-      });
+      // Look the frame up by id rather than scanning mainFrame.framesInSubtree:
+      // that getter yields `undefined` outright (no throw) when *any* frame in
+      // the subtree is mid-deletion, because Electron's vector->JS conversion
+      // bails on the whole array. With many workspace iframes coming and going
+      // under one webContents, a sibling teardown would take down an unrelated
+      // frame's injection — and the app with it (see the catch below).
+      try {
+        const frame = webFrameMain.fromId(frameProcessId, frameRoutingId);
+        if (!frame) return;
+        frame.executeJavaScript(script).catch(() => {
+          // Frame may be gone before the script runs ("Script not run")
+        });
+      } catch (error) {
+        // Frame teardown races also surface as throws ("Render frame was
+        // disposed before WebFrameMain could be accessed"). This handler runs
+        // on a native emit with no caller to catch it, so anything escaping
+        // here becomes an uncaughtException — which error-report-module turns
+        // into exit(1). Injection is best-effort; a lost tracker is not fatal.
+        this.logger.debug("Child frame script injection skipped", {
+          id: handle.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     });
   }
 

--- a/src/test/mocks/electron.ts
+++ b/src/test/mocks/electron.ts
@@ -50,9 +50,27 @@ export const contextBridge: { exposeInMainWorld: Mock } = {
   exposeInMainWorld: vi.fn(),
 };
 
+/**
+ * Mutable `webFrameMain` state. Tests swap `lookup` to control what
+ * `webFrameMain.fromId()` returns (or make it throw); `resetElectronFake()`
+ * restores the default "no such frame".
+ */
+export const webFrameMainState: {
+  lookup: (processId: number, routingId: number) => unknown;
+} = {
+  lookup: () => undefined,
+};
+
+export const webFrameMain: { fromId: Mock } = {
+  fromId: vi.fn((processId: number, routingId: number) =>
+    webFrameMainState.lookup(processId, routingId)
+  ),
+};
+
 /** Restore `appState` to its defaults. Shared across files, so tests must reset it. */
 export function resetElectronFake(): void {
   appState.isPackaged = false;
   appState.appPath = "/mock/app/path";
   appState.version = "1.0.0-test";
+  webFrameMainState.lookup = () => undefined;
 }


### PR DESCRIPTION
Fixes a `TypeError: Cannot read properties of undefined (reading 'find')` that exited the app (PostHog issue `019fb30f-b03a-7fd1-97f9-322449cd5aa2`, seen on Windows in 2026.7.30).

- `installChildFrameScript` located the freshly loaded frame by scanning `wc.mainFrame.framesInSubtree`. That getter silently evaluates to `undefined` — no throw — whenever *any* frame in the subtree is mid-deletion: Electron returns an empty handle for a `kReadyToBeDeleted` RenderFrameHost, gin's vector converter then bails on the whole array, and `gin::Arguments::Return` leaves the property unset.
- With many workspace iframes coming and going under one `webContents`, a sibling teardown broke injection for an unrelated frame. Thrown on a native emit with no caller to catch it, that reached `process.on("uncaughtException")` → `exit(1)`.
- Look the frame up by id via `webFrameMain.fromId(frameProcessId, frameRoutingId)` instead, which is unaffected by other frames' lifecycle (and drops an O(frames) scan per child-frame load).
- Wrap the handler body in try/catch: tighter races still surface as throws (`"Render frame was disposed …"`), and nothing in this handler may escape. Injection is best-effort, so a lost tracker logs at `debug`.
- The old test fake hardcoded a real `framesInSubtree` array, making the crash unreachable. Its `mainFrame` getter now throws so reintroducing the scan fails, plus cases for a missing frame, a throwing lookup, a malformed frame, and `executeJavaScript` throwing synchronously. Verified the new tests fail 6/7 against the old implementation.