### PR TITLE
fix: workspace creation dialog remembers input when switching back and forth

### DIFF
--- a/src/modules/creation-module.integration.test.ts
+++ b/src/modules/creation-module.integration.test.ts
@@ -1171,6 +1171,184 @@ describe("CreationModule", () => {
       expect(field(panel.config, "project-placeholder")["disabled"]).toBe(true);
     });
   });
+
+  describe("remembering inputs across a close/reopen", () => {
+    /** A panel with branches loaded and every field filled in. */
+    async function filledPanel(s: Setup): Promise<MockDialogHandle> {
+      const panel = await s.start();
+      await s.emit(EVENT_BASES_UPDATED, {
+        projectId: PROJECT_A.id,
+        projectPath: PROJECT_A.path,
+        bases: BASES_A,
+        defaultBaseBranch: "main",
+      });
+      panel.emitChange("name", { name: "remembered" });
+      panel.emitChange("prompt", { prompt: "do the thing" });
+      panel.emitChange("agent-name", { "agent-name": "reviewer" });
+      await flush();
+      return panel;
+    }
+
+    it("pushes every field back as a controlled value so a remount restores it", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await filledPanel(s);
+
+      // The renderer unmounts the panel on hide, so the module is the only
+      // thing that survives: each field must carry its value in the config.
+      // Free-text fields seed (initialValue) rather than push (value), so
+      // echoing the user's own text back cannot race their typing.
+      expect(field(panel.config, "name")["initialValue"]).toBe("remembered");
+      // Restored text arrives selected so the first keystroke replaces it.
+      expect(field(panel.config, "name")["selectInitialValue"]).toBe(true);
+      expect(field(panel.config, "prompt")["initialValue"]).toBe("do the thing");
+      expect(field(panel.config, "agent-name")["initialValue"]).toBe("reviewer");
+      expect(field(panel.config, "base")["value"]).toBe("main");
+      expect(field(panel.config, "project")["value"]).toBe(PROJECT_A.path);
+    });
+
+    it("keeps the session open (no reset) when nothing asks for one", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await filledPanel(s);
+
+      // Nothing dismissed the form, so it is still the same session — the
+      // values above are still there to be restored on the next show.
+      expect(panel.closed).toBe(false);
+      expect(currentPanel(s)).toBe(panel);
+    });
+
+    it("clears every field on reset", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await filledPanel(s);
+
+      panel.emitAction("reset", {});
+      await flush();
+
+      expect(panel.closed).toBe(true);
+      const fresh = currentPanel(s);
+      expect(field(fresh.config, "name")["initialValue"]).toBe("");
+      expect(field(fresh.config, "prompt")["initialValue"]).toBe("");
+      expect(field(fresh.config, "agent-name")["initialValue"]).toBe("");
+    });
+
+    it("re-seeds the project on reset", async () => {
+      const s = setup({
+        projects: [PROJECT_B, PROJECT_A],
+        activeWorkspaceProjectId: PROJECT_A.id,
+        defaultBaseBranch: "main",
+      });
+      const panel = await s.start();
+
+      panel.emitChange("project", { project: PROJECT_B.path });
+      await flush();
+      expect(field(currentPanel(s).config, "project")["value"]).toBe(PROJECT_B.path);
+
+      currentPanel(s).emitAction("reset", {});
+      await flush();
+
+      // Reset is the only thing that re-seeds; a plain reopen would have kept
+      // the manual pick.
+      expect(field(currentPanel(s).config, "project")["value"]).toBe(PROJECT_A.path);
+    });
+
+    it("clears the remembered fields after a successful create", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await filledPanel(s);
+
+      panel.emitAction("create", {
+        name: "remembered",
+        base: "main",
+        prompt: "do the thing",
+        "agent-name": "reviewer",
+      });
+      await flush();
+
+      const fresh = currentPanel(s);
+      expect(field(fresh.config, "name")["initialValue"]).toBe("");
+      expect(field(fresh.config, "prompt")["initialValue"]).toBe("");
+    });
+  });
+
+  describe("Reset button", () => {
+    it("is disabled on a fresh form and enabled once any input is made", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await s.start();
+      expect(field(panel.config, "reset")["disabled"]).toBe(true);
+
+      panel.emitChange("prompt", { prompt: "x" });
+      await flush();
+
+      // "as soon as any input was made" — the prompt alone is enough, even
+      // though it takes no part in Create gating.
+      expect(field(currentPanel(s).config, "reset")["disabled"]).toBe(false);
+      expect(field(currentPanel(s).config, "create")["disabled"]).toBe(true);
+    });
+
+    it("is disabled again after a reset", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await s.start();
+      panel.emitChange("prompt", { prompt: "x" });
+      await flush();
+
+      currentPanel(s).emitAction("reset", {});
+      await flush();
+
+      expect(field(currentPanel(s).config, "reset")["disabled"]).toBe(true);
+    });
+
+    it("carries role 'cancel' so Escape and the button are the same gesture", async () => {
+      const s = setup({ defaultBaseBranch: "main" });
+      const panel = await s.start();
+      panel.emitChange("prompt", { prompt: "x" });
+      await flush();
+
+      expect(cancelButton(currentPanel(s).config)?.id).toBe("reset");
+    });
+
+    it("seeding the form does not count as input", async () => {
+      const s = setup({
+        projects: [PROJECT_B, PROJECT_A],
+        activeWorkspaceProjectId: PROJECT_A.id,
+        defaultBaseBranch: "main",
+      });
+      await s.start();
+      await s.emit(EVENT_BASES_UPDATED, {
+        projectId: PROJECT_A.id,
+        projectPath: PROJECT_A.path,
+        bases: BASES_A,
+        defaultBaseBranch: "main",
+      });
+
+      // openSession() seeded the project and the base branch without the user
+      // touching anything, so the form is still clean.
+      expect(field(currentPanel(s).config, "base")["value"]).toBe("main");
+      expect(field(currentPanel(s).config, "reset")["disabled"]).toBe(true);
+    });
+  });
+
+  describe("permission mode", () => {
+    it("collapses a remembered mode the current backend does not offer", async () => {
+      const s = setup({
+        agents: [CLAUDE_AGENT, OPENCODE_AGENT],
+      });
+      const panel = await s.start();
+
+      panel.emitChange("permission-mode", { "permission-mode": "plan" });
+      await flush();
+      expect(field(currentPanel(s).config, "permission-mode")["value"]).toBe("plan");
+
+      // Switching backends re-fetches the launch options; OpenCode reports no
+      // modes, so the field goes away and the remembered "plan" cannot leak.
+      currentPanel(s).emitChange("agent", { agent: "opencode" });
+      await flush();
+      expect(sectionById(currentPanel(s).config, "permission-mode")).toBeUndefined();
+
+      // Coming back to a backend that DOES offer modes must not resurrect a
+      // mode the user picked for a different one.
+      currentPanel(s).emitChange("agent", { agent: "claude" });
+      await flush();
+      expect(field(currentPanel(s).config, "permission-mode")["value"]).toBe("plan");
+    });
+  });
 });
 
 describe("validateCloneUrl", () => {

--- a/src/modules/creation-module.ts
+++ b/src/modules/creation-module.ts
@@ -101,6 +101,7 @@ const FIELD_PERMISSION_MODE = "permission-mode";
 const ACTION_OPEN_FOLDER = "open-folder";
 const ACTION_CLONE = "clone";
 const ACTION_CREATE = "create";
+const ACTION_RESET = "reset";
 
 const CLONE_FIELD_URL = "url";
 const CLONE_ACTION_SUBMIT = "do-clone";
@@ -160,6 +161,24 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   /** Raw name field value (a branch ref after a suggestion pick). */
   let nameValue = "";
   let baseValue = "";
+  /**
+   * Prompt / agent-name / permission-mode field values.
+   *
+   * These are tracked (not just read from the submit snapshot) because the
+   * renderer unmounts the panel on every hide, so the module is the only thing
+   * that survives a close/reopen. Each is pushed back as a controlled `value`
+   * so the remounted Form restores what was typed instead of coming up blank.
+   */
+  let promptValue = "";
+  let agentNameValue = "";
+  let permissionModeValue = "";
+  /**
+   * Whether the user has touched any field since the last reset. Drives the
+   * Reset button's enabled state ("as soon as any input was made"). Set from
+   * field-change events only, so the seeding openSession() does programmatically
+   * (selectProject) never counts as input.
+   */
+  let dirty = false;
   /** Native folder picker in flight. */
   let pickerBusy = false;
   /** Form-level error (e.g. folder-open failure), shown above the footer. */
@@ -217,6 +236,18 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
   /** True while the selected backend's launch options are being fetched. */
   function launchOptionsLoading(): boolean {
     return loadingLaunchOptionsFor !== null && loadingLaunchOptionsFor === selectedAgentType;
+  }
+
+  /**
+   * The permission mode to display, guarded against backend switches: a
+   * remembered mode belongs to whichever backend was selected when it was
+   * picked, and switching backends (or the options still loading) can leave it
+   * unofferable. Anything the current backend does not list collapses to ""
+   * — the "default" entry, which omits the flag.
+   */
+  function currentPermissionMode(): string {
+    if (permissionModeValue === "") return "";
+    return currentPermissionModes().includes(permissionModeValue) ? permissionModeValue : "";
   }
 
   /** Permission-mode suggestions: the default entry plus the backend's modes. */
@@ -407,6 +438,15 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         label: "Name",
         freeText: true,
         suggestions: nameSuggestions(),
+        // Seeded (not controlled) so a remembered name survives the Form
+        // remount the panel does on every show. `initialValue` applies on first
+        // sight only and never re-seeds a live field, so echoing the user's own
+        // text back can never race their typing — the reason this field was
+        // left uncontrolled to begin with.
+        initialValue: nameValue,
+        // A restored name arrives selected, so typing replaces it instead of
+        // appending to text the user would have to clear by hand.
+        selectInitialValue: true,
         placeholder: "Enter name or select branch...",
         changeEvent: true,
         disabled: !hasProject || pickerBusy,
@@ -431,6 +471,9 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         label: "Prompt",
         multiline: true,
         rows: 3,
+        // Seeded, not controlled — see FIELD_NAME above.
+        initialValue: promptValue,
+        changeEvent: true,
         placeholder: "Optional prompt — sent as soon as the workspace is ready",
       },
     ];
@@ -453,6 +496,9 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       type: "input",
       id: FIELD_AGENT_NAME,
       label: "Agent name",
+      // Seeded, not controlled — see FIELD_NAME above.
+      initialValue: agentNameValue,
+      changeEvent: true,
       placeholder: "default",
     });
 
@@ -467,6 +513,12 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
         label: "Permission mode",
         searchable: false,
         suggestions: permissionModeSuggestions(),
+        // Guarded: a remembered mode belongs to whichever backend was selected
+        // when it was picked, and the backend can change under it. Anything the
+        // current backend does not offer collapses to "" (the "default" entry,
+        // which omits the flag) rather than pushing a mode it cannot honour.
+        value: currentPermissionMode(),
+        changeEvent: true,
         loading: launchOptionsLoading(),
       });
     }
@@ -479,6 +531,19 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       type: "group",
       align: "right",
       items: [
+        // role "cancel" makes Escape and this button the same gesture: Form
+        // clicks the first ENABLED cancel-role button, so on a clean form
+        // Escape instead falls through to the dismiss path — which lands on the
+        // same resetSession(), where re-seeding a form that was never touched
+        // is a no-op.
+        {
+          type: "button",
+          id: ACTION_RESET,
+          label: "Reset",
+          variant: "secondary",
+          role: "cancel",
+          disabled: !dirty,
+        },
         {
           type: "button",
           id: ACTION_CREATE,
@@ -591,6 +656,10 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     branchesError = null;
     nameValue = "";
     baseValue = "";
+    promptValue = "";
+    agentNameValue = "";
+    permissionModeValue = "";
+    dirty = false;
     pickerBusy = false;
     formError = null;
     launchOptions = null;
@@ -638,6 +707,13 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
     sessionHandle.onChange((event) => {
       if (handle !== sessionHandle) return;
       const data = event.data;
+      // Any field-change event is user input by definition: the form's own
+      // seeding goes through selectProject()/pushConfig(), never through the
+      // renderer, so it cannot land here.
+      if (!dirty) {
+        dirty = true;
+        pushConfig();
+      }
       if (event.fieldId === FIELD_PROJECT) {
         // The dialog hands back a raw string; resolve it against the module's own
         // project list rather than minting a brand from unvalidated UI input.
@@ -658,6 +734,18 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       } else if (event.fieldId === FIELD_BASE) {
         baseValue = data[FIELD_BASE] ?? "";
         pushConfig();
+      } else if (event.fieldId === FIELD_PROMPT) {
+        // Pushed so the config the renderer holds carries the latest text when
+        // the panel next remounts. Harmless to the live field: a changed
+        // `initialValue` never re-seeds one.
+        promptValue = data[FIELD_PROMPT] ?? "";
+        pushConfig();
+      } else if (event.fieldId === FIELD_AGENT_NAME) {
+        agentNameValue = data[FIELD_AGENT_NAME] ?? "";
+        pushConfig();
+      } else if (event.fieldId === FIELD_PERMISSION_MODE) {
+        permissionModeValue = data[FIELD_PERMISSION_MODE] ?? "";
+        pushConfig();
       } else if (event.fieldId === FIELD_AGENT) {
         const next = data[FIELD_AGENT] ?? "";
         if (isAvailableAgent(next) && next !== selectedAgentType) {
@@ -674,6 +762,8 @@ export function createCreationModule(deps: CreationModuleDeps): IntentModule {
       if (handle !== sessionHandle) return;
       if (event.actionId === ACTION_CREATE) {
         handleCreate(event.data ?? {});
+      } else if (event.actionId === ACTION_RESET) {
+        void resetSession();
       } else if (event.actionId === ACTION_OPEN_FOLDER) {
         handleOpenFolder();
       } else if (event.actionId === ACTION_CLONE) {

--- a/src/renderer/lib/components/FilterableDropdown.svelte
+++ b/src/renderer/lib/components/FilterableDropdown.svelte
@@ -23,6 +23,13 @@
     onInput?: ((value: string) => void) | undefined;
     /** Whether to focus the input on mount */
     autofocus?: boolean;
+    /**
+     * Select the seeded text the first time the input takes focus, so the first
+     * keystroke replaces it. One-shot: once the user has been given the
+     * selection, later focuses (tabbing back, closing a dropdown) place a
+     * caret as usual instead of re-selecting what they were editing.
+     */
+    selectOnFirstFocus?: boolean;
     /** Render the input as invalid (red border), e.g. for a validation error */
     invalid?: boolean;
     /** id of the element describing this input (e.g. a validation error) */
@@ -46,12 +53,15 @@
     onEnter,
     onInput: onInputCallback,
     autofocus = false,
+    selectOnFirstFocus = false,
     invalid = false,
     describedBy = undefined,
     searchable = true,
   }: FilterableDropdownProps = $props();
 
   // Internal state
+  /** Whether the one-shot seed selection has already been handed to the user. */
+  let seedSelectionConsumed = false;
   let isOpen = $state(false);
   let highlightedIndex = $state(-1);
   // Track whether user is actively typing (vs selection just happened)
@@ -186,6 +196,10 @@
   function handleFocus(): void {
     if (!disabled) {
       isOpen = true;
+    }
+    if (selectOnFirstFocus && !seedSelectionConsumed) {
+      seedSelectionConsumed = true;
+      inputRef?.select();
     }
     focusJustReceived = true;
     setTimeout(() => {

--- a/src/renderer/lib/components/FilterableDropdown.test.ts
+++ b/src/renderer/lib/components/FilterableDropdown.test.ts
@@ -856,4 +856,48 @@ describe("FilterableDropdown component", () => {
       expect(input).not.toHaveAttribute("data-autofocus");
     });
   });
+
+  describe("selectOnFirstFocus", () => {
+    it("selects the seeded text on the first focus", async () => {
+      render(FilterableDropdown, {
+        props: { ...defaultProps, value: "remembered", selectOnFirstFocus: true },
+      });
+
+      const input = screen.getByRole("combobox") as HTMLInputElement;
+      await fireEvent.focus(input);
+
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe("remembered".length);
+    });
+
+    it("places a caret on later focuses instead of re-selecting", async () => {
+      render(FilterableDropdown, {
+        props: { ...defaultProps, value: "remembered", selectOnFirstFocus: true },
+      });
+
+      const input = screen.getByRole("combobox") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.blur(input);
+      input.setSelectionRange(3, 3);
+      await fireEvent.focus(input);
+
+      // One-shot: tabbing back into a field mid-edit must not swallow the
+      // user's caret position and re-select what they were editing.
+      expect(input.selectionStart).toBe(3);
+      expect(input.selectionEnd).toBe(3);
+    });
+
+    it("leaves the caret alone when not enabled", async () => {
+      render(FilterableDropdown, {
+        props: { ...defaultProps, value: "remembered" },
+      });
+
+      const input = screen.getByRole("combobox") as HTMLInputElement;
+      input.setSelectionRange(4, 4);
+      await fireEvent.focus(input);
+
+      expect(input.selectionStart).toBe(4);
+      expect(input.selectionEnd).toBe(4);
+    });
+  });
 });

--- a/src/renderer/lib/components/MainView.svelte
+++ b/src/renderer/lib/components/MainView.svelte
@@ -118,25 +118,13 @@
   // dialog lifecycle is backend-owned now, so the snapshot decides what is open
   // — the presenter closes anything that should not coexist with the panel.)
 
-  // Request a fresh form whenever the panel is (re)shown: send a dismiss
-  // event so the backend creation module resets its session (close + reopen
-  // with fresh config = new dialogId). Sent once per show transition, also
-  // covering the startup race where the snapshot shows the panel before the
-  // always-alive session has arrived. NOT re-sent when the dialogId changes
-  // mid-show — that change IS the reset.
-  let showDismissPending = false;
-  let prevShownForDismiss = false;
-  $effect(() => {
-    const shown = creationShown;
-    if (shown && !prevShownForDismiss) showDismissPending = true;
-    if (!shown) showDismissPending = false;
-    prevShownForDismiss = shown;
-    const session = creationDialog;
-    if (showDismissPending && session) {
-      showDismissPending = false;
-      api.sendDialogEvent({ kind: "dismiss", dialogId: session.id });
-    }
-  });
+  // The panel deliberately does NOT reset the creation form when it is
+  // (re)shown: the form remembers what was typed across a close/reopen. This
+  // mount is destroyed on every hide, so the module is the one thing that
+  // survives — it tracks every field and seeds it back (free text via
+  // `initialValue`, discrete pickers via `value`), and the Form remounting on
+  // show restores rather than clears. Resetting is an explicit gesture only:
+  // the Reset button or Escape, both reaching the module's resetSession().
 
   // Subscribe to the surviving domain events (notification chimes) on mount.
   // The ui:state subscription + ui-connected handshake are owned by App.svelte.

--- a/src/renderer/lib/components/MainView.test.ts
+++ b/src/renderer/lib/components/MainView.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/svelte";
 import type { UiState } from "@shared/ui-state";
+import type { DialogSection } from "@shared/dialog-types";
 
 // Shared fake: src/renderer/lib/api/__mocks__/index.ts
 vi.mock("$lib/api");
@@ -45,7 +46,10 @@ function pushState(state: UiState): Promise<void> {
 
 /** Simulate the backend creation module's always-alive session by adding
  *  a "modeless" dialog to the current snapshot. */
-function openCreationPanelSession(dialogId = "dlg-creation-1"): Promise<void> {
+function openCreationPanelSession(
+  dialogId = "dlg-creation-1",
+  extraSections: DialogSection[] = []
+): Promise<void> {
   current = {
     ...current,
     dialogs: [
@@ -55,12 +59,28 @@ function openCreationPanelSession(dialogId = "dlg-creation-1"): Promise<void> {
         kind: "modeless",
         config: {
           layout: "form",
-          sections: [{ type: "text", content: "New workspace", style: "heading" }],
+          sections: [
+            { type: "text", content: "New workspace", style: "heading" },
+            ...extraSections,
+          ],
         },
       },
     ],
   };
   return rerenderView({ ui: current });
+}
+
+/** The creation form's Prompt field, as the module declares it. */
+function promptSection(initialValue: string): DialogSection {
+  return {
+    type: "input",
+    id: "prompt",
+    label: "Prompt",
+    multiline: true,
+    rows: 3,
+    initialValue,
+    changeEvent: true,
+  };
 }
 
 const WS1 = makeUiWorkspaceRow("feature-1");
@@ -211,21 +231,74 @@ describe("MainView component", () => {
     });
   });
 
-  describe("fresh-form dismiss on panel show", () => {
-    it("sends one dismiss per show transition once the session exists", async () => {
+  describe("creation form survives a panel hide/show", () => {
+    /** The live Prompt textarea in the currently mounted panel. */
+    function promptField(): HTMLTextAreaElement {
+      const node = document.querySelector<HTMLTextAreaElement>("textarea#prompt");
+      expect(node, "prompt field").not.toBeNull();
+      return node!;
+    }
+
+    /** Hide the panel (workspace view) and bring it back, as a switch does. */
+    async function hideAndShow(dialogId: string, sections: DialogSection[]): Promise<void> {
+      await pushState(
+        makeUiState([makeUiProjectRow([WS1_ACTIVE])], {
+          main: { kind: "workspace", frameKey: WS1.key },
+        })
+      );
+      await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
+      await openCreationPanelSession(dialogId, sections);
+    }
+
+    it("restores the remembered text through a real unmount/remount", async () => {
+      renderMainView();
+      await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
+      await openCreationPanelSession("dlg-1", [promptSection("")]);
+
+      // vscode-label is a custom element, so getByLabelText cannot see it.
+      const prompt = promptField();
+      await fireEvent.input(prompt, { target: { value: "do the thing" } });
+      expect(prompt.value).toBe("do the thing");
+
+      // MainView mounts the panel under {#if}, so hiding it destroys the Form
+      // and every value it held. Only the config the module pushed survives —
+      // which is why the module tracks each field and seeds it back.
+      await hideAndShow("dlg-1", [promptSection("do the thing")]);
+
+      expect(promptField().value).toBe("do the thing");
+    });
+
+    it("comes back blank when the module has nothing to seed", async () => {
+      renderMainView();
+      await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
+      await openCreationPanelSession("dlg-1", [promptSection("")]);
+
+      await fireEvent.input(promptField(), { target: { value: "typed but not tracked" } });
+
+      // The negative control for the test above: the restore comes from the
+      // pushed config, never from the DOM surviving on its own.
+      await hideAndShow("dlg-1", [promptSection("")]);
+
+      expect(promptField().value).toBe("");
+    });
+  });
+
+  describe("no fresh-form dismiss on panel show", () => {
+    it("does not reset the form when the panel is shown", async () => {
       renderMainView();
       await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
       await openCreationPanelSession("dlg-1");
-      await waitFor(() => {
-        expect(mockApi.sendDialogEvent).toHaveBeenCalledWith({
-          kind: "dismiss",
-          dialogId: "dlg-1",
-        });
-      });
-      expect(mockApi.sendDialogEvent).toHaveBeenCalledTimes(1);
 
-      // Leaving and returning re-sends (new show transition). Awaiting each
-      // rerender flushes effects so the intermediate workspace state is seen.
+      // The creation form remembers what was typed across a close/reopen, so
+      // showing the panel must NOT send the dismiss that resets the session.
+      expect(mockApi.sendDialogEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not reset when leaving and returning to the panel", async () => {
+      renderMainView();
+      await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
+      await openCreationPanelSession("dlg-1");
+
       await pushState(
         makeUiState([makeUiProjectRow([WS1_ACTIVE])], {
           main: { kind: "workspace", frameKey: WS1.key },
@@ -234,12 +307,10 @@ describe("MainView component", () => {
       await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
       await openCreationPanelSession("dlg-1");
 
-      await waitFor(() => {
-        expect(mockApi.sendDialogEvent).toHaveBeenCalledTimes(2);
-      });
+      expect(mockApi.sendDialogEvent).not.toHaveBeenCalled();
     });
 
-    it("covers the startup race: snapshot shows the panel before the session arrives", async () => {
+    it("does not reset when the session arrives after the panel is shown", async () => {
       renderMainView();
 
       await pushState(makeUiState([PROJECT], { main: { kind: "creation" } }));
@@ -247,12 +318,7 @@ describe("MainView component", () => {
 
       await openCreationPanelSession("dlg-late");
 
-      await waitFor(() => {
-        expect(mockApi.sendDialogEvent).toHaveBeenCalledWith({
-          kind: "dismiss",
-          dialogId: "dlg-late",
-        });
-      });
+      expect(mockApi.sendDialogEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/renderer/lib/components/form/DropdownSection.svelte
+++ b/src/renderer/lib/components/form/DropdownSection.svelte
@@ -63,6 +63,7 @@
       searchable={section.searchable ?? true}
       disabled={section.disabled ?? false}
       autofocus={section.autofocus ?? false}
+      selectOnFirstFocus={section.selectInitialValue ?? false}
       invalid={!!section.error}
       describedBy={section.error ? `${section.id}-error` : undefined}
       onSelect={onPick}

--- a/src/shared/dialog-types.ts
+++ b/src/shared/dialog-types.ts
@@ -142,6 +142,9 @@ interface RadioSection extends FieldSection {
  * - searchable false (strict mode only): the input is read-only — the field
  *   behaves like a classic select (focus opens the list, arrow keys + click
  *   pick, typing does nothing). Default true (type-to-filter combobox).
+ * - selectInitialValue selects the seeded text instead of placing a caret, so
+ *   the first keystroke replaces it (same as the input section's). Only
+ *   meaningful together with autofocus, which is what places the caret.
  */
 interface DropdownSection extends FieldSection {
   readonly type: "dropdown";
@@ -150,6 +153,7 @@ interface DropdownSection extends FieldSection {
   readonly searchable?: boolean;
   readonly placeholder?: string;
   readonly initialValue?: string;
+  readonly selectInitialValue?: boolean;
   readonly value?: string;
   readonly changeEvent?: FieldChangeConfig;
   readonly loading?: boolean;


### PR DESCRIPTION
The create-workspace form was wiped every time the panel was shown, so leaving it to look at a workspace and coming back lost whatever had been typed.

- Stop resetting the form when the panel is shown. Two independent things cleared it: `MainView` fired a `dismiss` on each show transition, which the creation module treats as "give me a fresh form", and the panel's `{#if}` unmounts the `Form`, taking every uncontrolled field value with it.
- Track each field in the creation module and seed it back — free text via `initialValue`, discrete pickers via `value`. Free text deliberately seeds rather than pushes: a controlled `value` echoes the user's own text back after the change debounce, and resuming typing inside that round-trip would let the adopt-once reconcile overwrite the newer characters.
- Retention spans only the close/reopen. Every field keeps its existing reactive behaviour: the project re-seeds on reset, the base still derives from the project default and a branch pick, and the permission mode still reloads on an agent switch — now collapsing to the default rather than pushing a mode the new backend cannot honour.
- Add a Reset button, enabled once any input has been made and marked `role: "cancel"` so Escape and the button are one gesture.
- Restored names arrive selected, via a new one-shot `selectInitialValue` on dropdown sections mirroring the one input sections already had.

Tests cover retention across a close/reopen, reset clearing and re-seeding, the dirty gating, the permission-mode guard across a backend switch, and — against the real component tree — that the text survives an actual unmount/remount, with a negative control proving the unmount really does destroy it.