### PR TITLE
fix: Permission mode ignored on new workspaces

### DIFF
--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -567,12 +567,14 @@ describe("CreationModule", () => {
       const s = setup({ defaultBaseBranch: "main" });
       const panel = await readyPanel(s);
 
+      // Single available agent: the agent dropdown isn't rendered, so the
+      // renderer's snapshot carries no "agent" key (see the single-backend
+      // regression test below).
       panel.emitAction("create", {
         project: PROJECT_A.path,
         name: "new-feature",
         base: "main",
         prompt: "",
-        agent: "claude",
       });
       await flush();
 
@@ -602,7 +604,6 @@ describe("CreationModule", () => {
         name: "origin/feature-x",
         base: "origin/feature-x",
         prompt: "",
-        agent: "claude",
       });
       await flush();
 
@@ -678,7 +679,6 @@ describe("CreationModule", () => {
         prompt: "   ",
         "permission-mode": "",
         "agent-name": "",
-        agent: "claude",
       });
       await flush();
 
@@ -691,6 +691,56 @@ describe("CreationModule", () => {
       expect(payload["agent"]).toEqual({ type: "claude" });
     });
 
+    // Regression: with a single available backend the agent dropdown is not
+    // rendered, so the snapshot has no "agent" key. Keying the arm off that
+    // field degraded the spec to the option-less "default" arm and silently
+    // dropped permissionMode/agentName — the prompt then ran under Claude's
+    // own default mode instead of the selected one.
+    it("keeps permissionMode and agentName when the agent field is absent (single backend)", async () => {
+      const s = setup({ defaultBaseBranch: "main", defaultAgent: "claude" });
+      const panel = await readyPanel(s);
+
+      // The dropdown is genuinely absent from the rendered form.
+      expect(sectionById(currentPanel(s).config, "agent")).toBeUndefined();
+
+      panel.emitAction("create", {
+        project: PROJECT_A.path,
+        name: "planned",
+        base: "main",
+        prompt: "do things",
+        "permission-mode": "plan",
+        "agent-name": "reviewer",
+      });
+      await flush();
+
+      expect(s.dispatcher.byType(INTENT_OPEN_WORKSPACE)[0]!.payload).toMatchObject({
+        agent: {
+          type: "claude",
+          prompt: "do things",
+          permissionMode: "plan",
+          agentName: "reviewer",
+        },
+      });
+    });
+
+    it("emits a typed arm for a mode-only create (no prompt, agent field absent)", async () => {
+      const s = setup({ defaultBaseBranch: "main", defaultAgent: "claude" });
+      const panel = await readyPanel(s);
+
+      panel.emitAction("create", {
+        project: PROJECT_A.path,
+        name: "mode-only",
+        base: "main",
+        prompt: "",
+        "permission-mode": "plan",
+      });
+      await flush();
+
+      expect(s.dispatcher.byType(INTENT_OPEN_WORKSPACE)[0]!.payload).toMatchObject({
+        agent: { type: "claude", permissionMode: "plan" },
+      });
+    });
+
     it("re-validates the snapshot: an invalid submit pushes errors instead of dispatching", async () => {
       const s = setup({ defaultBaseBranch: "main" });
       const panel = await readyPanel(s);
@@ -700,7 +750,6 @@ describe("CreationModule", () => {
         name: "existing",
         base: "main",
         prompt: "",
-        agent: "claude",
       });
       await flush();
 

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -713,12 +713,18 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     // (the field isn't rendered); "" means the default (omit the flag).
     const permissionMode = data[FIELD_PERMISSION_MODE] ?? "";
     const agentName = (data[FIELD_AGENT_NAME] ?? "").trim();
-    const agentSelection = data[FIELD_AGENT] ?? "";
+    // The agent dropdown is only rendered when more than one backend is
+    // available, so its field is absent from the snapshot on a single-backend
+    // install — fall back to the module's own resolved selection rather than
+    // treating that as "no backend" (which would drop permissionMode/agentName
+    // into the option-less "default" arm).
+    const agentSelection = data[FIELD_AGENT] ?? selectedAgentType ?? "";
 
     // The form knows the selected backend, so it always emits a typed arm
     // (carrying prompt + options); the resolver only persists it as the
-    // workspace's agent when it differs from the global default. With no
-    // backend selected, fall back to the prompt-only "default" arm.
+    // workspace's agent when it differs from the global default. Only with no
+    // backend at all (no agent installed) do we fall back to the prompt-only
+    // "default" arm.
     let agent: AgentSpec | undefined;
     if (isAvailableAgent(agentSelection)) {
       if (agentSelection === "claude") {


### PR DESCRIPTION
- The New-workspace form only renders the agent dropdown when more than one backend is available, so on a single-backend install the submitted snapshot has no `agent` key. `handleCreate` keyed the whole `AgentSpec` off that field, so its absence degraded the spec to the option-less `"default"` arm and silently dropped `permissionMode` and `agentName` — the initial prompt then ran under Claude's own default mode (`auto`) instead of the selected one.
- OpenCode is only downloaded for the configured agent, so a stock install that picked Claude has exactly one available backend: the permission mode selection never took effect there.
- Fall back to the module's own resolved `selectedAgentType` when the field is absent. This also fixes a mode-only create (no prompt), which previously emitted no agent spec at all.
- The submit tests hand-fed `agent: "claude"` into the action data while using the single-agent fixture, asserting a snapshot the renderer never sends; dropped it and covered both cases.

Reported via PostHog bug report `019fb29a-ee1a-7042-add2-21dc77970988`, and confirmed against the reporter's attached logs (`opencode … installed=false`, workspace goes straight to `busy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99Rn5pHdfdt9qSmzmGcXL