### PR TITLE
fix: Startup no longer fails when wrapper scripts are locked on Windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -719,6 +719,7 @@ const loggingModule = createLoggingModule({
 const scriptModule = createScriptModule({
   fileSystem: fileSystemLayer,
   pathProvider,
+  logger: appLogger,
 });
 
 const tempDirModule = createTempDirModule({

--- a/src/modules/script-module.integration.test.ts
+++ b/src/modules/script-module.integration.test.ts
@@ -13,10 +13,11 @@ import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
 import type { AppStartIntent, InitHookContext } from "../intents/app-start";
 import { createScriptModule } from "./script-module";
 import { createMockPathProvider } from "../boundaries/platform/path-provider.test-utils";
+import { FileSystemError } from "../shared/errors/service-errors";
 import { Path } from "../utils/path/path";
 
 // =============================================================================
-// Minimal Test Operation
+// Test Doubles
 // =============================================================================
 
 /** Runs "init" hook point with InitHookContext. */
@@ -30,53 +31,105 @@ function createMinimalInitOperation(scripts: readonly string[] = ["ch-claude", "
   });
 }
 
+interface FakeFsOptions {
+  /** Content per native path. A path absent here reads as ENOENT. */
+  readonly files?: Record<string, string>;
+  /** Entry names present in the bin directory. Defaults to the keys under /app-data/bin. */
+  readonly binEntries?: readonly string[];
+}
+
+/**
+ * Behavioural filesystem double: reads/writes a path->content map so the module's
+ * "write only what differs" decision is exercised for real rather than asserted
+ * against a call count.
+ */
+function createFakeFileSystem(options?: FakeFsOptions) {
+  const files = new Map(Object.entries(options?.files ?? {}));
+  const binEntries =
+    options?.binEntries ??
+    [...files.keys()]
+      .filter((p) => p.startsWith("/app-data/bin/"))
+      .map((p) => p.slice("/app-data/bin/".length));
+
+  return {
+    files,
+    readFile: vi.fn(async (path: Path) => {
+      const content = files.get(path.toString());
+      if (content === undefined) {
+        throw new FileSystemError("ENOENT", path.toString(), "ENOENT: no such file or directory");
+      }
+      return content;
+    }),
+    readdir: vi.fn(async () =>
+      binEntries.map((name) => ({
+        name,
+        isDirectory: false,
+        isFile: true,
+        isSymbolicLink: false,
+      }))
+    ),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn(async (path: Path) => {
+      files.delete(path.toString());
+    }),
+    copyTree: vi.fn(async (src: Path, dest: Path) => {
+      files.set(dest.toString(), files.get(src.toString()) ?? "");
+    }),
+    makeExecutable: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), silly: vi.fn() };
+
+function createHarness(
+  scripts: readonly string[],
+  fileSystem: ReturnType<typeof createFakeFileSystem>
+) {
+  // Distinct runtime vs asset roots: the wrappers MUST be read from runtimePath
+  // (extraResources / resources/bin, real files), NOT assetPath (inside
+  // app.asar, unreadable via original-fs in the packaged app). If this regresses
+  // to assetPath, the /runtime assertions below fail.
+  const pathProvider = createMockPathProvider({
+    dataRootDir: "/app-data",
+    runtimeRootDir: "/runtime",
+    assetsRootDir: "/assets",
+  });
+
+  const dispatcher = createMockDispatcher();
+  dispatcher.registerOperation(createMinimalInitOperation(scripts));
+  dispatcher.registerModule(
+    createScriptModule({
+      fileSystem: fileSystem as never,
+      pathProvider: pathProvider as never,
+      logger: logger as never,
+    })
+  );
+
+  return {
+    dispatch: () => dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} }),
+  };
+}
+
+/** The bundled sources every test starts from. */
+const BUNDLED = {
+  "/runtime/bin/ch-claude": "claude-sh",
+  "/runtime/bin/ch-claude.cjs": "claude-js",
+  "/runtime/bin/ch-claude.cmd": "claude-cmd",
+  "/runtime/bin/code": "code-sh",
+};
+const SCRIPTS = ["ch-claude", "ch-claude.cjs", "ch-claude.cmd", "code"];
+
 // =============================================================================
 // Tests
 // =============================================================================
 
 describe("ScriptModule Integration", () => {
-  it("copies only declared scripts from requiredScripts", async () => {
-    const fileSystem = {
-      rm: vi.fn().mockResolvedValue(undefined),
-      mkdir: vi.fn().mockResolvedValue(undefined),
-      copyTree: vi.fn().mockResolvedValue(undefined),
-      makeExecutable: vi.fn().mockResolvedValue(undefined),
-    };
+  it("writes declared scripts from runtimePath when the bin directory is empty", async () => {
+    const fileSystem = createFakeFileSystem({ files: { ...BUNDLED } });
+    await createHarness(SCRIPTS, fileSystem).dispatch();
 
-    // Distinct runtime vs asset roots: the wrappers MUST be copied from
-    // runtimePath (extraResources / resources/bin, real files), NOT assetPath
-    // (inside app.asar, unreadable via original-fs in the packaged app). If this
-    // regresses to assetPath, the /runtime assertions below fail.
-    const pathProvider = createMockPathProvider({
-      dataRootDir: "/app-data",
-      runtimeRootDir: "/runtime",
-      assetsRootDir: "/assets",
-    });
-
-    const dispatcher = createMockDispatcher();
-
-    const scripts = ["ch-claude", "ch-claude.cjs", "ch-claude.cmd", "code"];
-    dispatcher.registerOperation(createMinimalInitOperation(scripts));
-
-    const module = createScriptModule({
-      fileSystem: fileSystem as never,
-      pathProvider: pathProvider as never,
-    });
-    dispatcher.registerModule(module);
-
-    await dispatcher.dispatch<AppStartIntent>({
-      type: INTENT_APP_START,
-      payload: {},
-    });
-
-    // Should clean and recreate bin dir
-    expect(fileSystem.rm).toHaveBeenCalledWith(
-      new Path("/app-data/bin"),
-      expect.objectContaining({ recursive: true, force: true })
-    );
     expect(fileSystem.mkdir).toHaveBeenCalledWith(new Path("/app-data/bin"));
 
-    // Should copy each declared script from runtimePath (/runtime/bin), not assetPath
     expect(fileSystem.copyTree).toHaveBeenCalledTimes(4);
     expect(fileSystem.copyTree).toHaveBeenCalledWith(
       new Path("/runtime/bin/ch-claude"),
@@ -101,39 +154,158 @@ describe("ScriptModule Integration", () => {
     expect(fileSystem.makeExecutable).toHaveBeenCalledWith(new Path("/app-data/bin/code"));
   });
 
+  it("writes nothing when every script is already up to date", async () => {
+    // The regression this module exists for: on an ordinary launch the wrappers
+    // are byte-identical, so nothing is deleted or rewritten and a wrapper held
+    // open by a surviving agent process cannot fail startup.
+    const fileSystem = createFakeFileSystem({
+      files: {
+        ...BUNDLED,
+        "/app-data/bin/ch-claude": "claude-sh",
+        "/app-data/bin/ch-claude.cjs": "claude-js",
+        "/app-data/bin/ch-claude.cmd": "claude-cmd",
+        "/app-data/bin/code": "code-sh",
+      },
+    });
+
+    await createHarness(SCRIPTS, fileSystem).dispatch();
+
+    expect(fileSystem.copyTree).not.toHaveBeenCalled();
+    expect(fileSystem.rm).not.toHaveBeenCalled();
+  });
+
+  it("rewrites only the scripts whose content changed", async () => {
+    const fileSystem = createFakeFileSystem({
+      files: {
+        ...BUNDLED,
+        "/app-data/bin/ch-claude": "claude-sh",
+        "/app-data/bin/ch-claude.cjs": "claude-js-OLD",
+        "/app-data/bin/ch-claude.cmd": "claude-cmd",
+        "/app-data/bin/code": "code-sh",
+      },
+    });
+
+    await createHarness(SCRIPTS, fileSystem).dispatch();
+
+    expect(fileSystem.copyTree).toHaveBeenCalledTimes(1);
+    expect(fileSystem.copyTree).toHaveBeenCalledWith(
+      new Path("/runtime/bin/ch-claude.cjs"),
+      new Path("/app-data/bin/ch-claude.cjs")
+    );
+    expect(fileSystem.files.get("/app-data/bin/ch-claude.cjs")).toBe("claude-js");
+  });
+
+  it("prunes entries that are no longer required", async () => {
+    const fileSystem = createFakeFileSystem({
+      files: {
+        ...BUNDLED,
+        "/app-data/bin/ch-claude": "claude-sh",
+        "/app-data/bin/ch-claude.cjs": "claude-js",
+        "/app-data/bin/ch-claude.cmd": "claude-cmd",
+        "/app-data/bin/code": "code-sh",
+        // Left over from a previous agent selection.
+        "/app-data/bin/ch-opencode": "opencode-sh",
+        "/app-data/bin/ch-opencode.cmd": "opencode-cmd",
+      },
+    });
+
+    await createHarness(SCRIPTS, fileSystem).dispatch();
+
+    expect(fileSystem.rm).toHaveBeenCalledTimes(2);
+    expect(fileSystem.rm).toHaveBeenCalledWith(
+      new Path("/app-data/bin/ch-opencode"),
+      expect.objectContaining({ force: true })
+    );
+    expect(fileSystem.rm).toHaveBeenCalledWith(
+      new Path("/app-data/bin/ch-opencode.cmd"),
+      expect.objectContaining({ force: true })
+    );
+    expect(fileSystem.copyTree).not.toHaveBeenCalled();
+  });
+
+  it("does not fail startup when a stale script is locked", async () => {
+    const fileSystem = createFakeFileSystem({
+      files: {
+        ...BUNDLED,
+        "/app-data/bin/ch-claude": "claude-sh",
+        "/app-data/bin/ch-claude.cjs": "claude-js",
+        "/app-data/bin/ch-claude.cmd": "claude-cmd",
+        "/app-data/bin/code": "code-sh",
+        "/app-data/bin/ch-opencode.cmd": "opencode-cmd",
+      },
+    });
+    fileSystem.rm.mockRejectedValue(
+      new FileSystemError("EPERM", "/app-data/bin/ch-opencode.cmd", "EPERM: not permitted")
+    );
+
+    // Nothing requires the stale wrapper, so an undeletable one is only a warning.
+    await expect(createHarness(SCRIPTS, fileSystem).dispatch()).resolves.toBeUndefined();
+  });
+
+  it("retries a locked write and succeeds when the lock clears", async () => {
+    vi.useFakeTimers();
+    try {
+      const fileSystem = createFakeFileSystem({
+        files: { ...BUNDLED, "/app-data/bin/ch-claude": "claude-sh-OLD" },
+        binEntries: ["ch-claude"],
+      });
+      const realCopyTree = fileSystem.copyTree.getMockImplementation()!;
+      fileSystem.copyTree
+        .mockRejectedValueOnce(
+          new FileSystemError("EPERM", "/app-data/bin/ch-claude", "EPERM: not permitted")
+        )
+        .mockImplementation(realCopyTree);
+
+      const pending = createHarness(["ch-claude"], fileSystem).dispatch();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(fileSystem.copyTree).toHaveBeenCalledTimes(2);
+      expect(fileSystem.files.get("/app-data/bin/ch-claude")).toBe("claude-sh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails startup with an actionable message when an outdated script stays locked", async () => {
+    vi.useFakeTimers();
+    try {
+      const fileSystem = createFakeFileSystem({
+        files: { ...BUNDLED, "/app-data/bin/ch-claude": "claude-sh-OLD" },
+        binEntries: ["ch-claude"],
+      });
+      fileSystem.copyTree.mockRejectedValue(
+        new FileSystemError("EPERM", "/app-data/bin/ch-claude", "EPERM: not permitted")
+      );
+
+      const pending = createHarness(["ch-claude"], fileSystem).dispatch();
+      // Assert before advancing timers: an unhandled rejection otherwise escapes
+      // while the retry loop is still sleeping.
+      const assertion = expect(pending).rejects.toThrow(
+        /Could not update the CodeHydra wrapper script "ch-claude".*previous CodeHydra session/s
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+
+      expect(fileSystem.copyTree).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails startup when a bundled script is missing from the runtime directory", async () => {
+    // Packaging bug, not a lock — must not be silently tolerated.
+    const fileSystem = createFakeFileSystem({ files: {} });
+
+    await expect(createHarness(["ch-claude"], fileSystem).dispatch()).rejects.toThrow(/ENOENT/);
+  });
+
   it("handles empty requiredScripts list", async () => {
-    const fileSystem = {
-      rm: vi.fn().mockResolvedValue(undefined),
-      mkdir: vi.fn().mockResolvedValue(undefined),
-      copyTree: vi.fn().mockResolvedValue(undefined),
-      makeExecutable: vi.fn().mockResolvedValue(undefined),
-    };
+    const fileSystem = createFakeFileSystem({ files: { ...BUNDLED } });
 
-    const pathProvider = createMockPathProvider({
-      dataRootDir: "/app-data",
-      assetsRootDir: "/assets",
-    });
+    await createHarness([], fileSystem).dispatch();
 
-    const dispatcher = createMockDispatcher();
-
-    dispatcher.registerOperation(createMinimalInitOperation([]));
-
-    const module = createScriptModule({
-      fileSystem: fileSystem as never,
-      pathProvider: pathProvider as never,
-    });
-    dispatcher.registerModule(module);
-
-    await dispatcher.dispatch<AppStartIntent>({
-      type: INTENT_APP_START,
-      payload: {},
-    });
-
-    // Should still clean and recreate bin dir
-    expect(fileSystem.rm).toHaveBeenCalled();
     expect(fileSystem.mkdir).toHaveBeenCalled();
-
-    // Should not copy anything
     expect(fileSystem.copyTree).not.toHaveBeenCalled();
     expect(fileSystem.makeExecutable).not.toHaveBeenCalled();
   });

--- a/src/modules/script-module.ts
+++ b/src/modules/script-module.ts
@@ -1,9 +1,19 @@
 /**
- * ScriptModule - Copies required scripts to the app-data bin directory.
+ * ScriptModule - Keeps the app-data bin directory in sync with the required scripts.
  *
  * Provides the "init" hook on app-start. Reads `requiredScripts` from the
- * InitHookContext (collected from configure results) and copies them to
- * the bin directory using setupBinDirectory.
+ * InitHookContext, prunes entries that are no longer required, and rewrites the
+ * ones whose content differs from the bundled copy.
+ *
+ * The directory is converged in place rather than wiped and recreated. On Windows
+ * the wrappers living here are held open by running processes: every Claude agent
+ * is a `cmd.exe` executing `bin\ch-claude.cmd` (cmd keeps a batch file open for
+ * the whole invocation), and the directory is on the IDE server's PATH, so its
+ * terminals reach it too. A process surviving from a previous session therefore
+ * makes deleting or rewriting these files fail with EPERM — which used to abort
+ * startup on every launch, not just after an update. Writing only what actually
+ * changed means the common path (same version, nothing stale) touches no files at
+ * all and cannot collide with such a lock.
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -11,8 +21,24 @@ import type { HookContext } from "../intents/lib/operation";
 import type { InitHookContext } from "../intents/app-start";
 import type { FileSystemBoundary } from "../boundaries/platform/filesystem";
 import type { PathProvider } from "../boundaries/platform/path-provider";
+import type { Logger } from "../boundaries/platform/logging-types";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
+import { FileSystemError } from "../shared/errors/service-errors";
+import { getErrorMessage } from "../shared/error-utils";
 import { Path } from "../utils/path/path";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Write attempts (including the first) when a script write hits a file lock. */
+const WRITE_MAX_ATTEMPTS = 4;
+
+/**
+ * Base delay between write attempts. Grows linearly per attempt, mirroring the
+ * backoff `fs.rm` applies to the same error codes.
+ */
+const WRITE_RETRY_DELAY_MS = 150;
 
 // =============================================================================
 // Dependency Interface
@@ -21,6 +47,147 @@ import { Path } from "../utils/path/path";
 export interface ScriptModuleDeps {
   readonly fileSystem: FileSystemBoundary;
   readonly pathProvider: PathProvider;
+  readonly logger: Logger;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * True for the errors Windows raises when another process holds the file open.
+ * These are worth retrying: a handle in the middle of closing (a delete-pending
+ * file, an antivirus scan) clears within a few hundred milliseconds.
+ */
+function isLockError(error: unknown): boolean {
+  if (!(error instanceof FileSystemError)) {
+    return false;
+  }
+  return error.fsCode === "EPERM" || error.fsCode === "EACCES" || error.originalCode === "EBUSY";
+}
+
+/** Read a file, returning undefined when it doesn't exist. Other errors propagate. */
+async function readIfPresent(
+  fileSystem: FileSystemBoundary,
+  path: Path
+): Promise<string | undefined> {
+  try {
+    return await fileSystem.readFile(path);
+  } catch (error) {
+    if (error instanceof FileSystemError && error.fsCode === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Remove directory entries that are no longer required.
+ *
+ * Best-effort by design: a stale wrapper we cannot delete is not a startup
+ * blocker. Nothing requires it, and the only way to reach it is to call it by a
+ * name no current agent uses.
+ */
+async function pruneStaleScripts(
+  deps: ScriptModuleDeps,
+  binDir: Path,
+  requiredScripts: readonly string[]
+): Promise<void> {
+  const required = new Set(requiredScripts);
+
+  let entries;
+  try {
+    entries = await deps.fileSystem.readdir(binDir);
+  } catch (error) {
+    deps.logger.warn("Could not list the bin directory to prune stale scripts", {
+      path: binDir.toNative(),
+      error: getErrorMessage(error),
+    });
+    return;
+  }
+
+  for (const entry of entries) {
+    if (required.has(entry.name)) {
+      continue;
+    }
+    const stalePath = new Path(binDir, entry.name);
+    try {
+      await deps.fileSystem.rm(stalePath, { recursive: entry.isDirectory, force: true });
+    } catch (error) {
+      deps.logger.warn("Could not remove stale script", {
+        path: stalePath.toNative(),
+        error: getErrorMessage(error),
+      });
+    }
+  }
+}
+
+/**
+ * Copy a script into the bin directory, retrying while the destination looks
+ * locked by another process.
+ *
+ * Retries only help for a handle that is already closing. A wrapper held by a
+ * live agent from a previous session stays locked for that agent's whole
+ * session, so this eventually gives up and fails startup with an actionable
+ * message — running an outdated wrapper against a new app version is worse than
+ * refusing to start.
+ */
+async function writeScript(deps: ScriptModuleDeps, srcPath: Path, destPath: Path): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await deps.fileSystem.copyTree(srcPath, destPath);
+      return;
+    } catch (error) {
+      if (attempt >= WRITE_MAX_ATTEMPTS || !isLockError(error)) {
+        throw new Error(
+          `Could not update the CodeHydra wrapper script "${destPath.basename}" in ` +
+            `${destPath.dirname.toNative()}: ${getErrorMessage(error)}. ` +
+            `A process from a previous CodeHydra session is most likely still using it. ` +
+            `Close all CodeHydra windows, end any terminals or agents it started, then start ` +
+            `CodeHydra again.`,
+          { cause: error }
+        );
+      }
+      deps.logger.warn("Script is locked, retrying", {
+        path: destPath.toNative(),
+        attempt,
+        error: getErrorMessage(error),
+      });
+      await sleep(WRITE_RETRY_DELAY_MS * attempt);
+    }
+  }
+}
+
+/** Write each required script whose content differs from the bundled copy. */
+async function syncRequiredScripts(
+  deps: ScriptModuleDeps,
+  binDir: Path,
+  binAssetsDir: Path,
+  requiredScripts: readonly string[]
+): Promise<void> {
+  for (const name of requiredScripts) {
+    const srcPath = new Path(binAssetsDir, name);
+    const destPath = new Path(binDir, name);
+
+    // A missing or unreadable source is a packaging bug — let it abort startup.
+    const desired = await deps.fileSystem.readFile(srcPath);
+    const current = await readIfPresent(deps.fileSystem, destPath);
+
+    if (current !== desired) {
+      await writeScript(deps, srcPath, destPath);
+    }
+
+    if (!name.endsWith(".cmd") && !name.endsWith(".cjs")) {
+      // Unconditional: chmod never opens the file, so it cannot hit a lock, and
+      // it repairs a mode that was clobbered without rewriting the content.
+      await deps.fileSystem.makeExecutable(destPath);
+    }
+  }
 }
 
 // =============================================================================
@@ -28,7 +195,7 @@ export interface ScriptModuleDeps {
 // =============================================================================
 
 /**
- * Create a ScriptModule that copies required scripts during the "init" hook.
+ * Create a ScriptModule that syncs required scripts during the "init" hook.
  */
 export function createScriptModule(deps: ScriptModuleDeps): IntentModule {
   return {
@@ -49,21 +216,9 @@ export function createScriptModule(deps: ScriptModuleDeps): IntentModule {
             // real, un-archived copy on every target (dev + prod).
             const binAssetsDir = deps.pathProvider.runtimePath("bin");
 
-            // Clean bin directory to remove stale scripts before copying new ones
-            await deps.fileSystem.rm(binDir, { recursive: true, force: true });
             await deps.fileSystem.mkdir(binDir);
-
-            // Copy declared scripts
-            for (const name of requiredScripts) {
-              const srcPath = new Path(binAssetsDir, name);
-              const destPath = new Path(binDir, name);
-
-              await deps.fileSystem.copyTree(srcPath, destPath);
-
-              if (!name.endsWith(".cmd") && !name.endsWith(".cjs")) {
-                await deps.fileSystem.makeExecutable(destPath);
-              }
-            }
+            await pruneStaleScripts(deps, binDir, requiredScripts);
+            await syncRequiredScripts(deps, binDir, binAssetsDir, requiredScripts);
           },
         },
       },


### PR DESCRIPTION
Fixes a Windows startup crash: `EPERM: operation not permitted, rmdir '…\AppData\Roaming\codehydra\bin'` (PostHog `019fb30f`, `crash_source=startup`, `phase=init`).

**Cause** — `ScriptModule` deleted and recreated the app-data `bin` directory on every `app:start`, then re-copied every wrapper unconditionally. On Windows those wrappers are held open by live processes: each Claude agent is a `cmd.exe` executing `bin\ch-claude.cmd`, and the directory is on the IDE server's PATH. A process surviving from a previous session made the recursive `rm` fail with `EPERM`, and since the `init` hook aborts `app:start`, that killed startup outright. This ran on **every** launch, not just after an update.

**Fix** — converge the directory in place instead of wiping it:

- Prune only entries no longer in `requiredScripts`; failure logs a warning and continues, since nothing requires a stale wrapper.
- Write a required script only when its content differs from the bundled copy. On an ordinary launch nothing is stale and nothing differs, so the handler touches no files and cannot collide with a lock.
- Retry locked writes with linear backoff (matching the backoff `fs.rm` applies to the same codes) to ride out a handle that is already closing.
- If an *outdated* script stays locked, fail startup with a message naming the file and telling the user to close the previous session — an outdated wrapper is never run against a new app version.

**Tests** — `script-module.integration.test.ts` rewritten around a behavioural filesystem double so the "write only what differs" decision is exercised rather than asserted via call counts. 9 tests covering: empty bin, no-op when up to date (the regression guard), partial rewrite, pruning, locked stale file, locked write that clears on retry, locked outdated file, missing bundled source, empty script list.