### PR TITLE
fix(process): keep credentials in argv out of the log

### DIFF
--- a/src/boundaries/platform/process.boundary.test.ts
+++ b/src/boundaries/platform/process.boundary.test.ts
@@ -940,6 +940,29 @@ describe("ExecaProcessRunner", () => {
     );
 
     it(
+      "prefixes output lines with the pid, not the command",
+      async () => {
+        const logger = createBehavioralLogger();
+        const streamRunner = new ExecaProcessRunner(logger);
+
+        const proc = streamRunner.run(process.execPath, ["-e", 'console.log("prefixed-line")']);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const line = logger
+          .getMessagesByLevel("debug")
+          .find((m) => m.message.includes("prefixed-line"));
+        expect(line?.message).toBe(`[${proc.pid ?? 0}] stdout: prefixed-line`);
+        // The command is repeated once per line if it lands in the prefix; on a
+        // chatty process that is the bulk of the log.
+        expect(line?.message).not.toContain(process.execPath);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
       "streams output before wait() is called",
       async () => {
         const logger = createBehavioralLogger();
@@ -959,6 +982,231 @@ describe("ExecaProcessRunner", () => {
         expect(debugMessages.some((m) => m.message.includes("early-output"))).toBe(true);
 
         await proc.kill(100, 100);
+      },
+      TEST_TIMEOUT
+    );
+  });
+
+  describe("redactBy", () => {
+    /** A credential shaped like the YouTrack permanent token that leaked. */
+    const SECRET = "perm-AAAABBBBCCCCDDDDEEEEFFFF";
+    const REDACT_BY = "youtrack cmd";
+
+    /**
+     * Everything the logger was given, at every level, message text and context
+     * values alike. The leak assertions run against this rather than against
+     * debug-level messages: three of the sites that print the command log at
+     * info/warn/error, i.e. at or above the DEFAULT level, so scoping the
+     * assertion to debug would miss exactly the cases that leak without anyone
+     * turning debug on.
+     */
+    function allLoggedText(logger: ReturnType<typeof createBehavioralLogger>): string {
+      return logger
+        .getMessages()
+        .map((m) => `${m.message} ${m.context ? JSON.stringify(m.context) : ""}`)
+        .join("\n");
+    }
+
+    /**
+     * A shell line carrying a credential in argv, as the auto-workspace poller
+     * does. The `--` keeps node from claiming `--oauth2-bearer` as one of its
+     * own options and bailing out before the script runs.
+     */
+    function sensitiveLine(script: string): string {
+      return `"${process.execPath}" -e "${script}" -- --oauth2-bearer ${SECRET}`;
+    }
+
+    it(
+      "keeps a credential in argv out of the log on the normal exit path",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        const proc = redactRunner.run(sensitiveLine("process.exit(0)"), [], {
+          shell: true,
+          redactBy: REDACT_BY,
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        expect(allLoggedText(logger)).not.toContain(SECRET);
+        expect(allLoggedText(logger)).toContain(`<${REDACT_BY}>`);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "keeps a credential in argv out of the log on the kill path",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        const proc = redactRunner.run(sensitiveLine("setTimeout(() => {}, 30000)"), [], {
+          shell: true,
+          redactBy: REDACT_BY,
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        // "Killed" logs at info/warn — above the default log level, so this is
+        // the path that leaked for users who never enabled debug logging.
+        await proc.kill(100, 100);
+
+        const text = allLoggedText(logger);
+        expect(text).not.toContain(SECRET);
+        expect(text).toContain("Killed");
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "keeps a credential in argv out of the log on the wait-timeout path",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        const proc = redactRunner.run(sensitiveLine("setTimeout(() => {}, 30000)"), [], {
+          shell: true,
+          redactBy: REDACT_BY,
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        // The poller waits with a timeout, so "Wait timeout" fires on every
+        // slow source cmd.
+        const result = await proc.wait(50);
+        expect(result.running).toBe(true);
+        expect(allLoggedText(logger)).not.toContain(SECRET);
+
+        await proc.kill(100, 100);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "keeps a credential in argv out of the log when the spawn itself fails",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        // Not a shell spawn: a missing binary is what produces the ENOENT that
+        // reaches "Spawn failed", which logs at error level.
+        const proc = redactRunner.run(
+          "codehydra-definitely-not-a-real-binary",
+          ["--oauth2-bearer", SECRET],
+          { redactBy: REDACT_BY }
+        );
+        runningProcesses.push(proc);
+
+        await proc.wait();
+
+        expect(allLoggedText(logger)).not.toContain(SECRET);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "counts redacted output at debug and defers the content to silly",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        // Argv redaction cannot reach a response body, so the body is treated
+        // as untrusted too: an API response can carry a token of its own.
+        const body = "RESPONSE-BODY-abcdef";
+        const proc = redactRunner.run(process.execPath, ["-e", `console.log("${body}")`], {
+          redactBy: REDACT_BY,
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const debugText = logger
+          .getMessagesByLevel("debug")
+          .map((m) => m.message)
+          .join("\n");
+        expect(debugText).not.toContain(body);
+        expect(debugText).toContain(`stdout: ${Buffer.byteLength(body)} bytes`);
+
+        const sillyText = logger
+          .getMessagesByLevel("silly")
+          .map((m) => m.message)
+          .join("\n");
+        expect(sillyText).toContain(body);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "omits args and spawnargs from the Spawned record of a redacted spawn",
+      async () => {
+        const logger = createBehavioralLogger();
+        const redactRunner = new ExecaProcessRunner(logger);
+
+        const proc = redactRunner.run(process.execPath, ["-e", "process.exit(0)", SECRET], {
+          redactBy: REDACT_BY,
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        const spawned = logger.getMessagesByLevel("debug").find((m) => m.message === "Spawned");
+        expect(spawned?.context?.command).toBe(`<${REDACT_BY}>`);
+        // spawnargs re-embeds the real argv, so it has to go too.
+        expect(spawned?.context).not.toHaveProperty("args");
+        expect(spawned?.context).not.toHaveProperty("spawnargs");
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "leaves a spawn without redactBy fully logged",
+      async () => {
+        const logger = createBehavioralLogger();
+        const plainRunner = new ExecaProcessRunner(logger);
+
+        const proc = plainRunner.run(process.execPath, ["-e", 'console.log("plain-output")']);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        // Redaction is strictly opt-in: nothing is inferred, and an unflagged
+        // spawn keeps the command, args and output it logs today.
+        const spawned = logger.getMessagesByLevel("debug").find((m) => m.message === "Spawned");
+        expect(spawned?.context?.command).toBe(process.execPath);
+        expect(spawned?.context?.args).toContain("plain-output");
+
+        const debugText = logger
+          .getMessagesByLevel("debug")
+          .map((m) => m.message)
+          .join("\n");
+        expect(debugText).toContain("stdout: plain-output");
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "never logs the environment, redacted or not",
+      async () => {
+        const logger = createBehavioralLogger();
+        const envRunner = new ExecaProcessRunner(logger);
+
+        // Backs the guidance to keep credentials in env rather than argv:
+        // that only helps if env genuinely never reaches the log.
+        const proc = envRunner.run(process.execPath, ["-e", "process.exit(0)"], {
+          env: { ...process.env, YT_TOKEN: SECRET },
+        });
+        runningProcesses.push(proc);
+        trackProcess(proc);
+
+        await proc.wait();
+
+        expect(allLoggedText(logger)).not.toContain(SECRET);
       },
       TEST_TIMEOUT
     );

--- a/src/boundaries/platform/process.state-mock.ts
+++ b/src/boundaries/platform/process.state-mock.ts
@@ -45,6 +45,8 @@ export interface SpawnedProcessMockState extends MockState {
   readonly env: NodeJS.ProcessEnv | undefined;
   /** True when the caller asked for shell interpretation of `command`. */
   readonly shell: boolean;
+  /** The replacement identity the caller passed as `redactBy`, if any. */
+  readonly redactBy: string | undefined;
   readonly killCalls: ReadonlyArray<KillCallRecord>;
 }
 
@@ -92,6 +94,7 @@ interface MockSpawnedProcessOptions {
   cwd: string | undefined;
   env: NodeJS.ProcessEnv | undefined;
   shell: boolean;
+  redactBy: string | undefined;
   pid: number | undefined;
   waitResult: ProcessResult;
   killResult: KillResult;
@@ -106,6 +109,7 @@ class SpawnedProcessMockStateImpl implements SpawnedProcessMockState {
   readonly cwd: string | undefined;
   readonly env: NodeJS.ProcessEnv | undefined;
   readonly shell: boolean;
+  readonly redactBy: string | undefined;
   private readonly _killCalls: KillCallRecord[] = [];
 
   constructor(options: {
@@ -114,12 +118,14 @@ class SpawnedProcessMockStateImpl implements SpawnedProcessMockState {
     cwd: string | undefined;
     env: NodeJS.ProcessEnv | undefined;
     shell: boolean;
+    redactBy: string | undefined;
   }) {
     this.command = options.command;
     this.args = options.args;
     this.cwd = options.cwd;
     this.env = options.env;
     this.shell = options.shell;
+    this.redactBy = options.redactBy;
   }
 
   get killCalls(): ReadonlyArray<KillCallRecord> {
@@ -159,6 +165,7 @@ class MockSpawnedProcessImpl implements MockSpawnedProcess {
       cwd: options.cwd,
       env: options.env,
       shell: options.shell,
+      redactBy: options.redactBy,
     });
   }
 
@@ -265,7 +272,7 @@ class MockProcessRunnerImpl implements MockProcessRunner {
   run(
     command: string,
     args: readonly string[],
-    options?: { cwd?: string; env?: NodeJS.ProcessEnv; shell?: boolean }
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv; shell?: boolean; redactBy?: string }
   ): SpawnedProcess {
     // Get per-spawn configuration
     const config = this.onSpawn?.(command, args, options?.cwd, options?.env);
@@ -292,6 +299,7 @@ class MockProcessRunnerImpl implements MockProcessRunner {
       cwd: options?.cwd,
       env: options?.env,
       shell: options?.shell ?? false,
+      redactBy: options?.redactBy,
       pid,
       waitResult,
       killResult,

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -45,6 +45,23 @@ export interface ProcessOptions {
    * unmangled.
    */
   readonly shell?: boolean;
+  /**
+   * Mark this spawn as untrusted: its command line and its output may contain
+   * credentials, so neither is written to the log verbatim at debug level.
+   *
+   * The string is the replacement identity. Every log site that would print the
+   * command prints `command=<your text>` instead, and `args`/`spawnargs` are
+   * omitted entirely — nothing of the real command line is ever logged. Output
+   * lines are reduced to a byte count at debug (`stdout: 1234 bytes`); the full
+   * line is still emitted at `silly`, which is opt-in.
+   *
+   * There is deliberately NO pattern-matching fallback: a spawn without
+   * `redactBy` has its command, args and output logged in full. If you are
+   * putting a token, password or credential-bearing URL into argv — or running
+   * a user-authored command line that might — you MUST set this. Nothing else
+   * will catch it.
+   */
+  readonly redactBy?: string;
 }
 
 /**
@@ -156,14 +173,22 @@ const TIMEOUT_SYMBOL = Symbol("timeout");
 class ExecaSpawnedProcess implements SpawnedProcess {
   private readonly subprocess: ExecaSubprocess;
   private readonly logger: Logger;
-  private readonly command: string;
+  /**
+   * The only form of the command any log site may print. Computed once here so
+   * that a redacted spawn cannot leak through a site that forgot to redact —
+   * the raw command line is never stored on the instance.
+   */
+  readonly loggableCommand: string;
+  /** True when the caller passed `redactBy` (see ProcessOptions.redactBy). */
+  readonly redacted: boolean;
   private cachedResult: ProcessResult | null = null;
   private readonly streamingActive: boolean;
 
-  constructor(subprocess: ExecaSubprocess, logger: Logger, command: string) {
+  constructor(subprocess: ExecaSubprocess, logger: Logger, command: string, redactBy?: string) {
     this.subprocess = subprocess;
     this.logger = logger;
-    this.command = command;
+    this.redacted = redactBy !== undefined;
+    this.loggableCommand = redactBy !== undefined ? `<${redactBy}>` : command;
     this.streamingActive = this.setupStreamLogging();
   }
 
@@ -184,7 +209,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
       // 2. We can't send CTRL_C_EVENT to detached processes
       // So we skip the "graceful" phase entirely and go straight to forceful.
       await this.killProcess(pid, true);
-      this.logger.warn("Killed", { command: this.command, pid, signal: "TASKKILL" });
+      this.logger.warn("Killed", { command: this.loggableCommand, pid, signal: "TASKKILL" });
 
       // Wait for termTimeout (combined wait since we only do one kill)
       const timeout = (termTimeout ?? 0) + (killTimeout ?? 0);
@@ -202,7 +227,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
     // Unix: Two-phase SIGTERM → SIGKILL
     // 1. Send SIGTERM
     await this.killProcess(pid, false);
-    this.logger.info("Killed", { command: this.command, pid, signal: "SIGTERM" });
+    this.logger.info("Killed", { command: this.loggableCommand, pid, signal: "SIGTERM" });
 
     // 2. If termTimeout defined, wait for graceful exit
     if (termTimeout !== undefined) {
@@ -214,7 +239,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
 
     // 3. Send SIGKILL
     await this.killProcess(pid, true);
-    this.logger.warn("Killed", { command: this.command, pid, signal: "SIGKILL" });
+    this.logger.warn("Killed", { command: this.loggableCommand, pid, signal: "SIGKILL" });
 
     // 4. If killTimeout defined, wait for forced exit
     if (killTimeout !== undefined) {
@@ -299,7 +324,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
     if (raceResult === TIMEOUT_SYMBOL) {
       // Timeout occurred, process is still running
       this.logger.silly("Wait timeout", {
-        command: this.command,
+        command: this.loggableCommand,
         pid: this.pid ?? 0,
         timeout,
       });
@@ -373,7 +398,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
     } else {
       // Normal exit
       this.logger.debug("Exited", {
-        command: this.command,
+        command: this.loggableCommand,
         pid: this.pid ?? 0,
         exitCode: result.exitCode ?? -1,
       });
@@ -389,13 +414,29 @@ class ExecaSpawnedProcess implements SpawnedProcess {
   }
 
   /**
-   * Log non-empty lines at DEBUG level, prefixed with the command + pid.
+   * Log non-empty lines, prefixed with the pid. The pid (rather than the
+   * command) keeps the prefix short on chatty processes and correlates with
+   * the "Spawned" record, the OS, and the process-cleanup modules; it is
+   * reused by the OS over a long session, so resolve it against the nearest
+   * preceding "Spawned" line.
+   *
+   * For a redacted spawn the line content itself may carry credentials (argv
+   * redaction cannot reach a response body), so debug gets only a byte count
+   * and the content is deferred to `silly`, which is opt-in. Both calls are
+   * always made — the transport filters by level — so at `silly` a redacted
+   * spawn shows the count line and the content line.
+   *
    * Shared by the streaming logger and the batch (post-exit) logger.
    */
   private logLines(lines: string[], stream: "stdout" | "stderr"): void {
-    const prefix = `[${this.command} ${this.pid ?? 0}]`;
+    const prefix = `[${this.pid ?? 0}]`;
     for (const line of lines) {
       if (line.trim() === "") continue;
+      if (this.redacted) {
+        this.logger.debug(`${prefix} ${stream}: ${Buffer.byteLength(line)} bytes`);
+        this.logger.silly(`${prefix} ${stream}: ${line}`);
+        continue;
+      }
       this.logger.debug(`${prefix} ${stream}: ${line}`);
     }
   }
@@ -429,7 +470,7 @@ class ExecaSpawnedProcess implements SpawnedProcess {
 
       // Pure spawn error (ENOENT, EACCES, etc.)
       this.logger.error("Spawn failed", {
-        command: this.command,
+        command: this.loggableCommand,
         error: err.message,
       });
       return {
@@ -486,7 +527,7 @@ export class ExecaProcessRunner implements ProcessRunner {
       ...(options?.env && { env: options.env, extendEnv: false }),
     }) as ExecaSubprocess;
 
-    const spawned = new ExecaSpawnedProcess(subprocess, this.logger, command);
+    const spawned = new ExecaSpawnedProcess(subprocess, this.logger, command, options?.redactBy);
 
     // Check if spawn failed (no PID)
     if (spawned.pid === undefined) {
@@ -499,13 +540,21 @@ export class ExecaProcessRunner implements ProcessRunner {
       // shell transformation. On Windows a `.cmd` goes through cmd.exe, and how its
       // arguments end up quoted decides whether a batch script can parse them at all —
       // VSCodium's codium-server.cmd dies on a quoted first argument.
+      //
+      // A redacted spawn logs its replacement identity and nothing else: `args`
+      // and `spawnargs` are both derived from the real command line, and
+      // `spawnargs` in particular re-embeds it (`["/bin/sh", "-c", <line>]`).
       const child = subprocess as unknown as { spawnfile?: string; spawnargs?: string[] };
       this.logger.debug("Spawned", {
-        command,
-        args: args.join(" "),
+        // Same computed value the handle's own log sites use, so the two can
+        // never disagree about what is safe to print.
+        command: spawned.loggableCommand,
         pid: spawned.pid,
-        ...(child.spawnfile !== undefined && { spawnfile: child.spawnfile }),
-        ...(child.spawnargs !== undefined && { spawnargs: JSON.stringify(child.spawnargs) }),
+        ...(!spawned.redacted && {
+          args: args.join(" "),
+          ...(child.spawnfile !== undefined && { spawnfile: child.spawnfile }),
+          ...(child.spawnargs !== undefined && { spawnargs: JSON.stringify(child.spawnargs) }),
+        }),
       });
     }
 

--- a/src/modules/auto-workspace/cmd-runner.test.ts
+++ b/src/modules/auto-workspace/cmd-runner.test.ts
@@ -14,14 +14,14 @@ function runner(config: {
 describe("runCmd", () => {
   it("parses a JSON array from stdout", async () => {
     const processRunner = runner({ stdout: '[{"a":1},{"a":2}]' });
-    await expect(runCmd({ processRunner }, "echo")).resolves.toEqual([{ a: 1 }, { a: 2 }]);
+    await expect(runCmd({ processRunner }, "src", "echo")).resolves.toEqual([{ a: 1 }, { a: 2 }]);
   });
 
   it("hands the raw cmd to the runner with shell:true", async () => {
     const processRunner = createMockProcessRunner({ onSpawn: () => ({ stdout: "[]" }) });
     const cmd = `curl -H "Authorization: Bearer x" 'https://example.com'`;
 
-    await runCmd({ processRunner }, cmd);
+    await runCmd({ processRunner }, "youtrack", cmd);
 
     // Must NOT hand-roll `sh -c` / `cmd /c`: passing the line as an argv entry
     // leaves it to be escaped as an ordinary argument, and the `\"` that Windows
@@ -33,23 +33,41 @@ describe("runCmd", () => {
     expect(spawned.$.shell).toBe(true);
   });
 
-  it("throws on a non-zero exit code", async () => {
-    const processRunner = runner({ exitCode: 1, stderr: "boom" });
-    await expect(runCmd({ processRunner }, "x")).rejects.toThrow(/boom/);
+  it("marks the spawn redacted so the cmd never reaches the log", async () => {
+    const processRunner = createMockProcessRunner({ onSpawn: () => ({ stdout: "[]" }) });
+
+    await runCmd({ processRunner }, "youtrack", `curl --oauth2-bearer perm-SECRET https://yt`);
+
+    // The cmd is user-authored and routinely inlines an API token. Redaction is
+    // strictly opt-in in ProcessRunner — nothing is inferred from shell:true —
+    // so dropping this flag silently reinstates the leak.
+    expect(processRunner.$.spawned(0).$.redactBy).toBe("youtrack cmd");
+  });
+
+  it("throws on a non-zero exit code without quoting stderr", async () => {
+    const processRunner = runner({ exitCode: 1, stderr: "token perm-SECRET rejected" });
+
+    // This message reaches the module's `warn` line, which is emitted at the
+    // DEFAULT log level — a failing cmd that echoes its own credentials must
+    // not ride along. The byte count still says whether it said anything.
+    await expect(runCmd({ processRunner }, "youtrack", "x")).rejects.toThrow(
+      /cmd exited with 1 \(26 bytes of stderr\)/
+    );
+    await expect(runCmd({ processRunner }, "youtrack", "x")).rejects.not.toThrow(/perm-SECRET/);
   });
 
   it("throws on invalid JSON", async () => {
     const processRunner = runner({ stdout: "not json" });
-    await expect(runCmd({ processRunner }, "x")).rejects.toThrow(/not valid JSON/);
+    await expect(runCmd({ processRunner }, "src", "x")).rejects.toThrow(/not valid JSON/);
   });
 
   it("throws when stdout is not a JSON array", async () => {
     const processRunner = runner({ stdout: '{"items":[]}' });
-    await expect(runCmd({ processRunner }, "x")).rejects.toThrow(/not a JSON array/);
+    await expect(runCmd({ processRunner }, "src", "x")).rejects.toThrow(/not a JSON array/);
   });
 
   it("throws on a timeout (still running)", async () => {
     const processRunner = runner({ running: true, stdout: "" });
-    await expect(runCmd({ processRunner }, "x")).rejects.toThrow(/timed out/);
+    await expect(runCmd({ processRunner }, "src", "x")).rejects.toThrow(/timed out/);
   });
 });

--- a/src/modules/auto-workspace/cmd-runner.ts
+++ b/src/modules/auto-workspace/cmd-runner.ts
@@ -23,9 +23,20 @@ export interface RunCmdDeps {
  * Execute `cmd` and return the parsed top-level JSON array. Throws on non-zero
  * exit, timeout, non-JSON output, or output that is not an array — the caller
  * logs and skips the tick.
+ *
+ * `sourceName` is only used as the command's logged identity: the cmd is
+ * user-authored and routinely inlines an API token, so `redactBy` keeps the
+ * line itself out of the log entirely (see ProcessOptions.redactBy).
  */
-export async function runCmd(deps: RunCmdDeps, cmd: string): Promise<unknown[]> {
-  const proc = deps.processRunner.run(cmd, [], { shell: true });
+export async function runCmd(
+  deps: RunCmdDeps,
+  sourceName: string,
+  cmd: string
+): Promise<unknown[]> {
+  const proc = deps.processRunner.run(cmd, [], {
+    shell: true,
+    redactBy: `${sourceName} cmd`,
+  });
   const result = await proc.wait(CMD_TIMEOUT_MS);
 
   if (result.running) {
@@ -33,8 +44,15 @@ export async function runCmd(deps: RunCmdDeps, cmd: string): Promise<unknown[]> 
     throw new Error(`cmd timed out after ${CMD_TIMEOUT_MS}ms`);
   }
   if (result.exitCode !== 0) {
-    const stderr = result.stderr.slice(0, 500).trim();
-    throw new Error(`cmd exited with ${result.exitCode ?? "signal"}${stderr ? `: ${stderr}` : ""}`);
+    // Deliberately no stderr text: this message reaches the caller's `warn`
+    // line, which is emitted at the DEFAULT log level, and a failing cmd can
+    // echo its own credentials (a 401 body, a usage line quoting argv). The
+    // byte count says whether the cmd said anything at all; the text itself is
+    // recoverable at `silly` from the stderr line ProcessRunner logs.
+    const stderrBytes = Buffer.byteLength(result.stderr);
+    throw new Error(
+      `cmd exited with ${result.exitCode ?? "signal"} (${stderrBytes} bytes of stderr)`
+    );
   }
 
   let parsed: unknown;

--- a/src/modules/auto-workspace/module.integration.test.ts
+++ b/src/modules/auto-workspace/module.integration.test.ts
@@ -11,7 +11,7 @@
 
 import { createMockDispatcher } from "../../intents/lib/dispatcher.test-utils";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { SILENT_LOGGER } from "../../boundaries/platform/logging";
+import { createBehavioralLogger } from "../../boundaries/platform/logging.test-utils";
 import { z } from "zod/v4";
 import type {
   Operation,
@@ -177,6 +177,7 @@ template:
 interface CmdControl {
   items: unknown[];
   exitCode: number;
+  stderr: string;
 }
 
 function createSetup(options?: {
@@ -185,10 +186,15 @@ function createSetup(options?: {
   legacyStateFileContent?: string;
   existingEntries?: Record<string, StateEntry>;
 }) {
-  const cmd: CmdControl = { items: [], exitCode: 0 };
+  const cmd: CmdControl = { items: [], exitCode: 0, stderr: "" };
   const processRunner = createMockProcessRunner({
-    onSpawn: () => ({ exitCode: cmd.exitCode, stdout: JSON.stringify(cmd.items) }),
+    onSpawn: () => ({
+      exitCode: cmd.exitCode,
+      stdout: JSON.stringify(cmd.items),
+      stderr: cmd.stderr,
+    }),
   });
+  const logger = createBehavioralLogger();
 
   const fsEntries: Record<string, ReturnType<typeof file> | ReturnType<typeof directory>> = {
     "/data": directory(),
@@ -225,7 +231,7 @@ function createSetup(options?: {
 
   const module = createAutoWorkspaceModule({
     fs,
-    logger: SILENT_LOGGER,
+    logger,
     legacyStateFilePath: "/data/auto-workspaces.json",
     dispatcher,
     processRunner,
@@ -234,7 +240,17 @@ function createSetup(options?: {
   });
   dispatcher.registerModule(module);
 
-  return { dispatcher, fs, state, cmd, mockConfig, openProjectOp, openWorkspaceOp, setMetaOp };
+  return {
+    dispatcher,
+    fs,
+    state,
+    cmd,
+    logger,
+    mockConfig,
+    openProjectOp,
+    openWorkspaceOp,
+    setMetaOp,
+  };
 }
 
 const startIntent = (): AppStartIntent => ({
@@ -342,6 +358,25 @@ describe("AutoWorkspaceModule Integration", () => {
     cmd.exitCode = 0; // cmd recovers
     await tick();
     expect(entriesOf(state)).toHaveProperty("gh/1");
+  });
+
+  it("keeps a failing cmd's stderr out of the warn line", async () => {
+    vi.useFakeTimers();
+    const { dispatcher, cmd, logger } = createSetup({ sources: sourceYaml() });
+    cmd.items = [{ id: "1" }];
+    cmd.exitCode = 1;
+    cmd.stderr = "401 Unauthorized: token perm-SECRET is expired";
+
+    await dispatcher.dispatch(startIntent());
+
+    // This line is emitted at the DEFAULT log level, so a cmd that echoes its
+    // own credentials on failure would leak them to every bug report without
+    // anyone enabling debug logging.
+    const warned = logger.getMessagesByLevel("warn");
+    const text = warned.map((m) => `${m.message} ${JSON.stringify(m.context ?? {})}`).join("\n");
+    expect(text).toContain("Source cmd failed");
+    expect(text).not.toContain("perm-SECRET");
+    expect(text).toContain("46 bytes of stderr");
   });
 
   it("picks up a newly added source without a restart (each cycle re-reads config)", async () => {

--- a/src/modules/auto-workspace/module.ts
+++ b/src/modules/auto-workspace/module.ts
@@ -362,7 +362,7 @@ export function createAutoWorkspaceModule(deps: AutoWorkspaceModuleDeps): Intent
   async function pollSource(source: ParsedSource): Promise<boolean> {
     let items: unknown[];
     try {
-      items = await runCmd({ processRunner: deps.processRunner }, source.cmd);
+      items = await runCmd({ processRunner: deps.processRunner }, source.name, source.cmd);
     } catch (error) {
       deps.logger.warn("Source cmd failed, skipping tick", {
         source: source.name,


### PR DESCRIPTION
A bug report attached 11.5 MB of log in which a live YouTrack permanent token appeared 165 times, uploaded to PostHog. The auto-workspace poller hands its user-authored `cmd` to `ProcessRunner` with `shell: true`, so the whole command line lands in `command` and every log site echoed it — including as a 411-byte prefix on every output line.

- **`ProcessOptions.redactBy`** marks a spawn untrusted and names what to print instead. `loggableCommand` is computed once in the constructor and the raw line is never stored on the instance, so a site that forgets to redact has nothing to leak. `args` and `spawnargs` are dropped with it — the latter re-embeds the line as `["/bin/sh", "-c", <line>]`.
- **Not a debug-only leak.** Three of the eight sites that print the command log at info/warn/error (`Killed`, `Spawn failed`), and `cmd-runner` kills on its 30s timeout — so a user who never touched `log.level` still wrote the full command line on any slow poll or missing binary. That is why the fix lives in the boundary rather than behind a level gate.
- **No pattern-matching fallback, deliberately.** A shape list would have to be complete to be worth trusting, and a false positive silently guts the one field `[process]` exists for — in a boundary whose argv is full of high-entropy non-secrets (git SHAs, hashed bundle paths, UUID temp dirs). The cost is stated on the option: a future caller with a credential in argv that omits `redactBy` leaks in full.
- **Volume.** Output payload was ~83% of the 3.41 MB, so dropping the command echo alone would have recovered ~16%. A redacted spawn now logs a byte count at debug and defers content to `silly`. Unflagged spawns are untouched — ide-server and the agent servers stream for hours, and counting their output would erase the field people reach for. The per-line prefix becomes the pid. Together: ~310 bytes per poll cycle against ~22 KB, turning the reported window into ~51 KB.
- **Second path closed.** `cmd-runner`'s failure message carried 500 bytes of stderr into a warn line at the default log level; a failing cmd can echo its own credentials in a 401 body. It now reports a byte count.
- **Tests.** The leak assertions run over every level and both message text and context values, so a future line added at warn fails the test rather than quietly reopening the hole.