### PR TITLE
feat(mcp): target another workspace from the metadata tools

### DIFF
--- a/src/intents/resolve-workspace.integration.test.ts
+++ b/src/intents/resolve-workspace.integration.test.ts
@@ -171,6 +171,16 @@ describe("ResolveWorkspaceOperation Integration", () => {
       );
     });
 
+    // Coded so callers can distinguish "that workspace doesn't exist" from a
+    // genuine failure — the MCP tools turn this into `workspace-not-found`.
+    it("codes the not-found error as WORKSPACE_NOT_FOUND", async () => {
+      const { dispatcher } = createTestSetup();
+
+      await expect(dispatcher.dispatch(resolveIntent(WORKSPACE_PATH))).rejects.toMatchObject({
+        code: "WORKSPACE_NOT_FOUND",
+      });
+    });
+
     it("propagates hook handler errors (#4)", async () => {
       const { dispatcher } = createTestSetup(async () => {
         throw new Error("provider error");

--- a/src/intents/resolve-workspace.ts
+++ b/src/intents/resolve-workspace.ts
@@ -27,6 +27,7 @@ import {
 } from "./contract";
 import type { ProjectPath, WorkspaceClosing } from "./contract";
 import { throwHookErrors } from "./lib/hook-helpers";
+import { WorkspaceError } from "../shared/errors/service-errors";
 
 export const INTENT_RESOLVE_WORKSPACE = "workspace:resolve" as const;
 export const RESOLVE_WORKSPACE_OPERATION_ID = "resolve-workspace";
@@ -149,7 +150,13 @@ export class ResolveWorkspaceOperation implements Operation<typeof schemas> {
     }
 
     if (!projectPath || !workspaceName) {
-      throw new Error(`Workspace not found: ${payload.workspacePath}`);
+      // Coded so callers can tell "you named a workspace that isn't there" apart
+      // from a genuine failure — the MCP tools map it to `workspace-not-found`.
+      // Same code and message the provider already uses for this condition.
+      throw new WorkspaceError(
+        `Workspace not found: ${payload.workspacePath}`,
+        "WORKSPACE_NOT_FOUND"
+      );
     }
 
     return { projectPath, workspaceName, active, branch, metadata, closing };

--- a/src/intents/set-metadata.integration.test.ts
+++ b/src/intents/set-metadata.integration.test.ts
@@ -242,6 +242,17 @@ describe("SetMetadata Operation", () => {
       ).rejects.toThrow("Workspace not found: /nonexistent/path");
     });
 
+    // The code has to survive the nested workspace:resolve dispatch this
+    // operation makes — that is what lets the MCP tools report a bad target
+    // path as `workspace-not-found` rather than a generic internal error.
+    it("codes an unknown workspace path as WORKSPACE_NOT_FOUND", async () => {
+      const { dispatcher } = setup;
+
+      await expect(
+        dispatcher.dispatch(setMetadataIntent(wsPath("/nonexistent/path"), "key", "value"))
+      ).rejects.toMatchObject({ code: "WORKSPACE_NOT_FOUND" });
+    });
+
     it("no event emitted on error", async () => {
       const { dispatcher, workspacePath } = setup;
 

--- a/src/modules/mcp-module.ts
+++ b/src/modules/mcp-module.ts
@@ -34,7 +34,7 @@ import type { Logger, LogContext } from "../boundaries/platform/logging";
 import { SILENT_LOGGER, logAtLevel } from "../boundaries/platform/logging";
 import type { LogLevel } from "../boundaries/platform/logging-types";
 import type { IDisposable } from "../shared/types";
-import { getErrorMessage } from "../shared/errors/service-errors";
+import { getErrorMessage, WorkspaceError } from "../shared/errors/service-errors";
 import { type Workspace, type DeletionProgress } from "../shared/api/types";
 
 // Intent types for direct dispatch
@@ -77,8 +77,9 @@ import type { WorkspacePath } from "../intents/contract";
 
 /**
  * Optional target workspace path for tools that can act on a workspace other
- * than the session's own (hibernate/wake/delete). Omit to target the current
- * workspace; use project_list to discover other workspaces' paths.
+ * than the session's own (hibernate/wake/delete, get/set metadata). Omit to
+ * target the current workspace; use project_list to discover other workspaces'
+ * paths.
  */
 const targetWorkspacePathSchema = workspacePathSchema
   .min(1)
@@ -550,17 +551,24 @@ export class McpServer {
       "workspace_get_metadata",
       {
         description:
-          "Get all metadata for the current workspace. Always includes a 'base' key with the base branch name.",
-        inputSchema: z.object({}),
+          "Get all metadata for a workspace. Always includes a 'base' key with the base branch name. " +
+          "Omit workspacePath to read the current workspace; pass one to read another. " +
+          "Use project_list to discover paths.",
+        inputSchema: z.object({
+          workspacePath: targetWorkspacePathSchema,
+        }),
       },
-      this.createWorkspaceHandler(async (workspacePath) => {
-        const result = await this.dispatcher.dispatch<GetMetadataIntent>({
-          type: INTENT_GET_METADATA,
-          payload: { workspacePath },
-        });
-        if (!result) throw new Error("Get metadata dispatch returned no result");
-        return result;
-      })
+      this.createWorkspaceHandler(
+        async (sessionWorkspacePath, args: { workspacePath?: WorkspacePath | undefined }) => {
+          const workspacePath = args.workspacePath ?? sessionWorkspacePath;
+          const result = await this.dispatcher.dispatch<GetMetadataIntent>({
+            type: INTENT_GET_METADATA,
+            payload: { workspacePath },
+          });
+          if (!result) throw new Error("Get metadata dispatch returned no result");
+          return result;
+        }
+      )
     );
 
     // workspace_set_metadata
@@ -568,12 +576,15 @@ export class McpServer {
       "workspace_set_metadata",
       {
         description:
-          "Set or delete a metadata key for the current workspace. " +
+          "Set or delete a metadata key for a workspace. " +
+          "Omit workspacePath to target the current workspace; pass one to target another — " +
+          "for example to record which workspace created it. Use project_list to discover paths. " +
           "Use key 'title' to set the workspace's sidebar display title; set value to null to delete/clear the title and revert the row to the branch name (this is how you 'delete the workspace title' — do not use workspace_delete for that). " +
           "To set tags, use the 'tags.' prefix for the key (e.g., key: 'tags.bugfix'). " +
           "The value is a JSON object with an optional color field: '{\"color\":\"#ff0000\"}' or '{}' for no color. " +
           "To remove a tag, set value to null.",
         inputSchema: z.object({
+          workspacePath: targetWorkspacePathSchema,
           key: z
             .string()
             .describe("Metadata key (must start with letter, contain only letters/digits/hyphens)"),
@@ -583,7 +594,15 @@ export class McpServer {
         }),
       },
       this.createWorkspaceHandler(
-        async (workspacePath, args: { key: string; value: string | null }) => {
+        async (
+          sessionWorkspacePath,
+          args: {
+            workspacePath?: WorkspacePath | undefined;
+            key: string;
+            value: string | null;
+          }
+        ) => {
+          const workspacePath = args.workspacePath ?? sessionWorkspacePath;
           await this.dispatcher.dispatch<SetMetadataIntent>({
             type: INTENT_SET_METADATA,
             payload: { workspacePath, key: args.key, value: args.value },
@@ -1140,6 +1159,11 @@ export class McpServer {
 
   /**
    * Handle errors from API calls.
+   *
+   * A workspacePath naming a workspace that doesn't exist is the one caller
+   * mistake that is worth its own code — every tool taking a target path can
+   * hit it, and the caller can fix it by re-reading project_list. Everything
+   * else stays internal-error.
    */
   private handleError(error: unknown): {
     content: Array<{ type: "text"; text: string }>;
@@ -1147,7 +1171,11 @@ export class McpServer {
   } {
     const message = getErrorMessage(error);
     this.logger.error("Tool error", { error: message });
-    return this.errorResult("internal-error", message);
+    const code: McpErrorCode =
+      error instanceof WorkspaceError && error.code === "WORKSPACE_NOT_FOUND"
+        ? "workspace-not-found"
+        : "internal-error";
+    return this.errorResult(code, message);
   }
 }
 

--- a/src/modules/mcp-server.test.ts
+++ b/src/modules/mcp-server.test.ts
@@ -14,6 +14,8 @@ import { createMockLogger } from "../boundaries/platform/logging";
 import { Dispatcher } from "../intents/lib/dispatcher";
 import { createMockDispatcher as createBaseMockDispatcher } from "../intents/lib/dispatcher.test-utils";
 import type { Intent } from "../intents/lib/types";
+import { INTENT_GET_METADATA } from "../intents/get-metadata";
+import { INTENT_SET_METADATA } from "../intents/set-metadata";
 import { INTENT_HIBERNATE_WORKSPACE } from "../intents/hibernate-workspace";
 import { INTENT_WAKE_WORKSPACE } from "../intents/wake-workspace";
 import { INTENT_DELETE_WORKSPACE } from "../intents/delete-workspace";
@@ -24,6 +26,7 @@ import {
   type MockToolOperations,
 } from "./mcp-server.test-utils";
 import { createPortManagerMock } from "../boundaries/platform/port-manager.state-mock";
+import { WorkspaceError } from "../shared/errors/service-errors";
 
 /**
  * Create a Dispatcher with mock operations registered for all MCP tool intents.
@@ -62,6 +65,8 @@ function createMockMcpSdk() {
 }
 
 const testWorkspacePath = "/home/user/projects/my-app/.worktrees/feature-branch";
+/** A workspace other than the session's own — the target of the tools that take a path. */
+const otherWorkspacePath = "/home/user/projects/my-app/.worktrees/other-branch";
 
 /**
  * Send an initialize request to trigger session creation.
@@ -240,7 +245,6 @@ describe("McpServer", () => {
 
       const tools = mockMcpSdk.getRegisteredTools();
       const hibernateTool = tools.find((t) => t.name === "workspace_hibernate");
-      const otherWorkspacePath = "/home/user/projects/my-app/.worktrees/other-branch";
 
       await hibernateTool!.handler(
         { workspacePath: otherWorkspacePath },
@@ -256,7 +260,6 @@ describe("McpServer", () => {
 
       const tools = mockMcpSdk.getRegisteredTools();
       const wakeTool = tools.find((t) => t.name === "workspace_wake");
-      const otherWorkspacePath = "/home/user/projects/my-app/.worktrees/other-branch";
 
       await wakeTool!.handler(
         { workspacePath: otherWorkspacePath },
@@ -265,6 +268,107 @@ describe("McpServer", () => {
 
       const intent = mockDispatcher.operations.wake!.mock.calls[0]![0].intent as Intent;
       expect((intent.payload as { workspacePath: string }).workspacePath).toBe(otherWorkspacePath);
+    });
+
+    it("workspace_get_metadata reads the session workspace by default", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const getMetadataTool = tools.find((t) => t.name === "workspace_get_metadata");
+
+      await getMetadataTool!.handler(
+        {},
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.getMetadata!.mock.calls[0]![0].intent as Intent;
+      expect(intent.type).toBe(INTENT_GET_METADATA);
+      expect((intent.payload as { workspacePath: string }).workspacePath).toBe(testWorkspacePath);
+    });
+
+    it("workspace_get_metadata targets an explicit workspacePath argument", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const getMetadataTool = tools.find((t) => t.name === "workspace_get_metadata");
+
+      await getMetadataTool!.handler(
+        { workspacePath: otherWorkspacePath },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.getMetadata!.mock.calls[0]![0].intent as Intent;
+      expect((intent.payload as { workspacePath: string }).workspacePath).toBe(otherWorkspacePath);
+    });
+
+    it("workspace_set_metadata writes to the session workspace by default", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const setMetadataTool = tools.find((t) => t.name === "workspace_set_metadata");
+
+      await setMetadataTool!.handler(
+        { key: "tags.review", value: "{}" },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.setMetadata!.mock.calls[0]![0].intent as Intent;
+      expect(intent.type).toBe(INTENT_SET_METADATA);
+      expect(intent.payload).toMatchObject({
+        workspacePath: testWorkspacePath,
+        key: "tags.review",
+        value: "{}",
+      });
+    });
+
+    it("workspace_set_metadata targets an explicit workspacePath argument", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const setMetadataTool = tools.find((t) => t.name === "workspace_set_metadata");
+
+      // The provenance case: an agent tagging a workspace it just created.
+      await setMetadataTool!.handler(
+        { workspacePath: otherWorkspacePath, key: "tags.from-feature-branch", value: "{}" },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      const intent = mockDispatcher.operations.setMetadata!.mock.calls[0]![0].intent as Intent;
+      expect(intent.payload).toMatchObject({
+        workspacePath: otherWorkspacePath,
+        key: "tags.from-feature-branch",
+        value: "{}",
+      });
+    });
+
+    it("reports a target workspace that does not exist as workspace-not-found", async () => {
+      await sendInitialize(port);
+
+      const tools = mockMcpSdk.getRegisteredTools();
+      const setMetadataTool = tools.find((t) => t.name === "workspace_set_metadata");
+      mockDispatcher.operations.setMetadata!.mockRejectedValueOnce(
+        new WorkspaceError(`Workspace not found: ${otherWorkspacePath}`, "WORKSPACE_NOT_FOUND")
+      );
+
+      const result = await setMetadataTool!.handler(
+        { workspacePath: otherWorkspacePath, key: "tags.review", value: "{}" },
+        { authInfo: { extra: { workspacePath: testWorkspacePath } } }
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                code: "workspace-not-found",
+                message: `Workspace not found: ${otherWorkspacePath}`,
+              },
+            }),
+          },
+        ],
+        isError: true,
+      });
     });
 
     it("workspace_delete deletes the session workspace and reports success", async () => {


### PR DESCRIPTION
- `workspace_set_metadata` and `workspace_get_metadata` take an optional `workspacePath`, mirroring `workspace_hibernate`/`wake`/`delete` (omit = the calling workspace). This closes the gap that left an agent with no supported way to tag a workspace it created via `workspace_create` — the provenance case.
- Tool-schema only: both intents already accepted an arbitrary `workspacePath`, so there is no intent, IPC, or plugin-protocol change.
- `workspace:resolve` now throws a coded `WorkspaceError` for a path naming no workspace, reusing the `WORKSPACE_NOT_FOUND` code and exact message text the provider already uses. The MCP tools map it to `workspace-not-found` instead of `internal-error`; `hibernate`/`wake`/`delete` get the better code too.
- Tests: session-default and explicit-target for both tools, the error-code mapping, and an integration test proving the code survives the nested `workspace:resolve` dispatch.