### PR TITLE
fix: Don't refuse a workspace delete over commits a kept branch preserves

### DIFF
--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -468,7 +468,7 @@ All operations use the intent dispatcher. Intents are dispatched through operati
 | `resolve-workspace`    | `workspace:resolve`       | `resolve`                                                                                                    | --                                                                            |
 | `resolve-project`      | `project:resolve`         | `resolve`                                                                                                    | --                                                                            |
 | `open-workspace`       | `workspace:open`          | `create`, `setup`, `finalize`                                                                                | `workspace:loading`, `workspace:created`, `workspace:create-failed`           |
-| `delete-workspace`     | `workspace:delete`        | `preflight`, `shutdown`, `release`, `flush`, `delete`, `detect`                                              | `workspace:deleted`, `workspace:delete-failed`, `workspace:deletion-progress` |
+| `delete-workspace`     | `workspace:delete`        | `confirm`, `preflight`, `shutdown`, `release`, `flush`, `delete`, `detect`                                   | `workspace:deleted`, `workspace:delete-failed`, `workspace:deletion-progress` |
 | `hibernate-workspace`  | `workspace:hibernate`     | `capture`, `shutdown`, `release`                                                                             | `workspace:hibernated`, `workspace:hibernate-failed`                          |
 | `wake-workspace`       | `workspace:wake`          | `cleanup`                                                                                                    | `workspace:woken`, `workspace:wake-failed`                                    |
 | `switch-workspace`     | `workspace:switch`        | `activate`, `find-candidates`, `select-next`                                                                 | `workspace:switched`                                                          |
@@ -494,11 +494,13 @@ The `open-workspace` operation uses these hook modules:
 
 The `delete-workspace` operation uses these hook modules:
 
+- **confirm**: DeletionDialogModule (interactive dispatches only) -- parks on the confirmation dialog and contributes the user's `keepBranch` answer, or cancels the dispatch
+- **preflight**: WorktreeModule -- vetoes on workspace state (`{ blocked, reason }`). The handler owns both halves of the policy: whether the check applies (only a `removeWorktree` delete can lose work; `force` is an explicit teardown and `ignoreWarnings` the caller's opt-out) and what its findings mean. A handler that cannot read the state throws, failing the gate closed. The operation only sequences the gate and joins the reasons into the caller's error
 - **shutdown**: ViewModule (switch active workspace + destroy view), AgentModule (kill terminals, stop server, clear MCP/TUI tracking)
 - **release**: WindowsLockModule (detect + kill/close blocking processes) -- Windows-only, skipped in force mode. Skipped when `removeWorktree` is false.
 - **delete**: WorktreeModule (remove git worktree), IdeServerModule (delete .code-workspace file). Skipped when `removeWorktree` is false.
 
-The delete operation uses an `IdempotencyInterceptor` to prevent duplicate deletions of the same workspace. Force mode (`force: true`) bypasses the interceptor and wraps hook errors in try/catch. The `workspace:deleted` domain event triggers StateModule (removes workspace from state), the presenter (drops the row from the next `UiState` snapshot), and clears the idempotency flag. When `removeWorktree` is false, only the shutdown hooks run (runtime teardown without deleting the git worktree).
+Both gates run before any teardown or progress emission, so a refusal leaves the workspace untouched and the UI never sees a deletion panel. The delete operation uses an `IdempotencyInterceptor` to prevent duplicate deletions of the same workspace. Force mode (`force: true`) bypasses the interceptor and wraps hook errors in try/catch. The `workspace:deleted` domain event triggers StateModule (removes workspace from state), the presenter (drops the row from the next `UiState` snapshot), and clears the idempotency flag. When `removeWorktree` is false, only the shutdown hooks run (runtime teardown without deleting the git worktree).
 
 The `open-project` operation runs `select-folder` (when no path/URL given), `prepare` (e.g. git init), then `resolve` (clone if URL, validate git), `register` (generate ID, store state, persist), and `discover` (find existing workspaces).
 

--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -495,7 +495,7 @@ The `open-workspace` operation uses these hook modules:
 The `delete-workspace` operation uses these hook modules:
 
 - **confirm**: DeletionDialogModule (interactive dispatches only) -- parks on the confirmation dialog and contributes the user's `keepBranch` answer, or cancels the dispatch
-- **preflight**: WorktreeModule -- vetoes on workspace state (`{ blocked, reason }`). The handler owns both halves of the policy: whether the check applies (only a `removeWorktree` delete can lose work; `force` is an explicit teardown and `ignoreWarnings` the caller's opt-out) and what its findings mean. A handler that cannot read the state throws, failing the gate closed. The operation only sequences the gate and joins the reasons into the caller's error
+- **preflight**: WorktreeModule -- vetoes on workspace state (`{ blocked, reason }`). The handler owns both halves of the policy: whether the check applies (only a `removeWorktree` delete can lose work; `force` is an explicit teardown and `ignoreWarnings` the caller's opt-out) and what its findings mean -- uncommitted changes always block, unmerged commits only when `keepBranch` is false, since a kept branch keeps them reachable. A handler that cannot read the state throws, failing the gate closed. The operation only sequences the gate and joins the reasons into the caller's error
 - **shutdown**: ViewModule (switch active workspace + destroy view), AgentModule (kill terminals, stop server, clear MCP/TUI tracking)
 - **release**: WindowsLockModule (detect + kill/close blocking processes) -- Windows-only, skipped in force mode. Skipped when `removeWorktree` is false.
 - **delete**: WorktreeModule (remove git worktree), IdeServerModule (delete .code-workspace file). Skipped when `removeWorktree` is false.

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -44,20 +44,7 @@ import type {
   FlushHookInput,
   DeletePipelineHookInput,
 } from "./delete-workspace";
-import type {
-  HookContext,
-  HookOutput,
-  OperationContext,
-  Operation,
-  OperationSchemas,
-} from "./lib/operation";
-import {
-  INTENT_GET_PROJECT_BASES,
-  GET_PROJECT_BASES_OPERATION_ID,
-  getProjectBasesPayloadSchema,
-  getProjectBasesResultSchema,
-  type GetProjectBasesIntent,
-} from "./get-project-bases";
+import type { HookContext, HookOutput, OperationContext } from "./lib/operation";
 import type {
   BlockingProcess,
   DeletionProgress,
@@ -289,8 +276,6 @@ interface TestHarness {
   gitWorktreeProviderMock: {
     gitWorktreeProvider: { removeWorkspace: ReturnType<typeof vi.fn> };
   };
-  /** Payloads of every project:get-bases dispatched during the run. */
-  basesRefreshes: GetProjectBasesIntent["payload"][];
 }
 
 function createTestHarness(options?: {
@@ -305,9 +290,6 @@ function createTestHarness(options?: {
   serverStopError?: string;
   worktreeRemoveError?: string;
   initialProjects?: TestAppState["projects"];
-  isDirty?: boolean;
-  unmergedCommits?: number;
-  basesRefreshError?: string;
 }): TestHarness {
   const dispatcher = createMockDispatcher();
 
@@ -351,23 +333,6 @@ function createTestHarness(options?: {
   dispatcher.registerOperation(new DeleteWorkspaceOperation());
   dispatcher.registerOperation(new SwitchWorkspaceOperation());
   dispatcher.registerOperation(new GetActiveWorkspaceOperation());
-
-  // Stub project:get-bases so the preflight's remote refresh is observable. The
-  // real operation fetches; here we only record that it was asked to.
-  const basesRefreshes: GetProjectBasesIntent["payload"][] = [];
-  dispatcher.registerOperation({
-    id: GET_PROJECT_BASES_OPERATION_ID,
-    schemas: {
-      type: INTENT_GET_PROJECT_BASES,
-      payload: getProjectBasesPayloadSchema,
-      result: getProjectBasesResultSchema,
-    },
-    execute: async (ctx: OperationContext<GetProjectBasesIntent>) => {
-      basesRefreshes.push(ctx.intent.payload);
-      if (options?.basesRefreshError) throw new Error(options.basesRefreshError);
-      return { bases: [], projectPath: PROJECT_PATH, projectId: PROJECT_ID };
-    },
-  } as unknown as Operation<OperationSchemas>);
 
   // Add interceptor via module (inline, matching bootstrap pattern)
   const inProgressDeletions = new Set<string>();
@@ -788,31 +753,12 @@ function createTestHarness(options?: {
     },
   };
 
-  const deletePreflightModule: IntentModule = {
-    name: "test",
-    hooks: {
-      [DELETE_WORKSPACE_OPERATION_ID]: {
-        preflight: {
-          handler: async (): Promise<HookOutput<PreflightHookResult>> => {
-            return {
-              result: {
-                isDirty: options?.isDirty ?? false,
-                unmergedCommits: options?.unmergedCommits ?? 0,
-              },
-            };
-          },
-        },
-      },
-    },
-  };
-
   for (const m of [
     idempotencyModule,
     progressCaptureModule,
     resolveWorkspaceModule,
     resolveProjectModule,
     getActiveWorkspaceModule,
-    deletePreflightModule,
     deleteViewModule,
     deleteAgentModule,
     deleteWindowsLockModule,
@@ -838,7 +784,6 @@ function createTestHarness(options?: {
     gitWorktreeProviderState: gitWorktreeProviderMock,
     gitWorktreeProviderMock:
       gitWorktreeProviderMock as unknown as TestHarness["gitWorktreeProviderMock"],
-    basesRefreshes,
   };
 }
 
@@ -1761,11 +1706,40 @@ describe("DeleteWorkspaceOperation.safetyNet", () => {
 });
 
 describe("DeleteWorkspaceOperation.preflight", () => {
-  it("throws when workspace is dirty", async () => {
-    const harness = createTestHarness({ isDirty: true });
-    const intent = buildDeleteIntent();
+  /**
+   * Register a preflight-hook module on the harness dispatcher. Whether the
+   * check applies and what its findings mean belong to the handler (in
+   * production, the worktree module) — the operation only sequences the gate,
+   * so these tests drive the verdict directly.
+   */
+  function registerPreflight(
+    harness: TestHarness,
+    impl: (ctx: DeletePipelineHookInput) => PreflightHookResult
+  ): void {
+    harness.dispatcher.registerModule({
+      name: `test-preflight-${preflightModuleCounter++}`,
+      hooks: {
+        [DELETE_WORKSPACE_OPERATION_ID]: {
+          preflight: {
+            handler: async (ctx: HookContext): Promise<HookOutput<PreflightHookResult>> => ({
+              result: impl(ctx as DeletePipelineHookInput),
+            }),
+          },
+        },
+      },
+    });
+  }
 
-    await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow(
+  let preflightModuleCounter = 0;
+
+  it("aborts with the handler's reason, leaving the workspace untouched", async () => {
+    const harness = createTestHarness();
+    registerPreflight(harness, () => ({
+      blocked: true,
+      reason: "Workspace has uncommitted changes",
+    }));
+
+    await expect(harness.dispatcher.dispatch(buildDeleteIntent())).rejects.toThrow(
       "Preflight check failed: Workspace has uncommitted changes"
     );
 
@@ -1781,62 +1755,56 @@ describe("DeleteWorkspaceOperation.preflight", () => {
     // delete-failed emitted (resets idempotency)
     expect(harness.inProgressDeletions.has(WORKSPACE_PATH)).toBe(false);
 
-    // No progress events emitted (preflight throws before any progress)
+    // No progress events emitted (the gate runs before any progress)
     expect(harness.progressCaptures).toHaveLength(0);
   });
 
-  it("throws when workspace has unmerged commits", async () => {
-    const harness = createTestHarness({ unmergedCommits: 3 });
-    const intent = buildDeleteIntent();
+  it("joins the reasons of every blocking handler", async () => {
+    const harness = createTestHarness();
+    registerPreflight(harness, () => ({
+      blocked: true,
+      reason: "Workspace has uncommitted changes",
+    }));
+    registerPreflight(harness, () => ({
+      blocked: true,
+      reason: "Workspace has 2 unmerged commits",
+    }));
 
-    await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow(
-      "Preflight check failed: Workspace has 3 unmerged commits"
+    await expect(harness.dispatcher.dispatch(buildDeleteIntent())).rejects.toThrow(
+      "Preflight check failed: Workspace has uncommitted changes; Workspace has 2 unmerged commits"
     );
 
-    expect(harness.testState.serverStopped).toBe(false);
-    expect(harness.testState.worktreeRemoved).toBe(false);
-    expect(harness.testState.removedWorkspaces).toHaveLength(0);
     expect(harness.progressCaptures).toHaveLength(0);
   });
 
-  it("refreshes remotes before counting unmerged commits", async () => {
-    // Without this, a delete dispatched right after a server-side merge (/ship)
-    // measures against a stale origin/main and rejects the just-merged commits.
-    const harness = createTestHarness({ isDirty: false, unmergedCommits: 0 });
-
-    await harness.dispatcher.dispatch(buildDeleteIntent());
-
-    expect(harness.basesRefreshes).toContainEqual(
-      expect.objectContaining({ projectPath: PROJECT_PATH, refresh: true })
-    );
-  });
-
-  it("proceeds with the preflight when the refresh fails", async () => {
-    const harness = createTestHarness({
-      isDirty: false,
-      unmergedCommits: 0,
-      basesRefreshError: "network down",
+  it("aborts without faking a deletion failure when a handler throws", async () => {
+    const harness = createTestHarness();
+    harness.dispatcher.registerModule({
+      name: "test-preflight-throws",
+      hooks: {
+        [DELETE_WORKSPACE_OPERATION_ID]: {
+          preflight: {
+            handler: async (): Promise<HookOutput<PreflightHookResult>> => {
+              throw new Error("git failed");
+            },
+          },
+        },
+      },
     });
 
+    // A gate that could not run is not a teardown that failed: the dispatch
+    // aborts with the raw error and the UI never sees a progress panel.
+    await expect(harness.dispatcher.dispatch(buildDeleteIntent())).rejects.toThrow("git failed");
+    expect(harness.progressCaptures).toHaveLength(0);
+    expect(harness.testState.serverStopped).toBe(false);
+    expect(harness.testState.worktreeRemoved).toBe(false);
+  });
+
+  it("proceeds when no handler blocks", async () => {
+    const harness = createTestHarness();
+    registerPreflight(harness, () => ({}));
+
     await harness.dispatcher.dispatch(buildDeleteIntent());
-
-    // A fetch failure must not block deletion — fall through to stale refs.
-    expect(harness.testState.worktreeRemoved).toBe(true);
-  });
-
-  it("skips the refresh when preflight is skipped", async () => {
-    const harness = createTestHarness({ isDirty: true, unmergedCommits: 5 });
-
-    await harness.dispatcher.dispatch(buildDeleteIntent({ ignoreWarnings: true }));
-
-    expect(harness.basesRefreshes).toHaveLength(0);
-  });
-
-  it("proceeds when workspace is clean", async () => {
-    const harness = createTestHarness({ isDirty: false, unmergedCommits: 0 });
-    const intent = buildDeleteIntent();
-
-    await harness.dispatcher.dispatch(intent);
 
     // Deletion should have completed normally
     expect(harness.testState.worktreeRemoved).toBe(true);
@@ -1850,52 +1818,15 @@ describe("DeleteWorkspaceOperation.preflight", () => {
     expect(finalProgress.hasErrors).toBe(false);
   });
 
-  it("skips preflight when ignoreWarnings is true", async () => {
-    const harness = createTestHarness({ isDirty: true, unmergedCommits: 5 });
-    const intent = buildDeleteIntent({ ignoreWarnings: true });
+  it("proceeds when no preflight handler is registered", async () => {
+    const harness = createTestHarness();
 
-    await harness.dispatcher.dispatch(intent);
+    await harness.dispatcher.dispatch(buildDeleteIntent());
 
-    // Deletion should proceed despite dirty state
     expect(harness.testState.worktreeRemoved).toBe(true);
-    expect(harness.testState.removedWorkspaces).toContainEqual({
-      projectPath: PROJECT_PATH,
-      workspacePath: WORKSPACE_PATH,
-    });
-
-    const finalProgress = harness.progressCaptures[harness.progressCaptures.length - 1]!;
-    expect(finalProgress.completed).toBe(true);
-    expect(finalProgress.hasErrors).toBe(false);
   });
 
-  it("skips preflight when force is true", async () => {
-    const harness = createTestHarness({ isDirty: true });
-    const intent = buildDeleteIntent({ force: true });
-
-    await harness.dispatcher.dispatch(intent);
-
-    // Force deletion proceeds
-    expect(harness.testState.removedWorkspaces).toContainEqual({
-      projectPath: PROJECT_PATH,
-      workspacePath: WORKSPACE_PATH,
-    });
-  });
-
-  it("skips preflight when removeWorktree is false", async () => {
-    const harness = createTestHarness({ isDirty: true });
-    const intent = buildDeleteIntent({ removeWorktree: false });
-
-    await harness.dispatcher.dispatch(intent);
-
-    // Runtime teardown only — no preflight, no worktree removal
-    expect(harness.testState.serverStopped).toBe(true);
-
-    const finalProgress = harness.progressCaptures[harness.progressCaptures.length - 1]!;
-    expect(finalProgress.completed).toBe(true);
-    expect(finalProgress.hasErrors).toBe(false);
-  });
-
-  it("retry with ignoreWarnings and blockingPids skips preflight and proceeds to flush → delete", async () => {
+  it("retry with ignoreWarnings and blockingPids clears the gate and proceeds to flush → delete", async () => {
     const blockingProcesses: BlockingProcess[] = [
       { pid: 7777, name: "node.exe", commandLine: "node server.js", files: ["file.txt"], cwd: "." },
     ];
@@ -1907,12 +1838,18 @@ describe("DeleteWorkspaceOperation.preflight", () => {
       closeHandles: vi.fn().mockResolvedValue(undefined),
     };
 
-    // Dirty workspace — preflight would throw without ignoreWarnings
-    const harness = createTestHarness({ isDirty: true, workspaceLockHandler });
+    const harness = createTestHarness({ workspaceLockHandler });
+    // Stands in for the worktree module: dirty workspace, ignoreWarnings honored.
+    registerPreflight(harness, (ctx) =>
+      (ctx.intent as DeleteWorkspaceIntent).payload.ignoreWarnings
+        ? {}
+        : { blocked: true, reason: "Workspace has uncommitted changes" }
+    );
 
-    // First attempt (without ignoreWarnings): fails at preflight
-    const intent1 = buildDeleteIntent();
-    await expect(harness.dispatcher.dispatch(intent1)).rejects.toThrow("Preflight check failed");
+    // First attempt (without ignoreWarnings): blocked at the gate
+    await expect(harness.dispatcher.dispatch(buildDeleteIntent())).rejects.toThrow(
+      "Preflight check failed"
+    );
     expect(harness.progressCaptures).toHaveLength(0);
 
     // Retry with ignoreWarnings + blockingPids (simulates Kill & Retry)
@@ -1929,17 +1866,6 @@ describe("DeleteWorkspaceOperation.preflight", () => {
     const finalProgress = harness.progressCaptures[harness.progressCaptures.length - 1]!;
     expect(finalProgress.completed).toBe(true);
     expect(finalProgress.hasErrors).toBe(false);
-  });
-
-  it("throws with both dirty and unmerged messages when both are true", async () => {
-    const harness = createTestHarness({ isDirty: true, unmergedCommits: 2 });
-    const intent = buildDeleteIntent();
-
-    await expect(harness.dispatcher.dispatch(intent)).rejects.toThrow(
-      "Preflight check failed: Workspace has uncommitted changes; Workspace has 2 unmerged commits"
-    );
-
-    expect(harness.progressCaptures).toHaveLength(0);
   });
 });
 
@@ -2027,14 +1953,35 @@ describe("DeleteWorkspaceOperation.interactiveConfirm", () => {
     expect(harness.testState.worktreeRemoved).toBe(true);
   });
 
-  it("a confirmed interactive dispatch skips preflight (the user saw the warnings)", async () => {
-    // Dirty workspace would fail preflight on a plain dispatch.
-    const harness = createTestHarness({ isDirty: true, unmergedCommits: 2 });
+  it("a confirmed interactive dispatch reaches preflight handlers with ignoreWarnings set", async () => {
+    const harness = createTestHarness();
+    // Stands in for the worktree module: a dirty workspace that honors the flag.
+    const seen: Array<boolean | undefined> = [];
+    harness.dispatcher.registerModule({
+      name: "test-preflight-confirm",
+      hooks: {
+        [DELETE_WORKSPACE_OPERATION_ID]: {
+          preflight: {
+            handler: async (ctx: HookContext): Promise<HookOutput<PreflightHookResult>> => {
+              const { payload } = ctx.intent as DeleteWorkspaceIntent;
+              seen.push(payload.ignoreWarnings);
+              return {
+                result: payload.ignoreWarnings
+                  ? {}
+                  : { blocked: true, reason: "Workspace has uncommitted changes" },
+              };
+            },
+          },
+        },
+      },
+    });
     registerConfirm(harness, () => ({}));
-    const intent = buildDeleteIntent({ interactive: true });
 
-    const result = await harness.dispatcher.dispatch(intent);
+    const result = await harness.dispatcher.dispatch(buildDeleteIntent({ interactive: true }));
 
+    // The confirm hook's payload rewrite must reach the gate: the user answered
+    // with whatever the dialog had shown, so the check does not second-guess it.
+    expect(seen).toEqual([true]);
     expect(result).toEqual({ started: true });
     expect(harness.testState.worktreeRemoved).toBe(true);
   });

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -4,14 +4,18 @@
  * Steps:
  * 1. Dispatch workspace:resolve — resolves workspacePath to projectPath + workspaceName
  * 2. Dispatch project:resolve — resolves projectPath to projectId
- * 3. "shutdown" hook — ViewModule (switch + destroy view), AgentModule (kill terminals, stop server, clear MCP/TUI)
- * 4. "release" hook — WindowsLockModule (detect CWD + kill) [Windows-only]
- * 5. If blockingPids provided (retry): "flush" hook — kill provided PIDs
- * 6. "delete" hook — WorktreeModule (remove git worktree), IdeServerModule (delete .code-workspace file)
+ * 3. Gates, both before any teardown or progress emission: "confirm" (interactive
+ *    dispatches — DeletionDialogModule parks on a dialog) and "preflight"
+ *    (WorktreeModule vetoes on workspace state). Either one refusing aborts with
+ *    the workspace untouched.
+ * 4. "shutdown" hook — ViewModule (switch + destroy view), AgentModule (kill terminals, stop server, clear MCP/TUI)
+ * 5. "release" hook — WindowsLockModule (detect CWD + kill) [Windows-only]
+ * 6. If blockingPids provided (retry): "flush" hook — kill provided PIDs
+ * 7. "delete" hook — WorktreeModule (remove git worktree), IdeServerModule (delete .code-workspace file)
  *
  * If delete fails (and not force):
- * 7. "detect" — Full blocking process detection (RM + CWD + handles)
- * 8. Emit progress with blockers, emit workspace:delete-failed, return
+ * 8. "detect" — Full blocking process detection (RM + CWD + handles)
+ * 9. Emit progress with blockers, emit workspace:delete-failed, return
  *
  * On retry, the UI dispatches a new intent with blockingPids from the previous failure.
  * The flush hook kills those PIDs before re-attempting delete.
@@ -49,7 +53,6 @@ import type { ProjectPath, WorkspacePath } from "./contract";
 import { INTENT_SWITCH_WORKSPACE, type SwitchWorkspaceIntent } from "./switch-workspace";
 import { resolveWorkspaceIdentity } from "./lib/workspace-identity";
 import { INTENT_GET_ACTIVE_WORKSPACE, type GetActiveWorkspaceIntent } from "./get-active-workspace";
-import { INTENT_GET_PROJECT_BASES, type GetProjectBasesIntent } from "./get-project-bases";
 import { throwHookErrors, collectErrorMessages, lastDefined } from "./lib/hook-helpers";
 
 export const INTENT_DELETE_WORKSPACE = "workspace:delete" as const;
@@ -110,13 +113,20 @@ export const confirmResultSchema = z
 
 /**
  * Per-handler result for the "preflight" hook point.
- * Checks workspace for uncommitted changes and unmerged commits before deletion.
+ *
+ * A handler inspects the workspace and decides whether this delete may proceed:
+ * `blocked` with a `reason` vetoes the dispatch before any teardown runs. The
+ * decision is the handler's — the operation only sequences the gate and turns a
+ * veto into the caller's outcome — so a handler with nothing to object to (or
+ * nothing to check: force, runtime-only teardown, an explicit ignoreWarnings)
+ * returns an empty result. A handler that cannot determine the state throws,
+ * failing the gate closed rather than guessing.
  */
 export const preflightResultSchema = z
   .object({
-    isDirty: z.boolean().optional(),
-    unmergedCommits: z.number().optional(),
-    error: z.string().optional(),
+    blocked: z.boolean().optional(),
+    /** Why the delete was refused. Joined into the caller's error. */
+    reason: z.string().optional(),
   })
   .readonly();
 
@@ -500,16 +510,28 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
       active,
     };
 
+    // --- Preflight (modules veto on workspace state) ---
+    // Sits beside confirm and outside the safety net below: a gate that refuses
+    // must leave the workspace untouched, with no progress event ever emitted.
+    // Whether the check applies, and what its findings mean, belong to the
+    // handlers — this only sequences the gate and shapes the caller's error.
+    const { results: preflightResults, errors: preflightCollectErrors } = await ctx.hooks.collect(
+      "preflight",
+      pipelineCtx
+    );
+    throwHookErrors(preflightCollectErrors, "workspace:delete preflight hooks failed");
+    const reasons = preflightResults.filter((r) => r.blocked).map((r) => r.reason ?? "blocked");
+    if (reasons.length > 0) {
+      throw new Error(`Preflight check failed: ${reasons.join("; ")}`);
+    }
+
     // Safety net: catch unexpected errors after identity resolution to ensure
     // the UI always receives a terminal progress event (completed: true).
     // Without this, an unexpected throw after the first progress emission
     // leaves the UI permanently stuck on "Removing workspace".
     try {
       return await this.runPipelineBody(ctx, emit, identity, pipelineCtx, effectivePayload);
-    } catch (error) {
-      // Preflight errors must propagate (no progress events emitted yet)
-      if (error instanceof Error && error.message.startsWith("Preflight check failed:"))
-        throw error;
+    } catch {
       this.emitPipelineProgress(emit, identity, effectivePayload, {}, true, true);
       return { hasErrors: true, identity };
     }
@@ -522,49 +544,6 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
     pipelineCtx: DeletePipelineHookInput,
     payload: DeleteWorkspacePayload
   ): Promise<PipelineResult> {
-    // --- Preflight (dirty/unmerged check) ---
-    if (payload.removeWorktree && !payload.force && !payload.ignoreWarnings) {
-      // Fetch first so the unmerged count is measured against current refs. The
-      // interactive path gets this via get-workspace-status {refresh: true}; without
-      // it here, a programmatic delete right after a server-side merge (e.g. /ship)
-      // compares against a stale origin/main and rejects the just-merged commits as
-      // unmerged. Best-effort — a fetch failure falls through to the stale-ref read
-      // rather than blocking the delete.
-      try {
-        await ctx.dispatch<GetProjectBasesIntent>({
-          type: INTENT_GET_PROJECT_BASES,
-          payload: { projectPath: identity.projectPath, refresh: true, wait: true },
-        });
-      } catch {
-        // Fall through to the preflight read with possibly-stale refs.
-      }
-
-      const { results: preflightResults, errors: preflightCollectErrors } = await ctx.hooks.collect(
-        "preflight",
-        pipelineCtx
-      );
-
-      let isDirty = false;
-      let unmergedCommits = 0;
-      throwHookErrors(preflightCollectErrors, "workspace:delete preflight hooks failed");
-      for (const r of preflightResults) {
-        if (r.isDirty) isDirty = true;
-        if (r.unmergedCommits !== undefined && r.unmergedCommits > unmergedCommits)
-          unmergedCommits = r.unmergedCommits;
-        if (r.error) throw new Error(r.error);
-      }
-
-      if (isDirty || unmergedCommits > 0) {
-        const messages: string[] = [];
-        if (isDirty) messages.push("Workspace has uncommitted changes");
-        if (unmergedCommits > 0)
-          messages.push(
-            `Workspace has ${unmergedCommits} unmerged commit${unmergedCommits === 1 ? "" : "s"}`
-          );
-        throw new Error(`Preflight check failed: ${messages.join("; ")}`);
-      }
-    }
-
     // --- Shutdown ---
     this.emitPipelineProgress(emit, identity, payload, {}, false, false, "kill-terminals");
     const { results: shutdownResults, errors: shutdownCollectErrors } = await ctx.hooks.collect(

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -1221,6 +1221,36 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
       );
     });
 
+    it("ignores unmerged commits when the branch is kept", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(3);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath, {
+        keepBranch: true,
+      });
+
+      // The branch ref survives the worktree removal, so the commits stay
+      // reachable — nothing is lost, and no fetch is needed to know that.
+      expect(result).toEqual({});
+      expect(preflightSetup.provider.updateBases).not.toHaveBeenCalled();
+    });
+
+    it("still blocks a dirty workspace when the branch is kept", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      preflightSetup.provider.isDirty.mockResolvedValue(true);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath, {
+        keepBranch: true,
+      });
+
+      // Uncommitted changes live in the worktree, which goes either way.
+      expect(result).toEqual({ blocked: true, reason: "Workspace has uncommitted changes" });
+    });
+
     it("does not block a clean workspace", async () => {
       const preflightSetup = createPreflightTestSetup();
       const workspacePath = await setupWorkspace(preflightSetup);

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -139,9 +139,8 @@ const openWorkspaceOperation = createMinimalOperation<CreateHookResult>(
 
 /** Preflight result from the delete-workspace preflight hook. */
 interface PreflightResult {
-  readonly isDirty?: boolean | undefined;
-  readonly unmergedCommits?: number | undefined;
-  readonly error?: string | undefined;
+  readonly blocked?: boolean | undefined;
+  readonly reason?: string | undefined;
 }
 
 /**
@@ -179,7 +178,9 @@ const minimalPreflightOperation: Operation<typeof preflightSchemas> = {
       active: false,
     };
     const { results, errors } = await ctx.hooks.collect("preflight", preflightInput);
-    if (errors.length > 0) return { error: errors[0]!.message };
+    // Mirrors the real operation's throwHookErrors: a handler that cannot
+    // determine the state fails the gate closed instead of reporting "clean".
+    if (errors.length > 0) throw errors[0]!;
     return results[0] ?? {};
   },
 };
@@ -567,11 +568,18 @@ async function dispatchListWorkspaces(dispatcher: Dispatcher): Promise<ListWorks
 
 async function dispatchPreflight(
   dispatcher: Dispatcher,
-  workspacePath: WorkspacePath
+  workspacePath: WorkspacePath,
+  payloadOverrides?: Partial<DeleteWorkspaceIntent["payload"]>
 ): Promise<PreflightResult> {
   const intent: DeleteWorkspaceIntent = {
     type: "workspace:delete",
-    payload: { workspacePath, keepBranch: false, force: false, removeWorktree: true },
+    payload: {
+      workspacePath,
+      keepBranch: false,
+      force: false,
+      removeWorktree: true,
+      ...payloadOverrides,
+    },
   };
   return (await dispatcher.dispatch(intent as unknown as Intent)) as PreflightResult;
 }
@@ -1166,36 +1174,117 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   // ---------------------------------------------------------------------------
 
   describe("delete-workspace -> preflight", () => {
-    it("returns isDirty and unmergedCommits from provider", async () => {
-      const preflightSetup = createPreflightTestSetup();
+    /** Open a project with one workspace and return its path. */
+    async function setupWorkspace(
+      preflightSetup: Omit<TestSetup, "module">
+    ): Promise<WorkspacePath> {
       const projectPath = projPath("/projects/my-app");
-
       const ws = makeWorkspace("feature-1", projPath(projectPath));
       preflightSetup.provider.discover.mockResolvedValue([ws]);
       await dispatchOpenProject(preflightSetup.dispatcher, projPath(projectPath));
+      return wsPath(ws.path.toString());
+    }
+
+    it("blocks with a reason when the workspace is dirty", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
 
       preflightSetup.provider.isDirty.mockResolvedValue(true);
-      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(3);
 
-      const result = await dispatchPreflight(preflightSetup.dispatcher, wsPath(ws.path.toString()));
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
 
-      expect(result.isDirty).toBe(true);
-      expect(result.unmergedCommits).toBe(3);
+      expect(result).toEqual({ blocked: true, reason: "Workspace has uncommitted changes" });
     });
 
-    it("returns error when provider throws", async () => {
+    it("blocks with a reason when the branch has unmerged commits", async () => {
       const preflightSetup = createPreflightTestSetup();
-      const projectPath = projPath("/projects/my-app");
+      const workspacePath = await setupWorkspace(preflightSetup);
 
-      const ws = makeWorkspace("feature-1", projPath(projectPath));
-      preflightSetup.provider.discover.mockResolvedValue([ws]);
-      await dispatchOpenProject(preflightSetup.dispatcher, projPath(projectPath));
+      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(3);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
+
+      expect(result).toEqual({ blocked: true, reason: "Workspace has 3 unmerged commits" });
+    });
+
+    it("joins both reasons when the workspace is dirty and unmerged", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      preflightSetup.provider.isDirty.mockResolvedValue(true);
+      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(1);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
+
+      expect(result.reason).toBe(
+        "Workspace has uncommitted changes; Workspace has 1 unmerged commit"
+      );
+    });
+
+    it("does not block a clean workspace", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
+
+      expect(result).toEqual({});
+    });
+
+    it("fails closed when the provider throws", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
 
       preflightSetup.provider.isDirty.mockRejectedValue(new Error("git failed"));
 
-      const result = await dispatchPreflight(preflightSetup.dispatcher, wsPath(ws.path.toString()));
+      // A state it could not read must not report as "nothing to object to".
+      await expect(dispatchPreflight(preflightSetup.dispatcher, workspacePath)).rejects.toThrow(
+        "git failed"
+      );
+    });
 
-      expect(result.error).toBe("git failed");
+    it("refreshes remotes before counting unmerged commits", async () => {
+      // Without this, a delete right after a server-side merge (/ship) measures
+      // against a stale origin/main and rejects the just-merged commits.
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
+
+      expect(preflightSetup.provider.updateBases).toHaveBeenCalledWith(
+        new Path("/projects/my-app")
+      );
+    });
+
+    it("checks against stale refs when the refresh fails", async () => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      preflightSetup.provider.updateBases.mockRejectedValue(new Error("network down"));
+      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(2);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath);
+
+      // A fetch failure must not block the delete on its own, nor hide the count.
+      expect(result).toEqual({ blocked: true, reason: "Workspace has 2 unmerged commits" });
+    });
+
+    it.each([
+      ["force", { force: true }],
+      ["ignoreWarnings", { ignoreWarnings: true }],
+      ["a runtime-only teardown", { removeWorktree: false }],
+    ])("checks nothing for %s", async (_label, overrides) => {
+      const preflightSetup = createPreflightTestSetup();
+      const workspacePath = await setupWorkspace(preflightSetup);
+
+      preflightSetup.provider.isDirty.mockResolvedValue(true);
+      preflightSetup.provider.countUnmergedCommits.mockResolvedValue(5);
+
+      const result = await dispatchPreflight(preflightSetup.dispatcher, workspacePath, overrides);
+
+      expect(result).toEqual({});
+      // Not applicable means no work at all — notably no fetch.
+      expect(preflightSetup.provider.updateBases).not.toHaveBeenCalled();
+      expect(preflightSetup.provider.isDirty).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -445,24 +445,32 @@ export function createGitWorktreeWorkspaceModule(
               return { result: {} };
             }
 
-            // Fetch first so the unmerged count is measured against current
-            // refs; without it a delete right after a server-side merge (e.g.
-            // /ship) compares against a stale origin/main and rejects the
-            // just-merged commits as unmerged. Best-effort — a fetch failure
-            // falls through to the stale-ref read rather than blocking.
-            try {
-              await gitWorktreeProvider.updateBases(new Path(projectPath));
-            } catch {
-              // Stale refs beat no answer.
-            }
-
             const reasons: string[] = [];
             if (await gitWorktreeProvider.isDirty(new Path(wsPath))) {
               reasons.push("Workspace has uncommitted changes");
             }
-            const unmerged = await gitWorktreeProvider.countUnmergedCommits(new Path(wsPath));
-            if (unmerged > 0) {
-              reasons.push(`Workspace has ${unmerged} unmerged commit${unmerged === 1 ? "" : "s"}`);
+
+            // Unmerged commits only go missing when the branch goes with the
+            // worktree — a kept branch keeps them reachable. Skipping the check
+            // also skips the fetch, which is the expensive part of this gate.
+            if (!payload.keepBranch) {
+              // Fetch first so the count is measured against current refs;
+              // without it a delete right after a server-side merge (e.g.
+              // /ship) compares against a stale origin/main and rejects the
+              // just-merged commits as unmerged. Best-effort — a fetch failure
+              // falls through to the stale-ref read rather than blocking.
+              try {
+                await gitWorktreeProvider.updateBases(new Path(projectPath));
+              } catch {
+                // Stale refs beat no answer.
+              }
+
+              const unmerged = await gitWorktreeProvider.countUnmergedCommits(new Path(wsPath));
+              if (unmerged > 0) {
+                reasons.push(
+                  `Workspace has ${unmerged} unmerged commit${unmerged === 1 ? "" : "s"}`
+                );
+              }
             }
 
             if (reasons.length === 0) return { result: {} };

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -434,16 +434,39 @@ export function createGitWorktreeWorkspaceModule(
       [DELETE_WORKSPACE_OPERATION_ID]: {
         preflight: {
           handler: async (ctx: HookContext): Promise<HookOutput<PreflightHookResult>> => {
-            const { workspacePath: wsPath } = ctx as DeletePipelineHookInput;
-            try {
-              const isDirty = await gitWorktreeProvider.isDirty(new Path(wsPath));
-              const unmergedCommits = await gitWorktreeProvider.countUnmergedCommits(
-                new Path(wsPath)
-              );
-              return { result: { isDirty, unmergedCommits } };
-            } catch (error) {
-              return { result: { error: getErrorMessage(error) } };
+            const { projectPath, workspacePath: wsPath } = ctx as DeletePipelineHookInput;
+            const { payload } = ctx.intent as DeleteWorkspaceIntent;
+
+            // Only a worktree removal can lose work; force is an explicit
+            // teardown and ignoreWarnings the caller's opt-out. A failing read
+            // throws: the gate fails closed rather than reporting "nothing to
+            // object to" for a workspace it could not inspect.
+            if (!payload.removeWorktree || payload.force || payload.ignoreWarnings) {
+              return { result: {} };
             }
+
+            // Fetch first so the unmerged count is measured against current
+            // refs; without it a delete right after a server-side merge (e.g.
+            // /ship) compares against a stale origin/main and rejects the
+            // just-merged commits as unmerged. Best-effort — a fetch failure
+            // falls through to the stale-ref read rather than blocking.
+            try {
+              await gitWorktreeProvider.updateBases(new Path(projectPath));
+            } catch {
+              // Stale refs beat no answer.
+            }
+
+            const reasons: string[] = [];
+            if (await gitWorktreeProvider.isDirty(new Path(wsPath))) {
+              reasons.push("Workspace has uncommitted changes");
+            }
+            const unmerged = await gitWorktreeProvider.countUnmergedCommits(new Path(wsPath));
+            if (unmerged > 0) {
+              reasons.push(`Workspace has ${unmerged} unmerged commit${unmerged === 1 ? "" : "s"}`);
+            }
+
+            if (reasons.length === 0) return { result: {} };
+            return { result: { blocked: true, reason: reasons.join("; ") } };
           },
         },
         delete: {

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -778,8 +778,8 @@ export class McpServer {
           "Omit workspacePath to delete the current workspace, or pass a path to delete " +
           "another workspace (use project_list to discover paths). Blocks until deletion " +
           "finishes and returns { started: true } on success. Fails with an error if the " +
-          "target has uncommitted changes or unmerged commits (pass ignoreWarnings to " +
-          "override) or if processes block worktree removal.",
+          "target has uncommitted changes, or unmerged commits on a branch that is not " +
+          "kept (pass ignoreWarnings to override), or if processes block worktree removal.",
         inputSchema: z.object({
           workspacePath: targetWorkspacePathSchema,
           keepBranch: z


### PR DESCRIPTION
The workspace-delete preflight gate lived in the operation: it decided whether the dirty/unmerged check applied, what its findings meant, and fetched the remote refs to make the counts meaningful. The worktree module contributed raw facts and no judgment. Moving the policy to the module (per ARCHITECTURE.md: operations own control flow, modules own domain logic) surfaced two things the operation had gotten wrong.

**Fixes**

- A delete with `keepBranch` was refused over unmerged commits, but the branch ref survives the worktree removal and the commits stay reachable — nothing was at risk. The `workspace_delete` MCP tool then told the agent to pass `ignoreWarnings`, training callers to disable the guard for a case that was never dangerous. Uncommitted changes still block either way.
- A preflight check that *failed to run* (e.g. `git status` erroring) rendered as a failed deletion — terminal progress event, retry/dismiss panel — despite nothing having been torn down. The safety net told a policy error from a pipeline error by string prefix, and that prefix only matched the veto.

**Refactor**

- `preflightResultSchema` becomes a veto (`{ blocked, reason }`), the same shape as `confirm`'s `{ canceled }`. The handler owns applicability and verdict; the operation collects, joins reasons, aborts. Adding a new reason to block a delete no longer means editing the operation.
- The gate moves up beside `confirm`, above the safety net — both gates now run before any teardown or progress emission, which removes the string sniff.
- The fetch becomes a direct `updateBases()` call in the handler (hooks cannot dispatch child intents), and is now skipped when `keepBranch` makes the unmerged count irrelevant — the expensive half of the gate, measured at 21.8s on a large remote.

Tests split along the same seam: applicability and verdict in the module test, sequencing in the operation test.