### PR TITLE
fix(telemetry): degrade quietly when PostHog is unreachable

### DIFF
--- a/src/boundaries/platform/posthog.boundary.test.ts
+++ b/src/boundaries/platform/posthog.boundary.test.ts
@@ -32,17 +32,19 @@ interface IdentifyCall {
   properties: Record<string, unknown>;
 }
 
-function createFakeSdk(): {
+function createFakeSdk(opts?: { failDelivery?: boolean }): {
   client: PostHogSdkClient;
   captures: CaptureCall[];
   exceptions: ExceptionCall[];
   identifies: IdentifyCall[];
   flushes: number;
   shutdowns: number;
+  shutdownTimeouts: (number | undefined)[];
 } {
   const captures: CaptureCall[] = [];
   const exceptions: ExceptionCall[] = [];
   const identifies: IdentifyCall[] = [];
+  const shutdownTimeouts: (number | undefined)[] = [];
   const counters = { flushes: 0, shutdowns: 0 };
 
   const client: PostHogSdkClient = {
@@ -52,9 +54,12 @@ function createFakeSdk(): {
     identify: (params) => identifies.push(params),
     flush: async () => {
       counters.flushes += 1;
+      if (opts?.failDelivery) throw new Error("Network error while fetching PostHog");
     },
-    shutdown: async () => {
+    shutdown: async (shutdownTimeoutMs) => {
       counters.shutdowns += 1;
+      shutdownTimeouts.push(shutdownTimeoutMs);
+      if (opts?.failDelivery) throw new Error("Timeout while shutting down PostHog");
     },
   };
 
@@ -63,6 +68,7 @@ function createFakeSdk(): {
     captures,
     exceptions,
     identifies,
+    shutdownTimeouts,
     get flushes() {
       return counters.flushes;
     },
@@ -72,11 +78,11 @@ function createFakeSdk(): {
   };
 }
 
-function setup(opts?: { apiKey?: string | undefined }) {
-  const fake = createFakeSdk();
-  let factoryCalls = 0;
-  const sdkFactory: PostHogSdkFactory = () => {
-    factoryCalls += 1;
+function setup(opts?: { apiKey?: string | undefined; failDelivery?: boolean }) {
+  const fake = createFakeSdk({ failDelivery: opts?.failDelivery ?? false });
+  const sdkOptions: Parameters<PostHogSdkFactory>[1][] = [];
+  const sdkFactory: PostHogSdkFactory = (_apiKey, options) => {
+    sdkOptions.push(options);
     return fake.client;
   };
   const boundary = createPostHogBoundary({
@@ -85,7 +91,7 @@ function setup(opts?: { apiKey?: string | undefined }) {
     host: "https://test.posthog.com",
     sdkFactory,
   });
-  return { boundary, fake, getFactoryCalls: () => factoryCalls };
+  return { boundary, fake, sdkOptions, getFactoryCalls: () => sdkOptions.length };
 }
 
 // ============================================================================
@@ -200,5 +206,55 @@ describe("PostHogBoundary", () => {
 
     env.boundary.capture("evt2");
     expect(env.getFactoryCalls()).toBe(2); // recreated after shutdown
+  });
+
+  // --------------------------------------------------------------------------
+  // Unreachable host (offline, blocked egress). Telemetry must degrade quietly.
+  // --------------------------------------------------------------------------
+
+  it("bounds the SDK's request timeout and retries", () => {
+    env.boundary.configure({ distinctId: "id-1" });
+    env.boundary.capture("evt");
+
+    const options = env.sdkOptions[0]!;
+    expect(options.host).toBe("https://test.posthog.com");
+    // Well under the SDK defaults (10s / 3 retries / 3s apart), which let a
+    // single flush on a dead network run for ~40s.
+    expect(options.requestTimeout).toBeLessThanOrEqual(5_000);
+    expect(options.fetchRetryCount).toBeLessThanOrEqual(2);
+    expect(options.fetchRetryDelay).toBeLessThanOrEqual(3_000);
+  });
+
+  it("flush() swallows a delivery failure instead of rejecting its caller", async () => {
+    const offline = setup({ failDelivery: true });
+    offline.boundary.configure({ distinctId: "id-1" });
+    offline.boundary.capture("evt");
+
+    await expect(offline.boundary.flush()).resolves.toBeUndefined();
+    expect(offline.fake.flushes).toBe(1);
+  });
+
+  it("shutdown() swallows a delivery failure and still closes the client", async () => {
+    const offline = setup({ failDelivery: true });
+    offline.boundary.configure({ distinctId: "id-1" });
+    offline.boundary.capture("evt");
+
+    await expect(offline.boundary.shutdown()).resolves.toBeUndefined();
+
+    // Client dropped despite the failure, so a later send starts a fresh one.
+    offline.boundary.capture("evt2");
+    expect(offline.getFactoryCalls()).toBe(2);
+  });
+
+  it("shutdown() caps how long the SDK may spend flushing at exit", async () => {
+    env.boundary.configure({ distinctId: "id-1" });
+    env.boundary.capture("evt");
+    await env.boundary.shutdown();
+
+    const timeout = env.fake.shutdownTimeouts[0];
+    expect(timeout).toBeDefined();
+    // The SDK default is 30s, which would hold the app:shutdown "stop" hook
+    // (and therefore the quit) open on an unreachable network.
+    expect(timeout!).toBeLessThanOrEqual(5_000);
   });
 });

--- a/src/boundaries/platform/posthog.ts
+++ b/src/boundaries/platform/posthog.ts
@@ -14,6 +14,9 @@
  *   capture / captureException / identify   // lazily create the client on first use
  *   flush()                                  // force prompt delivery (user bug report)
  *   shutdown()                               // flush + close (app:shutdown, crash exit)
+ *
+ * Delivery is best-effort: `flush()`/`shutdown()` never reject, and both are
+ * bounded so an unreachable host can't stall a bug report or the app quit.
  */
 
 import { randomUUID } from "node:crypto";
@@ -46,11 +49,19 @@ export interface PostHogSdkClient {
 
   flush(): Promise<void>;
 
-  shutdown(): Promise<void>;
+  shutdown(shutdownTimeoutMs?: number): Promise<void>;
+}
+
+/** SDK construction options. See the tuning constants below for the rationale. */
+export interface PostHogSdkOptions {
+  readonly host: string;
+  readonly requestTimeout: number;
+  readonly fetchRetryCount: number;
+  readonly fetchRetryDelay: number;
 }
 
 /** Creates the low-level SDK client. Injected for testability. */
-export type PostHogSdkFactory = (apiKey: string, options: { host: string }) => PostHogSdkClient;
+export type PostHogSdkFactory = (apiKey: string, options: PostHogSdkOptions) => PostHogSdkClient;
 
 // =============================================================================
 // Boundary interface
@@ -76,10 +87,10 @@ export interface PostHogBoundary {
   /** Update person properties via $set (no-op without an api key or distinct id). */
   identify(properties: Record<string, unknown>): void;
 
-  /** Flush queued events without closing the client. */
+  /** Flush queued events without closing the client. Never rejects. */
   flush(): Promise<void>;
 
-  /** Flush and close the client. */
+  /** Flush and close the client, bounded so quit is never held up. Never rejects. */
   shutdown(): Promise<void>;
 }
 
@@ -90,8 +101,26 @@ export interface PostHogBoundary {
 /** Default PostHog host (EU region). */
 const DEFAULT_HOST = "https://eu.posthog.com";
 
+// Network tuning. The SDK defaults (10s per request, 3 retries, 3s apart) mean a
+// single flush on an unreachable network can occupy ~40s — long enough to stall
+// the awaited paths (bug report delivery) and app quit. These bound it to ~19s
+// worst case while still surviving a brief blip.
+
+/** Per-request timeout. SDK default: 10s. */
+const REQUEST_TIMEOUT_MS = 5_000;
+/** Retries after the first attempt. SDK default: 3. */
+const FETCH_RETRY_COUNT = 2;
+/** Delay between retries. SDK default: 3s. */
+const FETCH_RETRY_DELAY_MS = 2_000;
+/**
+ * Cap on the flush-and-close at exit. SDK default: 30s — an offline machine
+ * would hold the "stop" hook (and therefore the quit) open for all of it.
+ * Matches the crash-path cap in error-report-module.
+ */
+const SHUTDOWN_TIMEOUT_MS = 2_000;
+
 /** Default factory: the real posthog-node client. */
-function createDefaultSdkClient(apiKey: string, options: { host: string }): PostHogSdkClient {
+function createDefaultSdkClient(apiKey: string, options: PostHogSdkOptions): PostHogSdkClient {
   return new PostHog(apiKey, options);
 }
 
@@ -121,9 +150,26 @@ export function createPostHogBoundary(deps: PostHogBoundaryDeps): PostHogBoundar
   function ensureClient(): PostHogSdkClient | null {
     if (client) return client;
     if (!hasApiKey()) return null;
-    client = sdkFactory(deps.apiKey as string, { host });
+    client = sdkFactory(deps.apiKey as string, {
+      host,
+      requestTimeout: REQUEST_TIMEOUT_MS,
+      fetchRetryCount: FETCH_RETRY_COUNT,
+      fetchRetryDelay: FETCH_RETRY_DELAY_MS,
+    });
     deps.logger.debug("PostHog client created", { host });
     return client;
+  }
+
+  /**
+   * Telemetry delivery failures are logged, never propagated. The SDK also
+   * console.errors them itself (hardcoded, not overridable), which bypasses the
+   * log file — this is what makes them show up in `log.output=file` runs.
+   */
+  function logSendFailure(op: "flush" | "shutdown", error: unknown): void {
+    deps.logger.warn("PostHog delivery failed", {
+      op,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   return {
@@ -160,12 +206,27 @@ export function createPostHogBoundary(deps: PostHogBoundaryDeps): PostHogBoundar
 
     async flush(): Promise<void> {
       // Don't create a client just to flush.
-      if (client) await client.flush();
+      if (!client) return;
+      try {
+        await client.flush();
+      } catch (error) {
+        // A sink must never fail its caller: an unreachable PostHog (offline,
+        // captive portal, blocked egress) is expected. Unsent events stay
+        // queued for the next flush.
+        logSendFailure("flush", error);
+      }
     },
 
     async shutdown(): Promise<void> {
-      if (client) {
-        await client.shutdown();
+      if (!client) return;
+      const closing = client;
+      try {
+        await closing.shutdown(SHUTDOWN_TIMEOUT_MS);
+      } catch (error) {
+        logSendFailure("shutdown", error);
+      } finally {
+        // Dropped even on failure, so a later send starts a fresh client
+        // rather than reusing one that is already closing.
         client = null;
       }
     },


### PR DESCRIPTION
- Cap the SDK shutdown at 2s (SDK default: 30s), so an unreachable PostHog can no longer hold the `app:shutdown` "stop" hook — and therefore the quit — open
- Swallow `flush()`/`shutdown()` delivery failures and log them via the telemetry logger, instead of rejecting into the dispatcher as an opaque "hook error"
- Drop the client in a `finally` so a failed shutdown doesn't strand a half-closed one
- Tune the SDK's network defaults (10s × 4 attempts, 3s apart ≈ 40s per flush) down to 5s / 2 retries / 2s, via a new `PostHogSdkOptions` type on the existing factory seam
- Add boundary tests for the offline path: swallowed flush, swallowed shutdown + client recreation, the shutdown cap, and the tuned options