### PR TITLE
fix: workspace deletion failing with the worktree locked on Windows

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -163,7 +163,7 @@ export async function expectNoNativeDialogs(driver: AppDriver): Promise<void> {
 }
 
 /** One entry of the app's JSONL log. */
-interface LogEntry {
+export interface LogEntry {
   readonly timestamp?: string;
   readonly level?: string;
   readonly scope?: string;
@@ -233,6 +233,18 @@ export function expectNoErrorLogs(): void {
     "the app logged error(s) in the main process — it kept running, but something it " +
       "depends on is broken"
   ).toEqual([]);
+}
+
+/**
+ * Every main-process log entry since this spec's launch.
+ *
+ * The app is a black box to a spec otherwise: assertions can see the UI and the
+ * filesystem, but not the order the dispatcher ran hook handlers in — and for
+ * teardown that ordering IS the behaviour under test, with the visible symptom
+ * (a worktree that will not delete) only reproducing on Windows.
+ */
+export function appLogEntries(): readonly LogEntry[] {
+  return mainProcessLog(launchedAt);
 }
 
 export interface AppHandle {

--- a/e2e/workspace-lifecycle.e2e.ts
+++ b/e2e/workspace-lifecycle.e2e.ts
@@ -6,6 +6,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createTestGitRepo } from "../src/utils/testing/test-utils";
 import {
+  appLogEntries,
   createWorkspace,
   expandSidebar,
   openProject,
@@ -70,4 +71,53 @@ test("removing a workspace deletes its git worktree", async () => {
   expect(existsSync(join(dir, "beta.code-workspace"))).toBe(false);
   // The survivor is untouched.
   expect(existsSync(join(dir, "alpha"))).toBe(true);
+});
+
+test("teardown stops the agent before releasing its IDE frame", async () => {
+  // Regression guard for a deletion that failed on Windows with the worktree
+  // locked. The frame was released on the first deletion-progress event, which
+  // is emitted BEFORE the shutdown hook point runs — so the iframe went away,
+  // the IDE client disconnected, the extension host was disposed, and the
+  // "terminal closed" that came out of that was read as "the agent exited".
+  // It had not: it kept running with the workspace as its CWD, and Windows
+  // refused to remove the directory.
+  //
+  // Asserted from the dispatcher's own log rather than the UI, because the
+  // ordering is the behaviour under test and it is invisible from outside. The
+  // visible symptom only reproduces on Windows; this ordering is wrong on every
+  // platform, so pin the ordering.
+  const shutdownHooks = appLogEntries().filter(
+    (entry) =>
+      entry.message === "hook" &&
+      entry.context?.["op"] === "delete-workspace" &&
+      entry.context?.["hook"] === "shutdown"
+  );
+
+  expect(
+    shutdownHooks.length,
+    "no delete-workspace shutdown hook ran — the earlier removal test should have produced one"
+  ).toBeGreaterThan(0);
+
+  for (const entry of shutdownHooks) {
+    // `modules` is the run order across capability waves, so this reads the
+    // actual sequence rather than mere registration.
+    const ran = String(entry.context?.["modules"] ?? "").split(",");
+    const stopsAgent = ran.indexOf("plugin-server");
+    const releasesFrame = ran.indexOf("presentation");
+
+    expect(
+      stopsAgent,
+      `plugin-server did not run in the shutdown hook: ${ran.join(",")}`
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      releasesFrame,
+      `presentation did not run in the shutdown hook: ${ran.join(",")}. Its handler is what ` +
+        `releases the IDE frame; if it is missing, the frame is being released somewhere ` +
+        `ungated again.`
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      releasesFrame,
+      `the IDE frame was released before the agent was stopped (order: ${ran.join(",")})`
+    ).toBeGreaterThan(stopsAgent);
+  }
 });

--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -212,17 +212,35 @@ function setupTerminalCloseListener(): void {
   });
 }
 
-/** Timeout for graceful agent close in milliseconds */
-const AGENT_CLOSE_TIMEOUT_MS = 3000;
-
 /** Interval between Ctrl+C signals in milliseconds */
 const AGENT_CLOSE_SIGNAL_INTERVAL_MS = 500;
 
 /**
- * Close the agent terminal gracefully.
- * Sends repeated Ctrl+C signals to exit Claude Code, waits up to 3 seconds
- * for the terminal to close naturally (triggering WrapperEnd hook → gray status),
- * then force-disposes if still open.
+ * How long to keep signalling before giving up (ms).
+ *
+ * This bounds the Ctrl+C loop only — it does NOT dispose the terminal. An agent
+ * that has ignored ~12 signals is not going to take the next one, and the main
+ * process has its own, longer bound after which it falls back to process
+ * cleanup.
+ */
+const AGENT_CLOSE_SIGNAL_DEADLINE_MS = 6000;
+
+/**
+ * Ask the agent to exit by sending Ctrl+C until its terminal closes.
+ *
+ * Claude Code needs two Ctrl+C in succession (the first interrupts, the second
+ * exits), which is why this repeats rather than signalling once.
+ *
+ * There is deliberately NO force-dispose on a timeout. Disposing the terminal
+ * does not stop the agent: with VS Code's persistent terminal sessions the pty
+ * — and the whole tree below it, shell, agent CLI, and the MCP servers the
+ * agent spawned — keeps running, now detached, with the workspace as its CWD.
+ * All a dispose achieves is firing onDidCloseTerminal, which the main process
+ * reads as "the agent exited" and proceeds to remove a worktree the agent is
+ * still sitting in. Reporting a close we cannot back up is worse than not
+ * reporting one: the caller has its own bound (plugin-server-module's
+ * AGENT_CLOSE_TIMEOUT_MS) and can fall back to process cleanup, which it cannot
+ * do if we tell it everything is fine.
  *
  * Returns whether there was a terminal to close. Closing itself is
  * asynchronous — completion is reported to the main process by the
@@ -235,24 +253,28 @@ function closeAgentTerminal(): boolean {
 
   const terminal = agentTerminal;
 
-  // Send Ctrl+C repeatedly until terminal closes or timeout
+  // Send Ctrl+C repeatedly until the terminal closes on its own.
   terminal.sendText("\x03", false);
   const signalInterval = setInterval(() => {
     terminal.sendText("\x03", false);
   }, AGENT_CLOSE_SIGNAL_INTERVAL_MS);
 
-  // Wait for natural close, force-dispose on timeout
-  const timeout = setTimeout(() => {
+  const stopSignalling = (): void => {
     clearInterval(signalInterval);
+    clearTimeout(deadline);
     disposable.dispose();
-    terminal.dispose();
-  }, AGENT_CLOSE_TIMEOUT_MS);
+  };
+
+  // Give up signalling — but leave the terminal alone. See the note above on
+  // why a force-dispose here would be actively harmful.
+  const deadline = setTimeout(() => {
+    stopSignalling();
+    codehydraApi.log.debug("Agent did not exit; stopped signalling (terminal left running)");
+  }, AGENT_CLOSE_SIGNAL_DEADLINE_MS);
 
   const disposable = vscode.window.onDidCloseTerminal((closed) => {
     if (closed === terminal) {
-      clearInterval(signalInterval);
-      clearTimeout(timeout);
-      disposable.dispose();
+      stopSignalling();
     }
   });
 

--- a/resources/scripts/blocking-processes.ps1
+++ b/resources/scripts/blocking-processes.ps1
@@ -1,19 +1,22 @@
-# Unified script for detecting blocking processes and closing handles
+# Detect processes that would block removal of a directory.
 # Usage:
 #   blocking-processes.ps1 -BasePath "C:\path\to\dir" -Action Detect
-#   blocking-processes.ps1 -BasePath "C:\path\to\dir" -Action CloseHandles
+#   blocking-processes.ps1 -BasePath "C:\path\to\dir" -Action DetectCwd
 #
 # Output: JSON object with structure:
-#   -Action Detect: {"blocking": [...]}
-#   -Action CloseHandles: {"blocking": [...], "closed": [...]}
+#   {"blocking": [...]}
 #   Error: {"error": "message"}
+#
+# -Action Detect    full scan: Restart Manager file handles + CWD
+# -Action DetectCwd CWD only. Runs BEFORE a removal is attempted, so it is on
+#                   the critical path and deliberately does less work.
 
 param(
     [Parameter(Mandatory=$true)]
     [string]$BasePath,
     
     [Parameter(Mandatory=$true)]
-    [ValidateSet('Detect', 'DetectCwd', 'CloseHandles')]
+    [ValidateSet('Detect', 'DetectCwd')]
     [string]$Action
 )
 
@@ -26,51 +29,6 @@ function Write-JsonError {
 }
 
 # Note: ValidateSet already ensures exactly one valid mode is specified
-
-# For CloseHandles mode, check if we need elevation
-if ($Action -eq 'CloseHandles') {
-    # Use the enum instead of string 'Administrator' for reliability
-    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    
-    if (-not $isAdmin) {
-        # Create temp file for output from elevated process
-        # Note: Cannot use -RedirectStandardOutput with -Verb RunAs, so the elevated
-        # script writes to a temp file that we pass as a parameter
-        $outputFile = [System.IO.Path]::GetTempFileName()
-        
-        try {
-            # Escape paths for command line
-            $escapedScript = $MyInvocation.MyCommand.Path -replace "'", "''"
-            $escapedBasePath = $BasePath -replace "'", "''"
-            $escapedOutputFile = $outputFile -replace "'", "''"
-            
-            # Wrap in a command that redirects output to file
-            $wrappedCommand = "& '$escapedScript' -BasePath '$escapedBasePath' -Action CloseHandles | Out-File -FilePath '$escapedOutputFile' -Encoding UTF8"
-            
-            $process = Start-Process powershell -Verb RunAs -WindowStyle Hidden -Wait -PassThru -ArgumentList @(
-                '-NoProfile',
-                '-NonInteractive',
-                '-ExecutionPolicy', 'Bypass',
-                '-Command', $wrappedCommand
-            )
-            
-            # Read output from elevated process
-            if (Test-Path $outputFile) {
-                Get-Content $outputFile -Raw
-                Remove-Item $outputFile -Force -ErrorAction SilentlyContinue
-            }
-            exit $process.ExitCode
-        } catch {
-            Remove-Item $outputFile -Force -ErrorAction SilentlyContinue
-            if ($_.Exception.Message -match 'canceled by the user') {
-                Write-JsonError "UAC cancelled by user"
-                exit 1
-            }
-            Write-JsonError $_.Exception.Message
-            exit 1
-        }
-    }
-}
 
 try {
     Add-Type -TypeDefinition @'
@@ -196,7 +154,6 @@ public class BlockingProcessDetector {
     private const int PROCESS_QUERY_INFORMATION = 0x0400;
     private const int PROCESS_VM_READ = 0x0010;
     private const int PROCESS_DUP_HANDLE = 0x0040;
-    private const int DUPLICATE_CLOSE_SOURCE = 0x1;
     private const int STATUS_INFO_LENGTH_MISMATCH = unchecked((int)0xC0000004);
 
     // =============================================================================
@@ -592,35 +549,6 @@ public class BlockingProcessDetector {
         return handles;
     }
 
-    // =============================================================================
-    // Handle Closing
-    // =============================================================================
-
-    public static List<string> CloseFileHandles(List<HandleInfo> handles) {
-        var closed = new List<string>();
-        var processHandles = new Dictionary<int, IntPtr>();
-
-        foreach (var handle in handles) {
-            IntPtr processHandle;
-            if (!processHandles.TryGetValue(handle.ProcessId, out processHandle)) {
-                processHandle = OpenProcess(PROCESS_DUP_HANDLE, false, handle.ProcessId);
-                processHandles[handle.ProcessId] = processHandle;
-            }
-
-            if (processHandle == IntPtr.Zero) continue;
-
-            IntPtr dummy;
-            if (DuplicateHandle(processHandle, (IntPtr)handle.Handle, IntPtr.Zero, out dummy, 0, false, DUPLICATE_CLOSE_SOURCE)) {
-                closed.Add(handle.DosPath);
-            }
-        }
-
-        foreach (var h in processHandles.Values) {
-            if (h != IntPtr.Zero) CloseHandle(h);
-        }
-
-        return closed;
-    }
 }
 '@ -ErrorAction SilentlyContinue
 
@@ -690,13 +618,7 @@ public class BlockingProcessDetector {
     }
 
     if ($blockingProcesses.Count -eq 0) {
-        $output = @{
-            blocking = @()
-        }
-        if ($Action -eq 'CloseHandles') {
-            $output.closed = @()
-        }
-        $output | ConvertTo-Json -Compress -Depth 4
+        @{ blocking = @() } | ConvertTo-Json -Compress -Depth 4
         exit 0
     }
 
@@ -747,13 +669,6 @@ public class BlockingProcessDetector {
         $proc.Files = $procFiles
     }
 
-    # Step 4: For CloseHandles mode, close the handles
-    $closedPaths = @()
-    if ($Action -eq 'CloseHandles') {
-        $closedList = [BlockingProcessDetector]::CloseFileHandles($fileHandles)
-        $closedPaths = @($closedList)
-    }
-
     # Build output
     $blocking = @()
     foreach ($proc in $blockingProcesses) {
@@ -766,14 +681,7 @@ public class BlockingProcessDetector {
         }
     }
 
-    $output = @{
-        blocking = $blocking
-    }
-    if ($Action -eq 'CloseHandles') {
-        $output.closed = $closedPaths
-    }
-
-    $output | ConvertTo-Json -Compress -Depth 4
+    @{ blocking = $blocking } | ConvertTo-Json -Compress -Depth 4
     exit 0
 
 } catch {

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -638,6 +638,13 @@ export class GitWorktreeProvider {
           path: workspacePath.toString(),
           error: getErrorMessage(error),
         });
+        // Time the fallback. `fs.rm`'s internal retries are invisible from
+        // here — a removal rescued on the third attempt looks exactly like one
+        // that succeeded immediately — so the only signal that a holder let go
+        // late (rather than never having been there) is how long this took.
+        // Without it, "should the retry budget go up or down?" is unanswerable
+        // from a bug report, which is precisely where that question lands.
+        const rmStart = Date.now();
         try {
           await this.fileSystemLayer.rm(workspacePath, {
             recursive: true,
@@ -647,7 +654,10 @@ export class GitWorktreeProvider {
             timeout: GitWorktreeProvider.RM_FALLBACK_TIMEOUT_MS,
           });
           await this.gitClient.pruneWorktrees(projectRoot);
-          this.logger.info("Removed workspace via fallback", { path: workspacePath.toString() });
+          this.logger.info("Removed workspace via fallback", {
+            path: workspacePath.toString(),
+            elapsedMs: Date.now() - rmStart,
+          });
         } catch (fallbackError) {
           // Log BOTH failures. Reports of this only ever carried the git error,
           // which names the directory but never says what was holding it; the
@@ -658,6 +668,7 @@ export class GitWorktreeProvider {
           this.logger.warn("Recursive rm fallback failed too", {
             path: workspacePath.toString(),
             error: getErrorMessage(fallbackError),
+            elapsedMs: Date.now() - rmStart,
           });
           worktreeError = error as Error;
         }

--- a/src/boundaries/platform/process.boundary.test.ts
+++ b/src/boundaries/platform/process.boundary.test.ts
@@ -265,6 +265,58 @@ describe("ExecaProcessRunner", () => {
     );
   });
 
+  describe("kill(pid) — processes we did not spawn", () => {
+    // The blocking processes this exists for are found by a scan, so there is
+    // no handle for them. Same contract as the handle method, keyed by PID.
+
+    it(
+      "terminates a foreign PID and only returns once it is gone",
+      async () => {
+        // Spawned through the runner for cleanup, then killed BY PID as if we
+        // had merely discovered it — which is the case under test.
+        const proc = spawnLongRunning(runner, 30_000);
+        runningProcesses.push(proc);
+        trackProcess(proc);
+        const pid = proc.pid!;
+        expect(isProcessRunning(pid)).toBe(true);
+
+        const result = await runner.kill(pid, 1000, 1000);
+
+        expect(result.success).toBe(true);
+        // No settling delay: the point of this method over a bare taskkill is
+        // that it does not return until the process is actually down. If this
+        // needs a sleep, callers that remove a directory next will race it.
+        expect(isProcessRunning(pid)).toBe(false);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      "reports success for a PID that is already gone",
+      async () => {
+        const proc = spawnLongRunning(runner, 30_000);
+        runningProcesses.push(proc);
+        const pid = proc.pid!;
+        await proc.kill(1000, 1000);
+        expect(await waitForProcessDeath(pid, 1000)).toBe(true);
+
+        // A scan's results are stale by the time they are used, so "it exited
+        // between the scan and the kill" is the common case, not an error.
+        const result = await runner.kill(pid, 1000, 1000);
+
+        expect(result.success).toBe(true);
+      },
+      TEST_TIMEOUT
+    );
+
+    // Tree semantics are deliberately not re-tested here: kill(pid) and the
+    // handle's kill() both delegate to the same killProcessTree, which the
+    // "Windows kill() with process tree" case below already exercises. A second
+    // copy would have to kill the parent before it could read the child PID off
+    // stdout, which is exactly the kind of ordering-dependent test that earns
+    // its flakiness.
+  });
+
   describe("kill() behavior", () => {
     // Windows-specific test: kill always uses forceful termination
     it.skipIf(!isWindows)(

--- a/src/boundaries/platform/process.state-mock.ts
+++ b/src/boundaries/platform/process.state-mock.ts
@@ -69,6 +69,9 @@ export interface ProcessRunnerMockState extends MockState {
    * @throws Error if no match found
    */
   spawned(filter: { command: string }): MockSpawnedProcess;
+
+  /** PIDs passed to `kill(pid, …)`, in call order. */
+  readonly killedPids: readonly number[];
 }
 
 /**
@@ -188,13 +191,22 @@ class MockSpawnedProcessImpl implements MockSpawnedProcess {
  */
 class ProcessRunnerMockStateImpl implements ProcessRunnerMockState {
   private readonly processes: MockSpawnedProcess[] = [];
+  private readonly killed: number[] = [];
 
   get spawnedCount(): number {
     return this.processes.length;
   }
 
+  get killedPids(): readonly number[] {
+    return this.killed;
+  }
+
   addProcess(process: MockSpawnedProcess): void {
     this.processes.push(process);
+  }
+
+  addKilledPid(pid: number): void {
+    this.killed.push(pid);
   }
 
   spawned(indexOrFilter: number | { command: string }): MockSpawnedProcess {
@@ -251,6 +263,7 @@ class MockProcessRunnerImpl implements MockProcessRunner {
   private readonly defaultResult: ProcessResult;
   private readonly defaultKillResult: KillResult;
   private readonly onSpawn: OnSpawnCallback | undefined;
+  private readonly onKill: ((pid: number) => KillResult | void) | undefined;
 
   constructor(options?: MockProcessRunnerOptions) {
     this.defaultResult = {
@@ -263,6 +276,12 @@ class MockProcessRunnerImpl implements MockProcessRunner {
       reason: "SIGTERM",
     };
     this.onSpawn = options?.onSpawn;
+    this.onKill = options?.onKill;
+  }
+
+  async kill(pid: number, _termTimeout?: number, _killTimeout?: number): Promise<KillResult> {
+    this.state.addKilledPid(pid);
+    return this.onKill?.(pid) ?? this.defaultKillResult;
   }
 
   get $(): ProcessRunnerMockState {
@@ -353,6 +372,13 @@ export interface MockProcessRunnerOptions {
    * When this returns void or undefined, defaultResult is used.
    */
   onSpawn?: OnSpawnCallback;
+
+  /**
+   * Called when kill(pid, …) is invoked on a process we did not spawn.
+   * Return an override to model a process that refuses to die; returning void
+   * or undefined means it terminated.
+   */
+  onKill?: (pid: number) => KillResult | void;
 }
 
 /**

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -155,6 +155,29 @@ export interface ProcessRunner {
    * }
    */
   run(command: string, args: readonly string[], options?: ProcessOptions): SpawnedProcess;
+
+  /**
+   * Terminate a process we did NOT spawn, and wait for it to actually be gone.
+   *
+   * Same contract as `SpawnedProcess.kill` — SIGTERM → wait → SIGKILL → wait,
+   * children included, `{success: false}` when it is still running — but keyed
+   * by PID, because a blocking process discovered by a scan has no handle here.
+   *
+   * The waiting is the point. `taskkill` (and `process.kill`) return once the
+   * request has been made, not once the target is down, so a caller that only
+   * checks the kill command's exit status learns that it was *invoked*, not
+   * that anything died. Acting on that — attempting a directory removal
+   * immediately afterwards, say — races the teardown it just asked for.
+   *
+   * Caveat: process exit is observable, handle release is not. A `{success:
+   * true}` here means the process is gone, not that the OS has finished
+   * releasing what it held.
+   *
+   * @param pid - Process ID to terminate.
+   * @param termTimeout - Wait after SIGTERM (ms). undefined = skip to SIGKILL.
+   * @param killTimeout - Wait after SIGKILL (ms). undefined = return immediately.
+   */
+  kill(pid: number, termTimeout?: number, killTimeout?: number): Promise<KillResult>;
 }
 
 /**
@@ -166,6 +189,95 @@ type ExecaSubprocess = ReturnType<typeof execa>;
  * Symbol used to indicate timeout in Promise.race.
  */
 const TIMEOUT_SYMBOL = Symbol("timeout");
+
+/**
+ * Kill a process and its children using platform-appropriate method.
+ * - Windows: taskkill /pid <pid> /t /f for native tree killing
+ *   (Always uses /f because WM_CLOSE cannot signal console processes)
+ * - Unix: pkill -P to kill children, then process.kill for parent
+ *
+ * Works on any PID, not just one we spawned — the tree-kill mechanics are
+ * identical either way, and `ProcessRunner.kill` needs them for foreign PIDs.
+ *
+ * @param pid - Process ID to kill
+ * @param force - If true, use SIGKILL (Unix only). On Windows, always forceful.
+ */
+async function killProcessTree(pid: number, force: boolean): Promise<void> {
+  if (isWindows) {
+    // Windows: Always use /f because WM_CLOSE (sent by taskkill without /f)
+    // is ignored by console applications. We can't send CTRL_C_EVENT to
+    // detached processes, so forceful termination is our only option.
+    // The `force` parameter is ignored on Windows - always forceful.
+    const args = ["/pid", String(pid), "/t", "/f"];
+    try {
+      await execa("taskkill", args);
+    } catch {
+      // Process may have already exited, or taskkill failed
+      // (e.g., access denied, process not found)
+    }
+  } else {
+    // Unix: kill children first with pkill -P, then kill parent
+    const signal = force ? "SIGKILL" : "SIGTERM";
+
+    // Kill all child processes by parent PID.
+    // The signal must come first: BSD pkill (macOS) only accepts a signal as
+    // its first argument and rejects it anywhere else as an invalid option.
+    try {
+      await execa("pkill", [force ? "-9" : "-15", "-P", String(pid)]);
+    } catch {
+      // pkill returns non-zero if no processes matched - that's fine
+    }
+
+    // Kill the parent process
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Process may have already exited (ESRCH)
+    }
+  }
+}
+
+/** Interval between liveness probes while waiting for a foreign PID to exit. */
+const PID_EXIT_POLL_INTERVAL_MS = 50;
+
+/**
+ * Whether a process with this PID currently exists.
+ *
+ * Signal 0 performs the permission and existence checks without delivering a
+ * signal. ESRCH means gone; EPERM means it exists but belongs to someone else,
+ * which for our purposes is still "alive".
+ */
+function pidExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Wait for a foreign PID to disappear, up to `timeout` ms.
+ *
+ * Polls rather than waiting on a handle: we did not spawn this process, so
+ * there is no child handle to await. Returns true if it is gone.
+ *
+ * Note this observes process *exit*, which is not the same as the OS having
+ * released the file handles it held — termination is asynchronous with respect
+ * to teardown. It is still strictly better than the alternative of assuming a
+ * kill landed because the kill *command* exited.
+ */
+async function waitForPidExit(pid: number, timeout: number): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (!pidExists(pid)) return true;
+    if (Date.now() >= deadline) return false;
+    const remaining = deadline - Date.now();
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(PID_EXIT_POLL_INTERVAL_MS, remaining))
+    );
+  }
+}
 
 /**
  * SpawnedProcess implementation wrapping an execa subprocess.
@@ -253,48 +365,8 @@ class ExecaSpawnedProcess implements SpawnedProcess {
     return { success: false };
   }
 
-  /**
-   * Kill a process and its children using platform-appropriate method.
-   * - Windows: taskkill /pid <pid> /t /f for native tree killing
-   *   (Always uses /f because WM_CLOSE cannot signal console processes)
-   * - Unix: pkill -P to kill children, then process.kill for parent
-   *
-   * @param pid - Process ID to kill
-   * @param force - If true, use SIGKILL (Unix only). On Windows, always forceful.
-   */
   private async killProcess(pid: number, force: boolean): Promise<void> {
-    if (isWindows) {
-      // Windows: Always use /f because WM_CLOSE (sent by taskkill without /f)
-      // is ignored by console applications. We can't send CTRL_C_EVENT to
-      // detached processes, so forceful termination is our only option.
-      // The `force` parameter is ignored on Windows - always forceful.
-      const args = ["/pid", String(pid), "/t", "/f"];
-      try {
-        await execa("taskkill", args);
-      } catch {
-        // Process may have already exited, or taskkill failed
-        // (e.g., access denied, process not found)
-      }
-    } else {
-      // Unix: kill children first with pkill -P, then kill parent
-      const signal = force ? "SIGKILL" : "SIGTERM";
-
-      // Kill all child processes by parent PID.
-      // The signal must come first: BSD pkill (macOS) only accepts a signal as
-      // its first argument and rejects it anywhere else as an invalid option.
-      try {
-        await execa("pkill", [force ? "-9" : "-15", "-P", String(pid)]);
-      } catch {
-        // pkill returns non-zero if no processes matched - that's fine
-      }
-
-      // Kill the parent process
-      try {
-        process.kill(pid, signal);
-      } catch {
-        // Process may have already exited (ESRCH)
-      }
-    }
+    return killProcessTree(pid, force);
   }
 
   async wait(timeout?: number): Promise<ProcessResult> {
@@ -559,5 +631,45 @@ export class ExecaProcessRunner implements ProcessRunner {
     }
 
     return spawned;
+  }
+
+  async kill(pid: number, termTimeout?: number, killTimeout?: number): Promise<KillResult> {
+    // Already gone: nothing to do, and reporting success keeps callers from
+    // treating a race (it exited between the scan and the kill) as a failure.
+    if (!pidExists(pid)) {
+      return { success: true, reason: "SIGTERM" };
+    }
+
+    if (isWindows) {
+      // Windows has no graceful phase for console processes — see killProcessTree.
+      await killProcessTree(pid, true);
+      this.logger.warn("Killed foreign process", { pid, signal: "TASKKILL" });
+
+      const timeout = (termTimeout ?? 0) + (killTimeout ?? 0);
+      if (timeout > 0 && (await waitForPidExit(pid, timeout))) {
+        return { success: true, reason: "SIGKILL" };
+      }
+      if (timeout === 0) return { success: false };
+
+      this.logger.warn("Foreign process survived termination", { pid, timeout });
+      return { success: false };
+    }
+
+    await killProcessTree(pid, false);
+    this.logger.info("Killed foreign process", { pid, signal: "SIGTERM" });
+    if (termTimeout !== undefined && (await waitForPidExit(pid, termTimeout))) {
+      return { success: true, reason: "SIGTERM" };
+    }
+
+    await killProcessTree(pid, true);
+    this.logger.warn("Killed foreign process", { pid, signal: "SIGKILL" });
+    if (killTimeout !== undefined && (await waitForPidExit(pid, killTimeout))) {
+      return { success: true, reason: "SIGKILL" };
+    }
+
+    if (killTimeout !== undefined) {
+      this.logger.warn("Foreign process survived termination", { pid, timeout: killTimeout });
+    }
+    return { success: false };
   }
 }

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -759,8 +759,16 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
 
     // Delete operation (always present, runs before detect/flush in pipeline)
     const deleteStatus = this.hookPointStatus(state.del);
-    const deleteError =
-      state.del && state.del.errors.length > 0 ? state.del.errors.join("; ") : undefined;
+    // A release failure ("could not kill PID 1234") is reported alongside the
+    // removal error rather than on its own row: it is only ever an explanation
+    // for why the removal failed. On a successful removal it is noise — the
+    // process we could not kill evidently wasn't holding anything — so it is
+    // folded in only when there is a delete error to explain.
+    const deleteErrors = [
+      ...(state.del?.errors ?? []),
+      ...(state.del && state.del.errors.length > 0 ? (state.release?.errors ?? []) : []),
+    ];
+    const deleteError = deleteErrors.length > 0 ? deleteErrors.join("; ") : undefined;
 
     operations.push({
       id: "cleanup-workspace",
@@ -772,12 +780,22 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
     // Detection operation (from detect hook, shown after delete failure)
     if (state.detect?.blockingProcesses !== undefined) {
       const blockersFound = state.detect.blockingProcesses.length > 0;
+      // A detect handler that could not determine the answer reports it here.
+      // Without this, an empty list from a scan that timed out is rendered as a
+      // clean "done" — telling the user nothing is blocking the very removal
+      // that just refused to proceed. "We don't know" is the honest state, and
+      // it is the one that makes a retry worth attempting.
+      const detectError =
+        state.detect.errors.length > 0 ? state.detect.errors.join("; ") : undefined;
+      const status = blockersFound || detectError ? "error" : "done";
       operations.push({
         id: "detecting-blockers",
         label: "Detecting blocking processes...",
-        status: applyCurrentStep("detecting-blockers", blockersFound ? "error" : "done"),
-        ...(blockersFound && {
-          error: `Blocked by ${state.detect.blockingProcesses.length} process(es)`,
+        status: applyCurrentStep("detecting-blockers", status),
+        ...((blockersFound || detectError) && {
+          error: blockersFound
+            ? `Blocked by ${state.detect.blockingProcesses.length} process(es)`
+            : detectError,
         }),
       });
     } else if (currentStep === "detecting-blockers") {

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -24,7 +24,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 
 import type { IntentModule } from "../intents/lib/module";
-import type { HookOutput } from "../intents/lib/operation";
+import type { HookContext, HookOutput } from "../intents/lib/operation";
 import type { Dispatcher } from "../intents/lib/dispatcher";
 import type { DomainEvent } from "../intents/lib/types";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
@@ -55,10 +55,12 @@ import type { WakeWorkspaceIntent } from "../intents/wake-workspace";
 import { INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import type { OpenWorkspaceIntent } from "../intents/open-workspace";
 import {
+  DELETE_WORKSPACE_OPERATION_ID,
   INTENT_DELETE_WORKSPACE,
   EVENT_WORKSPACE_DELETION_PROGRESS,
 } from "../intents/delete-workspace";
 import type {
+  DeletePipelineHookInput,
   DeleteWorkspaceIntent,
   WorkspaceDeletionProgressEvent,
 } from "../intents/delete-workspace";
@@ -200,6 +202,22 @@ export class McpServer {
 
   /** Per-client MCP sessions, keyed by MCP session ID. */
   private sessions = new Map<string, McpSession>();
+
+  /**
+   * How many MCP sessions are currently open for a workspace.
+   *
+   * The client on the other end of an MCP session is the agent process itself,
+   * so a session that is still open during a teardown means the agent is still
+   * alive — the exact fact that is otherwise unobservable at that point, and the
+   * one that decides whether a worktree removal is about to fail.
+   */
+  sessionCountFor(workspacePath: string): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      if (session.workspacePath === workspacePath) count++;
+    }
+    return count;
+  }
 
   /**
    * Resolvers awaiting a terminal deletion-progress event, keyed by workspace
@@ -1162,6 +1180,11 @@ export class McpServerManager implements IDisposable {
   private mcpServer: McpServer | null = null;
   private port: number | null = null;
 
+  /** @see McpServer.sessionCountFor */
+  sessionCountFor(workspacePath: string): number {
+    return this.mcpServer?.sessionCountFor(workspacePath) ?? 0;
+  }
+
   constructor(
     portManager: PortManager,
     dispatcher: Dispatcher,
@@ -1260,6 +1283,30 @@ export function createMcpModule(deps: McpModuleDeps): IntentModule {
           handler: async (): Promise<HookOutput> => {
             const mcpPort = await mcpServerManager.start();
             return { provides: { mcpPort } };
+          },
+        },
+      },
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        // Diagnostics only — never fails, never blocks, returns nothing.
+        //
+        // The MCP client for a workspace is the agent process itself, so a
+        // session still open here means the agent outlived the teardown that
+        // was supposed to stop it, and is sitting in the directory we are about
+        // to remove. That is the single fact that explains most "deletion
+        // failed, nothing appears to be blocking it" reports, and until now the
+        // only way to recover it from a log was to notice a stray
+        // `Routing to session` line minutes later and correlate it by hand.
+        delete: {
+          handler: async (ctx: HookContext): Promise<HookOutput> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
+            const sessions = mcpServerManager.sessionCountFor(workspacePath);
+            if (sessions > 0) {
+              deps.logger?.warn("Workspace still has live MCP sessions at removal time", {
+                workspacePath,
+                sessions,
+              });
+            }
+            return {};
           },
         },
       },

--- a/src/modules/plugin-server-module.ts
+++ b/src/modules/plugin-server-module.ts
@@ -1074,6 +1074,18 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
             const normalized = workspacePathSchema.parse(new Path(wsPath).toString());
 
             closingWorkspaces.add(normalized);
+            // "agent-stopped" is provided on EVERY path — including the early
+            // returns inside closeAgentTerminal (no sidekick socket, no terminal
+            // to close), a close that timed out, and a thrown error. It does not
+            // claim the agent died; it means "we are done trying".
+            //
+            // It must be unconditional because handlers gated on it (the
+            // presenter's IDE-frame release) have to run for a workspace with no
+            // sidekick too. A throwing handler never merges its `provides`
+            // (dispatcher.ts) and its dependents are then skipped, so anything
+            // conditional here would strand the frame mounted — which is exactly
+            // the state that lets the agent survive the worktree removal.
+            let error: string | undefined;
             try {
               // Drop the config first. From here on a connecting sidekick gets
               // `env: null, agentType: null` and arms nothing — this, not the
@@ -1092,11 +1104,19 @@ export function createPluginServerModule(deps: PluginServerModuleDeps): IntentMo
               await closeAgentTerminal(normalized);
 
               connections.get(normalized)?.disconnect(true);
+            } catch (err) {
+              // Reported as a result error rather than rethrown: the operation
+              // treats both the same way (mergeShutdown folds collect errors and
+              // result errors together), but returning lets us still provide.
+              error = getErrorMessage(err);
             } finally {
               closingWorkspaces.delete(normalized);
             }
 
-            return { result: {} };
+            return {
+              result: error === undefined ? {} : { error },
+              provides: { "agent-stopped": true },
+            };
           },
         },
         delete: {

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -55,9 +55,12 @@ import {
 } from "../../intents/open-workspace";
 import type { Intent } from "../../intents/lib/types";
 import {
+  DELETE_WORKSPACE_OPERATION_ID,
   EVENT_WORKSPACE_DELETED,
   EVENT_WORKSPACE_DELETION_PROGRESS,
+  INTENT_DELETE_WORKSPACE,
 } from "../../intents/delete-workspace";
+import { ANY_VALUE } from "../../intents/lib/operation";
 import { EVENT_WORKSPACE_SWITCHED } from "../../intents/switch-workspace";
 import {
   HIBERNATE_WORKSPACE_OPERATION_ID,
@@ -793,16 +796,15 @@ describe("PresentationModule - ui:state snapshots", () => {
     expect(lastSnapshot(deps).sidebar.projects[0]!.workspaces).toEqual([]);
   });
 
-  it("unmounts the IDE frame as soon as a deletion starts", async () => {
+  it("keeps the IDE frame mounted until the agent has been stopped", async () => {
     const deps = createDeps();
     const module = await startModule(deps);
     const workspace = makeWorkspace("feat", { url: "http://127.0.0.1:1/feat" });
     await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
     await flush();
 
-    expect(lastSnapshot(deps).frames).toEqual({
-      [`${PROJECT_ID}/feat`]: "http://127.0.0.1:1/feat",
-    });
+    const frameKey = `${PROJECT_ID}/feat`;
+    expect(lastSnapshot(deps).frames).toEqual({ [frameKey]: "http://127.0.0.1:1/feat" });
 
     const progressBase = {
       workspacePath: workspace.path as WorkspacePath,
@@ -812,18 +814,40 @@ describe("PresentationModule - ui:state snapshots", () => {
       operations: [],
     };
 
+    // The pipeline emits its first progress event BEFORE the shutdown hook
+    // point runs. Unmounting here drops the iframe, which disconnects the IDE
+    // client and disposes the extension host — out from under the graceful
+    // agent exit still travelling over it. The agent then survives as an orphan
+    // holding the worktree, and removal fails. So the frame must stay.
     await emit(module, EVENT_WORKSPACE_DELETION_PROGRESS, {
       ...progressBase,
       completed: false,
       hasErrors: false,
     });
     await flush();
+    expect(lastSnapshot(deps).frames).toEqual({ [frameKey]: "http://127.0.0.1:1/feat" });
 
-    // A mounted frame keeps the IDE server holding the worktree — pty host,
-    // extension host, watchers — while we are trying to remove it.
+    // Only once the delete "shutdown" hook point has run — which the dispatcher
+    // defers until "agent-stopped" is provided — is the frame released.
+    await module.hooks![DELETE_WORKSPACE_OPERATION_ID]!["shutdown"]!.handler({
+      intent: {
+        type: INTENT_DELETE_WORKSPACE,
+        payload: {
+          workspacePath: workspace.path as WorkspacePath,
+          keepBranch: false,
+          force: false,
+          removeWorktree: true,
+        },
+      },
+      projectPath: PROJECT_PATH,
+      workspacePath: workspace.path as WorkspacePath,
+      workspaceName: workspace.name,
+      active: false,
+    } as never);
+    await flush();
     expect(lastSnapshot(deps).frames).toEqual({});
 
-    // And it stays unmounted after a failure, where workspace:deleted never
+    // And it stays released after a failure, where workspace:deleted never
     // arrives. The deletion panel covers the workspace area in its place.
     await emit(module, EVENT_WORKSPACE_DELETION_PROGRESS, {
       ...progressBase,
@@ -832,6 +856,15 @@ describe("PresentationModule - ui:state snapshots", () => {
     });
     await flush();
     expect(lastSnapshot(deps).frames).toEqual({});
+  });
+
+  it("gates the frame release on the agent-stopped capability", () => {
+    const module = createPresentationModule(createDeps());
+    const handler = module.hooks![DELETE_WORKSPACE_OPERATION_ID]!["shutdown"]!;
+
+    // Without this the handler runs in the first wave, i.e. before the agent has
+    // been asked to exit — which is the bug this whole hook exists to prevent.
+    expect(handler.requires).toEqual({ "agent-stopped": ANY_VALUE });
   });
 
   it("is the single source of deletion progress: full via accessor, render-ready on the row", async () => {

--- a/src/modules/presentation/presentation-module.ts
+++ b/src/modules/presentation/presentation-module.ts
@@ -84,10 +84,13 @@ import {
   type WorkspaceCreateFailedEvent,
 } from "../../intents/open-workspace";
 import {
+  DELETE_WORKSPACE_OPERATION_ID,
   EVENT_WORKSPACE_DELETED,
   EVENT_WORKSPACE_DELETION_PROGRESS,
   INTENT_DELETE_WORKSPACE,
+  type DeletePipelineHookInput,
   type DeleteWorkspaceIntent,
+  type ShutdownHookResult,
   type WorkspaceDeletedEvent,
   type WorkspaceDeletionProgressEvent,
 } from "../../intents/delete-workspace";
@@ -479,6 +482,17 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
    * render-ready row view omits (blocking-process pids, keepBranch).
    */
   const deletions = new Map<string, DeletionProgress>();
+  /**
+   * Workspaces whose IDE frame may be dropped from the `frames` region, keyed
+   * by workspace path.
+   *
+   * Populated by the delete "shutdown" handler below, which the dispatcher
+   * defers until the agent has been stopped. Deletion progress alone is NOT
+   * enough: the first progress event is emitted before the shutdown hook point
+   * runs, so unmounting on it tears down the IDE connection the graceful agent
+   * exit is still talking over.
+   */
+  const framesReleased = new Set<string>();
   /** Hibernation screenshot data URLs keyed by workspace key (null = missing). */
   const screenshots = new Map<string, string | null>();
   const screenshotLoads = new Set<string>();
@@ -1029,10 +1043,19 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       for (const workspace of project.workspaces.values()) {
         // A mounted frame is a live IDE client: the workspace stays open in the
         // IDE server, which keeps its pty host, extension host and file watchers
-        // holding the directory. Unmount as soon as a teardown starts, rather
-        // than on workspace:deleted — that only fires AFTER the worktree removal
-        // has already had to fight those handles (and never at all when the
-        // removal fails).
+        // holding the directory. Unmount during the teardown, rather than on
+        // workspace:deleted — that only fires AFTER the worktree removal has
+        // already had to fight those handles (and never at all when the removal
+        // fails).
+        //
+        // But NOT on deletion progress alone. The first progress event is
+        // emitted before the delete "shutdown" hook point runs, and unmounting
+        // there drops the iframe, which disconnects the IDE client and disposes
+        // the extension host — out from under the graceful agent exit that is
+        // still talking over it. The agent then survives as an orphan with the
+        // workspace as its CWD, and Windows refuses to remove the directory.
+        // So the release is gated on `framesReleased`, which the shutdown
+        // handler below fills once the agent has actually been stopped.
         //
         // Nothing is hidden by this. The pipeline switches away from the
         // workspace at the start, and if the user navigates back the deletion
@@ -1040,8 +1063,8 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
         // documented as rendering "over the already-torn-down frame". Dismissing
         // that panel dispatches a force delete, so an entry here can never
         // outlive the workspace.
-        const deleting = workspace.path !== null && deletions.has(workspace.path);
-        if (workspace.url !== undefined && !workspace.hibernated && !deleting) {
+        const released = workspace.path !== null && framesReleased.has(workspace.path);
+        if (workspace.url !== undefined && !workspace.hibernated && !released) {
           frames[workspaceKey(project.id, workspace.name)] = workspace.url;
         }
       }
@@ -1617,6 +1640,7 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
         const p = (event as WorkspaceDeletedEvent).payload;
         projects.get(p.projectId)?.workspaces.delete(p.workspaceName as string);
         deletions.delete(p.workspacePath);
+        framesReleased.delete(p.workspacePath);
         agentStatuses.delete(p.workspacePath);
         screenshots.delete(workspaceKey(p.projectId, p.workspaceName));
         scheduleUpdate();
@@ -1940,6 +1964,27 @@ export function createPresentationModule(deps: PresentationModuleDeps): UiPresen
       },
       [CLOSE_PROJECT_OPERATION_ID]: {
         confirm: { handler: confirmClose },
+      },
+      [DELETE_WORKSPACE_OPERATION_ID]: {
+        // Release the workspace's IDE frame — but only after the agent has been
+        // stopped. `requires` defers this to a later wave than the plugin-server
+        // handler that asks the agent to exit, so the iframe (and with it the
+        // IDE client connection the request travels over) survives until that
+        // has either succeeded or hit its own timeout.
+        //
+        // Dropping the frame earlier is what orphans the agent: the disconnect
+        // disposes the extension host, whose terminals then report "closed"
+        // while the pty — and the agent under it — keeps running with the
+        // workspace as its CWD, so the worktree removal cannot delete it.
+        shutdown: {
+          requires: { "agent-stopped": ANY_VALUE },
+          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
+            const { workspacePath } = ctx as DeletePipelineHookInput;
+            framesReleased.add(workspacePath);
+            scheduleUpdate();
+            return { result: {} };
+          },
+        },
       },
       [HIBERNATE_WORKSPACE_OPERATION_ID]: {
         // Collapse the sidebar out of the hibernation screenshot and restore it

--- a/src/modules/windows-file-lock-module.boundary.test.ts
+++ b/src/modules/windows-file-lock-module.boundary.test.ts
@@ -148,12 +148,13 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
         const { pid } = await spawnFileLockingProcess();
 
         // Detect blocking processes
-        const processes = await runDetectAction(
+        const { processes } = await runDetectAction(
           processRunner,
           scriptPath,
           new Path(tempDir),
           "Detect",
-          createMockLogger()
+          createMockLogger(),
+          TEST_TIMEOUT
         );
 
         // Verify the blocking process is detected
@@ -179,12 +180,13 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
         const { pid } = await spawnFileLockingProcess();
 
         // Detect blocking processes
-        const processes = await runDetectAction(
+        const { processes } = await runDetectAction(
           processRunner,
           scriptPath,
           new Path(tempDir),
           "Detect",
-          createMockLogger()
+          createMockLogger(),
+          TEST_TIMEOUT
         );
 
         // Find our process
@@ -202,12 +204,13 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
       "returns empty array when no processes are blocking",
       async () => {
         // No locking process, just query the empty temp dir
-        const processes = await runDetectAction(
+        const { processes } = await runDetectAction(
           processRunner,
           scriptPath,
           new Path(tempDir),
           "Detect",
-          createMockLogger()
+          createMockLogger(),
+          TEST_TIMEOUT
         );
 
         expect(processes).toEqual([]);
@@ -218,7 +221,7 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
 
   describe("killBlockingProcesses", () => {
     it(
-      "kills processes via taskkill",
+      "returns only once the process is actually gone",
       async () => {
         // Spawn a process that locks the file
         const { pid } = await spawnFileLockingProcess();
@@ -226,14 +229,15 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
         // Verify process is running
         expect(isProcessRunning(pid)).toBe(true);
 
-        // Kill the process
-        await killBlockingProcesses(processRunner, [pid], createMockLogger());
+        const survivors = await killBlockingProcesses(processRunner, [pid], createMockLogger());
 
-        // Give taskkill time to complete
-        await delay(500);
-
-        // Process should be dead now
+        // No settling delay here, deliberately. Termination is asynchronous, so
+        // this used to need one — which is the whole bug: the delete hook ran
+        // milliseconds after taskkill returned and raced the teardown it had
+        // just asked for. If this assertion needs a sleep to pass, the waiting
+        // is not working.
         expect(isProcessRunning(pid)).toBe(false);
+        expect(survivors).toEqual([]);
 
         // Clean up references since process is dead
         lockingProcess = null;
@@ -242,13 +246,18 @@ describe.skipIf(!isWindows)("WindowsFileLockModule functions (boundary)", () => 
       TEST_TIMEOUT
     );
 
+    // The "process refuses to die" path is covered in
+    // windows-file-lock-module.integration.test.ts via the mock's onKill. There
+    // is no safe way to construct a genuinely unkillable process here: PID 0 is
+    // the obvious candidate but `process.kill(0, …)` addresses the caller's own
+    // process group, which would take out the test runner.
+
     it(
       "succeeds when no PIDs are provided",
       async () => {
-        // Should not throw even with empty array
-        await expect(
-          killBlockingProcesses(processRunner, [], createMockLogger())
-        ).resolves.toBeUndefined();
+        await expect(killBlockingProcesses(processRunner, [], createMockLogger())).resolves.toEqual(
+          []
+        );
       },
       TEST_TIMEOUT
     );

--- a/src/modules/windows-file-lock-module.integration.test.ts
+++ b/src/modules/windows-file-lock-module.integration.test.ts
@@ -237,7 +237,8 @@ describe("WindowsFileLockModule Integration", () => {
               exitCode: 0,
             };
           }
-          // taskkill: success
+          // any later spawn (there should be none — the kill no longer shells
+          // out to taskkill from this module)
           return { exitCode: 0 };
         },
       });
@@ -252,10 +253,9 @@ describe("WindowsFileLockModule Integration", () => {
         expect.arrayContaining(["-Action", "DetectCwd", "-File", SCRIPT_PATH])
       );
 
-      // Verify kill was called
-      const killProc = runner.$.spawned(1);
-      expect(killProc.$.command).toBe("taskkill");
-      expect(killProc.$.args).toEqual(["/pid", "1234", "/t", "/f"]);
+      // The kill goes through the boundary now, which waits for the process to
+      // actually be gone rather than assuming a returning taskkill means dead.
+      expect(runner.$.killedPids).toEqual([1234]);
     });
 
     it("skips when force=true", async () => {
@@ -266,16 +266,44 @@ describe("WindowsFileLockModule Integration", () => {
       expect(() => runner.$.spawned(0)).toThrow();
     });
 
-    it("swallows errors from detection", async () => {
+    it("reports a timed-out scan instead of silently passing", async () => {
       runner = createMockProcessRunner({
         onSpawn: () => ({ exitCode: null, running: true }),
       });
 
       const dispatcher = createReleaseSetup(runner);
-      const result = await dispatcher.dispatch(makeDeleteIntent());
+      const result = (await dispatcher.dispatch(makeDeleteIntent())) as { error?: string };
 
-      // No error propagated
-      expect(result).toEqual({});
+      // Non-fatal — the removal is still attempted — but a scan that never
+      // finished must not look like a scan that found nothing. This used to be
+      // discarded by a bare catch, leaving the user with a failed deletion and
+      // a dialog claiming nothing was blocking.
+      expect(result.error).toContain("scan timed out");
+    });
+
+    it("reports processes it could not terminate", async () => {
+      let callIndex = 0;
+      runner = createMockProcessRunner({
+        onSpawn: () => {
+          callIndex++;
+          if (callIndex === 1) {
+            return {
+              stdout: createDetectJson([
+                { pid: 1234, name: "node.exe", commandLine: "node server.js", cwd: "." },
+              ]),
+              exitCode: 0,
+            };
+          }
+          return { exitCode: 0 };
+        },
+        onKill: () => ({ success: false }),
+      });
+
+      const dispatcher = createReleaseSetup(runner);
+      const result = (await dispatcher.dispatch(makeDeleteIntent())) as { error?: string };
+
+      expect(result.error).toContain("node.exe");
+      expect(result.error).toContain("1234");
     });
 
     it("skips kill when no processes detected", async () => {
@@ -286,9 +314,9 @@ describe("WindowsFileLockModule Integration", () => {
       const dispatcher = createReleaseSetup(runner);
       await dispatcher.dispatch(makeDeleteIntent());
 
-      // Only detection was spawned, no taskkill
+      // Only detection was spawned, and nothing was killed
       expect(runner.$.spawned(0).$.command).toBe("powershell");
-      expect(() => runner.$.spawned(1)).toThrow();
+      expect(runner.$.killedPids).toEqual([]);
     });
   });
 
@@ -330,7 +358,7 @@ describe("WindowsFileLockModule Integration", () => {
       expect(runner.$.spawned(0).$.args).toEqual(expect.arrayContaining(["-Action", "Detect"]));
     });
 
-    it("returns empty array on timeout", async () => {
+    it("reports 'could not determine' on timeout rather than a clean empty scan", async () => {
       runner = createMockProcessRunner({
         onSpawn: () => ({ exitCode: null, running: true }),
       });
@@ -340,7 +368,11 @@ describe("WindowsFileLockModule Integration", () => {
 
       const result = (await dispatcher.dispatch(makeDeleteIntent())) as DetectHookResult;
 
+      // Empty AND an error. Without the error the progress row renders as
+      // "Detecting blocking processes... done", telling the user nothing is
+      // blocking the removal that just refused to proceed.
       expect(result.blockingProcesses).toEqual([]);
+      expect(result.error).toContain("scan timed out");
       const warnings = logger.getMessagesByLevel("warn");
       expect(warnings).toHaveLength(1);
       expect(warnings[0]!.message).toBe("Blocking process detection timed out");
@@ -360,26 +392,28 @@ describe("WindowsFileLockModule Integration", () => {
       const dispatcher = createFlushSetup(runner, [1234, 5678]);
       await dispatcher.dispatch(makeDeleteIntent());
 
-      expect(runner.$.spawned(0).$.command).toBe("taskkill");
-      expect(runner.$.spawned(0).$.args).toEqual(["/pid", "1234", "/pid", "5678", "/t", "/f"]);
+      expect(runner.$.killedPids).toEqual([1234, 5678]);
     });
 
-    it("returns error on failure", async () => {
+    it("names the PIDs that survived termination", async () => {
       runner = createMockProcessRunner({
-        onSpawn: () => ({ exitCode: 1, stderr: "access denied" }),
+        onKill: (pid) => (pid === 1234 ? { success: false } : undefined),
       });
 
-      const dispatcher = createFlushSetup(runner, [1234]);
+      const dispatcher = createFlushSetup(runner, [1234, 5678]);
       const result = (await dispatcher.dispatch(makeDeleteIntent())) as FlushHookResult;
 
-      expect(result.error).toContain("Failed to kill processes");
+      // The point of waiting: a process that ignored the kill is reportable,
+      // instead of the removal failing later with an unexplained EBUSY.
+      expect(result.error).toContain("1234");
+      expect(result.error).not.toContain("5678");
     });
 
     it("skips kill when blockingPids is empty", async () => {
       const dispatcher = createFlushSetup(runner, []);
       await dispatcher.dispatch(makeDeleteIntent());
 
-      // No processes spawned
+      expect(runner.$.killedPids).toEqual([]);
       expect(() => runner.$.spawned(0)).toThrow();
     });
   });
@@ -445,7 +479,7 @@ describe("WindowsFileLockModule Integration", () => {
       await dispatcher.dispatch(makeHibernateIntent());
 
       expect(runner.$.spawned(0).$.command).toBe("powershell");
-      expect(runner.$.spawned(1).$.command).toBe("taskkill");
+      expect(runner.$.killedPids).toEqual([1234]);
     });
 
     it("swallows errors from detection during hibernation", async () => {

--- a/src/modules/windows-file-lock-module.test.ts
+++ b/src/modules/windows-file-lock-module.test.ts
@@ -243,10 +243,12 @@ describe.skipIf(process.platform !== "win32")("runDetectAction", () => {
       SCRIPT_PATH,
       testPath,
       "Detect",
-      createMockLogger()
+      createMockLogger(),
+      8_000
     );
 
-    expect(result).toEqual([
+    expect(result.timedOut).toBe(false);
+    expect(result.processes).toEqual([
       {
         pid: 1234,
         name: "node.exe",
@@ -262,7 +264,7 @@ describe.skipIf(process.platform !== "win32")("runDetectAction", () => {
       defaultResult: { stdout: createDetectJson([]) },
     });
 
-    await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", createMockLogger());
+    await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", createMockLogger(), 8_000);
 
     expect(runner).toHaveSpawned([
       {
@@ -278,24 +280,28 @@ describe.skipIf(process.platform !== "win32")("runDetectAction", () => {
     });
     const logger = createMockLogger();
 
-    const result = await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", logger);
+    const result = await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", logger, 8_000);
 
-    expect(result).toEqual([]);
+    // A non-zero exit is a real answer ("the scan ran and failed"), not the
+    // same state as never finding out — only a timeout sets timedOut.
+    expect(result).toEqual({ processes: [], timedOut: false });
     expect(logger.warn).toHaveBeenCalledWith(
       "Blocking process detection failed",
       expect.objectContaining({ exitCode: 1, stderr: "PowerShell error" })
     );
   });
 
-  it("returns empty array and kills process on timeout", async () => {
+  it("reports timedOut (not a clean empty scan) and kills the process on timeout", async () => {
     const runner = createMockProcessRunner({
       onSpawn: () => ({ running: true, exitCode: null }),
     });
     const logger = createMockLogger();
 
-    const result = await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", logger);
+    const result = await runDetectAction(runner, SCRIPT_PATH, testPath, "Detect", logger, 8_000);
 
-    expect(result).toEqual([]);
+    // The distinction that matters: an empty list from a timed-out scan must
+    // NOT be reported as "nothing is blocking".
+    expect(result).toEqual({ processes: [], timedOut: true });
     expect(logger.warn).toHaveBeenCalledWith(
       "Blocking process detection timed out",
       expect.objectContaining({ path: testPath.toString() })

--- a/src/modules/windows-file-lock-module.test.ts
+++ b/src/modules/windows-file-lock-module.test.ts
@@ -221,14 +221,20 @@ describe("parseDetectOutput", () => {
 });
 
 // =============================================================================
-// runDetectAction (Windows-only: requires Path with Windows-style paths)
+// runDetectAction
 // =============================================================================
+//
+// The module only ever runs on Windows, but these tests drive a mock
+// ProcessRunner and assert on the action passed and the JSON parsed back — none
+// of which is platform-dependent. Gating them on win32 only meant every change
+// to this function went unverified on the machine making it, which is how a
+// signature change reached CI unnoticed. Use a path the host can represent and
+// let them run everywhere.
 
-describe.skipIf(process.platform !== "win32")("runDetectAction", () => {
-  let testPath: Path;
-  if (process.platform === "win32") {
-    testPath = new Path("C:\\workspace\\test");
-  }
+describe("runDetectAction", () => {
+  const testPath = new Path(
+    process.platform === "win32" ? "C:\\workspace\\test" : "/workspace/test"
+  );
 
   it("parses valid detect output", async () => {
     const output = createDetectJson([
@@ -311,46 +317,58 @@ describe.skipIf(process.platform !== "win32")("runDetectAction", () => {
 });
 
 // =============================================================================
-// killBlockingProcesses (Windows-only: uses taskkill)
+// killBlockingProcesses
 // =============================================================================
+//
+// Not platform-gated. These drive a mock ProcessRunner and never touch a path,
+// so there was never anything Windows-specific about them — but the gate made
+// them invisible on every other OS, which is how they went on asserting a
+// taskkill invocation that no longer happens.
 
-describe.skipIf(process.platform !== "win32")("killBlockingProcesses", () => {
-  it("calls taskkill with correct arguments for single PID", async () => {
+describe("killBlockingProcesses", () => {
+  it("terminates each PID through the boundary rather than shelling out", async () => {
     const runner = createMockProcessRunner();
 
-    await killBlockingProcesses(runner, [1234], createMockLogger());
+    const survivors = await killBlockingProcesses(runner, [1234], createMockLogger());
 
-    expect(runner).toHaveSpawned([{ command: "taskkill", args: ["/pid", "1234", "/t", "/f"] }]);
+    // ProcessRunner.kill waits for the process to actually be gone; a taskkill
+    // spawn would only tell us the request was made.
+    expect(runner.$.killedPids).toEqual([1234]);
+    expect(runner.$.spawnedCount).toBe(0);
+    expect(survivors).toEqual([]);
   });
 
-  it("batches multiple PIDs in single taskkill call", async () => {
+  it("terminates every PID it is given", async () => {
     const runner = createMockProcessRunner();
 
     await killBlockingProcesses(runner, [1234, 5678, 9012], createMockLogger());
 
-    expect(runner).toHaveSpawned([
-      {
-        command: "taskkill",
-        args: ["/pid", "1234", "/pid", "5678", "/pid", "9012", "/t", "/f"],
-      },
-    ]);
+    expect(runner.$.killedPids).toEqual([1234, 5678, 9012]);
   });
 
-  it("does not call taskkill when no PIDs provided", async () => {
+  it("does nothing when no PIDs provided", async () => {
     const runner = createMockProcessRunner();
 
     await killBlockingProcesses(runner, [], createMockLogger());
 
-    expect(runner).toHaveSpawned([]);
+    expect(runner.$.killedPids).toEqual([]);
+    expect(runner.$.spawnedCount).toBe(0);
   });
 
-  it("throws error when taskkill fails", async () => {
+  it("reports the PIDs that survived instead of throwing", async () => {
     const runner = createMockProcessRunner({
-      defaultResult: { exitCode: 1, stderr: "Access denied" },
+      onKill: (pid) => (pid === 1234 ? { success: false } : undefined),
     });
+    const logger = createMockLogger();
 
-    await expect(killBlockingProcesses(runner, [1234], createMockLogger())).rejects.toThrow(
-      "Failed to kill processes"
+    const survivors = await killBlockingProcesses(runner, [1234, 5678], logger);
+
+    // Returned, not thrown: one process refusing to die must not abort the
+    // cleanup of the others, and the caller needs the PID to name it to the user.
+    expect(survivors).toEqual([1234]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Blocking processes survived termination",
+      expect.objectContaining({ pids: "1234" })
     );
   });
 });

--- a/src/modules/windows-file-lock-module.ts
+++ b/src/modules/windows-file-lock-module.ts
@@ -15,11 +15,26 @@
  * - workspace-lifecycle-module claims the workspace, and the git and sidekick
  *   paths refuse to start new work in it,
  * - the plugin server asks the agent to exit and waits for it,
- * - the presenter unmounts the IDE frame so the IDE server lets go.
+ * - the presenter releases the IDE frame so the IDE server lets go — but only
+ *   AFTER the above, gated on the "agent-stopped" capability. Releasing it
+ *   earlier disconnects the IDE client out from under the agent exit, which
+ *   orphans the agent in the workspace and is what this module then cannot fix.
  *
  * What is left for this module is what none of that can reach: processes we do
  * not own — a user's own shell sitting in the workspace, an external editor,
- * antivirus, the search indexer. Keep it best-effort and keep it cheap.
+ * antivirus, the search indexer.
+ *
+ * Two things follow from "backstop", and both were got wrong before:
+ * - Being cheap is not the goal; being *bounded* is. A scan that gives up early
+ *   returns nothing, and nothing is indistinguishable from "all clear" — which
+ *   is how a deletion came to fail while the dialog reported no blockers. The
+ *   budgets below are ceilings, not delays: a scan that finishes fast is
+ *   unaffected by a generous one, so the pre-removal scan gets room to finish
+ *   and only the post-failure scan (where a user waits on a dialog) starts
+ *   short, escalating once it has proven the short budget insufficient.
+ * - A kill is not done when the kill *command* returns. Termination is
+ *   asynchronous, so every kill here goes through ProcessRunner.kill, which
+ *   waits for the process to actually be gone and reports the ones that aren't.
  *
  * Hooks:
  * - delete-workspace → release: CWD-only scan + kill blocking processes (best-effort)
@@ -27,8 +42,8 @@
  * - delete-workspace → flush: kill PIDs collected by detect
  * - hibernate-workspace → release: CWD-only scan + kill blocking processes (best-effort)
  *
- * Detection uses blocking-processes.ps1 with Restart Manager API, NtQuerySystemInformation,
- * and taskkill for process termination.
+ * Detection uses blocking-processes.ps1 (Restart Manager API for file handles,
+ * PEB reads for CWD); termination goes through the ProcessRunner boundary.
  */
 
 import type { IntentModule } from "../intents/lib/module";
@@ -77,17 +92,44 @@ interface DetectOutput {
 const MAX_FILES_PER_PROCESS = 20;
 
 /**
- * Timeout for detect operations.
+ * Timeout for the post-failure "Detect" scan.
  *
  * This runs only after a removal already failed, and the user is sitting in
  * front of a dialog that cannot tell them anything until it returns — 30s of
  * that produced a 63-second failed deletion in one user's logs, and then
- * reported no blockers anyway. The scan is dominated by PowerShell startup and
- * Add-Type compilation, so a shorter budget mostly cuts dead waiting.
+ * reported no blockers anyway. So the FIRST attempt gets a short budget: fail
+ * fast and say "could not determine" rather than stalling the dialog.
+ *
+ * When it does time out we escalate (see DETECT_TIMEOUT_ESCALATED_MS): a
+ * timeout is a ceiling, not a delay, so a bigger one costs nothing on the runs
+ * that finish quickly, and by the time the user is retrying they have already
+ * accepted that this is going slowly.
  */
 const DETECT_TIMEOUT_MS = 8_000;
 
-/** Timeout for taskkill */
+/**
+ * Budget for "Detect" once a scan has already timed out in this session.
+ *
+ * A scan blowing its budget is a property of the machine — process count and
+ * load — not of the workspace being deleted, which is why the escalation is
+ * module-wide rather than keyed by path.
+ */
+const DETECT_TIMEOUT_ESCALATED_MS = 45_000;
+
+/**
+ * Timeout for the pre-emptive CWD scan in the "release" hook.
+ *
+ * Deliberately generous, and NOT the same budget as the post-failure Detect
+ * above. Nothing is waiting on a dialog here — this runs before the removal is
+ * attempted, and its whole job is to find the processes that would make that
+ * removal fail. Returning empty because the clock ran out doesn't save the user
+ * any time; it just moves the failure later and strips the explanation. Since
+ * the timeout only bounds a scan that is genuinely stuck, a larger one costs
+ * nothing on a machine where the scan completes.
+ */
+const DETECT_CWD_TIMEOUT_MS = 45_000;
+
+/** Wait after signalling a blocking process before declaring it a survivor. */
 const KILL_TIMEOUT_MS = 5_000;
 
 // =============================================================================
@@ -162,6 +204,20 @@ function isValidBlockingProcess(
 }
 
 /**
+ * Outcome of a scan.
+ *
+ * `timedOut` exists because an empty `processes` list is otherwise ambiguous:
+ * it means either "nothing is holding this directory" or "we never found out".
+ * Collapsing the two is what let a deletion fail while the dialog reported
+ * "Detecting blocking processes… done" with no blockers — the app asserting a
+ * clean bill of health on the one thing that was actually wrong.
+ */
+export interface DetectScanResult {
+  readonly processes: BlockingProcess[];
+  readonly timedOut: boolean;
+}
+
+/**
  * Run a detect action using the blocking-processes.ps1 script.
  * Exported for boundary tests.
  */
@@ -170,8 +226,9 @@ export async function runDetectAction(
   scriptPath: string,
   path: Path,
   action: "Detect" | "DetectCwd",
-  logger: Logger
-): Promise<BlockingProcess[]> {
+  logger: Logger,
+  timeoutMs: number
+): Promise<DetectScanResult> {
   const proc = processRunner.run("powershell", [
     "-NoProfile",
     "-NonInteractive",
@@ -185,15 +242,16 @@ export async function runDetectAction(
     action,
   ]);
 
-  const result = await proc.wait(DETECT_TIMEOUT_MS);
+  const result = await proc.wait(timeoutMs);
 
   if (result.running) {
     logger.warn("Blocking process detection timed out", {
       path: path.toString(),
       action,
+      timeoutMs,
     });
     await proc.kill(1000, 1000);
-    return [];
+    return { processes: [], timedOut: true };
   }
 
   if (result.exitCode !== 0) {
@@ -203,43 +261,52 @@ export async function runDetectAction(
       exitCode: result.exitCode,
       stderr: result.stderr,
     });
-    return [];
+    return { processes: [], timedOut: false };
   }
 
-  return parseDetectOutput(result.stdout, logger);
+  return { processes: parseDetectOutput(result.stdout, logger), timedOut: false };
 }
 
 /**
- * Kill processes by their PIDs using taskkill.
- * Exported for boundary tests.
+ * Terminate blocking processes and wait for each to actually be gone.
+ *
+ * Returns the PIDs that were still alive afterwards. Exported for boundary tests.
+ *
+ * This used to shell out to a single `taskkill /pid … /t /f` and check its exit
+ * code — which tells you taskkill was *invoked*, not that anything died.
+ * Termination is asynchronous: the call returns before the OS has torn the
+ * process down, so the worktree removal that follows a few milliseconds later
+ * raced the very cleanup it had just requested. `ProcessRunner.kill` waits, and
+ * reports per PID, so a process that refuses to die becomes something we can
+ * name to the user instead of an unexplained EBUSY.
  */
 export async function killBlockingProcesses(
   processRunner: ProcessRunner,
   pids: number[],
   logger: Logger
-): Promise<void> {
+): Promise<number[]> {
   if (pids.length === 0) {
-    return;
+    return [];
   }
-
-  // Build taskkill arguments: /pid X /pid Y /t /f
-  const args: string[] = [];
-  for (const pid of pids) {
-    args.push("/pid", String(pid));
-  }
-  args.push("/t", "/f");
 
   logger.info("Killing blocking processes", {
     pids: pids.join(","),
   });
 
-  const killProc = processRunner.run("taskkill", args);
-  const result = await killProc.wait(KILL_TIMEOUT_MS);
+  const outcomes = await Promise.all(
+    pids.map(async (pid) => ({
+      pid,
+      result: await processRunner.kill(pid, KILL_TIMEOUT_MS, KILL_TIMEOUT_MS),
+    }))
+  );
 
-  if (result.exitCode !== 0) {
-    const failedPids = pids.join(", ");
-    throw new Error(`Failed to kill processes (PIDs: ${failedPids}): ${result.stderr}`);
+  const survivors = outcomes.filter((o) => !o.result.success).map((o) => o.pid);
+  if (survivors.length > 0) {
+    logger.warn("Blocking processes survived termination", {
+      pids: survivors.join(","),
+    });
   }
+  return survivors;
 }
 
 // =============================================================================
@@ -253,6 +320,16 @@ interface WindowsFileLockModuleDeps {
 }
 
 export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): IntentModule {
+  /**
+   * Whether a "Detect" scan has already blown its budget in this session.
+   *
+   * Module-wide on purpose: a scan that cannot finish in 8s says something
+   * about this machine's process count and load, not about the workspace that
+   * happened to be deleted first. Never reset — the escalated budget is a
+   * ceiling, so carrying it costs nothing on the runs that finish quickly.
+   */
+  let detectHasTimedOut = false;
+
   return {
     name: "windows-file-lock",
     requires: { platform: "win32" },
@@ -267,8 +344,8 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
               return { result: {} };
             }
 
-            await runCwdReleaseKill(deps, workspacePath, "deletion");
-            return { result: {} };
+            const error = await runCwdReleaseKill(deps, workspacePath, "deletion");
+            return { result: error === undefined ? {} : { error } };
           },
         },
         detect: {
@@ -276,20 +353,34 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
             const { workspacePath } = ctx as DeletePipelineHookInput;
 
             try {
-              const detected = await runDetectAction(
+              const scan = await runDetectAction(
                 deps.processRunner,
                 deps.scriptPath,
                 new Path(workspacePath),
                 "Detect",
-                deps.logger
+                deps.logger,
+                detectHasTimedOut ? DETECT_TIMEOUT_ESCALATED_MS : DETECT_TIMEOUT_MS
               );
-              return { result: { blockingProcesses: detected } };
+              if (scan.timedOut) {
+                // Escalate so a retry — which the user is about to reach for,
+                // since we just told them the removal failed — gets a budget
+                // that can actually finish.
+                detectHasTimedOut = true;
+                return {
+                  result: {
+                    blockingProcesses: [],
+                    error:
+                      "Could not determine which processes hold the workspace (scan timed out)",
+                  },
+                };
+              }
+              return { result: { blockingProcesses: scan.processes } };
             } catch (error) {
               deps.logger.warn("Detection failed", {
                 workspacePath,
                 error: getErrorMessage(error),
               });
-              return { result: { blockingProcesses: [] } };
+              return { result: { blockingProcesses: [], error: getErrorMessage(error) } };
             }
           },
         },
@@ -298,7 +389,16 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
             const { blockingPids } = ctx as FlushHookInput;
             if (blockingPids.length > 0) {
               try {
-                await killBlockingProcesses(deps.processRunner, [...blockingPids], deps.logger);
+                const survivors = await killBlockingProcesses(
+                  deps.processRunner,
+                  [...blockingPids],
+                  deps.logger
+                );
+                if (survivors.length > 0) {
+                  return {
+                    result: { error: `Could not terminate pid ${survivors.join(", ")}` },
+                  };
+                }
               } catch (error) {
                 return { result: { error: getErrorMessage(error) } };
               }
@@ -311,6 +411,9 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
         release: {
           handler: async (ctx: HookContext): Promise<HookOutput<HibernateReleaseHookResult>> => {
             const { workspacePath } = ctx as HibernatePipelineHookInput;
+            // Hibernation has no error channel on its release result and no
+            // removal to explain, so the outcome is logged (inside
+            // runCwdReleaseKill) rather than reported.
             await runCwdReleaseKill(deps, workspacePath, "hibernation");
             return { result: {} };
           },
@@ -320,31 +423,56 @@ export function createWindowsFileLockModule(deps: WindowsFileLockModuleDeps): In
   };
 }
 
+/**
+ * Scan for processes with a CWD under the workspace and kill them.
+ *
+ * Returns a message when something went wrong, rather than swallowing it. The
+ * failure is still non-fatal — the caller reports it and carries on — but a
+ * process we could not kill is the single most actionable thing we can put in
+ * front of a user whose deletion then fails on a locked directory, and it used
+ * to be discarded by a bare `catch {}`.
+ */
 async function runCwdReleaseKill(
   deps: WindowsFileLockModuleDeps,
   workspacePath: string,
   phase: "deletion" | "hibernation"
-): Promise<void> {
+): Promise<string | undefined> {
   try {
-    const cwdProcesses = await runDetectAction(
+    const scan = await runDetectAction(
       deps.processRunner,
       deps.scriptPath,
       new Path(workspacePath),
       "DetectCwd",
+      deps.logger,
+      DETECT_CWD_TIMEOUT_MS
+    );
+    if (scan.timedOut) {
+      return "Could not determine which processes hold the workspace (scan timed out)";
+    }
+    if (scan.processes.length === 0) {
+      return undefined;
+    }
+
+    deps.logger.info(`Killing CWD-blocking processes before ${phase}`, {
+      workspacePath,
+      pids: scan.processes.map((p) => p.pid).join(","),
+    });
+    const survivors = await killBlockingProcesses(
+      deps.processRunner,
+      scan.processes.map((p) => p.pid),
       deps.logger
     );
-    if (cwdProcesses.length > 0) {
-      deps.logger.info(`Killing CWD-blocking processes before ${phase}`, {
-        workspacePath,
-        pids: cwdProcesses.map((p) => p.pid).join(","),
-      });
-      await killBlockingProcesses(
-        deps.processRunner,
-        cwdProcesses.map((p) => p.pid),
-        deps.logger
-      );
+    if (survivors.length > 0) {
+      const named = survivors
+        .map((pid) => {
+          const proc = scan.processes.find((p) => p.pid === pid);
+          return proc ? `${proc.name} (pid ${pid})` : `pid ${pid}`;
+        })
+        .join(", ");
+      return `Could not terminate: ${named}`;
     }
-  } catch {
-    // Non-fatal: CWD detection/kill failure shouldn't block the operation
+    return undefined;
+  } catch (error) {
+    return getErrorMessage(error);
   }
 }


### PR DESCRIPTION
Reported via PostHog: a `ci-failures` workspace refused to delete on Windows, and the dialog said nothing was blocking it. Both halves were ours.

**The frame was released too early.** The presenter dropped a workspace's IDE frame as soon as a deletion-progress entry existed — but that event is emitted *before* the shutdown hook point runs. So the iframe went away first, the IDE client disconnected, the extension host was disposed, and its terminals reported "closed" 45 ms after the sidekick's first Ctrl+C — before the 500 ms repeat could send the second one Claude Code needs to exit. That report is synthesized into `WrapperEnd`, so the agent was declared gone. It wasn't: with persistent terminal sessions the pty survives a client disconnect, so it kept running with the workspace as its CWD and Windows refused the directory. Its MCP session was still taking requests four minutes later.

Now gated on an `agent-stopped` capability that plugin-server provides on every path (including its early returns and errors — a throwing handler never merges `provides`, and its dependents are then skipped). The sidekick's force-dispose is gone: disposing a terminal doesn't stop the agent, it only manufactures the "closed" report that caused this.

**The scan that should have explained it never finished.** One 8 s budget served both the post-failure scan (where a user waits on a dialog) and the pre-emptive CWD scan (on the critical path). Both hit the wall, and a timeout returned `[]` — indistinguishable from a clean scan, which is why the dialog claimed nothing was blocking. Budgets are now split, a timeout is reported separately from empty, and it escalates once the short budget has proven insufficient.

**Three error channels existed end-to-end and were discarded at the last step:** `detect.errors` was never read, `release.error` never populated behind a bare `catch {}`, and a kill reported one exit code for N pids. All wired up.

**`taskkill` returns when the request is made, not when the target is down**, so `ProcessRunner.kill(pid, …)` adds the existing kill contract for a pid we didn't spawn, and waits. A process that survives is now nameable to the user.

Also un-gated two `describe` blocks that were `skipIf(win32)` despite driving a mock — that gate is why stale assertions reached CI unnoticed. 8 tests that ran on one of three platforms now run on all three.

Verified on CI run 30632763731: all 16 jobs green, including `Validate (windows-2025)` and `E2E (windows)`.