### PR TITLE
fix: Detect and recover a dead editor process

### DIFF
--- a/src/boundaries/shell/ui-view-manager.integration.test.ts
+++ b/src/boundaries/shell/ui-view-manager.integration.test.ts
@@ -270,4 +270,134 @@ describe("UiViewManager", () => {
       expect(() => manager.destroy()).not.toThrow();
     });
   });
+
+  // ===========================================================================
+  // Child frame script
+  //
+  // The script is injected into every workspace iframe. Its probe responder is
+  // the only witness to that shared renderer process dying — Electron reports
+  // no event for a subframe process — so these run the real injected source
+  // against a fake frame window rather than asserting on its text.
+  // ===========================================================================
+
+  describe("child frame script", () => {
+    interface FakeWindow {
+      parent: FakeWindow;
+      top: FakeWindow;
+      posted: unknown[];
+      listeners: ((event: { source: unknown; data: unknown }) => void)[];
+      __chProbe?: boolean;
+      __chFocusTracker?: boolean;
+      postMessage(message: unknown): void;
+      addEventListener(
+        type: string,
+        listener: (event: { source: unknown; data: unknown }) => void
+      ): void;
+    }
+
+    /** A frame window whose parent is the UI page (`parent === top`). */
+    function createFrameWindow(): { win: FakeWindow; uiPage: FakeWindow } {
+      const uiPage = { posted: [] as unknown[] } as unknown as FakeWindow;
+      uiPage.postMessage = (message: unknown): void => {
+        uiPage.posted.push(message);
+      };
+      const win: FakeWindow = {
+        parent: uiPage,
+        top: uiPage,
+        posted: [],
+        listeners: [],
+        postMessage: () => {},
+        addEventListener: (type, listener) => {
+          if (type === "message") win.listeners.push(listener);
+        },
+      };
+      return { win, uiPage };
+    }
+
+    /** The script the manager actually installs into workspace iframes. */
+    function installedScript(): string {
+      const ctx = createDeps();
+      const install = vi.spyOn(ctx.viewLayer, "installChildFrameScript");
+      new UiViewManager(ctx.deps).create();
+      const call = install.mock.calls[0];
+      if (!call) throw new Error("no child frame script was installed");
+      return call[1];
+    }
+
+    /** Run the injected source against a fake frame window. */
+    function run(script: string, win: FakeWindow): void {
+      const document = { addEventListener: (): void => {}, contains: (): boolean => false };
+      new Function("window", "document", script)(win, document);
+    }
+
+    /** Deliver a message to the frame, as the UI page by default. */
+    function send(win: FakeWindow, data: unknown, source: unknown = win.parent): void {
+      for (const listener of win.listeners) listener({ source, data });
+    }
+
+    it("answers a ping from the UI page", () => {
+      const { win, uiPage } = createFrameWindow();
+      run(installedScript(), win);
+
+      send(win, { __chPing: true });
+
+      expect(uiPage.posted).toEqual([{ __chAlive: true }]);
+    });
+
+    it("ignores messages that are not pings", () => {
+      const { win, uiPage } = createFrameWindow();
+      run(installedScript(), win);
+
+      send(win, { __chPing: false });
+      send(win, "hello");
+      send(win, null);
+
+      expect(uiPage.posted).toEqual([]);
+    });
+
+    it("ignores a ping that did not come from the UI page", () => {
+      const { win, uiPage } = createFrameWindow();
+      run(installedScript(), win);
+
+      send(win, { __chPing: true }, { spoofed: true });
+
+      expect(uiPage.posted).toEqual([]);
+    });
+
+    it("stays silent in VSCodium's nested webview frames", () => {
+      // A webview nested inside a workspace frame: its parent is that frame,
+      // not the UI page, so the UI could not attribute its answer.
+      const { win, uiPage } = createFrameWindow();
+      const workspaceFrame = { ...win };
+      win.parent = workspaceFrame as FakeWindow;
+      run(installedScript(), win);
+
+      send(win, { __chPing: true });
+
+      expect(win.listeners).toHaveLength(0);
+      expect(uiPage.posted).toEqual([]);
+    });
+
+    it("does not register a second responder when injected again", () => {
+      const { win, uiPage } = createFrameWindow();
+      const script = installedScript();
+
+      run(script, win);
+      run(script, win);
+      send(win, { __chPing: true });
+
+      expect(win.listeners).toHaveLength(1);
+      expect(uiPage.posted).toEqual([{ __chAlive: true }]);
+    });
+
+    it("survives a parent that rejects postMessage", () => {
+      const { win } = createFrameWindow();
+      run(installedScript(), win);
+      win.parent.postMessage = (): never => {
+        throw new Error("cross-origin");
+      };
+
+      expect(() => send(win, { __chPing: true })).not.toThrow();
+    });
+  });
 });

--- a/src/boundaries/shell/ui-view-manager.ts
+++ b/src/boundaries/shell/ui-view-manager.ts
@@ -60,6 +60,43 @@ const CHILD_FRAME_FOCUS_TRACKER = `
 `;
 
 /**
+ * Script injected into every workspace iframe so it can prove its renderer
+ * process is still running. Answers a `__chPing` from the UI page with
+ * `__chAlive`; WorkspaceFrames probes a frame when it shows it and logs one
+ * that stays silent.
+ *
+ * Why the frames have to answer for themselves: all workspace iframes are
+ * same-origin (the one IDE server port), so Chromium hosts them in a single
+ * shared renderer process — separate from the UI page's. When that process
+ * dies every workbench blanks at once, and nothing in the main process sees
+ * it: `app.on('child-process-gone')` excludes renderers by contract, and
+ * `render-process-gone` only fires for a webContents' *primary* frame, never a
+ * subframe. The frames are the only witnesses (PostHog issue 019fb265: five
+ * workbenches went blank simultaneously, the IDE server logged five client
+ * disconnects, and CodeHydra's own log had nothing at all).
+ *
+ * Only direct children of the UI page answer. VSCodium's own nested webview
+ * iframes receive this script too — their `parent` is the workspace frame
+ * rather than the UI page, so they would answer a probe the UI cannot
+ * attribute to any frame it mounted.
+ */
+const CHILD_FRAME_PROBE = `
+  (function(){
+    if (window.__chProbe) return;
+    if (window.parent === window || window.parent !== window.top) return;
+    window.__chProbe = true;
+    window.addEventListener('message', function(e){
+      if (e.source !== window.parent) return;
+      if (!e.data || e.data.__chPing !== true) return;
+      try { window.parent.postMessage({ __chAlive: true }, '*'); } catch(err) {}
+    });
+  })();
+`;
+
+/** Everything injected into a workspace iframe once it finishes loading. */
+const CHILD_FRAME_SCRIPT = `${CHILD_FRAME_FOCUS_TRACKER}${CHILD_FRAME_PROBE}`;
+
+/**
  * Renderer hooks installed by the WorkspaceFrames component on `window`.
  * Used for main-initiated focus routing and screenshot rect lookup.
  */
@@ -181,7 +218,7 @@ export class UiViewManager implements IViewManager {
       return { action: "deny" };
     });
 
-    this.viewLayer.installChildFrameScript(uiViewHandle, CHILD_FRAME_FOCUS_TRACKER);
+    this.viewLayer.installChildFrameScript(uiViewHandle, CHILD_FRAME_SCRIPT);
 
     this.uiViewHandle = uiViewHandle;
     // (Re)wire any onFromUI subscriptions onto the new view's webContents.

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -447,11 +447,13 @@ export class DefaultViewBoundary implements ViewBoundary {
     try {
       await state.webContents.loadURL(url);
     } catch (error) {
-      // Navigation failures are transient (network changes, sleep/resume, etc.)
-      // and already handled by the did-fail-load event which triggers retry with backoff.
-      // Swallow the rejection to prevent unhandled promise rejections in fire-and-forget callers.
+      // Swallow the rejection so fire-and-forget callers don't raise an
+      // unhandled rejection. Nothing retries: the sole caller loads the UI
+      // page itself (UiViewManager.loadUI), and a UI that fails to come up
+      // surfaces through the renderer crash guard, not here. Workspace
+      // iframes never route through this — they navigate in the renderer.
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.debug("Navigation failed (handled via did-fail-load)", {
+      this.logger.warn("Navigation failed", {
         id: handle.id,
         url,
         error: message,

--- a/src/renderer/lib/components/WorkspaceFrames.svelte
+++ b/src/renderer/lib/components/WorkspaceFrames.svelte
@@ -23,6 +23,12 @@
   are only focused while in "workspace" mode; entering shortcut mode blurs
   the frame so navigation keys don't reach VS Code.
 
+  Liveness: showing a frame pings it, and it answers via the probe responder
+  the UiViewManager injects alongside the focus tracker. All workspace iframes
+  are same-origin, so Chromium hosts them in one shared renderer process; when
+  it dies every workbench blanks at once and no main-process event reports it.
+  A frame that does not answer is logged — nothing reloads on its own.
+
   Exposes two window hooks for the main process (UiViewManager):
   - __chFocusActiveFrame(): focus the active frame (window-focus handler,
     post-terminal-focus refresh)
@@ -31,8 +37,19 @@
 -->
 <script lang="ts">
   import { onMount } from "svelte";
-  import { SvelteMap } from "svelte/reactivity";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import type { UIMode } from "@shared/ipc";
+  import { createLogger } from "$lib/logging";
+
+  const logger = createLogger("ui");
+
+  /**
+   * How long a frame gets to answer the probe sent when it is shown. Generous:
+   * a workbench whose main thread is briefly blocked, or one still loading its
+   * document, must not be mistaken for a dead one. Detection only logs, so
+   * erring long costs nothing.
+   */
+  const PROBE_TIMEOUT_MS = 5_000;
 
   interface FrameHooks {
     __chFocusActiveFrame?: () => void;
@@ -69,6 +86,71 @@
         frameEls.delete(key);
       },
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Liveness
+  //
+  // A dead frame is indistinguishable from a live one out here, so the frame
+  // has to answer for itself: showing one sends it a ping, and a frame that
+  // stays silent is logged. The frames are the only witnesses to their own
+  // renderer process dying — Electron surfaces no event for a subframe process
+  // (PostHog issue 019fb265). Detection only reports; nothing reloads.
+  // ---------------------------------------------------------------------------
+
+  /** Keys that have answered at least once — separates dead from never-loaded. */
+  const everAnswered = new SvelteSet<string>();
+
+  /** The frame currently being probed, and its pending verdict. */
+  let probeKey: string | null = null;
+  let probeTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+
+  function cancelProbe(): void {
+    if (probeTimer !== undefined) clearTimeout(probeTimer);
+    probeTimer = undefined;
+    probeKey = null;
+  }
+
+  function probeFrame(key: string, el: HTMLIFrameElement): void {
+    cancelProbe();
+    probeKey = key;
+    try {
+      el.contentWindow?.postMessage({ __chPing: true }, "*");
+    } catch {
+      // Cross-origin frame may reject; the timeout reports it anyway
+    }
+    probeTimer = setTimeout(() => {
+      probeTimer = undefined;
+      probeKey = null;
+      logger.warn(
+        everAnswered.has(key)
+          ? "Workspace frame stopped responding (renderer may have died)"
+          : "Workspace frame never responded (may never have finished loading)",
+        { key }
+      );
+    }, PROBE_TIMEOUT_MS);
+  }
+
+  /** The mounted frame that sent a message, by window identity. */
+  function keyForSource(source: MessageEvent["source"]): string | undefined {
+    if (source === null) return undefined;
+    for (const [key, el] of frameEls) {
+      if (el.contentWindow === source) return key;
+    }
+    return undefined;
+  }
+
+  function handleFrameMessage(event: MessageEvent): void {
+    const data: unknown = event.data;
+    const alive =
+      typeof data === "object" &&
+      data !== null &&
+      (data as { __chAlive?: unknown }).__chAlive === true;
+    if (!alive) return;
+    const key = keyForSource(event.source);
+    if (key === undefined) return;
+    everAnswered.add(key);
+    if (key === probeKey) cancelProbe();
   }
 
   function activeFrame(): HTMLIFrameElement | undefined {
@@ -111,6 +193,9 @@
   // server instead of showing the IDE server's own "Reload" dialog. frameEls
   // holds exactly the mounted (non-hibernated) frames.
   function reloadFrames(): void {
+    // A reloading frame is legitimately silent until its script is re-injected;
+    // drop any probe in flight rather than read the navigation as a death.
+    cancelProbe();
     for (const el of frameEls.values()) {
       // Re-assigning src (via a local, to dodge no-self-assign) forces a fresh
       // navigation even though the resolved URL is identical.
@@ -141,6 +226,31 @@
     if (mode === "workspace") {
       focusFrame(el);
     }
+  });
+
+  // Probe the frame being shown, exactly once per switch.
+  //
+  // Separate from the show flow above, which also tracks `mode` — that flips on
+  // every sidebar hover and shortcut toggle. This effect still reruns whenever
+  // the mounted set changes (frameEls is reactive), so `probedKey` is what
+  // pins it to one check per switch: a workspace being created or hibernated
+  // elsewhere must not re-open a verdict on the frame already on screen.
+  // Leaving it unset while the element is missing is deliberate — the frame of
+  // a just-created workspace registers after the switch lands, and the rerun
+  // that brings it is the run that gets to probe it.
+  let probedKey: string | null = null;
+  $effect(() => {
+    const key = activeKey;
+    if (key === null) {
+      cancelProbe();
+      probedKey = null;
+      return;
+    }
+    if (key === probedKey) return;
+    const el = frameEls.get(key);
+    if (!el) return;
+    probedKey = key;
+    probeFrame(key, el);
   });
 
   // Mode routing: returning to workspace mode focuses the active frame
@@ -177,10 +287,15 @@
       return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
     };
     hooks.__chReloadFrames = reloadFrames;
+
+    window.addEventListener("message", handleFrameMessage);
+
     return () => {
       delete hooks.__chFocusActiveFrame;
       delete hooks.__chActiveFrameRect;
       delete hooks.__chReloadFrames;
+      window.removeEventListener("message", handleFrameMessage);
+      cancelProbe();
     };
   });
 </script>

--- a/src/renderer/lib/components/WorkspaceFrames.svelte
+++ b/src/renderer/lib/components/WorkspaceFrames.svelte
@@ -27,7 +27,8 @@
   the UiViewManager injects alongside the focus tracker. All workspace iframes
   are same-origin, so Chromium hosts them in one shared renderer process; when
   it dies every workbench blanks at once and no main-process event reports it.
-  A frame that does not answer is logged — nothing reloads on its own.
+  A frame that does not answer is logged, and reloaded if it had answered
+  before (the workbench session lives on the IDE server, so a reload is cheap).
 
   Exposes two window hooks for the main process (UiViewManager):
   - __chFocusActiveFrame(): focus the active frame (window-focus handler,
@@ -44,12 +45,13 @@
   const logger = createLogger("ui");
 
   /**
-   * How long a frame gets to answer the probe sent when it is shown. Generous:
-   * a workbench whose main thread is briefly blocked, or one still loading its
-   * document, must not be mistaken for a dead one. Detection only logs, so
-   * erring long costs nothing.
+   * How long a frame gets to answer the probe sent when it is shown. Generous
+   * on purpose: a wrong verdict reloads a workbench the user is looking at, so
+   * a main thread that is merely blocked must not be read as a dead renderer.
+   * The user is staring at a blank frame either way — waiting costs them
+   * nothing, guessing early costs them their editor state.
    */
-  const PROBE_TIMEOUT_MS = 5_000;
+  const PROBE_TIMEOUT_MS = 10_000;
 
   interface FrameHooks {
     __chFocusActiveFrame?: () => void;
@@ -93,9 +95,9 @@
   //
   // A dead frame is indistinguishable from a live one out here, so the frame
   // has to answer for itself: showing one sends it a ping, and a frame that
-  // stays silent is logged. The frames are the only witnesses to their own
-  // renderer process dying — Electron surfaces no event for a subframe process
-  // (PostHog issue 019fb265). Detection only reports; nothing reloads.
+  // stays silent is logged and reloaded. The frames are the only witnesses to
+  // their own renderer process dying — Electron surfaces no event for a
+  // subframe process (PostHog issue 019fb265).
   // ---------------------------------------------------------------------------
 
   /** Keys that have answered at least once — separates dead from never-loaded. */
@@ -122,11 +124,27 @@
     probeTimer = setTimeout(() => {
       probeTimer = undefined;
       probeKey = null;
+
+      // Recover only a frame that had answered before. Reloading is safe —
+      // the workbench session lives on the IDE server, which is why a server
+      // restart already reloads every frame — but it is only useful for a
+      // frame that was alive and stopped. One that has never answered is
+      // either still loading (a reload would restart that from scratch) or
+      // pointed at a server that is not serving (a reload changes nothing).
+      const recover = everAnswered.has(key);
+      const target = recover ? frameEls.get(key) : undefined;
+      if (target) {
+        // Re-assigning src (via a local, to dodge no-self-assign) forces a
+        // fresh navigation even though the resolved URL is identical.
+        const url = target.src;
+        target.src = url;
+      }
+
       logger.warn(
-        everAnswered.has(key)
+        recover
           ? "Workspace frame stopped responding (renderer may have died)"
           : "Workspace frame never responded (may never have finished loading)",
-        { key }
+        { key, reloaded: target !== undefined }
       );
     }, PROBE_TIMEOUT_MS);
   }

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -8,10 +8,11 @@
  * window hooks the main process calls.
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "@testing-library/svelte";
 
 import WorkspaceFrames from "./WorkspaceFrames.svelte";
+import { createMockApi } from "../test-utils";
 
 interface FrameHooks {
   __chFocusActiveFrame?: () => void;
@@ -126,5 +127,212 @@ describe("WorkspaceFrames", () => {
 
     const hooks = window as FrameHooks;
     expect(hooks.__chActiveFrameRect!()).toBeNull();
+  });
+
+  // ===========================================================================
+  // Liveness
+  //
+  // Showing a frame pings it; a frame that does not answer is logged. The
+  // frames are the only witnesses to their shared renderer process dying —
+  // Electron reports no event for a subframe process. Detection logs; it never
+  // reloads.
+  // ===========================================================================
+
+  describe("liveness", () => {
+    /** happy-dom leaves contentWindow null, so give each frame an identity. */
+    function giveWindows(container: HTMLElement): Map<string, { pings: unknown[] }> {
+      const windows = new Map<string, { pings: unknown[] }>();
+      for (const el of frames(container)) {
+        const win = {
+          pings: [] as unknown[],
+          postMessage: (message: unknown) => win.pings.push(message),
+        };
+        Object.defineProperty(el, "contentWindow", { configurable: true, value: win });
+        windows.set(el.dataset.key!, win);
+      }
+      return windows;
+    }
+
+    /** Answer a probe as the given frame. */
+    function answer(source: object): void {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { __chAlive: true },
+          source: source as MessageEventSource,
+        })
+      );
+    }
+
+    /** The log events the component emitted through the renderer logger. */
+    function logs() {
+      return vi
+        .mocked(window.api.emitEvent)
+        .mock.calls.map(([event]) => event)
+        .filter((event): event is Extract<typeof event, { kind: "log" }> => event.kind === "log")
+        .map(({ level, message, context }) => ({ level, message, context }));
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      window.api = createMockApi();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("pings the frame being shown, and only that one", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+
+      expect(windows.get("test-12345678/ws1")!.pings).toEqual([{ __chPing: true }]);
+      expect(windows.get("test-12345678/ws2")!.pings).toEqual([]);
+    });
+
+    it("checks once per switch, not again when the mounted set changes", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      // ws2 hibernates while ws1 stays on screen: no new verdict on ws1.
+      await rerender({ frames: [FRAMES[0]!], activeKey: FRAMES[0]!.key });
+
+      expect(windows.get("test-12345678/ws1")!.pings).toEqual([{ __chPing: true }]);
+    });
+
+    it("checks again when the same frame is shown a second time", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      answer(windows.get("test-12345678/ws1")!);
+      await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
+      answer(windows.get("test-12345678/ws2")!);
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+
+      expect(windows.get("test-12345678/ws1")!.pings).toEqual([
+        { __chPing: true },
+        { __chPing: true },
+      ]);
+    });
+
+    it("logs a shown frame that never answers", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(logs()).toEqual([
+        {
+          level: "warn",
+          message: "Workspace frame never responded (may never have finished loading)",
+          context: { key: "test-12345678/ws1" },
+        },
+      ]);
+    });
+
+    it("stays quiet when the frame answers the probe", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      answer(windows.get("test-12345678/ws1")!);
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(logs()).toEqual([]);
+      expect(windows.get("test-12345678/ws1")!.pings).toEqual([{ __chPing: true }]);
+    });
+
+    it("reports a frame that answered before differently from one that never did", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      // ws1 answers once, so it is known-good...
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      answer(windows.get("test-12345678/ws1")!);
+      // ...then goes away and stops answering when shown again.
+      await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
+      answer(windows.get("test-12345678/ws2")!);
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(logs()).toEqual([
+        {
+          level: "warn",
+          message: "Workspace frame stopped responding (renderer may have died)",
+          context: { key: "test-12345678/ws1" },
+        },
+      ]);
+    });
+
+    it("drops the verdict when the shown frame changes before it lands", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(2_000);
+      // Switched away before ws1's probe timed out: only ws2 is judged.
+      await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
+      answer(windows.get("test-12345678/ws2")!);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(logs()).toEqual([]);
+    });
+
+    it("does not judge a frame while nothing is shown", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: FRAMES[0]!.key },
+      });
+      giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: null });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(logs()).toEqual([]);
+    });
+
+    it("does not read a reload as a death", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      (window as FrameHooks).__chReloadFrames!();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(logs()).toEqual([]);
+    });
+
+    it("ignores answers that are not from a mounted frame", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      giveWindows(container);
+
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      // A stray postMessage from an unrelated window must not clear the probe.
+      answer({});
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(logs().map((entry) => entry.context?.["key"])).toEqual(["test-12345678/ws1"]);
+    });
   });
 });

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -132,10 +132,10 @@ describe("WorkspaceFrames", () => {
   // ===========================================================================
   // Liveness
   //
-  // Showing a frame pings it; a frame that does not answer is logged. The
-  // frames are the only witnesses to their shared renderer process dying —
-  // Electron reports no event for a subframe process. Detection logs; it never
-  // reloads.
+  // Showing a frame pings it; a frame that does not answer is logged, and
+  // reloaded if it had answered before. The frames are the only witnesses to
+  // their shared renderer process dying — Electron reports no event for a
+  // subframe process.
   // ===========================================================================
 
   describe("liveness", () => {
@@ -151,6 +151,22 @@ describe("WorkspaceFrames", () => {
         windows.set(el.dataset.key!, win);
       }
       return windows;
+    }
+
+    /** Spy on each frame's src setter while keeping its URL readable. */
+    function trackSrc(container: HTMLElement): Map<string, ReturnType<typeof vi.fn>> {
+      const setters = new Map<string, ReturnType<typeof vi.fn>>();
+      for (const el of frames(container)) {
+        const original = el.src;
+        const setter = vi.fn();
+        Object.defineProperty(el, "src", {
+          configurable: true,
+          get: () => original,
+          set: setter,
+        });
+        setters.set(el.dataset.key!, setter);
+      }
+      return setters;
     }
 
     /** Answer a probe as the given frame. */
@@ -231,13 +247,13 @@ describe("WorkspaceFrames", () => {
       giveWindows(container);
 
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
-      await vi.advanceTimersByTimeAsync(6_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([
         {
           level: "warn",
           message: "Workspace frame never responded (may never have finished loading)",
-          context: { key: "test-12345678/ws1" },
+          context: { key: "test-12345678/ws1", reloaded: false },
         },
       ]);
     });
@@ -250,7 +266,7 @@ describe("WorkspaceFrames", () => {
 
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
       answer(windows.get("test-12345678/ws1")!);
-      await vi.advanceTimersByTimeAsync(6_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([]);
       expect(windows.get("test-12345678/ws1")!.pings).toEqual([{ __chPing: true }]);
@@ -269,13 +285,57 @@ describe("WorkspaceFrames", () => {
       await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
       answer(windows.get("test-12345678/ws2")!);
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
-      await vi.advanceTimersByTimeAsync(6_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([
         {
           level: "warn",
           message: "Workspace frame stopped responding (renderer may have died)",
-          context: { key: "test-12345678/ws1" },
+          context: { key: "test-12345678/ws1", reloaded: true },
+        },
+      ]);
+    });
+
+    it("reloads a frame that answered before and then stopped", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+      const setters = trackSrc(container);
+
+      // ws1 proves itself alive, so it is a frame worth recovering...
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      answer(windows.get("test-12345678/ws1")!);
+      await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
+      answer(windows.get("test-12345678/ws2")!);
+      // ...and goes silent when shown again.
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      expect(setters.get("test-12345678/ws1")!).toHaveBeenCalledWith(
+        "http://127.0.0.1:9000/?folder=/workspaces/ws1"
+      );
+      expect(setters.get("test-12345678/ws2")!).not.toHaveBeenCalled();
+    });
+
+    it("does not reload a frame that has never answered", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      giveWindows(container);
+      const setters = trackSrc(container);
+
+      // Still loading, or pointed at a server that is not serving: a reload
+      // restarts the first case and changes nothing in the second.
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      expect(setters.get("test-12345678/ws1")!).not.toHaveBeenCalled();
+      expect(logs()).toEqual([
+        {
+          level: "warn",
+          message: "Workspace frame never responded (may never have finished loading)",
+          context: { key: "test-12345678/ws1", reloaded: false },
         },
       ]);
     });
@@ -287,11 +347,11 @@ describe("WorkspaceFrames", () => {
       const windows = giveWindows(container);
 
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
       // Switched away before ws1's probe timed out: only ws2 is judged.
       await rerender({ frames: FRAMES, activeKey: FRAMES[1]!.key });
       answer(windows.get("test-12345678/ws2")!);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([]);
     });
@@ -303,7 +363,7 @@ describe("WorkspaceFrames", () => {
       giveWindows(container);
 
       await rerender({ frames: FRAMES, activeKey: null });
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([]);
     });
@@ -316,7 +376,7 @@ describe("WorkspaceFrames", () => {
 
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
       (window as FrameHooks).__chReloadFrames!();
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs()).toEqual([]);
     });
@@ -330,7 +390,7 @@ describe("WorkspaceFrames", () => {
       await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
       // A stray postMessage from an unrelated window must not clear the probe.
       answer({});
-      await vi.advanceTimersByTimeAsync(6_000);
+      await vi.advanceTimersByTimeAsync(11_000);
 
       expect(logs().map((entry) => entry.context?.["key"])).toEqual(["test-12345678/ws1"]);
     });


### PR DESCRIPTION
All workspace iframes are same-origin, so Chromium hosts them in a single shared renderer process, separate from the UI page's. When that process dies every workbench blanks at once — and nothing in the main process notices: `app.on('child-process-gone')` excludes renderers by contract, and `render-process-gone` only fires for a webContents' primary frame, never a subframe.

That blind spot is why PostHog issue `019fb265` ("vscode is not shown anymore") left no trace in 9.8 MB of debug logs. The IDE server recorded five `ManagementConnection` disconnects inside 14 ms and then waited 3h for a reconnection that never came; CodeHydra logged nothing at all, and the snapshot pushed 1.7 s before the report was entirely healthy.

- The script injected on `did-frame-finish-load` now answers a `__chPing` from the UI page, so a frame can prove its renderer is alive
- Showing a frame pings it; one still silent 10 s later is logged and reloaded
- Only a frame that has answered before is reloaded — one that never answered is either still loading or pointed at a server that is not serving, and a reload helps neither. Both cases log; the context records which happened
- Checked once per switch, so a workspace created or hibernated elsewhere cannot reopen a verdict on the frame already on screen
- Corrects a comment (and its log line) in `view.ts` claiming `loadURL` failures were "already handled by the did-fail-load event which triggers retry with backoff" — no such handler has ever existed

The underlying cause of the renderer death is still unknown; no Electron API exposes a reason for a subframe process. What changes is that the next occurrence self-heals and leaves a timestamped log line to correlate against.