### PR TITLE
fix(presenter): log a bounded ui:state projection at debug

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -857,16 +857,33 @@ The logging system provides comprehensive logging across both main and renderer 
 
 ### Configuration
 
-| Variable        | Values                   | Description                                           |
-| --------------- | ------------------------ | ----------------------------------------------------- |
-| `CH_LOGLEVEL`   | debug\|info\|warn\|error | Override default log level                            |
-| `CH_PRINT_LOGS` | any non-empty value      | Print logs to stdout/stderr                           |
-| `CH_LOGGER`     | comma-separated names    | Only log from specified loggers (e.g., `git,process`) |
+Logging is configured through the normal config keys (registered by
+`createLoggingModule`), so each one works as a `config.json` entry, an env var,
+or a CLI flag — see the Configuration section of CLAUDE.md for the precedence
+rules.
+
+| Config key   | Env var          | Values                            | Description              |
+| ------------ | ---------------- | --------------------------------- | ------------------------ |
+| `log.level`  | `CH_LOG__LEVEL`  | `<level>` or `<level>:<filter>`   | Level, optionally scoped |
+| `log.output` | `CH_LOG__OUTPUT` | `file`, `console`, `file,console` | Output destinations      |
+| `log.format` | `CH_LOG__FORMAT` | `text`\|`json`                    | Text lines or JSONL      |
+
+Levels, most verbose first: `silly`, `debug`, `info`, `warn`, `error`. The
+optional filter is a comma-separated **whitelist** of logger names (or `*` for
+all) — naming loggers restricts output to them; it cannot exclude one from an
+otherwise unfiltered level. A line that should stay out of a default `debug`
+capture therefore belongs at `silly`, not behind a filter.
+
+```bash
+CH_LOG__LEVEL=debug CH_LOG__OUTPUT=console pnpm dev   # everything, to stdout
+CH_LOG__LEVEL=debug:git,process pnpm dev              # only those two scopes
+CH_LOG__LEVEL=silly:presenter pnpm dev                # one scope, maximum detail
+```
 
 **Default Levels**:
 
-- Development (isDevelopment=true): DEBUG
-- Production (isDevelopment=false): WARN
+- Development (isDevelopment=true): `debug` (computed default)
+- Production (isDevelopment=false): `warn`
 
 ### Logger Names/Scopes
 
@@ -886,6 +903,33 @@ The logging system provides comprehensive logging across both main and renderer 
 | `[app]`       | Application Lifecycle     | Bootstrap, startup, shutdown          |
 | `[ui]`        | Renderer Components       | Dialog events, user actions           |
 | `[extension]` | PluginServer              | Extension-side logs forwarded to main |
+| `[presenter]` | PresentationModule        | ui:event intake, ui:state pushes      |
+
+(An abridged list — CLAUDE.md carries the full set of `LoggerName` values.)
+
+### Payload Size
+
+A log line's context must be bounded by something small. Anything that scales
+with user data — a git branch list, a file's contents, a screenshot, an SDK
+response — belongs in the log as a size, an id, or a count, not verbatim.
+`FileSystemBoundary.writeFileBuffer` is the pattern: it logs `size`, never
+`content`.
+
+The file rotates at 20 MB and bug reports ship a gzipped tail of it, so an
+unbounded line does not merely bloat the log — it evicts the context a report
+is read for. Payloads also leave the machine: bug reports attach the log, so a
+line that dumps a dialog's render model or a screenshot is exfiltrating what it
+renders.
+
+`[presenter]` logs each `ui:state` push at two fidelities:
+
+| Level   | Context key | Content                                                                                                                                              |
+| ------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debug` | `state`     | Bounded projection: frames as keys, dialogs as `id` + `kind`, a hibernated `main.screenshot` as its length. Rows, notifications, and flags verbatim. |
+| `silly` | `snapshot`  | The verbatim snapshot, unbounded.                                                                                                                    |
+
+The projection is built from a mapped type over `UiState`, so a new field is a
+compile error until it is deliberately projected. Both lines fire at `silly`.
 
 ### Log File Location
 

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -404,9 +404,14 @@ describe("PresentationModule - ui:state snapshots", () => {
         notifications: [],
       },
     ]);
+    // The push is logged at two fidelities (see "push logging" below): the
+    // bounded projection at debug, the verbatim snapshot at silly.
     const logger = deps.loggingService.getLogger("presenter");
-    expect(logger?.debug).toHaveBeenCalledWith("ui:state push", {
+    expect(logger?.silly).toHaveBeenCalledWith("ui:state push", {
       snapshot: JSON.stringify(snapshots(deps)[0]),
+    });
+    expect(logger?.debug).toHaveBeenCalledWith("ui:state push", {
+      state: expect.stringContaining('"main":{"kind":"starting"}') as string,
     });
   });
 
@@ -2474,5 +2479,139 @@ describe("PresentationModule - background-focus suppression", () => {
 
     const result = await interceptor(module).before(openIntent("mcp", true));
     expect(stealFocusOf(result)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Push logging
+//
+// Every push is logged twice: a bounded projection at `debug` (what a bug
+// report captured at the default level carries) and the verbatim snapshot at
+// `silly`. The projection drops exactly the three unbounded fields — dialog
+// configs, frame URLs, and the hibernation screenshot's bytes.
+// =============================================================================
+
+describe("PresentationModule - push logging", () => {
+  /** The context of the last `debug` "ui:state push", parsed back from JSON. */
+  function loggedProjection(deps: Deps): Record<string, unknown> {
+    const logger = deps.loggingService.getLogger("presenter")!;
+    const call = logger.debug.mock.calls.filter(([message]) => message === "ui:state push").at(-1);
+    expect(call).toBeDefined();
+    return JSON.parse(call![1]!.state as string) as Record<string, unknown>;
+  }
+
+  it("projects frames to their keys and drops the IDE URLs", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat", { url: "http://127.0.0.1:25448/?folder=/ws/feat" });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
+    await flush();
+
+    expect(lastSnapshot(deps).frames).toEqual({ [`${PROJECT_ID}/feat`]: workspace.url });
+    expect(loggedProjection(deps).frames).toEqual([`${PROJECT_ID}/feat`]);
+  });
+
+  it("projects dialogs to id + kind, dropping the config", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    // A create-workspace dialog carries one dropdown suggestion per branch —
+    // 428 remote branches was 22.8 KB of the 26.7 KB snapshot in the report.
+    module.dialog(
+      {
+        sections: [
+          {
+            type: "dropdown",
+            id: "name",
+            suggestions: [
+              {
+                items: Array.from({ length: 428 }, (_, i) => ({
+                  value: `origin/feature-${i}`,
+                  label: `origin/feature-${i}`,
+                })),
+              },
+            ],
+          },
+        ],
+      },
+      { kind: "panel" }
+    );
+    await flush();
+
+    const dialogs = lastSnapshot(deps).dialogs;
+    expect(dialogs).toHaveLength(1);
+    expect(dialogs[0]!.config.sections).toHaveLength(1);
+
+    const projected = loggedProjection(deps);
+    expect(projected.dialogs).toEqual([{ id: dialogs[0]!.id, kind: "panel" }]);
+    expect(JSON.stringify(projected)).not.toContain("origin/feature-");
+  });
+
+  it("projects the hibernation screenshot to its length", async () => {
+    const deps = createDeps();
+    deps.fileSystem.readFileBuffer = vi.fn(() => Promise.resolve(Buffer.from("PNG")));
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat", { metadata: { hibernated: "true" } });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
+    await flush();
+    await flush();
+
+    const main = lastSnapshot(deps).main as { kind: string; screenshot: string };
+    expect(main.screenshot).toMatch(/^data:image\/png;base64,/);
+    expect(loggedProjection(deps).main).toEqual({
+      kind: "hibernated",
+      screenshot: main.screenshot.length,
+    });
+    expect(JSON.stringify(loggedProjection(deps))).not.toContain("data:image");
+  });
+
+  it("preserves a null screenshot (the PNG read failed)", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat", { metadata: { hibernated: "true" } });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await emit(module, EVENT_WORKSPACE_SWITCHED, switchedPayload(workspace));
+    await flush();
+    await flush();
+
+    expect(lastSnapshot(deps).main).toEqual({ kind: "hibernated", screenshot: null });
+    expect(loggedProjection(deps).main).toEqual({ kind: "hibernated", screenshot: null });
+  });
+
+  it("keeps rows, notifications and flags verbatim", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat", { metadata: { "tags.new": '{"color":"blue"}' } });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    module.notification({ title: "Update available", type: "info" });
+    await flush();
+
+    const snapshot = lastSnapshot(deps);
+    const projected = loggedProjection(deps);
+    expect(projected.sidebar).toEqual(snapshot.sidebar);
+    expect(projected.notifications).toEqual(snapshot.notifications);
+    expect(projected.mode).toBe(snapshot.mode);
+    expect(projected.theme).toBe(snapshot.theme);
+    expect(projected.capturing).toBe(snapshot.capturing);
+    expect(projected.labelScroll).toBe(snapshot.labelScroll);
+    expect(projected.silent).toBe(snapshot.silent);
+  });
+
+  it("logs the verbatim snapshot at silly", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat", { url: "http://127.0.0.1:25448/?folder=/ws/feat" });
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+    await flush();
+
+    const logger = deps.loggingService.getLogger("presenter")!;
+    const call = logger.silly.mock.calls.filter(([message]) => message === "ui:state push").at(-1);
+    expect(call).toBeDefined();
+    expect(JSON.parse(call![1]!.snapshot as string)).toEqual(lastSnapshot(deps));
+    // One line of each per push — silly is additive, not a replacement.
+    expect(logger.silly.mock.calls.length).toBe(
+      logger.debug.mock.calls.filter(([message]) => message === "ui:state push").length
+    );
   });
 });

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -375,6 +375,49 @@ function buildCloseConfirmConfig(
   return { sections };
 }
 
+/**
+ * The snapshot projection logged on every push at `debug` (minified JSON).
+ *
+ * A verbatim snapshot is unbounded, and two fields carry nearly all of it: a
+ * hibernated `main` inlines the workspace screenshot as a base64 data URL
+ * (~1.25 MB for a real 940 KB PNG), and a create-workspace dialog's `config`
+ * holds one dropdown suggestion per branch (22.8 KB at 428 remote branches).
+ * Re-serialised on every push, that made `[presenter]` 64% of an 11.5 MB bug
+ * report — ~1 MB/hour from this one line. Dropping the dialog config also
+ * keeps the settings dialog's unredacted `Config.getEffective()` values out of
+ * the log file that bug reports attach.
+ *
+ * Everything else stays verbatim: rows are ~155 bytes each and carry what a
+ * report is read for (which row hung in `creating`, which deletion failed and
+ * why, which agent was busy). The mapped type is the guard — a new `UiState`
+ * field fails to compile here until it is deliberately projected.
+ *
+ * The verbatim snapshot remains available one level down (`log.level=silly:presenter`).
+ */
+function projectForLog(state: UiState): string {
+  const projected: { [K in keyof UiState]: unknown } = {
+    sidebar: state.sidebar,
+    // The mounted-frame *set* is the diagnostic fact (an orphaned frame, a
+    // frame surviving a teardown); each URL is just the IDE port plus the
+    // worktree path, both already elsewhere in the log.
+    frames: Object.keys(state.frames),
+    main:
+      state.main.kind === "hibernated"
+        ? { ...state.main, screenshot: state.main.screenshot?.length ?? null }
+        : state.main,
+    theme: state.theme,
+    labelScroll: state.labelScroll,
+    silent: state.silent,
+    mode: state.mode,
+    capturing: state.capturing,
+    // Which dialogs are open, in open order — enough for the modal-stack
+    // questions ("was the app blocked", "did the loading dialog never close").
+    dialogs: state.dialogs.map(({ id, kind }) => ({ id, kind })),
+    notifications: state.notifications,
+  };
+  return JSON.stringify(projected);
+}
+
 export function createPresentationModule(deps: PresentationModuleDeps): UiPresenter {
   const logger = deps.loggingService.createLogger("presenter");
 
@@ -1046,7 +1089,11 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
     inPush = false;
     const snapshot = buildSnapshot();
     deps.viewManager.sendToUI(ApiIpcChannels.UI_STATE, snapshot);
-    logger.debug("ui:state push", { snapshot: JSON.stringify(snapshot) });
+    // Two fidelities, same message: `state` is the bounded projection every
+    // debug-level bug report carries, `snapshot` the verbatim dump (both fire
+    // at silly — the projection stays greppable either way).
+    logger.debug("ui:state push", { state: projectForLog(snapshot) });
+    logger.silly("ui:state push", { snapshot: JSON.stringify(snapshot) });
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
- `[presenter]` serialised the entire `UiState` on every push, making it 64% of an 11.5 MB bug report (7.34 MB / 274 lines, ~1 MB per hour) and clipping the context the report was filed for
- Two fields carried nearly all of it: a create-workspace dialog's `config` (one dropdown suggestion per branch — 22.8 KB at 428 remote branches) and a hibernated `main.screenshot` inlined as a base64 data URL (~1.25 MB for a real 940 KB PNG)
- `debug` now logs a bounded projection (`state=`): `frames` as keys, `dialogs` as `id` + `kind`, a hibernated screenshot as its length; rows, notifications and flags stay verbatim. ~26.8 KB → ~4.5 KB per push, and the two unbounded cases become constant-size
- The verbatim dump moves one level down to `silly` (`snapshot=`, `log.level=silly:presenter`), so nothing is lost for local reproduction
- The projection is built from a mapped type over `UiState`, so a new field is a compile error until it is deliberately projected
- Dropping the dialog config also keeps the settings dialog's unredacted `Config.getEffective()` values out of the log file that bug reports attach (still reachable at `silly`, where the verbatim dump lives)
- `docs/ARCHITECTURE.md` documented three env vars that no longer exist (`CH_LOGLEVEL` / `CH_PRINT_LOGS` / `CH_LOGGER`); replaced with the real config keys, plus a note that the level filter is a whitelist and a new payload-size rule

Not addressed here: the same screenshot is structured-cloned over IPC on every push, and `[process]` (30% of the same report) is being handled separately.