### PR TITLE
fix: failed ide reconnect after resume on windows

### DIFF
--- a/src/intents/app-resume.ts
+++ b/src/intents/app-resume.ts
@@ -4,11 +4,18 @@
  * Single hook point:
  * - "resume" - Probe IDE server health and restart it if the probe fails.
  *              Handlers return a `ResumeHookResult` (data only, no closures):
- *              `{ restarted: true }` when a stale IDE server was replaced, or
+ *              `{ restarted: true }` when a stale IDE server was replaced,
+ *              `{ staleClients: true }` when the server survived but the suspend
+ *              outlasted what its clients can reconnect across, or
  *              `{ failed: { error } }` when recovery failed. The operation turns
- *              those results into domain events — `ide-server:restarted`
- *              (view-module reloads the workspace iframes whose connections to the
- *              replaced server are stale) and `app:resume-failed`.
+ *              those results into domain events — `ide-server:restarted` and
+ *              `ide-server:sessions-stale` (view-module reloads the workspace
+ *              iframes on either, since both leave their sessions dead) and
+ *              `app:resume-failed`.
+ *
+ * The intent payload carries `sleptMs`, the wall-clock suspend gap measured by
+ * electron-lifecycle-module (which owns the power monitor). Handlers apply their
+ * own thresholds to it; the operation itself never interprets it.
  *
  * After hooks complete, emits `app:resumed` for telemetry subscribers
  * (telemetry-module) that don't depend on server state.
@@ -45,11 +52,25 @@ export const EVENT_APP_RESUME_FAILED = "app:resume-failed" as const;
 
 export const EVENT_IDE_SERVER_RESTARTED = "ide-server:restarted" as const;
 
+export const EVENT_IDE_SERVER_SESSIONS_STALE = "ide-server:sessions-stale" as const;
+
 // =============================================================================
 // Contract schemas (single source of truth)
 // =============================================================================
 
-export const appResumePayloadSchema = z.object({}).readonly();
+export const appResumePayloadSchema = z
+  .object({
+    /**
+     * Wall-clock milliseconds the machine spent suspended, measured by the
+     * lifecycle module that owns the power monitor. Handlers decide for
+     * themselves what a given gap means — e.g. ide-server-module compares it
+     * against the IDE's client reconnection grace. Optional so a dispatch that
+     * has no measurement (tests, a manual re-dispatch) stays valid; absent is
+     * read as "no gap worth acting on".
+     */
+    sleptMs: z.number().nonnegative().optional(),
+  })
+  .readonly();
 
 /**
  * Per-handler result for the "resume" hook point (data only).
@@ -60,6 +81,12 @@ export const resumeHookResultSchema = z
   .object({
     /** A stale server was killed and a fresh one is now listening (→ ide-server:restarted). */
     restarted: z.boolean().optional(),
+    /**
+     * The server itself is healthy, but the suspend outlasted what its clients
+     * can recover from, so every open session is dead (→ ide-server:sessions-stale).
+     * Distinct from `restarted`: nothing was replaced, only the clients lost.
+     */
+    staleClients: z.boolean().optional(),
     /** Recovery failed; human-readable error for display (→ app:resume-failed). */
     failed: z.object({ error: z.string() }).readonly().optional(),
   })
@@ -73,6 +100,9 @@ export const appResumeFailedPayloadSchema = z.object({ error: z.string() }).read
 
 /** Payload emitted by `ide-server:restarted`. */
 export const ideServerRestartedPayloadSchema = z.object({}).readonly();
+
+/** Payload emitted by `ide-server:sessions-stale`. */
+export const ideServerSessionsStalePayloadSchema = z.object({}).readonly();
 
 /** The resume hook point receives the bare intent. */
 const appResumeHookInputSchema = hookCtxSchema(appResumePayloadSchema, {});
@@ -91,6 +121,7 @@ export const schemas = {
     [EVENT_APP_RESUMED]: appResumedPayloadSchema,
     [EVENT_APP_RESUME_FAILED]: appResumeFailedPayloadSchema,
     [EVENT_IDE_SERVER_RESTARTED]: ideServerRestartedPayloadSchema,
+    [EVENT_IDE_SERVER_SESSIONS_STALE]: ideServerSessionsStalePayloadSchema,
   },
 } satisfies OperationSchemas;
 
@@ -124,6 +155,22 @@ export interface IdeServerRestartedEvent extends DomainEvent {
   readonly payload: z.infer<typeof ideServerRestartedPayloadSchema>;
 }
 
+/**
+ * Emitted by ide-server-module when the machine resumed from a suspend long
+ * enough to outlast the IDE's client-side reconnection grace. The server
+ * process survived — the probe passed, nothing was restarted — but every
+ * workspace iframe's session is unrecoverable, and each is about to show the
+ * IDE's own modal "Cannot reconnect. Please reload the window."
+ *
+ * view-module reacts identically to `ide-server:restarted`: reload the frames.
+ * The two are kept apart because the causes are different (a replaced server
+ * vs. expired client sessions) and only this module can judge the second.
+ */
+export interface IdeServerSessionsStaleEvent extends DomainEvent {
+  readonly type: typeof EVENT_IDE_SERVER_SESSIONS_STALE;
+  readonly payload: z.infer<typeof ideServerSessionsStalePayloadSchema>;
+}
+
 // =============================================================================
 // Operation
 // =============================================================================
@@ -140,6 +187,9 @@ export class AppResumeOperation implements Operation<typeof schemas> {
     for (const result of results) {
       if (result.restarted) {
         await ctx.emit({ type: EVENT_IDE_SERVER_RESTARTED, payload: {} });
+      }
+      if (result.staleClients) {
+        await ctx.emit({ type: EVENT_IDE_SERVER_SESSIONS_STALE, payload: {} });
       }
       if (result.failed) {
         await ctx.emit({

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -466,8 +466,14 @@ describe("ElectronLifecycleModule Integration", () => {
   // app-start/activate — powerMonitor resume dispatches app:resume
   // ---------------------------------------------------------------------------
   describe("app-start/activate — powerMonitor resume", () => {
-    it("dispatches app:resume on powerMonitor resume event", async () => {
-      const mockApp = createMockApp();
+    /**
+     * Wire up the module with a captured "resume" callback, run app:start so the
+     * heartbeat is armed, and hand back the pieces the assertions need.
+     */
+    async function setupResume(): Promise<{
+      fireResume: () => void;
+      mockDispatcher: { dispatch: ReturnType<typeof vi.fn> };
+    }> {
       const resumeCallbacks: (() => void)[] = [];
       const mockPowerMonitor = {
         on: vi.fn((event: string, callback: () => void) => {
@@ -477,30 +483,97 @@ describe("ElectronLifecycleModule Integration", () => {
       const mockDispatcher = { dispatch: vi.fn().mockResolvedValue(undefined) };
 
       const dispatcher = createMockDispatcher();
-
       dispatcher.registerOperation(
         createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start")
       );
-
-      const module = createElectronLifecycleModule(
-        createDeps({
-          app: mockApp,
-          powerMonitor: mockPowerMonitor,
-          dispatcher: mockDispatcher,
-        })
+      dispatcher.registerModule(
+        createElectronLifecycleModule(
+          createDeps({
+            app: createMockApp(),
+            powerMonitor: mockPowerMonitor,
+            dispatcher: mockDispatcher,
+          })
+        )
       );
-      dispatcher.registerModule(module);
 
-      await dispatcher.dispatch<AppStartIntent>({
-        type: INTENT_APP_START,
-        payload: {},
-      });
+      await dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} });
 
-      // Simulate resume
       expect(resumeCallbacks.length).toBe(1);
-      resumeCallbacks[0]!();
+      return { fireResume: () => resumeCallbacks[0]!(), mockDispatcher };
+    }
 
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith({ type: "app:resume", payload: {} });
+    function dispatchedSleptMs(mockDispatcher: {
+      dispatch: ReturnType<typeof vi.fn>;
+    }): number | undefined {
+      const intent = mockDispatcher.dispatch.mock.calls[0]![0] as {
+        type: string;
+        payload: { sleptMs?: number };
+      };
+      expect(intent.type).toBe("app:resume");
+      return intent.payload.sleptMs;
+    }
+
+    it("dispatches app:resume on powerMonitor resume event", async () => {
+      const { fireResume, mockDispatcher } = await setupResume();
+
+      fireResume();
+
+      expect(mockDispatcher.dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatchedSleptMs(mockDispatcher)).toBeTypeOf("number");
+    });
+
+    it("reports the wall-clock gap the machine spent suspended", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-07-30T20:22:54Z"));
+        const { fireResume, mockDispatcher } = await setupResume();
+
+        // The 12h53m gap from the reported incident.
+        vi.setSystemTime(new Date("2026-07-31T09:15:43Z"));
+        fireResume();
+
+        // Measured from the last heartbeat stamp, so it may over-state the
+        // suspend by up to one interval — never under-state it.
+        const sleptMs = dispatchedSleptMs(mockDispatcher)!;
+        expect(sleptMs).toBeGreaterThanOrEqual(12 * 60 * 60 * 1000);
+        expect(sleptMs).toBeLessThan(13 * 60 * 60 * 1000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not let heartbeat ticks that come due on wake erase the gap", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-07-30T20:22:54Z"));
+        const { fireResume, mockDispatcher } = await setupResume();
+
+        // Jump the clock as a suspend does, then let the timers that came due
+        // during it run — as they do on wake, before "resume" is delivered.
+        vi.setSystemTime(new Date("2026-07-31T09:15:43Z"));
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        fireResume();
+
+        expect(dispatchedSleptMs(mockDispatcher)!).toBeGreaterThanOrEqual(12 * 60 * 60 * 1000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reports a negligible gap when the machine did not actually sleep", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-07-30T20:22:54Z"));
+        const { fireResume, mockDispatcher } = await setupResume();
+
+        // A spurious resume with no preceding suspend must not look like one.
+        fireResume();
+
+        expect(dispatchedSleptMs(mockDispatcher)).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -4,7 +4,8 @@
  * Provides:
  * - "before-ready" hook on app:start (noAsar, data paths, electron flags)
  * - "init" hook on app:start (waits for Electron app ready, provides "app-ready" capability)
- * - "start" hook on app:start (power monitor resume handler)
+ * - "start" hook on app:start (power monitor resume handler + the wall-clock
+ *   heartbeat whose gap becomes `sleptMs` on the app:resume payload)
  * - "quit" hook on app:shutdown (calls app.quit())
  */
 
@@ -19,7 +20,22 @@ import type { Dispatcher } from "../intents/lib/dispatcher";
 import { storeString } from "../boundaries/platform/store-definition";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
-import { INTENT_APP_RESUME } from "../intents/app-resume";
+import { INTENT_APP_RESUME, type AppResumeIntent } from "../intents/app-resume";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * How often we stamp "the machine was awake at this instant". The gap between
+ * the last stamp and a resume is how long the machine spent suspended.
+ *
+ * A heartbeat rather than powerMonitor's "suspend" event, because that event is
+ * not reliably delivered — Windows hybrid sleep and hibernate can skip it — and
+ * a missed suspend would silently report a gap of zero. A stamp needs nothing
+ * to fire at suspend time.
+ */
+const AWAKE_HEARTBEAT_MS = 60_000;
 
 // =============================================================================
 // Helpers
@@ -164,6 +180,47 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
     },
   });
 
+  // ---------------------------------------------------------------------------
+  // Suspend-gap tracking
+  //
+  // This module owns the power monitor, so it also owns the one fact only it
+  // can observe: how long the machine was actually away. It ships that on the
+  // app:resume payload and interprets none of it — what a given gap *means* is
+  // the business of whichever handler cares (see ide-server-module).
+  // ---------------------------------------------------------------------------
+
+  let lastAwakeAt = Date.now();
+  let heartbeat: NodeJS.Timeout | null = null;
+
+  function startHeartbeat(): void {
+    if (heartbeat !== null) return;
+    heartbeat = setInterval(() => {
+      const now = Date.now();
+      // Advance only on a plausible tick. Timers that come due during a suspend
+      // fire on wake, possibly before the "resume" handler below runs, and
+      // advancing on one of those would erase the very gap we exist to measure.
+      if (now - lastAwakeAt <= AWAKE_HEARTBEAT_MS * 2) {
+        lastAwakeAt = now;
+      }
+    }, AWAKE_HEARTBEAT_MS);
+    // Never hold the process open for this.
+    heartbeat.unref();
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeat === null) return;
+    clearInterval(heartbeat);
+    heartbeat = null;
+  }
+
+  /** Consume the gap since the last stamp and re-arm for the next suspend. */
+  function takeSleptMs(): number {
+    const now = Date.now();
+    const sleptMs = now - lastAwakeAt;
+    lastAwakeAt = now;
+    return sleptMs;
+  }
+
   return {
     name: "electron-lifecycle",
     hooks: {
@@ -225,9 +282,14 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
         },
         start: {
           handler: async (): Promise<void> => {
+            startHeartbeat();
             deps.powerMonitor.on("resume", () => {
-              deps.logger.info("System resumed — dispatching app:resume");
-              void deps.dispatcher.dispatch({ type: INTENT_APP_RESUME, payload: {} });
+              const sleptMs = takeSleptMs();
+              deps.logger.info("System resumed — dispatching app:resume", { sleptMs });
+              void deps.dispatcher.dispatch<AppResumeIntent>({
+                type: INTENT_APP_RESUME,
+                payload: { sleptMs },
+              });
             });
           },
         },
@@ -235,6 +297,7 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
       [APP_SHUTDOWN_OPERATION_ID]: {
         quit: {
           handler: async () => {
+            stopHeartbeat();
             deps.app.quit();
           },
         },

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -48,6 +48,7 @@ import {
   INTENT_APP_RESUME,
   EVENT_APP_RESUMED,
   EVENT_APP_RESUME_FAILED,
+  EVENT_IDE_SERVER_SESSIONS_STALE,
   EVENT_IDE_SERVER_RESTARTED,
 } from "../../intents/app-resume";
 import type { DomainEvent } from "../../intents/lib/types";
@@ -1585,6 +1586,86 @@ describe("IdeServerModule", () => {
       expect(resumedEvents).toHaveLength(1);
       // Healthy probe → no restart → no frame reload
       expect(restartedEvents).toHaveLength(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // Stale client sessions: the server survives the suspend, its clients don't
+    // -------------------------------------------------------------------------
+
+    /** Past VSCodium's 3h ProtocolConstants.ReconnectionGraceTime. */
+    const SLEPT_PAST_GRACE_MS = 4 * 60 * 60 * 1000;
+
+    it("reports stale clients when a healthy server outlasted the reconnection grace", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = await startIdeServer(deps);
+
+      const staleEvents: DomainEvent[] = [];
+      const restartedEvents: DomainEvent[] = [];
+      dispatcher.subscribe(EVENT_IDE_SERVER_SESSIONS_STALE, (e) => staleEvents.push(e));
+      dispatcher.subscribe(EVENT_IDE_SERVER_RESTARTED, (e) => restartedEvents.push(e));
+
+      const initialRunCount = asMockRunner(deps).$.spawnedCount;
+
+      await dispatcher.dispatch({
+        type: INTENT_APP_RESUME,
+        payload: { sleptMs: SLEPT_PAST_GRACE_MS },
+      });
+
+      // The frames are unrecoverable and must be reloaded...
+      expect(staleEvents).toHaveLength(1);
+      // ...but nothing was wrong with the server, so it is neither restarted
+      // nor reported as such.
+      expect(restartedEvents).toHaveLength(0);
+      expect(asMockRunner(deps).$.spawnedCount).toBe(initialRunCount);
+    });
+
+    it("leaves a healthy server's sessions alone when the suspend stayed inside the grace", async () => {
+      const deps = createMockDeps();
+      const { dispatcher } = await startIdeServer(deps);
+
+      const staleEvents: DomainEvent[] = [];
+      dispatcher.subscribe(EVENT_IDE_SERVER_SESSIONS_STALE, (e) => staleEvents.push(e));
+
+      // 30 minutes — the IDE reconnects on its own well inside 3h.
+      await dispatcher.dispatch({
+        type: INTENT_APP_RESUME,
+        payload: { sleptMs: 30 * 60 * 1000 },
+      });
+
+      expect(staleEvents).toHaveLength(0);
+    });
+
+    it("reports a restart rather than stale clients when a long suspend also killed the server", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const deps = createMockDeps();
+        const { dispatcher } = await startIdeServer(deps);
+
+        // Probe fails, restart succeeds.
+        const fetch = deps.httpClient.fetch as ReturnType<typeof vi.fn>;
+        for (let i = 0; i < 10; i++) fetch.mockResolvedValueOnce({ status: 503 });
+        fetch.mockResolvedValue({ status: 200 });
+
+        const staleEvents: DomainEvent[] = [];
+        const restartedEvents: DomainEvent[] = [];
+        dispatcher.subscribe(EVENT_IDE_SERVER_SESSIONS_STALE, (e) => staleEvents.push(e));
+        dispatcher.subscribe(EVENT_IDE_SERVER_RESTARTED, (e) => restartedEvents.push(e));
+
+        const resumePromise = dispatcher.dispatch({
+          type: INTENT_APP_RESUME,
+          payload: { sleptMs: SLEPT_PAST_GRACE_MS },
+        });
+        await vi.advanceTimersByTimeAsync(6000);
+        await resumePromise;
+
+        // The restart already invalidates every session; reporting both would
+        // reload the frames twice for one resume.
+        expect(restartedEvents).toHaveLength(1);
+        expect(staleEvents).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("skips probe when the IDE server was never started", async () => {

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -53,6 +53,7 @@ import {
   APP_RESUME_OPERATION_ID,
   APP_RESUME_HOOK_RESUME,
   type ResumeHookResult,
+  type AppResumeIntent,
 } from "../../intents/app-resume";
 import { SETUP_OPERATION_ID } from "../../intents/setup";
 import { streamProgress } from "../../intents/lib/hook-helpers";
@@ -90,6 +91,22 @@ interface IdeServerConfig {
 
 /** Fixed production port for the embedded IDE server (stable IndexedDB origin). */
 const IDE_SERVER_PORT = 25448;
+
+/**
+ * The distribution's client-side reconnection grace — VSCodium's
+ * `ProtocolConstants.ReconnectionGraceTime`, 108e5 ms in the bundled workbench.
+ *
+ * A workspace iframe disconnected for longer than this cannot recover on its
+ * own. Its reconnect loop compares the elapsed disconnect time against the
+ * grace *before* it reaches the branches that retry transient network errors,
+ * so the first failure after a long sleep — and the network stack is routinely
+ * still down at that moment — is treated as permanent rather than retried. The
+ * workbench then shows a modal "Cannot reconnect. Please reload the window."
+ *
+ * Lives here rather than in view-module because it is a fact about the IDE
+ * distribution we serve, not about how frames are rendered.
+ */
+const IDE_RECONNECTION_GRACE_MS = 3 * 60 * 60 * 1000;
 
 /**
  * Determine the IDE server port from build info.
@@ -772,12 +789,14 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
       // -------------------------------------------------------------------
       [APP_RESUME_OPERATION_ID]: {
         [APP_RESUME_HOOK_RESUME]: {
-          handler: async (): Promise<HookOutput<ResumeHookResult>> => {
+          handler: async (ctx: HookContext): Promise<HookOutput<ResumeHookResult>> => {
             const port = currentPort;
             if (port === null) {
               // Never started — nothing to probe or restart.
               return {};
             }
+
+            const { sleptMs = 0 } = (ctx.intent as AppResumeIntent).payload;
 
             try {
               await waitForHealthy({
@@ -786,6 +805,19 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IntentModule {
                 intervalMs: 500,
                 errorMessage: "IDE server health check timed out after 5s",
               });
+
+              // The server itself came through the suspend fine — but a sleep
+              // past the grace above killed every workspace iframe's session
+              // regardless, and each is about to show the distribution's own
+              // unrecoverable "Cannot reconnect" modal. Report it so the frames
+              // get reloaded before the user is ever asked to do it by hand.
+              if (sleptMs >= IDE_RECONNECTION_GRACE_MS) {
+                logger.info("Suspend outlasted the IDE reconnection grace; sessions are stale", {
+                  sleptMs,
+                  graceMs: IDE_RECONNECTION_GRACE_MS,
+                });
+                return { result: { staleClients: true } };
+              }
               return {};
             } catch {
               // Fall through to restart

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -30,8 +30,8 @@ import {
   APP_SHUTDOWN_OPERATION_ID,
 } from "../intents/app-shutdown";
 import type { AppShutdownIntent } from "../intents/app-shutdown";
-import { EVENT_IDE_SERVER_RESTARTED } from "../intents/app-resume";
-import type { IdeServerRestartedEvent } from "../intents/app-resume";
+import { EVENT_IDE_SERVER_RESTARTED, EVENT_IDE_SERVER_SESSIONS_STALE } from "../intents/app-resume";
+import type { IdeServerRestartedEvent, IdeServerSessionsStaleEvent } from "../intents/app-resume";
 import {
   INTENT_DELETE_WORKSPACE,
   DELETE_WORKSPACE_OPERATION_ID,
@@ -200,6 +200,25 @@ describe("ViewModule Integration", () => {
         payload: {},
       };
       await module.events![EVENT_IDE_SERVER_RESTARTED]!.handler(event);
+
+      expect(viewManager.reloadFrames).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ide-server:sessions-stale → reload workspace iframes. Same remedy as a
+  // restart, different cause: the server survived the suspend but every frame's
+  // session outlasted what the IDE can reconnect across.
+  // -------------------------------------------------------------------------
+  describe("ide-server:sessions-stale", () => {
+    it("asks the view manager to reload frames", async () => {
+      const { viewManager, module } = createTestSetup();
+
+      const event: IdeServerSessionsStaleEvent = {
+        type: EVENT_IDE_SERVER_SESSIONS_STALE,
+        payload: {},
+      };
+      await module.events![EVENT_IDE_SERVER_SESSIONS_STALE]!.handler(event);
 
       expect(viewManager.reloadFrames).toHaveBeenCalledTimes(1);
     });

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -31,7 +31,7 @@ import type { SelectFolderHookResult } from "../intents/open-project";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
 import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
-import { EVENT_IDE_SERVER_RESTARTED } from "../intents/app-resume";
+import { EVENT_IDE_SERVER_RESTARTED, EVENT_IDE_SERVER_SESSIONS_STALE } from "../intents/app-resume";
 import { projectPathSchema } from "../intents/contract";
 
 // =============================================================================
@@ -202,6 +202,19 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       // server instead of leaving the IDE server's "Reload" dialog in each one.
       // -------------------------------------------------------------------
       [EVENT_IDE_SERVER_RESTARTED]: {
+        handler: async (): Promise<void> => {
+          viewManager.reloadFrames();
+        },
+      },
+
+      // -------------------------------------------------------------------
+      // ide-server:sessions-stale → same remedy, different cause. The server
+      // was never replaced; a suspend outlasted what its clients can reconnect
+      // across, so every frame's session is dead and would otherwise sit there
+      // showing the IDE's own "Cannot reconnect" dialog. ide-server-module owns
+      // that judgement — this module only knows how to reload.
+      // -------------------------------------------------------------------
+      [EVENT_IDE_SERVER_SESSIONS_STALE]: {
         handler: async (): Promise<void> => {
           viewManager.reloadFrames();
         },


### PR DESCRIPTION
Sleeping longer than the IDE's client-side reconnection grace (VSCodium's `ReconnectionGraceTime`, 3h) brings the machine back with **every** workspace iframe showing "Cannot reconnect. Please reload the window." — all at once, because a suspend severs every socket in the same instant.

The workbench gives up instead of retrying: its reconnect loop checks the elapsed disconnect time against the grace *before* the branches that retry transient network errors, so the first failure after a long sleep (when the network stack is typically still down) is classified permanent. In the reported 12h53m overnight sleep the server was still parked and reconnectable, yet no management connection ever reconnected.

We already reload frames on `ide-server:restarted`, but that requires the server to have *died* — here it did not (the resume probe answered 200 in 477ms, same pid across the sleep). `app:resume` probes server liveness; a suspend breaks the clients' sessions. Independent things, so the recovery never armed.

- Report stale client sessions as their own signal, split across three modules:
  - `electron-lifecycle-module` owns the power monitor, measures the suspend gap and ships it as `sleptMs` on the `app:resume` payload — interpreting none of it. Uses a wall-clock heartbeat rather than powerMonitor's `suspend` event, which Windows hybrid sleep and hibernate can skip.
  - `ide-server-module` owns the grace constant and the judgement, returning `{ staleClients: true }` — on the healthy branch only, since a restart already invalidates every session.
  - `view-module` handles the resulting `ide-server:sessions-stale` exactly as `ide-server:restarted`. Same remedy, different cause, and it needs to know neither.
- The gap is measured from the last heartbeat stamp, so it over-states the sleep by at most one interval and can never under-state it — it errs toward a harmless extra reload, never a missed dialog.
- 8 new integration tests across the three modules.

Recovers by discarding the sessions. Not losing them would be better — the workbench's grace is configurable via `updateGraceTime` — but that needs the server side raised to match and is left for later. This reload is worth keeping either way, as the only thing that covers a server that *did* dispose them.