### PR TITLE
fix: Alt+F4 was not reliably working

### DIFF
--- a/src/boundaries/shell/view.test.ts
+++ b/src/boundaries/shell/view.test.ts
@@ -20,22 +20,17 @@ import type { WindowHandle } from "./types";
 
 vi.mock("electron");
 
-type FrameLoadListener = (
-  event: unknown,
-  isMainFrame: boolean,
-  frameProcessId: number,
-  frameRoutingId: number
-) => void;
+type WebContentsListener = (...args: unknown[]) => void;
 
 interface FakeFrame {
   executeJavaScript: ReturnType<typeof vi.fn>;
 }
 
-const listeners = new Map<string, FrameLoadListener[]>();
+const listeners = new Map<string, WebContentsListener[]>();
 
 const fakeWebContents = {
   isDestroyed: () => false,
-  on: (event: string, listener: FrameLoadListener) => {
+  on: (event: string, listener: WebContentsListener) => {
     const list = listeners.get(event) ?? [];
     list.push(listener);
     listeners.set(event, list);
@@ -57,10 +52,14 @@ const windowHandle: WindowHandle = { id: "window-1", __brand: "WindowHandle" };
 
 import { DefaultViewBoundary } from "./view";
 
-function emitFrameFinishLoad(isMainFrame: boolean, processId: number, routingId: number): void {
-  for (const listener of listeners.get("did-frame-finish-load") ?? []) {
-    listener(undefined, isMainFrame, processId, routingId);
+function emit(event: string, ...args: unknown[]): void {
+  for (const listener of listeners.get(event) ?? []) {
+    listener(...args);
   }
+}
+
+function emitFrameFinishLoad(isMainFrame: boolean, processId: number, routingId: number): void {
+  emit("did-frame-finish-load", undefined, isMainFrame, processId, routingId);
 }
 
 function createFrame(): FakeFrame {
@@ -184,5 +183,30 @@ describe("DefaultViewBoundary installChildFrameScript", () => {
 
     expect(frame.executeJavaScript).toHaveBeenCalledWith("tracker()");
     expect(rejectionHandled).toBe(true);
+  });
+});
+
+describe("DefaultViewBoundary unload vetoes", () => {
+  let boundary: DefaultViewBoundary;
+  let logger: MockLogger;
+
+  beforeEach(() => {
+    listeners.clear();
+    resetElectronFake();
+    logger = createMockLogger();
+    boundary = new DefaultViewBoundary(windowLayer, logger);
+  });
+
+  it("ignores a frame's beforeunload veto so the window still closes", () => {
+    // The embedded VSCodium workbench vetoes unload whenever a modifier key is
+    // held ("window.confirmBeforeClose": "keyboardOnly" on web), so Alt+F4 was
+    // silently dropped by Electron's default handling and the app kept running.
+    boundary.adoptWindowWebContents(windowHandle);
+    const event = { preventDefault: vi.fn() };
+
+    emit("will-prevent-unload", event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith("unload veto ignored ui");
   });
 });

--- a/src/boundaries/shell/view.ts
+++ b/src/boundaries/shell/view.ts
@@ -417,6 +417,26 @@ export class DefaultViewBoundary implements ViewBoundary {
       this.logger.debug(`focus ${label}`);
     });
 
+    // Never let a page frame veto the window close.
+    //
+    // Every workspace iframe shares this webContents, so any of them can cancel
+    // an OS close request from a `beforeunload` handler — and Electron's default
+    // answer to that veto is to silently drop the close: no dialog, no close, no
+    // log line. The embedded VSCodium workbench vetoes routinely: its web
+    // lifecycle service prevents unload whenever a modifier key is held down
+    // (`window.confirmBeforeClose` defaults to "keyboardOnly" on web), which is
+    // every Alt+F4 that beats its own Alt keyUp. The `close` event fires, the
+    // window stays, and the user presses again until one attempt happens to race
+    // the other way.
+    //
+    // preventDefault() means "ignore the veto and unload anyway", so the close
+    // proceeds to `window-all-closed` → app:shutdown, which is what runs the
+    // orderly teardown.
+    webContents.on("will-prevent-unload", (event) => {
+      this.logger.debug(`unload veto ignored ${label}`);
+      event.preventDefault();
+    });
+
     const handle = createViewHandle(id);
     this.logger.debug("Window webContents adopted as view", {
       id,


### PR DESCRIPTION
- Alt+F4 (and the titlebar close button with any modifier held) often did nothing: the window's `close` event fired, the window stayed, and the app kept running until a later press happened to get through.
- Cause: the embedded VSCodium workbench vetoes `beforeunload` whenever a modifier key is held (its web default is `"window.confirmBeforeClose": "keyboardOnly"`), and Electron's default answer to a veto is to silently drop the close — no dialog, no close, no log line. Alt+F4 holds Alt by definition, so the close request raced the Alt keyUp and usually lost.
- Fix: listen for `will-prevent-unload` on the adopted window webContents and `preventDefault()` it, telling Electron to unload anyway. The close then proceeds to `window-all-closed` → `app:shutdown`, which runs the orderly teardown.
- The `app:shutdown` paths were already immune (`windowLayer.dispose()` destroys the window, bypassing `beforeunload`); only OS close requests were affected.
- Covered by a boundary test in `view.test.ts`; the fake webContents' listener store is generalized so non-frame-load events can be emitted.