### PR TITLE
fix: Waking a workspace no longer reloads it immediately

### DIFF
--- a/src/boundaries/shell/ui-view-manager.integration.test.ts
+++ b/src/boundaries/shell/ui-view-manager.integration.test.ts
@@ -335,9 +335,29 @@ describe("UiViewManager", () => {
       for (const listener of win.listeners) listener({ source, data });
     }
 
+    /**
+     * Install the script and discard the announcement it makes on install, so
+     * a test about ping handling starts from a settled page.
+     */
+    function installAndSettle(win: FakeWindow, uiPage: FakeWindow): void {
+      run(installedScript(), win);
+      uiPage.posted.length = 0;
+    }
+
+    it("announces itself as soon as it is installed", () => {
+      // The renderer probes a frame when its element mounts, which is before
+      // this script arrives on load-finish — so a ping alone can never prove a
+      // freshly mounted frame alive (PostHog issue 019fc47c).
+      const { win, uiPage } = createFrameWindow();
+
+      run(installedScript(), win);
+
+      expect(uiPage.posted).toEqual([{ __chAlive: true }]);
+    });
+
     it("answers a ping from the UI page", () => {
       const { win, uiPage } = createFrameWindow();
-      run(installedScript(), win);
+      installAndSettle(win, uiPage);
 
       send(win, { __chPing: true });
 
@@ -346,7 +366,7 @@ describe("UiViewManager", () => {
 
     it("ignores messages that are not pings", () => {
       const { win, uiPage } = createFrameWindow();
-      run(installedScript(), win);
+      installAndSettle(win, uiPage);
 
       send(win, { __chPing: false });
       send(win, "hello");
@@ -357,7 +377,7 @@ describe("UiViewManager", () => {
 
     it("ignores a ping that did not come from the UI page", () => {
       const { win, uiPage } = createFrameWindow();
-      run(installedScript(), win);
+      installAndSettle(win, uiPage);
 
       send(win, { __chPing: true }, { spoofed: true });
 
@@ -366,7 +386,8 @@ describe("UiViewManager", () => {
 
     it("stays silent in VSCodium's nested webview frames", () => {
       // A webview nested inside a workspace frame: its parent is that frame,
-      // not the UI page, so the UI could not attribute its answer.
+      // not the UI page, so the UI could not attribute its announcement or its
+      // answer to any frame it mounted.
       const { win, uiPage } = createFrameWindow();
       const workspaceFrame = { ...win };
       win.parent = workspaceFrame as FakeWindow;
@@ -378,12 +399,15 @@ describe("UiViewManager", () => {
       expect(uiPage.posted).toEqual([]);
     });
 
-    it("does not register a second responder when injected again", () => {
+    it("does not register a second responder or re-announce when injected again", () => {
       const { win, uiPage } = createFrameWindow();
       const script = installedScript();
 
+      installAndSettle(win, uiPage);
       run(script, win);
-      run(script, win);
+
+      expect(uiPage.posted).toEqual([]);
+
       send(win, { __chPing: true });
 
       expect(win.listeners).toHaveLength(1);
@@ -398,6 +422,20 @@ describe("UiViewManager", () => {
       };
 
       expect(() => send(win, { __chPing: true })).not.toThrow();
+    });
+
+    it("installs even when the announcement is rejected", () => {
+      // A parent that rejects postMessage must not abort installation — the
+      // responder still has to be registered for the probe that follows.
+      const { win, uiPage } = createFrameWindow();
+      uiPage.postMessage = (): never => {
+        throw new Error("cross-origin");
+      };
+
+      expect(() => {
+        run(installedScript(), win);
+      }).not.toThrow();
+      expect(win.listeners).toHaveLength(1);
     });
   });
 });

--- a/src/boundaries/shell/ui-view-manager.ts
+++ b/src/boundaries/shell/ui-view-manager.ts
@@ -61,9 +61,19 @@ const CHILD_FRAME_FOCUS_TRACKER = `
 
 /**
  * Script injected into every workspace iframe so it can prove its renderer
- * process is still running. Answers a `__chPing` from the UI page with
- * `__chAlive`; WorkspaceFrames probes a frame when it shows it and logs one
- * that stays silent.
+ * process is still running. Announces `__chAlive` as soon as it is installed
+ * and answers a later `__chPing` with the same; WorkspaceFrames probes a frame
+ * when it shows it and logs one that stays silent.
+ *
+ * The unprompted announcement is what makes a freshly mounted frame provable.
+ * This script arrives on `did-frame-finish-load`, but WorkspaceFrames probes a
+ * frame the moment its element mounts — so on a create or a wake the ping is
+ * delivered to a document with no listener yet and is simply ignored, and the
+ * probe is one-shot. Announcing on install reports liveness at the instant the
+ * frame becomes able to report it, whichever side wins the race: it cancels a
+ * probe already waiting, or is recorded ahead of one still to come (PostHog
+ * issue 019fc47c: a woken workspace was reloaded ten seconds in, after it had
+ * fully come up, because its probe could never have been answered).
  *
  * Why the frames have to answer for themselves: all workspace iframes are
  * same-origin (the one IDE server port), so Chromium hosts them in a single
@@ -90,6 +100,7 @@ const CHILD_FRAME_PROBE = `
       if (!e.data || e.data.__chPing !== true) return;
       try { window.parent.postMessage({ __chAlive: true }, '*'); } catch(err) {}
     });
+    try { window.parent.postMessage({ __chAlive: true }, '*'); } catch(err) {}
   })();
 `;
 

--- a/src/renderer/lib/components/WorkspaceFrames.svelte
+++ b/src/renderer/lib/components/WorkspaceFrames.svelte
@@ -86,6 +86,7 @@
     return {
       destroy() {
         frameEls.delete(key);
+        forgetFrame(key);
       },
     };
   }
@@ -98,9 +99,22 @@
   // stays silent is logged and reloaded. The frames are the only witnesses to
   // their own renderer process dying — Electron surfaces no event for a
   // subframe process (PostHog issue 019fb265).
+  //
+  // A frame also announces itself unprompted once its injected script installs
+  // (ui-view-manager's CHILD_FRAME_PROBE), which is how a frame mounted after
+  // the probe was sent still gets to answer it: the probe fires at mount, but
+  // the script only arrives on load-finish. Both paths land in
+  // `handleFrameMessage`, so a probe is settled by whichever comes first.
   // ---------------------------------------------------------------------------
 
-  /** Keys that have answered at least once — separates dead from never-loaded. */
+  /**
+   * Keys whose *currently mounted* frame has answered at least once —
+   * separates dead from never-loaded. Scoped to the frame element, not the
+   * workspace: hibernating unmounts the frame, and the one a wake mounts is a
+   * new document that has proven nothing yet. Letting the key outlive its
+   * frame is what turned a woken workspace's unanswerable probe into a reload
+   * (PostHog issue 019fc47c), so `forgetFrame` clears it on unmount.
+   */
   const everAnswered = new SvelteSet<string>();
 
   /** The frame currently being probed, and its pending verdict. */
@@ -111,6 +125,12 @@
     if (probeTimer !== undefined) clearTimeout(probeTimer);
     probeTimer = undefined;
     probeKey = null;
+  }
+
+  /** Drop the liveness record of a frame that is going away. */
+  function forgetFrame(key: string): void {
+    everAnswered.delete(key);
+    if (key === probeKey) cancelProbe();
   }
 
   function probeFrame(key: string, el: HTMLIFrameElement): void {

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -272,6 +272,55 @@ describe("WorkspaceFrames", () => {
       expect(windows.get("test-12345678/ws1")!.pings).toEqual([{ __chPing: true }]);
     });
 
+    it("lets a frame that finishes loading late settle its own probe", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+      const setters = trackSrc(container);
+
+      // The probe goes out at mount, before the injected script exists; the
+      // frame announces itself when that script installs on load-finish. The
+      // deadline is a grace period for loading, not an instant handshake.
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      await vi.advanceTimersByTimeAsync(4_000);
+      answer(windows.get("test-12345678/ws1")!);
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      expect(logs()).toEqual([]);
+      expect(setters.get("test-12345678/ws1")!).not.toHaveBeenCalled();
+    });
+
+    it("makes a remounted frame prove itself again", async () => {
+      const { container, rerender } = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: null },
+      });
+      const windows = giveWindows(container);
+
+      // ws1 proves itself alive...
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      answer(windows.get("test-12345678/ws1")!);
+
+      // ...then hibernates, which unmounts its frame. What a wake mounts is a
+      // new document that has proven nothing, so its silence must read as
+      // never-answered rather than as a death worth reloading (PostHog issue
+      // 019fc47c).
+      await rerender({ frames: [FRAMES[1]!], activeKey: FRAMES[1]!.key });
+      await rerender({ frames: FRAMES, activeKey: FRAMES[0]!.key });
+      giveWindows(container);
+      const setters = trackSrc(container);
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      expect(setters.get("test-12345678/ws1")!).not.toHaveBeenCalled();
+      expect(logs()).toEqual([
+        {
+          level: "warn",
+          message: "Workspace frame never responded (may never have finished loading)",
+          context: { key: "test-12345678/ws1", reloaded: false },
+        },
+      ]);
+    });
+
     it("reports a frame that answered before differently from one that never did", async () => {
       const { container, rerender } = render(WorkspaceFrames, {
         props: { frames: FRAMES, activeKey: null },


### PR DESCRIPTION
Waking a hibernated workspace reloaded it about ten seconds later, discarding a workbench that had already fully come up — extension host, plugin client, MCP session, agent back at idle — and restarting it from scratch. Reported via PostHog issue `019fc47c` on v2026.7.31, the release the frame-liveness watchdog shipped in.

- The liveness probe is sent when a frame's element mounts, but the script that answers it is injected on `did-frame-finish-load`. A ping delivered to a document with no listener yet is ignored, and the probe is one-shot — so a freshly mounted frame could never pass it.
- `everAnswered` was only ever added to, while frames unmount on hibernation, so the key outlived the document it described. At the deadline that stale entry turned the verdict into "was alive and stopped, reload it" instead of the harmless "never answered".
- `CHILD_FRAME_PROBE` now announces `__chAlive` when it installs, as well as answering pings, so a probe is settled by whichever arrives first. `handleFrameMessage` already accepted an unsolicited answer, so the renderer needed no change to receive it.
- `forgetFrame()` scopes `everAnswered` to the mounted frame, clearing it and any probe aimed at it on unmount, so what a wake mounts has to prove itself again.
- Side effect: the spurious `never responded` warning that every workspace create and wake used to emit is gone.
- Tests: guards for both halves (each verified to fail with its fix backed out), plus the existing `019fb265` recovery coverage left intact.

Reproduced and verified against a live app before and after the change.