### PR TITLE
fix: Dialogs no longer lose focus to surfaces opening behind them

### DIFF
--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -4,9 +4,14 @@
   Renders one DialogView per open dialog of kind "modal" (the blocking popups)
   from the ui:state snapshot. The non-blocking kinds — "modeless" (creation) and
   "panel" (deletion) — are rendered by MainView as PanelViews instead.
+
+  Modals stack above everything else and above each other, so the topmost one
+  (last in open order) owns focus; the ones below it stop placing focus until
+  it closes. Same rule as MainView's panels — see $lib/utils/focus-owner.
 -->
 <script lang="ts">
   import type { UiDialog } from "@shared/ui-state";
+  import { topmostModalId } from "$lib/utils/focus-owner";
   import DialogView from "./DialogView.svelte";
   import ErrorBoundary from "./ErrorBoundary.svelte";
 
@@ -16,12 +21,14 @@
   }
 
   const { dialogs }: Props = $props();
+
+  const topModal = $derived(topmostModalId(dialogs));
 </script>
 
 {#each dialogs.filter((d) => d.kind === "modal") as entry (entry.id)}
   <!-- Per-dialog wall: a render error in one modal shows a fallback for that
        modal only, leaving the rest of the UI live and navigable. -->
   <ErrorBoundary label="dialog:{entry.id}">
-    <DialogView dialogId={entry.id} config={entry.config} />
+    <DialogView dialogId={entry.id} config={entry.config} focusOwned={topModal === entry.id} />
   </ErrorBoundary>
 {/each}

--- a/src/renderer/lib/components/DialogView.svelte
+++ b/src/renderer/lib/components/DialogView.svelte
@@ -16,9 +16,15 @@
   interface Props {
     dialogId: string;
     config: DialogConfig;
+    /**
+     * Whether this modal is the topmost one, and so entitled to place focus.
+     * A modal opened underneath another stops autofocusing until it is on top
+     * again — see $lib/utils/focus-owner.
+     */
+    focusOwned?: boolean;
   }
 
-  const { dialogId, config }: Props = $props();
+  const { dialogId, config, focusOwned = true }: Props = $props();
 
   /** Derive heading text from sections for aria-label. */
   const heading = $derived.by(() => {
@@ -43,7 +49,7 @@
     <Logo />
   </div>
   <div class="card" class:scroll-layout={scrollLayout}>
-    <Form {dialogId} {config} />
+    <Form {dialogId} {config} {focusOwned} />
   </div>
 </div>
 

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -31,6 +31,7 @@
 
   // Setup functions
   import { setupDomainEventBindings } from "$lib/utils/setup-domain-event-bindings";
+  import { focusOwnerId } from "$lib/utils/focus-owner";
 
   // Components
   import Sidebar from "./Sidebar.svelte";
@@ -74,8 +75,13 @@
    * most one panel dialog exists at a time.
    */
   const panelDialog = $derived(ui.dialogs.find((d) => d.kind === "panel"));
-  /** Whether a blocking modal is open above the panels (drives panel refocus). */
-  const modalAbove = $derived(ui.dialogs.some((d) => d.kind === "modal"));
+  /**
+   * The single surface entitled to place DOM focus right now. A panel only
+   * autofocuses while it owns focus, so one appearing behind an open modal
+   * (deletion progress, the mid-session loading spinner, the creation ground
+   * state) cannot yank the caret out of it. See $lib/utils/focus-owner.
+   */
+  const focusOwner = $derived(focusOwnerId(ui));
   /** The creation panel is the ground state: shown whenever main says so. */
   const creationShown = $derived(main?.kind === "creation");
 
@@ -234,7 +240,7 @@
       dialogId={creationDialog?.id}
       config={creationDialog?.config}
       kind="modeless"
-      {modalAbove}
+      focusOwned={focusOwner === creationDialog?.id}
     />
   {/if}
 
@@ -245,7 +251,12 @@
        workspace and are mutually exclusive, so they never coexist with the
        creation ground state or each other. -->
   {#if main?.kind === "workspace" && panelDialog}
-    <PanelView dialogId={panelDialog?.id} config={panelDialog?.config} kind="panel" {modalAbove} />
+    <PanelView
+      dialogId={panelDialog?.id}
+      config={panelDialog?.config}
+      kind="panel"
+      focusOwned={focusOwner === panelDialog?.id}
+    />
   {/if}
 
   {#if main?.kind === "hibernated"}

--- a/src/renderer/lib/components/PanelView.svelte
+++ b/src/renderer/lib/components/PanelView.svelte
@@ -18,8 +18,9 @@
     just keeps the empty/reconnecting frame from flickering through.
   - Blocking modals (z 1000) stack above both.
   - Keyboard (Escape, Cmd/Ctrl+Enter -> primary, Tab trap) is owned by Form.
-  - When the last blocking modal stacked above closes, the panel re-places focus
-    on the form's autofocus control (focus would otherwise be lost to <body>).
+  - Focus placement is owned by Form too, gated on `focusOwned`: a panel that
+    appears while a modal is stacked above it never takes the caret, and gets
+    it when that modal closes. See $lib/utils/focus-owner.
   - Form is keyed by dialogId: a backend close + reopen remounts it with fresh
     field values (the reset gesture).
 -->
@@ -38,26 +39,16 @@
     config: DialogConfig | undefined;
     /** "modeless" (creation, above sidebar) or "panel" (deletion, below sidebar). */
     kind: Extract<DialogKind, "modeless" | "panel">;
-    /** Whether a blocking modal is open above (drives refocus on close). */
-    modalAbove: boolean;
+    /** Whether this panel is the surface entitled to place focus. */
+    focusOwned?: boolean;
   }
 
-  const { dialogId, config, kind, modalAbove }: Props = $props();
-
-  let formRef: Form | undefined = $state();
+  const { dialogId, config, kind, focusOwned = true }: Props = $props();
 
   /** Derive heading text from sections for the accessible name. */
   const heading = $derived.by(() => {
     const headingSection = config?.sections.find((s) => s.type === "text" && s.style === "heading");
     return headingSection?.type === "text" ? headingSection.content : "Panel";
-  });
-
-  // Refocus the form when the last modal above the panel closes (modals steal
-  // focus while open; on close the panel is the active surface again).
-  let hadModalAbove = false;
-  $effect(() => {
-    if (hadModalAbove && !modalAbove) formRef?.refocus();
-    hadModalAbove = modalAbove;
   });
 </script>
 
@@ -73,7 +64,7 @@
            fallback instead of escaping to the crash guard. -->
       <ErrorBoundary label="panel:{kind}">
         {#key dialogId}
-          <Form bind:this={formRef} {dialogId} {config} {kind} />
+          <Form {dialogId} {config} {kind} {focusOwned} />
         {/key}
       </ErrorBoundary>
     {/if}

--- a/src/renderer/lib/components/PanelView.test.ts
+++ b/src/renderer/lib/components/PanelView.test.ts
@@ -3,7 +3,7 @@
  * Section/action rendering and the keyboard contract (Escape, Cmd/Ctrl+Enter,
  * Tab trap) live in Form.test.ts — these cover only the panel shell:
  * accessible name, the dialogId-keyed Form remount (the reset gesture), and
- * refocusing the form when the last modal stacked above the panel closes.
+ * the focus-ownership gate (a panel only places focus while it owns it).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -39,10 +39,10 @@ function createConfig(overrides?: Partial<DialogConfig>): DialogConfig {
 function renderPanel(
   config: DialogConfig,
   dialogId = "panel-1",
-  modalAbove = false,
+  focusOwned = true,
   kind: "modeless" | "panel" = "modeless"
 ) {
-  return render(PanelView, { props: { dialogId, config, kind, modalAbove } });
+  return render(PanelView, { props: { dialogId, config, kind, focusOwned } });
 }
 
 describe("PanelView component (panel surface)", () => {
@@ -75,7 +75,7 @@ describe("PanelView component (panel surface)", () => {
     });
   });
 
-  describe("refocus on modal close", () => {
+  describe("focus ownership", () => {
     // A multiline autofocus input renders as a native <textarea> with
     // data-autofocus — focusable in happy-dom, unlike vscode-elements.
     const autofocusConfig = createConfig({
@@ -85,30 +85,55 @@ describe("PanelView component (panel surface)", () => {
       ],
     });
 
-    it("re-places focus on the autofocus control when the last modal above closes", async () => {
-      const { rerender } = renderPanel(autofocusConfig, "panel-1", false);
-      const textarea = document.querySelector("textarea")!;
-      await waitFor(() => expect(document.activeElement).toBe(textarea));
+    /**
+     * Stand-in for the caret the user is typing in elsewhere (e.g. the modal
+     * above). An <input> so it never collides with the panel's own <textarea>
+     * in the queries below.
+     */
+    function focusElsewhere(): HTMLInputElement {
+      const outside = document.createElement("input");
+      document.body.appendChild(outside);
+      outside.focus();
+      return outside;
+    }
 
-      // A modal opens above the panel and takes focus elsewhere.
-      await rerender({ dialogId: "panel-1", config: autofocusConfig, modalAbove: true });
-      textarea.blur();
-      await waitFor(() => expect(document.activeElement).not.toBe(textarea));
+    // The reported bug (PostHog 019fb2cb): a panel arriving BEHIND an open
+    // modal — deletion progress, the mid-session loading spinner, the creation
+    // ground state — ran its mount autofocus and yanked the caret out of the
+    // dialog the user was typing in.
+    it("does not take focus when it mounts without owning focus", async () => {
+      const outside = focusElsewhere();
 
-      // Modal closes — the panel is the active surface again.
-      await rerender({ dialogId: "panel-1", config: autofocusConfig, modalAbove: false });
+      renderPanel(autofocusConfig, "panel-1", false);
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
-      await waitFor(() => expect(document.activeElement).toBe(textarea));
+      expect(document.activeElement).toBe(outside);
     });
 
-    it("a modal opening above does not disturb existing panel focus", async () => {
+    it("takes focus on mount when it owns focus", async () => {
+      renderPanel(autofocusConfig, "panel-1", true);
+
+      await waitFor(() => expect(document.activeElement).toBe(document.querySelector("textarea")));
+    });
+
+    it("places focus when ownership transfers to it (the modal above closed)", async () => {
+      const outside = focusElsewhere();
       const { rerender } = renderPanel(autofocusConfig, "panel-1", false);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(document.activeElement).toBe(outside);
+
+      // Modal closes — the panel is the entitled surface again.
+      await rerender({ dialogId: "panel-1", config: autofocusConfig, focusOwned: true });
+
+      await waitFor(() => expect(document.activeElement).toBe(document.querySelector("textarea")));
+    });
+
+    it("losing ownership does not blur the panel (the new owner places focus)", async () => {
+      const { rerender } = renderPanel(autofocusConfig, "panel-1", true);
       const textarea = document.querySelector("textarea")!;
       await waitFor(() => expect(document.activeElement).toBe(textarea));
 
-      // A modal opens above (modalAbove false→true). The refocus gate fires
-      // only on the true→false close, so focus is left exactly where it is.
-      await rerender({ dialogId: "panel-1", config: autofocusConfig, modalAbove: true });
+      await rerender({ dialogId: "panel-1", config: autofocusConfig, focusOwned: false });
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(document.activeElement).toBe(textarea);
@@ -159,7 +184,7 @@ describe("PanelView component (panel surface)", () => {
     it("renders only the shell, no Form, when config/dialogId are undefined", () => {
       expect(() =>
         render(PanelView, {
-          props: { dialogId: undefined, config: undefined, kind: "modeless", modalAbove: false },
+          props: { dialogId: undefined, config: undefined, kind: "modeless", focusOwned: false },
         })
       ).not.toThrow();
 
@@ -178,7 +203,7 @@ describe("PanelView component (panel surface)", () => {
         dialogId: undefined,
         config: undefined,
         kind: "modeless",
-        modalAbove: false,
+        focusOwned: false,
       });
 
       expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();

--- a/src/renderer/lib/components/form/Form.svelte
+++ b/src/renderer/lib/components/form/Form.svelte
@@ -55,9 +55,22 @@
      * "panel" swallow it (no-op).
      */
     kind?: DialogKind;
+    /**
+     * Whether this form is the surface entitled to place DOM focus — the
+     * topmost open surface, see `$lib/utils/focus-owner`. A form that does not
+     * own focus never MOVES it: no mount autofocus, no autofocus-follow, no
+     * orphan-restore. That is what keeps a panel appearing behind an open
+     * modal (deletion progress, the mid-session loading spinner, the creation
+     * ground state) from yanking the caret out of it. Ownership arriving later
+     * — the surface above closed — places focus then (see the transfer effect).
+     *
+     * Defaults to true: a surface that never loses ownership (a lone modal)
+     * need not pass it.
+     */
+    focusOwned?: boolean;
   }
 
-  const { dialogId, config, kind = "modal" }: Props = $props();
+  const { dialogId, config, kind = "modal", focusOwned = true }: Props = $props();
 
   /**
    * All field sections of the config in declaration order — top-level
@@ -361,21 +374,43 @@
     }, 0);
   }
 
-  /** Focus the control marked data-autofocus (after a tick for mounting). */
+  /**
+   * Focus the control marked data-autofocus (after a tick for mounting).
+   * No-op while this form does not own focus — re-checked when the deferred
+   * callback fires, since ownership can change within the tick.
+   */
   function focusAutofocusTarget(): void {
+    if (!focusOwned) return;
     scheduleFocus(() => {
+      if (!focusOwned) return;
       const target = formRef?.querySelector<HTMLElement>("[data-autofocus]");
       target?.focus();
     });
   }
 
   /**
-   * Re-place focus on the autofocus control. Exposed for hosting surfaces
-   * that regain focus ownership (e.g. the panel when the last modal stacked
-   * above it closes and focus would otherwise be lost to <body>).
+   * Place focus on this form's entry control: an explicit autofocus control
+   * wins, else the computed default target (first enabled field, else the
+   * primary button). In the form layout (settings) the default target is
+   * skipped — focusing the first field would open its dropdown list — so an
+   * unflagged form-layout config leaves focus unset.
+   *
+   * Used for both mount and ownership transfer, so a form with no explicit
+   * autofocus flag (e.g. the bug report dialog) still regains its caret when
+   * the surface above it closes. Ownership-gated like focusAutofocusTarget.
    */
-  export function refocus(): void {
-    focusAutofocusTarget();
+  function placeFocus(): void {
+    if (!focusOwned) return;
+    scheduleFocus(() => {
+      if (!focusOwned) return;
+      const explicit = formRef?.querySelector<HTMLElement>("[data-autofocus]");
+      if (explicit) {
+        explicit.focus();
+        return;
+      }
+      if (layout === "form") return;
+      defaultFocusTarget()?.focus();
+    });
   }
 
   /** The id of the control carrying the autofocus flag, or null. */
@@ -416,21 +451,31 @@
     return formRef.querySelector<HTMLElement>("vscode-button[data-primary]:not([disabled])");
   }
 
-  // Auto-focus on mount: an explicit autofocus control wins, else the
-  // computed default target (first enabled field, else the primary button).
-  // In the form layout (settings) we skip the default target: focusing the
-  // first field would open its dropdown list, so we leave focus unset unless a
-  // control opts in with an explicit autofocus flag.
+  // Auto-focus on mount — but only when this form owns focus. A panel mounting
+  // underneath an open modal must leave the modal's caret alone.
   onMount(() => {
-    scheduleFocus(() => {
-      const explicit = formRef?.querySelector<HTMLElement>("[data-autofocus]");
-      if (explicit) {
-        explicit.focus();
-        return;
-      }
-      if (layout === "form") return;
-      defaultFocusTarget()?.focus();
-    });
+    placeFocus();
+  });
+
+  // Ownership transfer: when this form BECOMES the focus owner (the modal or
+  // panel stacked above it closed), place focus — it would otherwise sit on
+  // <body>, where the form-global keyboard contract (Escape, Tab trap) can no
+  // longer see it. Losing ownership never blurs; the surface taking over
+  // places its own focus.
+  //
+  // Gated on an actual CHANGE, not just an effect run: a config re-send
+  // re-reads every prop, and re-placing focus on each of those would undo the
+  // user's own focus moves (the "re-sends never steal focus" contract above).
+  // The first run only records the initial ownership — mount focus is
+  // onMount's job.
+  let hadFocusOwnership: boolean | undefined = undefined;
+  $effect(() => {
+    const owned = focusOwned;
+    if (owned === hadFocusOwnership) return;
+    const isFirstRun = hadFocusOwnership === undefined;
+    hadFocusOwnership = owned;
+    if (isFirstRun || !owned) return;
+    placeFocus();
   });
 
   // Focus follows when a config update MOVES the autofocus flag to a

--- a/src/renderer/lib/components/form/Form.test.ts
+++ b/src/renderer/lib/components/form/Form.test.ts
@@ -1520,6 +1520,120 @@ describe("Form component", () => {
     });
   });
 
+  // ---- Focus ownership ----
+  //
+  // A form only ever MOVES focus while it is the surface entitled to it (the
+  // topmost one — see $lib/utils/focus-owner). Without this, a panel or a
+  // lower modal placed its own focus while the user was typing in the dialog
+  // above it: PostHog 019fb2cb, "bug report dialog looses focus".
+
+  describe("focus ownership", () => {
+    const flaggedAndDefault: DialogConfig = {
+      sections: [
+        {
+          type: "dropdown",
+          id: "a",
+          suggestions: [{ items: [{ value: "x", label: "x" }] }],
+          autofocus: true,
+        },
+        {
+          type: "dropdown",
+          id: "b",
+          suggestions: [{ items: [{ value: "y", label: "y" }] }],
+        },
+      ],
+    };
+
+    /**
+     * Stand-in for the caret the user is typing in on the surface above. An
+     * <input> so it never collides with a form's own <textarea> in queries.
+     */
+    function focusElsewhere(): HTMLInputElement {
+      const outside = document.createElement("input");
+      document.body.appendChild(outside);
+      outside.focus();
+      return outside;
+    }
+
+    it("does not autofocus on mount while another surface owns focus", async () => {
+      const outside = focusElsewhere();
+
+      render(Form, {
+        props: { dialogId: "test-dialog", config: flaggedAndDefault, focusOwned: false },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(document.activeElement).toBe(outside);
+    });
+
+    it("does not follow a moved autofocus flag while another surface owns focus", async () => {
+      const outside = focusElsewhere();
+      const { rerender } = render(Form, {
+        props: { dialogId: "test-dialog", config: flaggedAndDefault, focusOwned: false },
+      });
+
+      // The backend moves the autofocus flag from "a" to "b" — normally a
+      // focus move, but this form is not entitled to place focus.
+      await rerender({
+        dialogId: "test-dialog",
+        config: {
+          sections: [
+            { type: "dropdown", id: "a", suggestions: [{ items: [{ value: "x", label: "x" }] }] },
+            {
+              type: "dropdown",
+              id: "b",
+              suggestions: [{ items: [{ value: "y", label: "y" }] }],
+              autofocus: true,
+            },
+          ],
+        } satisfies DialogConfig,
+        focusOwned: false,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(document.activeElement).toBe(outside);
+    });
+
+    it("places focus when ownership transfers to it", async () => {
+      const { rerender } = render(Form, {
+        props: { dialogId: "test-dialog", config: flaggedAndDefault, focusOwned: false },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(document.activeElement?.id).not.toBe("a-input");
+
+      await rerender({ dialogId: "test-dialog", config: flaggedAndDefault, focusOwned: true });
+
+      await waitFor(() => {
+        expect(document.activeElement?.id).toBe("a-input");
+      });
+    });
+
+    // A config with no explicit autofocus flag (the bug report dialog) must
+    // still get its caret back when the surface above it closes — the transfer
+    // resolves the same target mount does, not just [data-autofocus].
+    it("falls back to the default target on transfer when no flag is set", async () => {
+      const unflagged: DialogConfig = {
+        sections: [
+          { type: "input", id: "description", multiline: true },
+          {
+            type: "group",
+            items: [{ type: "button", id: "send", label: "Send", variant: "primary" }],
+          },
+        ],
+      };
+      const { rerender } = render(Form, {
+        props: { dialogId: "test-dialog", config: unflagged, focusOwned: false },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await rerender({ dialogId: "test-dialog", config: unflagged, focusOwned: true });
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(document.querySelector("textarea"));
+      });
+    });
+  });
+
   // ---- Field-change channel ----
 
   describe("field-change channel", () => {

--- a/src/renderer/lib/utils/focus-owner.test.ts
+++ b/src/renderer/lib/utils/focus-owner.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the focus-ownership derivation (pure function over the snapshot).
+ * The rule it encodes: modals outrank everything and each other (last in open
+ * order wins); below them `main` decides which single non-modal surface is on
+ * screen, mirroring MainView's render conditions.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { UiDialog, UiMainView } from "@shared/ui-state";
+import type { DialogKind } from "@shared/dialog-types";
+import { focusOwnerId, topmostModalId } from "./focus-owner";
+
+function dialog(id: string, kind: DialogKind): UiDialog {
+  return { id, kind, config: { sections: [] } };
+}
+
+const WORKSPACE: UiMainView = { kind: "workspace", frameKey: "p1/ws" };
+const CREATION: UiMainView = { kind: "creation" };
+
+describe("topmostModalId", () => {
+  it("returns null when no modal is open", () => {
+    expect(topmostModalId([dialog("panel-1", "panel"), dialog("create-1", "modeless")])).toBeNull();
+  });
+
+  it("returns the last modal in open order (the topmost one)", () => {
+    const dialogs = [
+      dialog("create-1", "modeless"),
+      dialog("bug-report", "modal"),
+      dialog("settings", "modal"),
+    ];
+
+    expect(topmostModalId(dialogs)).toBe("settings");
+  });
+
+  it("ignores non-modal sessions opened after the modal", () => {
+    const dialogs = [dialog("bug-report", "modal"), dialog("panel-1", "panel")];
+
+    expect(topmostModalId(dialogs)).toBe("bug-report");
+  });
+});
+
+describe("focusOwnerId", () => {
+  it("gives the frame ownership (null) when only workspace content is showing", () => {
+    expect(focusOwnerId({ dialogs: [], main: WORKSPACE })).toBeNull();
+  });
+
+  // The reported bug: a panel appearing behind an open modal must not own
+  // focus, so its form never autofocuses over the dialog the user is typing in.
+  it("keeps ownership on the modal when a panel opens behind it", () => {
+    const dialogs = [dialog("bug-report", "modal"), dialog("panel-1", "panel")];
+
+    expect(focusOwnerId({ dialogs, main: WORKSPACE })).toBe("bug-report");
+  });
+
+  it("keeps ownership on the modal when main falls back to the creation panel", () => {
+    const dialogs = [dialog("create-1", "modeless"), dialog("bug-report", "modal")];
+
+    expect(focusOwnerId({ dialogs, main: CREATION })).toBe("bug-report");
+  });
+
+  it("hands ownership to the panel once the modal above it closes", () => {
+    const dialogs = [dialog("panel-1", "panel")];
+
+    expect(focusOwnerId({ dialogs, main: WORKSPACE })).toBe("panel-1");
+  });
+
+  it("hands ownership to the creation panel in the creation ground state", () => {
+    const dialogs = [dialog("create-1", "modeless")];
+
+    expect(focusOwnerId({ dialogs, main: CREATION })).toBe("create-1");
+  });
+
+  // The creation session is always alive, so it is in the snapshot even while
+  // a workspace is showing — it only owns focus when main actually renders it.
+  it("does not give the always-alive creation session ownership while a workspace shows", () => {
+    const dialogs = [dialog("create-1", "modeless")];
+
+    expect(focusOwnerId({ dialogs, main: WORKSPACE })).toBeNull();
+  });
+
+  it("does not give a panel ownership while main shows the creation ground state", () => {
+    const dialogs = [dialog("panel-1", "panel")];
+
+    expect(focusOwnerId({ dialogs, main: CREATION })).toBeNull();
+  });
+
+  it("gives nobody ownership on the hibernated and startup screens", () => {
+    const dialogs = [dialog("create-1", "modeless"), dialog("panel-1", "panel")];
+
+    expect(focusOwnerId({ dialogs, main: { kind: "hibernated", screenshot: null } })).toBeNull();
+    expect(focusOwnerId({ dialogs, main: { kind: "starting" } })).toBeNull();
+  });
+});

--- a/src/renderer/lib/utils/focus-owner.ts
+++ b/src/renderer/lib/utils/focus-owner.ts
@@ -1,0 +1,59 @@
+/**
+ * Focus ownership: which open surface is entitled to place DOM focus.
+ *
+ * Every surface that can move focus (each `Form`, and the workspace frames)
+ * obeys one rule: place focus only while you own it. Without that rule a
+ * surface appearing UNDERNEATH an open dialog still ran its mount autofocus
+ * and yanked the caret out of the dialog the user was typing in — the
+ * "bug report dialog looses focus" report (PostHog 019fb2cb).
+ *
+ * Ownership is a pure derivation over the snapshot; there is no renderer-side
+ * focus state. The snapshot already carries everything needed:
+ *   - `dialogs` is in open order, so the LAST modal is the topmost one, and
+ *     modals (DialogView, z-index 1000) outrank every non-modal surface.
+ *   - `main` decides which single non-modal surface is on screen, mirroring
+ *     MainView's render conditions: "creation" shows the modeless creation
+ *     panel, "workspace" may show a "panel" session (deletion progress or the
+ *     mid-session loading spinner) over the frame.
+ *
+ * `null` means no dialog surface owns focus — the workspace frame does, which
+ * WorkspaceFrames already gates on `mode === "workspace"`.
+ *
+ * NOTE: this governs focus moves that go through our code. A workspace iframe
+ * whose VSCodium focuses itself on load is outside it by design; that class is
+ * handled (if at all) main-side, by not making such a workspace active.
+ */
+
+import type { UiDialog, UiState } from "@shared/ui-state";
+
+/**
+ * The topmost open modal's id, or null when none is open. Modals stack above
+ * everything else and above each other, so this alone decides ownership among
+ * modal surfaces — which is why DialogHost can use it without consulting
+ * `main`.
+ */
+export function topmostModalId(dialogs: readonly UiDialog[]): string | null {
+  for (let index = dialogs.length - 1; index >= 0; index--) {
+    const dialog = dialogs[index];
+    if (dialog?.kind === "modal") return dialog.id;
+  }
+  return null;
+}
+
+/**
+ * The id of the dialog session entitled to place focus, or null when none is
+ * (the workspace frame owns it).
+ */
+export function focusOwnerId(ui: Pick<UiState, "dialogs" | "main">): string | null {
+  const modal = topmostModalId(ui.dialogs);
+  if (modal !== null) return modal;
+  // Below the modals exactly one non-modal surface is rendered, and `main`
+  // says which — the two branches mirror MainView's `{#if}` conditions.
+  if (ui.main.kind === "creation") {
+    return ui.dialogs.find((dialog) => dialog.kind === "modeless")?.id ?? null;
+  }
+  if (ui.main.kind === "workspace") {
+    return ui.dialogs.find((dialog) => dialog.kind === "panel")?.id ?? null;
+  }
+  return null;
+}


### PR DESCRIPTION
Reported via the in-app bug reporter (PostHog issue `019fb2cb`): *"bug report dialog looses focus"*.

- A panel arriving **underneath** an open dialog still ran its mount autofocus and yanked the caret out of the dialog being typed in. The concrete case: deleting the last workspace (or a failed creation) flips `main` to `creation`, which mounts the creation panel, resets its session to a fresh `dialogId`, and the remounted `Form` focuses its autofocus control — straight over the modal above it.
- Focus placement is now gated on **ownership**: `focusOwnerId()` derives purely from the snapshot which single surface is entitled to place focus (modals outrank everything and each other, last in open order wins; below them `main` picks the one non-modal surface on screen). No renderer state — `dialogs` is already in open order and `main` already says what is rendered.
- `Form` owns the whole policy: mount autofocus, autofocus-follow and orphan-restore all no-op while unowned, and a transfer effect places focus when ownership arrives — so a dialog also gets its caret **back** when the surface above it closes. That restore resolves the same target mount does, so a config with no explicit autofocus flag (the bug report dialog) recovers too; previously only `[data-autofocus]` was handled for panels, and modals had no restore at all.
- Also fixes modal-over-modal: a dialog opened above another no longer competes with it, and hands focus back on close.
- This is the `ffce0be0` guard applied to the other focus mover — that one covered the workspace frame (gated on mode), this one covers the forms.

**Verification**: A/B against the pre-fix build under appctrl. With a caret in an open modal, making the creation panel appear behind it moves focus to the panel's name field before the change (`INPUT#name-input{autofocus} in=PANEL`, 2 focus events) and leaves it untouched after (0 focus events). Full deletion flow re-run on the fixed build. Plus focused tests for the ownership rule and ownership gating in `Form`/`PanelView`.

**Known gap, accepted**: a workspace iframe whose VSCodium focuses itself once its frame lands visible never passes through this rule, so the *"new workspace is loading in the background"* half of the report is unchanged.