### PR TITLE
feat(cleanup): sweep the data root of stale files at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,21 +377,22 @@ CH_LOG__LEVEL=debug CH_LOG__OUTPUT=console pnpm dev
 
 ### Logger Names
 
-| Logger              | Module                               |
-| ------------------- | ------------------------------------ |
-| `[process]`         | Process spawning                     |
-| `[network]`         | HTTP requests, ports                 |
-| `[fs]`              | Filesystem operations                |
-| `[git]`             | Git operations                       |
-| `[opencode]`        | OpenCode SDK                         |
-| `[opencode-server]` | OpenCode server manager              |
-| `[keepfiles]`       | .keepfiles copying                   |
-| `[api]`             | IPC handlers                         |
-| `[window]`          | WindowManager                        |
-| `[view]`            | ViewManager                          |
-| `[badge]`           | BadgeManager                         |
-| `[power]`           | Sleep prevention                     |
-| `[app]`             | Application lifecycle                |
-| `[state]`           | StateService (state.json)            |
-| `[ui]`              | Renderer UI components               |
-| `[presenter]`       | PresentationModule (ui:event intake) |
+| Logger              | Module                                 |
+| ------------------- | -------------------------------------- |
+| `[process]`         | Process spawning                       |
+| `[network]`         | HTTP requests, ports                   |
+| `[fs]`              | Filesystem operations                  |
+| `[git]`             | Git operations                         |
+| `[opencode]`        | OpenCode SDK                           |
+| `[opencode-server]` | OpenCode server manager                |
+| `[keepfiles]`       | .keepfiles copying                     |
+| `[api]`             | IPC handlers                           |
+| `[window]`          | WindowManager                          |
+| `[view]`            | ViewManager                            |
+| `[badge]`           | BadgeManager                           |
+| `[power]`           | Sleep prevention                       |
+| `[app]`             | Application lifecycle                  |
+| `[state]`           | StateService (state.json)              |
+| `[ui]`              | Renderer UI components                 |
+| `[presenter]`       | PresentationModule (ui:event intake)   |
+| `[cleanup]`         | CleanupModule (stale data-root sweeps) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -285,6 +285,25 @@ The UI shows a scrollable list of blocking processes (with files and CWD) and of
 - Re-checks worktree registration before each deletion (TOCTOU protection)
 - Concurrency guard prevents multiple cleanups running simultaneously
 
+### Data Root Cleanup
+
+`CleanupModule` (`src/modules/cleanup-module.ts`) sweeps the data root of things nothing uses any more. It runs on the `app:start` "start" hook, **fire-and-forget**: reclaiming gigabytes can take seconds and nothing waits on the result. That is safe because every path a rule touches is one nothing else writes — retired directories no code references, log files older than the current session, bundle versions other than the live one. The one sweep that _is_ order-critical, clearing the temp root before a workspace writes its agent config into it, stays in `TempDirModule`, awaited in the earlier "init" hook.
+
+Rules are declared by the composition root (`src/main.ts`) and run in order, so a rule that retires a path can precede one that sweeps its parent — `claude/configs` is retired before the `claude` bundle rule, so the retired directory is never mistaken for a version to keep.
+
+| Rule kind    | Behaviour                                                               |
+| ------------ | ----------------------------------------------------------------------- |
+| `retire`     | Delete a path we no longer use, whole (file or tree)                    |
+| `keepRecent` | Keep the newest N entries **by name**                                   |
+| `pruneEmpty` | Delete childless directories directly under a path                      |
+| `bundle`     | Keep only the live version of a downloaded bundle; packaged builds only |
+
+`keepRecent` sorts by name, not timestamp: session logs are named for the launch that wrote them (`2026-08-28T07-35-51-<id>.log`), so lexicographic order is already chronological and no `stat` is needed. Names that are not session logs rank **oldest**, so a stray file in the log directory is the first thing swept.
+
+`bundle` reads its live version when it runs, not when it is declared, so it reflects resolved configuration. It is skipped in development builds: dev shares its data root with binaries `pnpm install` and the test helpers download, pinned to versions the running app does not resolve. A null live version (Claude ships its binary rather than downloading one) means no version directory is expected, so every one is a leftover.
+
+Every rule is best-effort and isolated: a failure is logged at warn and the remaining rules still run. An **absent** target is silent (the normal case); an **unreadable** one is reported, so cleanup never quietly behaves as though there were nothing to clean. One info line summarises what was removed.
+
 ### Workspace Session Model
 
 All workspaces share a single global Electron session to enable extension storage (globalState, secrets) to be shared across workspaces.

--- a/e2e/cleanup.e2e.ts
+++ b/e2e/cleanup.e2e.ts
@@ -118,7 +118,7 @@ test("caps the log directory and keeps this launch's own log", async () => {
   // If `generateSessionFilename()` ever stops matching the rule's pattern, every
   // real log ranks "oldest" and this launch's own file is swept along with the
   // seeded ones — leaving nothing to debug the app with.
-  const sessionLogs = remaining.filter((name) => /^\d{4}-\d{2}-\d{2}T/.test(name) && name !== "");
+  const sessionLogs = remaining.filter((name) => /^\d{4}-\d{2}-\d{2}t/i.test(name) && name !== "");
   expect(
     sessionLogs.some((name) => !name.includes("-seeded.")),
     `no real session log survived the sweep; remaining: ${remaining.join(", ")}`

--- a/e2e/cleanup.e2e.ts
+++ b/e2e/cleanup.e2e.ts
@@ -1,0 +1,126 @@
+/**
+ * Startup cleanup: the app sweeps its own data root of things nothing uses.
+ *
+ * The value this spec adds over `cleanup-module.integration.test.ts` is that it
+ * runs against the *real* data root, so it proves what a mock cannot:
+ *
+ * - The `keepRecent` rule's name ordering matches the filenames electron-log
+ *   actually produces. The integration test asserts against invented names, so
+ *   a change to `generateSessionFilename()` would sail past it and quietly turn
+ *   every session log into an "unrecognized" entry ranked oldest — which is to
+ *   say, into something cleanup deletes first.
+ * - The module is registered and its hook actually fires in a packaged app.
+ *
+ * The `bundle` rules are deliberately not asserted. They are gated on
+ * `buildInfo.isDevelopment`, which comes from `_CH_BUILD_RELEASE` at build time,
+ * and CI's packaged artifacts are dev-flavored (see env.ts) — so either outcome
+ * would be correct here and the assertion would only encode which artifact
+ * happened to run.
+ */
+import { expect, test } from "@playwright/test";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_ROOT, resetDataState, type Agent } from "./env";
+import { launchApp, useApp } from "./fixtures";
+
+/** Matches the sweep's own limit: `{ kind: "keepRecent", path: "logs", keep: 20 }`. */
+const LOG_KEEP = 20;
+
+/** More than the limit, so the cut is guaranteed to bite whatever else is there. */
+const SEEDED_LOGS = 25;
+
+/** `cold: true` only means "don't launch for me" — this spec has to seed first. */
+const app = useApp({ cold: true });
+
+function seedStaleData(): void {
+  // A retired tree: the IDE server we shipped before VSCodium.
+  mkdirSync(join(DATA_ROOT, "code-server", "4.127.0", "lib"), { recursive: true });
+  writeFileSync(join(DATA_ROOT, "code-server", "4.127.0", "lib", "node"), "stale binary");
+
+  // Agent hook/MCP configs from before they moved under the temp root.
+  mkdirSync(join(DATA_ROOT, "claude", "configs", "feature-a-1a2b3c"), { recursive: true });
+  writeFileSync(
+    join(DATA_ROOT, "claude", "configs", "feature-a-1a2b3c", "codehydra-hooks.json"),
+    "{}"
+  );
+
+  // A screenshot directory whose project is gone, next to one that is still live.
+  mkdirSync(join(DATA_ROOT, "screenshots", "ghost-project-deadbeef"), { recursive: true });
+  mkdirSync(join(DATA_ROOT, "screenshots", "live-project-cafe1234"), { recursive: true });
+  writeFileSync(join(DATA_ROOT, "screenshots", "live-project-cafe1234", "feature.png"), "png");
+
+  // Session logs from a long time ago: dated 2020, so every real log outranks
+  // them and they are what the cut reaches first.
+  const logsDir = join(DATA_ROOT, "logs");
+  mkdirSync(logsDir, { recursive: true });
+  for (let i = 0; i < SEEDED_LOGS; i++) {
+    const index = String(i).padStart(2, "0");
+    // Plain text, not JSONL: the log-reading fixtures skip unparsable lines, so
+    // these cannot be mistaken for something this run logged.
+    writeFileSync(join(logsDir, `2020-01-01T00-00-${index}-seeded.log`), "seeded\n");
+  }
+}
+
+function logFiles(): string[] {
+  const logsDir = join(DATA_ROOT, "logs");
+  return existsSync(logsDir) ? readdirSync(logsDir) : [];
+}
+
+test.beforeAll(async () => {
+  // Warm start, same as every other warm spec: keep config.json, bundles, VSIXes.
+  resetDataState({ keepConfig: true });
+  seedStaleData();
+
+  // Seeded *before* launch, so the app sees it the way a real upgrade would.
+  expect(existsSync(join(DATA_ROOT, "code-server"))).toBe(true);
+  expect(logFiles().length).toBeGreaterThanOrEqual(SEEDED_LOGS);
+
+  await launchApp(app(), { agent: test.info().project.name as Agent });
+});
+
+test("retires directories and files nothing uses any more", async () => {
+  // The sweep is fire-and-forget, so poll rather than assume it finished by the
+  // time the UI came up — not blocking startup is the point of the design.
+  await expect
+    .poll(() => existsSync(join(DATA_ROOT, "code-server")), { timeout: 30_000 })
+    .toBe(false);
+
+  await expect
+    .poll(() => existsSync(join(DATA_ROOT, "claude", "configs")), { timeout: 30_000 })
+    .toBe(false);
+});
+
+test("prunes screenshot directories whose project is gone, and keeps the rest", async () => {
+  await expect
+    .poll(() => existsSync(join(DATA_ROOT, "screenshots", "ghost-project-deadbeef")), {
+      timeout: 30_000,
+    })
+    .toBe(false);
+
+  // Over-deleting here would silently drop the previews of every hibernated
+  // workspace, which is exactly the failure a sweep must not have.
+  expect(existsSync(join(DATA_ROOT, "screenshots", "live-project-cafe1234", "feature.png"))).toBe(
+    true
+  );
+});
+
+test("caps the log directory and keeps this launch's own log", async () => {
+  // Exactly the limit: we seeded more than that, and this launch's own file is
+  // newer than every seeded one, so the cut lands in a known place.
+  await expect.poll(() => logFiles().length, { timeout: 30_000 }).toBe(LOG_KEEP);
+
+  const remaining = logFiles();
+
+  // The oldest seeded log is the first thing past the cut.
+  expect(remaining).not.toContain("2020-01-01T00-00-00-seeded.log");
+
+  // The regression this spec exists for: a real session log must still be here.
+  // If `generateSessionFilename()` ever stops matching the rule's pattern, every
+  // real log ranks "oldest" and this launch's own file is swept along with the
+  // seeded ones — leaving nothing to debug the app with.
+  const sessionLogs = remaining.filter((name) => /^\d{4}-\d{2}-\d{2}T/.test(name) && name !== "");
+  expect(
+    sessionLogs.some((name) => !name.includes("-seeded.")),
+    `no real session log survived the sweep; remaining: ${remaining.join(", ")}`
+  ).toBe(true);
+});

--- a/src/boundaries/platform/logging-types.ts
+++ b/src/boundaries/platform/logging-types.ts
@@ -65,7 +65,8 @@ export type LoggerName =
   | "power" // AppBoundary.allowPowerSaving - sleep prevention
   | "error-report" // ErrorReportModule - crash + manual bug report
   | "auto-tagging" // AutoTaggingModule - "new" tag on background workspaces
-  | "notification"; // OsNotificationModule + OsNotificationBoundary - OS toasts
+  | "notification" // OsNotificationModule + OsNotificationBoundary - OS toasts
+  | "cleanup"; // CleanupModule - stale data-root sweeps
 
 /**
  * Context data for log entries.

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,7 @@ import { createElectronLifecycleModule } from "./modules/electron-lifecycle-modu
 import { createLoggingModule } from "./modules/logging-module";
 import { createScriptModule } from "./modules/script-module";
 import { createTempDirModule } from "./modules/temp-dir-module";
+import { createCleanupModule } from "./modules/cleanup-module";
 import { createErrorReportModule } from "./modules/error-report-module";
 import { createShortcutModule } from "./modules/shortcut-module";
 import { createDevtoolsModule } from "./modules/devtools-module";
@@ -793,6 +794,42 @@ const tempDirModule = createTempDirModule({
   pathProvider,
 });
 
+// Sweeps of the data root that nothing waits on. Order matters: `claude/configs`
+// is retired before the `claude` bundle rule sweeps its parent, so the retired
+// directory is never mistaken for a version. The temp root is deliberately absent
+// — clearing it is order-critical and stays in tempDirModule, awaited in "init".
+const cleanupModule = createCleanupModule({
+  fileSystem: fileSystemLayer,
+  pathProvider,
+  logger: loggingService.createLogger("cleanup"),
+  isPackagedBuild: !buildInfo.isDevelopment,
+  rules: [
+    // Agent hook/MCP configs. They bake in this launch's ports and plugin token,
+    // so they were never data: they now live under the temp root.
+    { kind: "retire", path: "claude/configs" },
+    // The IDE server we shipped before VSCodium. Nothing has read it since the
+    // `code-server.port` -> `ide-server.port` rename.
+    { kind: "retire", path: "code-server" },
+    // OpenCode's config is passed inline via OPENCODE_CONFIG_CONTENT; this file
+    // is what the old on-disk approach left behind.
+    { kind: "retire", path: "opencode/opencode.codehydra.json" },
+    // One log file per launch, and electron-log only ever rotates the current
+    // one, so nothing bounded the directory's growth.
+    { kind: "keepRecent", path: "logs", keep: 20 },
+    // Hibernation screenshots are deleted on wake and on workspace delete; the
+    // per-project directory is what outlives the project.
+    { kind: "pruneEmpty", path: "screenshots" },
+    { kind: "bundle", path: "claude", live: () => claudeVersionConfig.get(), packagedOnly: true },
+    {
+      kind: "bundle",
+      path: "opencode",
+      live: () => opencodeVersionConfig.get(),
+      packagedOnly: true,
+    },
+    { kind: "bundle", path: "vscodium", live: () => ideServerModule.version(), packagedOnly: true },
+  ],
+});
+
 const shortcutModule = createShortcutModule({
   viewManager,
   windowLayer,
@@ -979,6 +1016,7 @@ dispatcher.registerModule(electronLifecycleModule);
 dispatcher.registerModule(loggingModule);
 dispatcher.registerModule(scriptModule);
 dispatcher.registerModule(tempDirModule);
+dispatcher.registerModule(cleanupModule);
 dispatcher.registerModule(shortcutModule);
 dispatcher.registerModule(devtoolsModule);
 dispatcher.registerModule(debugModule);

--- a/src/modules/agent-module/claude/provider.integration.test.ts
+++ b/src/modules/agent-module/claude/provider.integration.test.ts
@@ -60,9 +60,9 @@ describe("ClaudeCodeProvider integration", () => {
     mockPathProvider = createMockPathProvider();
     mockFileSystem = createFileSystemMock({
       entries: {
-        "/app-data": directory(),
-        "/app-data/claude": directory(),
-        "/app-data/claude/configs": directory(),
+        "/test/temp": directory(),
+        "/test/temp/claude": directory(),
+        "/test/temp/claude/configs": directory(),
       },
     });
 

--- a/src/modules/agent-module/claude/server-manager.integration.test.ts
+++ b/src/modules/agent-module/claude/server-manager.integration.test.ts
@@ -63,9 +63,9 @@ describe("ClaudeCodeServerManager integration", () => {
     mockPathProvider = createMockPathProvider();
     mockFileSystem = createFileSystemMock({
       entries: {
-        "/app-data": directory(),
-        "/app-data/claude": directory(),
-        "/app-data/claude/configs": directory(),
+        "/test/temp": directory(),
+        "/test/temp/claude": directory(),
+        "/test/temp/claude/configs": directory(),
       },
     });
 
@@ -974,6 +974,22 @@ describe("ClaudeCodeServerManager integration", () => {
       const pathB = serverManager.getHooksConfigPath("/workspace/feature-b");
 
       expect(pathA.toString()).not.toBe(pathB.toString());
+    });
+
+    it("generates configs under the temp root, not app data", async () => {
+      // The generated files bake in this launch's bridge port, plugin port and
+      // plugin token, so one that outlives the launch is wrong, not merely
+      // stale. temp-dir-module clears the temp root on every app:start; app
+      // data is never cleared, which is how these accumulated forever.
+      await serverManager.startServer("/workspace/feature-a");
+
+      const hooksPath = serverManager.getHooksConfigPath("/workspace/feature-a");
+      const mcpPath = serverManager.getMcpConfigPath("/workspace/feature-a");
+
+      expect(hooksPath.toString()).toContain("/test/temp/claude/configs/");
+      expect(mcpPath.toString()).toContain("/test/temp/claude/configs/");
+      expect(hooksPath.toString()).not.toContain("/test/app-data/");
+      expect(mcpPath.toString()).not.toContain("/test/app-data/");
     });
 
     it("resolves the system prompt from the runtime dir, shared by all workspaces", () => {

--- a/src/modules/agent-module/claude/server-manager.ts
+++ b/src/modules/agent-module/claude/server-manager.ts
@@ -909,9 +909,13 @@ export class ClaudeCodeServerManager implements AgentServerManager {
    * Creates both hooks.json and mcp.json in the workspace's config directory.
    */
   private async generateConfigFiles(workspacePath: string): Promise<void> {
-    // Config directory is in the app data, not in the workspace
+    // Config directory is in the app temp dir, not in the workspace.
+    // Temp, not data: the generated files bake in this launch's bridge port,
+    // plugin port and plugin token, so a file that outlives the launch is not
+    // just garbage but actively wrong. temp-dir-module clears the temp root on
+    // every app:start, which is exactly the lifetime these files want.
     // Using a hash of workspace path to make it unique
-    const configDir = this.pathProvider.dataPath("claude/configs");
+    const configDir = this.pathProvider.tempPath("claude/configs");
 
     // Generate a safe directory name from workspace path
     const safeWorkspaceName = this.getConfigDirName(workspacePath);
@@ -996,7 +1000,7 @@ export class ClaudeCodeServerManager implements AgentServerManager {
   private configFilePath(workspacePath: string, filename: string): Path {
     const normalizedPath = new Path(workspacePath).toString();
     const safeWorkspaceName = this.getConfigDirName(normalizedPath);
-    return new Path(this.pathProvider.dataPath("claude/configs"), safeWorkspaceName, filename);
+    return new Path(this.pathProvider.tempPath("claude/configs"), safeWorkspaceName, filename);
   }
 
   /**

--- a/src/modules/cleanup-module.integration.test.ts
+++ b/src/modules/cleanup-module.integration.test.ts
@@ -1,0 +1,389 @@
+// @vitest-environment node
+/**
+ * Integration tests for CleanupModule through the Dispatcher.
+ *
+ * Tests verify the full pipeline:
+ * - app:start / start → every rule runs against a behavioral filesystem
+ *
+ * The sweep is fire-and-forget, so the dispatch resolves before it finishes.
+ * Tests wait on the observable outcome (`vi.waitFor`) rather than on the
+ * handler, which is exactly the guarantee the module offers: startup does not
+ * block on cleanup.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
+import { createMinimalOperation } from "../intents/lib/operation.test-utils";
+import { INTENT_APP_START, APP_START_OPERATION_ID } from "../intents/app-start";
+import type { AppStartIntent } from "../intents/app-start";
+import { createMockPathProvider } from "../boundaries/platform/path-provider.test-utils";
+import {
+  createFileSystemMock,
+  directory,
+  file,
+  type MockFileSystemBoundary,
+} from "../boundaries/platform/filesystem.state-mock";
+import { SILENT_LOGGER } from "../boundaries/platform/logging.test-utils";
+import type { Logger } from "../boundaries/platform/logging";
+import { createCleanupModule, type CleanupRule } from "./cleanup-module";
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+interface SetupOptions {
+  readonly entries?: Record<string, ReturnType<typeof directory> | ReturnType<typeof file>>;
+  readonly rules: readonly CleanupRule[];
+  readonly isPackagedBuild?: boolean;
+  readonly logger?: Logger;
+}
+
+interface TestSetup {
+  readonly run: () => Promise<void>;
+  readonly fileSystem: MockFileSystemBoundary;
+}
+
+function createTestSetup(options: SetupOptions): TestSetup {
+  const dispatcher = createMockDispatcher();
+  // The data root always exists in a real install (config.json lives in it), and
+  // `retire` asks the parent whether its target is there — so seed it.
+  const fileSystem = createFileSystemMock({
+    entries: { "/test/app-data": directory(), ...options.entries },
+  });
+
+  dispatcher.registerOperation(
+    createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "start", {
+      throwOnError: false,
+    })
+  );
+
+  dispatcher.registerModule(
+    createCleanupModule({
+      fileSystem,
+      pathProvider: createMockPathProvider(),
+      logger: options.logger ?? SILENT_LOGGER,
+      isPackagedBuild: options.isPackagedBuild ?? true,
+      rules: options.rules,
+    })
+  );
+
+  return {
+    fileSystem,
+    run: async () => {
+      await dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} });
+    },
+  };
+}
+
+/** Path helper: everything a rule touches hangs off the mock data root. */
+function data(subpath: string): string {
+  return `/test/app-data/${subpath}`;
+}
+
+function exists(fileSystem: MockFileSystemBoundary, path: string): boolean {
+  return fileSystem.$.entries.has(path);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("CleanupModule Integration", () => {
+  describe("retire", () => {
+    it("removes a retired directory and everything under it", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("code-server")]: directory(),
+          [data("code-server/4.127.0")]: directory(),
+          [data("code-server/4.127.0/node")]: file("binary"),
+        },
+        rules: [{ kind: "retire", path: "code-server" }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("code-server"))).toBe(false);
+        expect(exists(fileSystem, data("code-server/4.127.0/node"))).toBe(false);
+      });
+    });
+
+    it("removes a retired file", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("opencode")]: directory(),
+          [data("opencode/opencode.codehydra.json")]: file("{}"),
+          [data("opencode/1.0.223")]: directory(),
+        },
+        rules: [{ kind: "retire", path: "opencode/opencode.codehydra.json" }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("opencode/opencode.codehydra.json"))).toBe(false);
+      });
+      // Retiring one entry must not take its neighbours with it.
+      expect(exists(fileSystem, data("opencode/1.0.223"))).toBe(true);
+    });
+
+    it("reports nothing when the retired path was never there", async () => {
+      const logger = { ...SILENT_LOGGER, info: vi.fn(), warn: vi.fn() };
+      const { run } = createTestSetup({
+        entries: { [data("logs")]: directory() },
+        rules: [{ kind: "retire", path: "code-server" }],
+        logger,
+      });
+
+      await run();
+      await vi.waitFor(() => expect(logger.warn).not.toHaveBeenCalled());
+
+      // An absent path is the normal case on most machines: no summary line,
+      // and certainly no warning.
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("keepRecent", () => {
+    it("keeps the newest entries by name and deletes the rest", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("logs")]: directory(),
+          [data("logs/2026-01-12T21-33-04-aaaa.log")]: file("old"),
+          [data("logs/2026-06-10T10-00-00-bbbb.log")]: file("older"),
+          [data("logs/2026-08-28T07-35-51-cccc.log")]: file("current"),
+        },
+        rules: [{ kind: "keepRecent", path: "logs", keep: 2 }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("logs/2026-01-12T21-33-04-aaaa.log"))).toBe(false);
+      });
+      expect(exists(fileSystem, data("logs/2026-08-28T07-35-51-cccc.log"))).toBe(true);
+      expect(exists(fileSystem, data("logs/2026-06-10T10-00-00-bbbb.log"))).toBe(true);
+    });
+
+    it("ranks entries that are not session logs as oldest", async () => {
+      // `electron.log` is Chromium's own log, not ours. Sorted naively it would
+      // beat every timestamped name ("e" > "2") and survive forever; it must be
+      // the first thing to go instead.
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("logs")]: directory(),
+          [data("logs/electron.log")]: file("chromium"),
+          [data("logs/2026-08-27T14-09-13-aaaa.log")]: file("older"),
+          [data("logs/2026-08-28T07-35-51-bbbb.log")]: file("current"),
+        },
+        rules: [{ kind: "keepRecent", path: "logs", keep: 2 }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("logs/electron.log"))).toBe(false);
+      });
+      expect(exists(fileSystem, data("logs/2026-08-28T07-35-51-bbbb.log"))).toBe(true);
+      expect(exists(fileSystem, data("logs/2026-08-27T14-09-13-aaaa.log"))).toBe(true);
+    });
+
+    it("keeps everything when the directory holds fewer than the limit", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("logs")]: directory(),
+          [data("logs/2026-08-28T07-35-51-aaaa.log")]: file("current"),
+        },
+        rules: [{ kind: "keepRecent", path: "logs", keep: 20 }],
+      });
+
+      await run();
+      await vi.waitFor(() => expect(exists(fileSystem, data("logs"))).toBe(true));
+
+      expect(exists(fileSystem, data("logs/2026-08-28T07-35-51-aaaa.log"))).toBe(true);
+    });
+  });
+
+  describe("pruneEmpty", () => {
+    it("removes childless directories and leaves the rest alone", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("screenshots")]: directory(),
+          [data("screenshots/gone-abc123")]: directory(),
+          [data("screenshots/live-def456")]: directory(),
+          [data("screenshots/live-def456/feature.png")]: file("png"),
+        },
+        rules: [{ kind: "pruneEmpty", path: "screenshots" }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("screenshots/gone-abc123"))).toBe(false);
+      });
+      expect(exists(fileSystem, data("screenshots/live-def456/feature.png"))).toBe(true);
+    });
+  });
+
+  describe("bundle", () => {
+    it("keeps only the live version", async () => {
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("vscodium")]: directory(),
+          [data("vscodium/1.120.00001")]: directory(),
+          [data("vscodium/1.126.04524")]: directory(),
+          [data("vscodium/1.126.04524/node")]: file("binary"),
+        },
+        rules: [
+          { kind: "bundle", path: "vscodium", live: () => "1.126.04524", packagedOnly: true },
+        ],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("vscodium/1.120.00001"))).toBe(false);
+      });
+      expect(exists(fileSystem, data("vscodium/1.126.04524/node"))).toBe(true);
+    });
+
+    it("removes every version when nothing is downloaded for this agent", async () => {
+      // Claude ships its binary rather than downloading one (CLAUDE_VERSION is
+      // null), so any version directory is a leftover from a config override.
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("claude")]: directory(),
+          [data("claude/1.2.3")]: directory(),
+        },
+        rules: [{ kind: "bundle", path: "claude", live: () => null, packagedOnly: true }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => expect(exists(fileSystem, data("claude/1.2.3"))).toBe(false));
+    });
+
+    it("does nothing in a development build", async () => {
+      // Dev shares its data root with binaries pnpm install and the test
+      // helpers download, pinned to versions the running app does not resolve.
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("opencode")]: directory(),
+          [data("opencode/0.9.0")]: directory(),
+        },
+        rules: [{ kind: "bundle", path: "opencode", live: () => "1.0.223", packagedOnly: true }],
+        isPackagedBuild: false,
+      });
+
+      await run();
+      await vi.waitFor(() => expect(exists(fileSystem, data("opencode"))).toBe(true));
+
+      expect(exists(fileSystem, data("opencode/0.9.0"))).toBe(true);
+    });
+
+    it("reads the live version when it runs, not when it is declared", async () => {
+      let resolved = "0.9.0";
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("opencode")]: directory(),
+          [data("opencode/0.9.0")]: directory(),
+          [data("opencode/1.0.223")]: directory(),
+        },
+        rules: [{ kind: "bundle", path: "opencode", live: () => resolved, packagedOnly: true }],
+      });
+
+      // Config settles after the module is constructed.
+      resolved = "1.0.223";
+      await run();
+
+      await vi.waitFor(() => expect(exists(fileSystem, data("opencode/0.9.0"))).toBe(false));
+      expect(exists(fileSystem, data("opencode/1.0.223"))).toBe(true);
+    });
+  });
+
+  describe("rule isolation", () => {
+    it("runs the remaining rules after one fails, and warns about the failure", async () => {
+      const logger = { ...SILENT_LOGGER, warn: vi.fn(), info: vi.fn() };
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          // Unreadable, not absent: the rule must report it rather than treat
+          // the directory as empty and claim there was nothing to clean.
+          [data("screenshots")]: directory({ error: "EACCES" }),
+          [data("logs")]: directory(),
+          [data("logs/2026-01-12T21-33-04-aaaa.log")]: file("old"),
+          [data("logs/2026-08-28T07-35-51-bbbb.log")]: file("current"),
+        },
+        rules: [
+          { kind: "pruneEmpty", path: "screenshots" },
+          { kind: "keepRecent", path: "logs", keep: 1 },
+        ],
+        logger,
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("logs/2026-01-12T21-33-04-aaaa.log"))).toBe(false);
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Cleanup rule failed",
+        expect.objectContaining({ rule: "pruneEmpty", path: "screenshots" })
+      );
+    });
+
+    it("runs rules in declaration order", async () => {
+      // `claude/configs` is retired before the bundle rule sweeps its parent,
+      // so the retired directory is never mistaken for a version to keep.
+      const seen: string[] = [];
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("claude")]: directory(),
+          [data("claude/configs")]: directory(),
+          [data("claude/configs/feature-a-1a2b")]: directory(),
+        },
+        rules: [
+          { kind: "retire", path: "claude/configs" },
+          {
+            kind: "bundle",
+            path: "claude",
+            live: () => {
+              seen.push("bundle");
+              return null;
+            },
+            packagedOnly: true,
+          },
+        ],
+      });
+
+      await run();
+
+      await vi.waitFor(() => expect(seen).toEqual(["bundle"]));
+      expect(exists(fileSystem, data("claude/configs"))).toBe(false);
+    });
+
+    it("summarises what it removed once, at info", async () => {
+      const logger = { ...SILENT_LOGGER, warn: vi.fn(), info: vi.fn() };
+      const { run } = createTestSetup({
+        entries: {
+          [data("code-server")]: directory(),
+          [data("screenshots")]: directory(),
+          [data("screenshots/gone-abc123")]: directory(),
+        },
+        rules: [
+          { kind: "retire", path: "code-server" },
+          { kind: "pruneEmpty", path: "screenshots" },
+        ],
+        logger,
+      });
+
+      await run();
+
+      await vi.waitFor(() => expect(logger.info).toHaveBeenCalledTimes(1));
+      expect(logger.info).toHaveBeenCalledWith(
+        "Cleanup removed stale entries",
+        expect.objectContaining({ entries: 2 })
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/cleanup-module.integration.test.ts
+++ b/src/modules/cleanup-module.integration.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../boundaries/platform/filesystem.state-mock";
 import { SILENT_LOGGER } from "../boundaries/platform/logging.test-utils";
 import type { Logger } from "../boundaries/platform/logging";
+import { Path } from "../utils/path/path";
 import { createCleanupModule, type CleanupRule } from "./cleanup-module";
 
 // =============================================================================
@@ -81,7 +82,10 @@ function data(subpath: string): string {
 }
 
 function exists(fileSystem: MockFileSystemBoundary, path: string): boolean {
-  return fileSystem.$.entries.has(path);
+  // Through `Path`, not the raw literal: it lowercases on Windows, so a name
+  // holding an uppercase letter (every `...T07-35-51...` log) is stored under a
+  // key the literal never matches.
+  return fileSystem.$.entries.has(new Path(path).toString());
 }
 
 // =============================================================================
@@ -186,6 +190,31 @@ describe("CleanupModule Integration", () => {
       });
       expect(exists(fileSystem, data("logs/2026-08-28T07-35-51-bbbb.log"))).toBe(true);
       expect(exists(fileSystem, data("logs/2026-08-27T14-09-13-aaaa.log"))).toBe(true);
+    });
+
+    it("still recognises session logs when their names arrived lowercased", async () => {
+      // What Windows looks like: `Path` lowercases there (it models a
+      // case-insensitive filesystem), so names reach the rule as
+      // `2026-08-28t07-...`. When the pattern anchored on an uppercase `T`,
+      // nothing matched, every entry ranked equal, and `electron.log` won the
+      // name sort on "e" > "2" — surviving while the real logs were swept.
+      const { run, fileSystem } = createTestSetup({
+        entries: {
+          [data("logs")]: directory(),
+          [data("logs/electron.log")]: file("chromium"),
+          [data("logs/2026-08-27t14-09-13-aaaa.log")]: file("older"),
+          [data("logs/2026-08-28t07-35-51-bbbb.log")]: file("current"),
+        },
+        rules: [{ kind: "keepRecent", path: "logs", keep: 2 }],
+      });
+
+      await run();
+
+      await vi.waitFor(() => {
+        expect(exists(fileSystem, data("logs/electron.log"))).toBe(false);
+      });
+      expect(exists(fileSystem, data("logs/2026-08-28t07-35-51-bbbb.log"))).toBe(true);
+      expect(exists(fileSystem, data("logs/2026-08-27t14-09-13-aaaa.log"))).toBe(true);
     });
 
     it("keeps everything when the directory holds fewer than the limit", async () => {

--- a/src/modules/cleanup-module.ts
+++ b/src/modules/cleanup-module.ts
@@ -1,0 +1,291 @@
+/**
+ * CleanupModule - Sweeps the data root of things nothing uses any more.
+ *
+ * Hook handlers:
+ * - app:start / start: run every rule, fire-and-forget.
+ *
+ * Fire-and-forget is deliberate. Reclaiming gigabytes can take seconds and
+ * nothing waits on the result, so awaiting it would only delay the UI. It is
+ * safe precisely because every path a rule touches is one nothing else writes:
+ * retired directories no code references, log files older than the current
+ * session, and bundle versions other than the live one. The one sweep that is
+ * order-critical — clearing the temp root before a workspace writes its agent
+ * config into it — deliberately stays in temp-dir-module, where it is awaited
+ * in the earlier "init" hook.
+ *
+ * Rules are declared by the composition root and run in order, so a rule that
+ * retires a path can precede one that sweeps its parent.
+ *
+ * Every rule is best-effort: a failure is logged at warn and the remaining
+ * rules still run. Cleanup must never be the reason the app fails to start.
+ */
+
+import type { IntentModule } from "../intents/lib/module";
+import type { Logger } from "../boundaries/platform/logging";
+import type { FileSystemBoundary, DirEntry } from "../boundaries/platform/filesystem";
+import type { PathProvider } from "../boundaries/platform/path-provider";
+import { Path } from "../utils/path/path";
+import { getErrorMessage } from "../shared/error-utils";
+import { FileSystemError } from "../shared/errors/service-errors";
+import { APP_START_OPERATION_ID } from "../intents/app-start";
+
+// =============================================================================
+// Rules
+// =============================================================================
+
+/**
+ * Delete a path we no longer use, whole. For a directory left behind by a
+ * rename or a retired feature — nothing reads it, so there is nothing to keep.
+ */
+export interface RetireRule {
+  readonly kind: "retire";
+  /** Path relative to the data root. */
+  readonly path: string;
+}
+
+/**
+ * Keep the newest `keep` entries of a directory, by name.
+ *
+ * By name, not by timestamp: session log files are named for the launch that
+ * wrote them (`2026-08-28T07-35-51-<id>.log`), so a lexicographic sort is
+ * already chronological, and it needs no `stat` per entry. Names that are not
+ * session logs rank oldest, which is what we want — a stray file in the log
+ * directory is exactly the thing to sweep first.
+ */
+export interface KeepRecentRule {
+  readonly kind: "keepRecent";
+  /** Path relative to the data root. */
+  readonly path: string;
+  /** How many entries survive. */
+  readonly keep: number;
+}
+
+/**
+ * Delete childless directories directly under a path.
+ *
+ * For a tree whose leaves are already pruned by whoever owns them (hibernation
+ * screenshots are deleted on wake and on workspace delete) but whose per-owner
+ * directories are left behind when the owner goes away.
+ */
+export interface PruneEmptyRule {
+  readonly kind: "pruneEmpty";
+  /** Path relative to the data root. */
+  readonly path: string;
+}
+
+/**
+ * Keep only the live version of a downloaded bundle, delete every other child.
+ *
+ * `live` is read when the rule runs, not when it is declared, so it reflects
+ * the resolved configuration. An empty live version (an agent that ships its
+ * binary rather than downloading one) means no version directory is expected,
+ * so everything goes.
+ */
+export interface BundleRule {
+  readonly kind: "bundle";
+  /** Path relative to the data root. */
+  readonly path: string;
+  /** The version this launch resolved, or null when nothing is downloaded. */
+  readonly live: () => string | null;
+  /**
+   * Skip in development builds. Dev shares its data root with the binaries
+   * that `pnpm install` and the test helpers download, and those are pinned to
+   * versions the running app does not resolve.
+   */
+  readonly packagedOnly: true;
+}
+
+export type CleanupRule = RetireRule | KeepRecentRule | PruneEmptyRule | BundleRule;
+
+// =============================================================================
+// Dependencies
+// =============================================================================
+
+export interface CleanupModuleDeps {
+  readonly fileSystem: Pick<FileSystemBoundary, "rm" | "readdir">;
+  readonly pathProvider: Pick<PathProvider, "dataPath">;
+  readonly logger: Logger;
+  /** False in development builds; gates `packagedOnly` rules. */
+  readonly isPackagedBuild: boolean;
+  readonly rules: readonly CleanupRule[];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** A session log file, named for the launch that wrote it. */
+const SESSION_LOG_NAME = /^\d{4}-\d{2}-\d{2}T/;
+
+/**
+ * Order entries newest-first for `keepRecent`. Session logs sort by name
+ * (chronological by construction); anything else ranks oldest, whatever it is
+ * called.
+ */
+function newestFirst(a: DirEntry, b: DirEntry): number {
+  const aIsLog = SESSION_LOG_NAME.test(a.name);
+  const bIsLog = SESSION_LOG_NAME.test(b.name);
+  if (aIsLog !== bIsLog) {
+    return aIsLog ? -1 : 1;
+  }
+  return b.name.localeCompare(a.name);
+}
+
+// =============================================================================
+// Module Factory
+// =============================================================================
+
+export function createCleanupModule(deps: CleanupModuleDeps): IntentModule {
+  const { fileSystem, pathProvider, logger, isPackagedBuild, rules } = deps;
+
+  /** Delete one path, whether it is a file or a whole tree. */
+  async function remove(target: Path): Promise<void> {
+    await fileSystem.rm(target, { recursive: true, force: true });
+  }
+
+  /**
+   * List a directory, treating "it isn't there" as "nothing to do". A rule
+   * whose target never existed on this machine is the normal case, not a
+   * failure worth reporting. Any other error — an unreadable directory, say —
+   * propagates, so the rule reports it rather than quietly behaving as though
+   * the directory were empty and there was nothing to clean.
+   */
+  async function listOrEmpty(target: Path): Promise<readonly DirEntry[]> {
+    try {
+      return await fileSystem.readdir(target);
+    } catch (error) {
+      if (error instanceof FileSystemError && error.fsCode === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  async function runRetire(rule: RetireRule): Promise<number> {
+    const target = pathProvider.dataPath(rule.path);
+
+    // Ask the parent whether the target is even there. `rm` with `force` would
+    // happily no-op on an absent path, but then every launch would report
+    // retiring paths that no machine has had for months. Checking via the
+    // parent listing works for a retired file as well as a retired tree.
+    const siblings = await listOrEmpty(target.dirname);
+    if (!siblings.some((entry) => entry.name === target.basename)) {
+      return 0;
+    }
+
+    await remove(target);
+    return 1;
+  }
+
+  async function runKeepRecent(rule: KeepRecentRule): Promise<number> {
+    const dir = pathProvider.dataPath(rule.path);
+    const entries = [...(await listOrEmpty(dir))].sort(newestFirst);
+    const doomed = entries.slice(rule.keep);
+
+    let removed = 0;
+    for (const entry of doomed) {
+      await remove(new Path(dir, entry.name));
+      removed++;
+    }
+    return removed;
+  }
+
+  async function runPruneEmpty(rule: PruneEmptyRule): Promise<number> {
+    const dir = pathProvider.dataPath(rule.path);
+    const entries = await listOrEmpty(dir);
+
+    let removed = 0;
+    for (const entry of entries) {
+      if (!entry.isDirectory) {
+        continue;
+      }
+      const child = new Path(dir, entry.name);
+      const contents = await listOrEmpty(child);
+      if (contents.length > 0) {
+        continue;
+      }
+      await remove(child);
+      removed++;
+    }
+    return removed;
+  }
+
+  async function runBundle(rule: BundleRule): Promise<number> {
+    if (!isPackagedBuild) {
+      return 0;
+    }
+
+    const dir = pathProvider.dataPath(rule.path);
+    const live = rule.live();
+    const entries = await listOrEmpty(dir);
+
+    let removed = 0;
+    for (const entry of entries) {
+      if (entry.name === live) {
+        continue;
+      }
+      await remove(new Path(dir, entry.name));
+      removed++;
+    }
+    return removed;
+  }
+
+  function runRule(rule: CleanupRule): Promise<number> {
+    switch (rule.kind) {
+      case "retire":
+        return runRetire(rule);
+      case "keepRecent":
+        return runKeepRecent(rule);
+      case "pruneEmpty":
+        return runPruneEmpty(rule);
+      case "bundle":
+        return runBundle(rule);
+    }
+  }
+
+  /**
+   * Run every rule in declaration order, isolating failures so one unwritable
+   * directory cannot cost us the rest of the sweep.
+   */
+  async function sweep(): Promise<void> {
+    let total = 0;
+    const done: string[] = [];
+
+    for (const rule of rules) {
+      try {
+        const removed = await runRule(rule);
+        if (removed > 0) {
+          total += removed;
+          done.push(`${rule.kind} ${rule.path} (${removed})`);
+        }
+      } catch (error) {
+        logger.warn("Cleanup rule failed", {
+          rule: rule.kind,
+          path: rule.path,
+          error: getErrorMessage(error),
+        });
+      }
+    }
+
+    if (total > 0) {
+      logger.info("Cleanup removed stale entries", { entries: total, rules: done.join(", ") });
+    }
+  }
+
+  return {
+    name: "cleanup",
+    hooks: {
+      [APP_START_OPERATION_ID]: {
+        start: {
+          handler: (): Promise<void> => {
+            // Fire-and-forget: sweep() never rejects (each rule is isolated),
+            // but the promise is deliberately not awaited, so startup does not
+            // wait on gigabytes of deletion.
+            void sweep();
+            return Promise.resolve();
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/modules/cleanup-module.ts
+++ b/src/modules/cleanup-module.ts
@@ -114,8 +114,16 @@ export interface CleanupModuleDeps {
 // Helpers
 // =============================================================================
 
-/** A session log file, named for the launch that wrote it. */
-const SESSION_LOG_NAME = /^\d{4}-\d{2}-\d{2}T/;
+/**
+ * A session log file, named for the launch that wrote it.
+ *
+ * Case-insensitive on purpose. `Path` lowercases on Windows (it models a
+ * case-insensitive filesystem), so a name that reached us through one arrives
+ * as `2026-08-28t07-...`. Anchoring on an uppercase `T` would mean no session
+ * log matches there — every entry would rank equal, `electron.log` would sort
+ * first on `'e' > '2'` and survive, and the real logs would be swept instead.
+ */
+const SESSION_LOG_NAME = /^\d{4}-\d{2}-\d{2}t/i;
 
 /**
  * Order entries newest-first for `keepRecent`. Session logs sort by name

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -218,6 +218,8 @@ export interface IdeServerModuleHandle {
   readonly module: IntentModule;
   /** Absolute path to the IDE server's bundled node interpreter. */
   nodePath(): string;
+  /** The IDE bundle version this launch resolved (config override or built-in). */
+  version(): string;
 }
 
 export function createIdeServerModule(deps: IdeServerModuleDeps): IdeServerModuleHandle {
@@ -1067,5 +1069,8 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IdeServerModul
       const { ideServerDir } = resolveIdeServerPaths();
       return getIdeServer().nodeBinary(ideServerDir, deps.platform);
     },
+    // Read at call time, like nodePath: the version only settles once config
+    // has loaded.
+    version: () => vscodiumVersionConfig.get(),
   };
 }


### PR DESCRIPTION
- **`claude/configs` moves under the temp root.** The hook and MCP config files bake in this launch's bridge port, plugin port and plugin token — minted fresh every launch — so a file that outlives the launch is wrong, not merely stale. They were written to `<data>/claude/configs`, which nothing ever cleared (1589 directories on one machine), sharing a namespace with the `claude/<version>` binary bundles. `temp-dir-module` already clears the temp root on every `app:start`, which is exactly the lifetime these files want.

- **New `CleanupModule`** runs a declarative rule table on the `app:start` "start" hook, fire-and-forget: reclaiming gigabytes can take seconds and nothing waits on the result. Safe because every path a rule touches is one nothing else writes. The order-critical sweep — clearing the temp root before a workspace writes its agent config into it — stays in `TempDirModule`, awaited in "init".

- **Four rule kinds**: `retire` (delete a path we no longer use), `keepRecent` (keep the newest N by name), `pruneEmpty` (drop childless directories), `bundle` (keep only the live version; packaged builds only, since dev shares its data root with binaries pinned to other versions).

- **What it reclaims**: `<data>/code-server` (3.4 GB — the IDE server we shipped before VSCodium, unreferenced since the `code-server.port` → `ide-server.port` rename), `<data>/logs` capped at 20 (one file per launch, and electron-log only ever rotates the current one), the retired `claude/configs`, a stale `opencode.codehydra.json`, and screenshot directories whose project is gone. ~4.7 GB on a real machine.

- **`keepRecent` sorts by name, not mtime**: session logs are named for the launch that wrote them, so lexicographic order is already chronological and no `stat` is needed. Names that are not session logs rank oldest, so Chromium's own `electron.log` is swept first rather than outliving every real log by sorting after the digits.

- **Failure handling**: rules are isolated — a failure warns and the rest still run. An absent target is silent (the normal case); an unreadable one is reported, so cleanup never quietly behaves as though there were nothing to clean.

- **Tests**: 15 integration tests against the behavioral filesystem mock, plus `e2e/cleanup.e2e.ts`, which seeds stale data into the real data root before launch and asserts the sweep. The e2e proves what a mock cannot: that the filenames `generateSessionFilename()` actually produces still match the rule's pattern.

Left alone deliberately: `pruneStaleScripts` (cohesive with script install), `cleanupOrphanedWorkspaces` (git-aware, per-project, runs at project:open), the auto-workspace legacy-file migration (its delete must follow the import), and `electron/sessionData` (Chromium's own cache).

Known follow-up, not in this PR: `<data>/releases` grows without bound (88 AppImages / 11 GB on one machine). It is written by the launcher packages (`packages/npm/codehydra.js`, `packages/pypi/src/codehydra/__init__.py`), not the app, and neither prunes.