### PR TITLE
fix: running instance is focused on re-launch

### DIFF
--- a/e2e/cli.e2e.ts
+++ b/e2e/cli.e2e.ts
@@ -18,7 +18,14 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createTestGitRepo } from "../src/utils/testing/test-utils";
-import { DATA_ROOT, createWorkspace, openProject, useApp, workspacesDir } from "./fixtures";
+import {
+  DATA_ROOT,
+  createWorkspace,
+  openProject,
+  useApp,
+  waitForConnectionDetails,
+  workspacesDir,
+} from "./fixtures";
 
 const isWindows = process.platform === "win32";
 const BIN_DIR = join(DATA_ROOT, "bin");
@@ -64,30 +71,6 @@ function json(run: Run): unknown {
     `expected success.\n  spawn error: ${run.error ?? "none"}\n  stderr: ${run.stderr}\n  stdout: ${run.stdout}`
   ).toBe(0);
   return JSON.parse(run.stdout) as unknown;
-}
-
-/**
- * Wait until the app has published its connection details.
- *
- * `launchApp` returns once the UI is visible, and the UI is shown at the
- * `show-ui` hook point — two points before `start`, where the plugin server
- * binds and the port and token are written. So a `ch` invocation immediately
- * after launch legitimately races startup and reports the app as not running.
- */
-async function waitForConnectionDetails(timeoutMs = 60_000): Promise<void> {
-  const statePath = join(DATA_ROOT, "state.json");
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    try {
-      const state = JSON.parse(readFileSync(statePath, "utf-8")) as Record<string, unknown>;
-      if (typeof state["plugin.port"] === "number" && state["plugin.port"] > 0) return;
-    } catch {
-      // Not written yet, or written but not yet complete.
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(`CodeHydra did not publish connection details within ${timeoutMs}ms`);
 }
 
 let repo: { path: string; cleanup: () => Promise<void> };

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 // Explicit .ts extension so `scripts/record-demo.ts` can import these fixtures
 // under bare node (which requires extensions in relative ESM specifiers).
-import { createDriver, type AppDriver } from "../scripts/appctrl.ts";
+import { DEV_ELECTRON, DRIVER_APP_ARGS, createDriver, type AppDriver } from "../scripts/appctrl.ts";
 import {
   DATA_ROOT,
   REPO_ROOT,
@@ -81,6 +81,32 @@ async function appFlags(options: LaunchAppOptions): Promise<string[]> {
  * logs directory outlives a single app).
  */
 let launchedAt = 0;
+
+/**
+ * The exact command the driver would use to start the app.
+ *
+ * For a caller that has to launch CodeHydra *itself* rather than through the
+ * driver — see `single-instance.e2e.ts`, which needs a second process the
+ * driver knows nothing about. Built from the same `appFlags()` and the same
+ * `DRIVER_APP_ARGS` that `launchApp` goes through, so the two cannot drift:
+ * a flag added for the driven app is added here for free.
+ */
+export async function launchCommand(options: LaunchAppOptions = {}): Promise<{
+  exe: string;
+  argv: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}> {
+  // Same rule launchApp applies below: a packaged build resolves its own app
+  // path, a dev launch needs the repo as argv[1].
+  const packaged = mode() === "packaged";
+  return {
+    exe: packaged ? packagedExecutable() : DEV_ELECTRON,
+    argv: [...(packaged ? [] : [REPO_ROOT]), ...DRIVER_APP_ARGS, ...(await appFlags(options))],
+    cwd: REPO_ROOT,
+    env: { ...process.env, _CH_ROOT_DIR: ROOT_DIR },
+  };
+}
 
 export async function launchApp(driver: AppDriver, options: LaunchAppOptions = {}): Promise<void> {
   const args = await appFlags(options);
@@ -302,6 +328,30 @@ export function useApp(options: LaunchAppOptions & { cold?: boolean } = {}): App
   });
 
   return () => driver;
+}
+
+/**
+ * Wait until the app has published its connection details.
+ *
+ * `launchApp` returns once the UI is visible, and the UI is shown at the
+ * `show-ui` hook point — two points before `start`, where the plugin server
+ * binds and the port and token are written. So anything that reads them
+ * immediately after launch legitimately races startup.
+ */
+export async function waitForConnectionDetails(timeoutMs = 60_000): Promise<void> {
+  const statePath = join(DATA_ROOT, "state.json");
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const state = JSON.parse(readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+      if (typeof state["plugin.port"] === "number" && state["plugin.port"] > 0) return;
+    } catch {
+      // Not written yet, or written but not yet complete.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`CodeHydra did not publish connection details within ${timeoutMs}ms`);
 }
 
 /** Cold start: an empty root, so the wizard and the downloads both run for real. */

--- a/e2e/single-instance.e2e.ts
+++ b/e2e/single-instance.e2e.ts
@@ -1,0 +1,101 @@
+/**
+ * A second launch is refused, silently, and leaves the running instance intact.
+ *
+ * Everything about the wiring — that before-ready bails, that the reactivation
+ * subscription presents the window — is covered by fast tests with behavioural
+ * mocks. What only a real launch can prove is the assumption the whole design
+ * rests on: that Electron keys its single-instance lock on the `userData`
+ * directory electron-lifecycle relocates into the data root. If it did not, the
+ * lock would be machine-wide and every data root — e2e runs under
+ * `_CH_ROOT_DIR`, `pnpm dev` worktrees — would contend with the installed app.
+ *
+ * The second process is started from the driver's own launch recipe, which
+ * gives it a free `--ide-server.port` of its own — so nothing but the lock can
+ * stop it. Without the lock it would start completely, and the
+ * state.json assertion below is what would catch the damage: its shutdown would
+ * withdraw the *running* instance's CLI connection details, breaking `ch` in
+ * every workspace of a perfectly healthy app.
+ *
+ * Runs in both modes: `launchCommand()` resolves the packaged binary under
+ * `pnpm test:e2e` and `node_modules`' Electron under `pnpm test:e2e:dev`. The
+ * lock is claimed in before-ready and is indifferent to which one started the
+ * process.
+ */
+import { expect, test } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_ROOT, launchCommand, useApp, waitForConnectionDetails } from "./fixtures";
+
+const STATE_FILE = join(DATA_ROOT, "state.json");
+
+interface PluginState {
+  readonly port: number;
+  readonly token: string | null;
+}
+
+/**
+ * The CLI connection details `ch` resolves an instance by. StateService writes
+ * dot-separated keys flat, so these are `state["plugin.port"]`, not a nested
+ * `plugin` object.
+ */
+function readPluginState(): PluginState {
+  expect(existsSync(STATE_FILE), `expected ${STATE_FILE} to exist`).toBe(true);
+  const state = JSON.parse(readFileSync(STATE_FILE, "utf-8")) as Record<string, unknown>;
+  const port = state["plugin.port"];
+  const token = state["plugin.token"];
+  return {
+    port: typeof port === "number" ? port : 0,
+    token: typeof token === "string" ? token : null,
+  };
+}
+
+const app = useApp();
+
+test("a second launch exits quietly and leaves the first instance untouched", async () => {
+  // The UI is up two hook points before `start`, where the plugin server binds
+  // and publishes. Reading state.json without this races startup.
+  await waitForConnectionDetails();
+
+  // Sanity: the running instance published connection details for `ch`.
+  const before = readPluginState();
+  expect(before.port).toBeGreaterThan(0);
+  expect(before.token).not.toBeNull();
+
+  // The driver's own launch recipe for whichever mode is running, so this
+  // second process is the same app the first one is — and stays that way when
+  // the flags in fixtures change. Its own free ide-server.port comes from
+  // appFlags(), which means nothing but the lock can stop it.
+  const { exe, argv, cwd, env } = await launchCommand();
+  const second = spawnSync(exe, argv, {
+    cwd,
+    env,
+    encoding: "utf-8",
+    // A refused launch returns in well under a second; this is only here so a
+    // second instance that *wasn't* refused gets killed instead of outliving
+    // the run. Distinguished from a spawn failure below — without that, "the
+    // lock didn't stop it" reports as the very misleading "failed to spawn".
+    timeout: 30_000,
+  });
+
+  const timedOut = (second.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
+  expect(
+    timedOut,
+    "the second launch was still running after 30s — the single-instance lock did not refuse it"
+  ).toBe(false);
+  expect(second.error, `second launch failed to spawn: ${String(second.error)}`).toBeUndefined();
+  // 0, not a failure code: nothing went wrong. The user asked for CodeHydra and
+  // CodeHydra is in front of them.
+  expect(second.status, `second launch stderr:\n${second.stderr}`).toBe(0);
+  // Silently: no "Startup Failed" box, no diagnostic report.
+  expect(second.stderr).not.toContain("already in use");
+  expect(second.stdout).not.toContain("Startup Failed");
+
+  // The running instance still owns state.json. A second instance that reached
+  // app:shutdown would have reset these to 0 / null on its way out.
+  expect(readPluginState()).toEqual(before);
+
+  // And it is still a working app, not just a healthy-looking file.
+  const driver = app();
+  await expect(driver.uiPage().locator("body")).toBeVisible();
+});

--- a/scripts/appctrl.ts
+++ b/scripts/appctrl.ts
@@ -35,6 +35,18 @@ const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 /** The Electron binary used for unpackaged (dev) launches. */
 export const DEV_ELECTRON = join(REPO_ROOT, "node_modules/electron/dist/electron");
 
+/**
+ * Flags the driver prepends to every launch it makes.
+ *
+ * Never chime or toast at whoever is driving the app — a driven app is
+ * unfocused by definition, which is exactly when notifications fire. Prepended,
+ * not appended, so an explicit caller value wins (parseCliArgs: last wins).
+ *
+ * Exported so a caller that has to start the app *itself*, outside the driver,
+ * can present the same app to the OS (see e2e/fixtures.ts `launchCommand`).
+ */
+export const DRIVER_APP_ARGS = ["--silent=true", "--notification=disabled"] as const;
+
 // =============================================================================
 // Shared types & pure helpers
 // =============================================================================
@@ -265,11 +277,7 @@ export function createDriver() {
       }
     }
 
-    // Never chime or toast at whoever is driving the app — a driven app is
-    // unfocused by definition, which is exactly when notifications fire.
-    // Prepended, not appended, so an explicit caller value wins (parseCliArgs:
-    // last wins).
-    const appArgs = ["--silent=true", "--notification=disabled", ...args];
+    const appArgs = [...DRIVER_APP_ARGS, ...args];
 
     if (appPath !== null) {
       try {

--- a/src/boundaries/shell/app.state-mock.ts
+++ b/src/boundaries/shell/app.state-mock.ts
@@ -39,10 +39,22 @@ class AppBoundaryMockStateImpl implements MockState {
   relaunchCount = 0;
   /** Last id passed to setAppUserModelId(), or null when never called. */
   appUserModelId: string | null = null;
+  /** Whether ensureSingleInstance() reports this process as the primary one. */
+  isPrimaryInstance = true;
+  /** Number of times ensureSingleInstance() was called. */
+  singleInstanceChecks = 0;
+  /** Exit code the process terminated with, or null while still running. */
+  exitCode: number | null = null;
   readonly themeUpdatedCallbacks = new CallbackSet();
+  readonly reactivateCallbacks = new CallbackSet();
 
   triggerThemeUpdated(): void {
     this.themeUpdatedCallbacks.trigger();
+  }
+
+  /** Simulate another launch asking this instance to come forward. */
+  triggerReactivate(): void {
+    this.reactivateCallbacks.trigger();
   }
 
   snapshot(): Snapshot {
@@ -61,6 +73,9 @@ class AppBoundaryMockStateImpl implements MockState {
 export interface AppBoundaryMockState extends MockState {
   snapshot(): Snapshot;
   toString(): string;
+
+  /** Simulate another launch asking this instance to come forward. */
+  triggerReactivate(): void;
 }
 
 // =============================================================================
@@ -89,6 +104,14 @@ export interface MockAppBoundaryOptions {
    * @default true
    */
   shouldUseDarkColors?: boolean;
+
+  /**
+   * Whether ensureSingleInstance() reports this process as the primary one.
+   * Set false to drive the branch where another instance already holds the
+   * lock — the mock records the exit instead of terminating the test runner.
+   * @default true
+   */
+  primaryInstance?: boolean;
 }
 
 /**
@@ -115,10 +138,11 @@ export interface MockAppBoundaryOptions {
  * ```
  */
 export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): MockAppBoundary {
-  const { platform = "darwin", shouldUseDarkColors = true } = options;
+  const { platform = "darwin", shouldUseDarkColors = true, primaryInstance = true } = options;
 
   const state = new AppBoundaryMockStateImpl();
   state.shouldUseDarkColors = shouldUseDarkColors;
+  state.isPrimaryInstance = primaryInstance;
 
   // Create dock only for macOS
   const dock: AppDock | undefined =
@@ -154,6 +178,22 @@ export function createAppBoundaryMock(options: MockAppBoundaryOptions = {}): Moc
 
     relaunch(): void {
       state.relaunchCount += 1;
+    },
+
+    ensureSingleInstance(): boolean {
+      state.singleInstanceChecks += 1;
+      if (state.isPrimaryInstance) {
+        return true;
+      }
+      // The real boundary calls app.exit(0) here and never returns. A mock
+      // cannot terminate the process, so it records the exit and returns false
+      // — callers bail on false, taking the same branch production takes.
+      state.exitCode = 0;
+      return false;
+    },
+
+    onReactivate(callback: () => void) {
+      return state.reactivateCallbacks.add(callback);
     },
 
     setAppUserModelId(id: string): void {
@@ -208,6 +248,12 @@ export interface AppBoundaryMatchers {
    * @param id - Expected id, or null when it should never have been set
    */
   toHaveAppUserModelId(id: string | null): void;
+
+  /**
+   * Assert the code the process exited with via ensureSingleInstance().
+   * @param code - Expected exit code, or null when it should still be running
+   */
+  toHaveExitedWithCode(code: number | null): void;
 }
 
 // Extend vitest's assertion interface
@@ -265,6 +311,18 @@ const appBoundaryMatchers: MatcherImplementationsFor<
         pass
           ? `Expected app user model id NOT to be ${JSON.stringify(id)}`
           : `Expected app user model id to be ${JSON.stringify(id)}, but got ${JSON.stringify(actual)}`,
+    };
+  },
+
+  toHaveExitedWithCode(received, code) {
+    const actual = received.$.exitCode;
+    const pass = actual === code;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected process NOT to have exited with code ${JSON.stringify(code)}`
+          : `Expected process to have exited with code ${JSON.stringify(code)}, but got ${JSON.stringify(actual)}`,
     };
   },
 };

--- a/src/boundaries/shell/app.ts
+++ b/src/boundaries/shell/app.ts
@@ -86,6 +86,42 @@ export interface AppBoundary {
   relaunch(): void;
 
   /**
+   * Claim this machine's single-instance lock, or terminate the process.
+   *
+   * Electron keys the lock on the `userData` directory, which
+   * electron-lifecycle relocates to `<dataRoot>/electron/userData` — so the
+   * lock is per data root for free: a packaged install, an e2e run under
+   * `_CH_ROOT_DIR`, and each `pnpm dev` worktree all contend separately, which
+   * is exactly the granularity we want.
+   *
+   * Exits with code 0 when another instance already holds it: nothing failed,
+   * the user asked for CodeHydra and CodeHydra is now in front of them. The
+   * exit is hard (`app.exit`, not `app.quit`) so it skips `before-quit` →
+   * `app:shutdown`. A second instance never started anything, and running the
+   * stop hooks would have it withdraw the *running* instance's `plugin.port`
+   * and `plugin.token` from the shared `state.json`, breaking `ch` there.
+   *
+   * @returns `true` when this process is the primary instance. In production it
+   *   never returns otherwise; the boolean exists so a mock can drive the same
+   *   branch the real exit takes, and callers must bail on `false`.
+   */
+  ensureSingleInstance(): boolean;
+
+  /**
+   * Subscribe to another launch asking us to come forward.
+   *
+   * Covers both spellings of that request — Electron's `second-instance`
+   * (Windows/Linux) and `activate` (macOS, where re-launching the bundle
+   * activates the running app rather than spawning a second process). One
+   * subscription for both so a platform cannot be wired while the other is
+   * forgotten.
+   *
+   * @param callback - Called when the app should present itself
+   * @returns Unsubscribe function
+   */
+  onReactivate(callback: () => void): Unsubscribe;
+
+  /**
    * Set the Application User Model ID (Windows).
    *
    * Windows keys toasts to the AUMID of the shortcut that launched the app. Our
@@ -176,6 +212,31 @@ export class DefaultAppBoundary implements AppBoundary {
     this.logger.info("Relaunching app");
     app.relaunch();
     app.quit();
+  }
+
+  ensureSingleInstance(): boolean {
+    if (app.requestSingleInstanceLock()) {
+      return true;
+    }
+    this.logger.info("Another instance already holds the single-instance lock; exiting");
+    // Hard exit: `app.quit()` would fire `before-quit` → `app:shutdown`, whose
+    // stop hooks would tear down state this process never set up.
+    app.exit(0);
+    return false;
+  }
+
+  onReactivate(callback: () => void): Unsubscribe {
+    // Electron passes arguments to both events; we deliberately take none —
+    // presenting the window is all either one means to us.
+    const listener = (): void => {
+      callback();
+    };
+    app.on("second-instance", listener);
+    app.on("activate", listener);
+    return () => {
+      app.off("second-instance", listener);
+      app.off("activate", listener);
+    };
   }
 
   setAppUserModelId(id: string): void {

--- a/src/boundaries/shell/window-manager.ts
+++ b/src/boundaries/shell/window-manager.ts
@@ -192,6 +192,17 @@ export class WindowManager {
   }
 
   /**
+   * Brings the window in front of the user: un-minimizes, shows, and focuses.
+   *
+   * Used when a second launch asks the running instance to come forward, where
+   * the window is typically minimized or buried and `focus()` alone would not
+   * surface it.
+   */
+  present(): void {
+    this.windowLayer.present(this.windowHandle);
+  }
+
+  /**
    * Whether the window currently has OS focus.
    *
    * False when another app is in front, when minimized, and when the user has

--- a/src/boundaries/shell/window.state-mock.ts
+++ b/src/boundaries/shell/window.state-mock.ts
@@ -412,6 +412,13 @@ export function createWindowBoundaryMock(): MockWindowBoundary {
       window.isFocused = true;
     },
 
+    present(handle: WindowHandle): void {
+      const window = getWindow(handle);
+      // The real boundary un-minimizes, shows, and focuses. The mock models
+      // only focus — the observable outcome all three exist to produce.
+      window.isFocused = true;
+    },
+
     isFocused(handle: WindowHandle): boolean {
       return getWindow(handle).isFocused;
     },

--- a/src/boundaries/shell/window.ts
+++ b/src/boundaries/shell/window.ts
@@ -150,6 +150,19 @@ export interface WindowBoundary {
   focus(handle: WindowHandle): void;
 
   /**
+   * Bring a window in front of the user: un-minimize it, show it, and focus it.
+   *
+   * `focus()` alone is not enough for a window the user has minimized or whose
+   * OS window is hidden, which is exactly the state it tends to be in when a
+   * second launch asks the running instance to come forward. One method rather
+   * than three primitives so the correct ordering lives in one place.
+   *
+   * @param handle - Handle to the window
+   * @throws ShellError with code WINDOW_NOT_FOUND if handle is invalid
+   */
+  present(handle: WindowHandle): void;
+
+  /**
    * Whether the window currently has OS focus.
    *
    * False when another application is in front, when the window is minimized,
@@ -382,6 +395,15 @@ export class DefaultWindowBoundary implements WindowBoundary {
 
   focus(handle: WindowHandle): void {
     const state = this.getWindowState(handle);
+    state.window.focus();
+  }
+
+  present(handle: WindowHandle): void {
+    const state = this.getWindowState(handle);
+    if (state.window.isMinimized()) {
+      state.window.restore();
+    }
+    state.window.show();
     state.window.focus();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -497,6 +497,7 @@ const viewModule = createViewModule({
   dialogLayer,
   menuLayer,
   windowManager,
+  appLayer,
   uiHtmlPath,
   uiPreloadPath,
 });

--- a/src/modules/electron-lifecycle-module.integration.test.ts
+++ b/src/modules/electron-lifecycle-module.integration.test.ts
@@ -326,6 +326,80 @@ describe("ElectronLifecycleModule Integration", () => {
       expect(mockApp.commandLine.appendSwitch).toHaveBeenCalledWith("no-proxy-server");
     });
 
+    it("claims the single-instance lock only after userData has been redirected", async () => {
+      // Electron keys the lock on `userData`. Claiming it before the redirect
+      // would key it on the system default, so every data root — dev
+      // worktrees, e2e runs under _CH_ROOT_DIR — would contend with the
+      // installed app instead of getting its own lock.
+      const order: string[] = [];
+      const mockApp = createMockApp();
+      vi.mocked(mockApp.setPath).mockImplementation((name: string) => {
+        order.push(`setPath:${name}`);
+      });
+      const appLayer = createAppBoundaryMock();
+      const claim = appLayer.ensureSingleInstance.bind(appLayer);
+      appLayer.ensureSingleInstance = () => {
+        order.push("lock");
+        return claim();
+      };
+
+      const dispatcher = createMockDispatcher();
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
+      dispatcher.registerModule(
+        createElectronLifecycleModule(createDeps({ app: mockApp, appLayer }))
+      );
+
+      await dispatcher.dispatch<AppStartIntent>({
+        type: INTENT_APP_START,
+        payload: {},
+      });
+
+      expect(order.indexOf("lock")).toBeGreaterThan(order.indexOf("setPath:userData"));
+    });
+
+    it("abandons before-ready when another instance already holds the lock", async () => {
+      // The real boundary has already exited the process by the time
+      // ensureSingleInstance() reports false. Everything after the claim must
+      // be skipped, or a second launch would keep configuring an app that is
+      // on its way out — and touch state the running instance owns.
+      const mockApp = createMockApp();
+      const appLayer = createAppBoundaryMock({ primaryInstance: false });
+
+      const dispatcher = createMockDispatcher();
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
+      dispatcher.registerModule(
+        createElectronLifecycleModule(createDeps({ app: mockApp, appLayer }))
+      );
+
+      await dispatcher.dispatch<AppStartIntent>({
+        type: INTENT_APP_START,
+        payload: {},
+      });
+
+      expect(appLayer).toHaveExitedWithCode(0);
+      expect(appLayer).toHaveAppUserModelId(null);
+      expect(mockApp.commandLine.appendSwitch).not.toHaveBeenCalled();
+    });
+
+    it("carries on through before-ready when it is the primary instance", async () => {
+      const mockApp = createMockApp();
+      const appLayer = createAppBoundaryMock();
+
+      const dispatcher = createMockDispatcher();
+      dispatcher.registerOperation(new MinimalBeforeReadyOperation());
+      dispatcher.registerModule(
+        createElectronLifecycleModule(createDeps({ app: mockApp, appLayer }))
+      );
+
+      await dispatcher.dispatch<AppStartIntent>({
+        type: INTENT_APP_START,
+        payload: {},
+      });
+
+      expect(appLayer).toHaveExitedWithCode(null);
+      expect(appLayer).toHaveAppUserModelId("com.codehydra.app");
+    });
+
     it("sets the Windows app user model id to match electron-builder's appId", async () => {
       // Windows keys toasts to the launching shortcut's AUMID. If Electron's
       // runtime id disagrees with the one NSIS stamped, notifications can

--- a/src/modules/electron-lifecycle-module.ts
+++ b/src/modules/electron-lifecycle-module.ts
@@ -144,7 +144,7 @@ export interface ElectronLifecycleModuleDeps {
     commandLine: { appendSwitch(key: string, value?: string): void };
     setPath(name: string, path: string): void;
   };
-  readonly appLayer: Pick<AppBoundary, "setAppUserModelId">;
+  readonly appLayer: Pick<AppBoundary, "setAppUserModelId" | "ensureSingleInstance">;
   readonly buildInfo: { isPackaged: boolean };
   readonly pathProvider: Pick<PathProvider, "dataPath">;
   readonly asyncWatcher: Pick<AsyncWatcher, "check">;
@@ -239,6 +239,16 @@ export function createElectronLifecycleModule(deps: ElectronLifecycleModuleDeps)
             // Redirect data paths to isolate from system defaults
             for (const name of ["userData", "sessionData", "logs", "crashDumps"]) {
               deps.app.setPath(name, deps.pathProvider.dataPath(`electron/${name}`).toNative());
+            }
+            // Strictly after the setPath loop above: Electron keys the
+            // single-instance lock on `userData`, so claiming it before the
+            // redirect would key it on the system default and make every data
+            // root — dev worktrees, e2e runs under `_CH_ROOT_DIR` — contend
+            // with the installed app. Returns false only when another instance
+            // holds the lock, and then the process is already exiting; bail so
+            // nothing below touches state that instance owns.
+            if (!deps.appLayer.ensureSingleInstance()) {
+              return { result: {} };
             }
             // Windows keys toasts to the launching shortcut's AUMID; ours is
             // stamped by the NSIS installer from electron-builder's appId, so

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { createMockDispatcher } from "../intents/lib/dispatcher.test-utils";
+import { createAppBoundaryMock } from "../boundaries/shell/app.state-mock";
 import { describe, it, expect, vi } from "vitest";
 import { z } from "zod/v4";
 import { Dispatcher } from "../intents/lib/dispatcher";
@@ -332,6 +333,110 @@ describe("ViewModule Integration", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Reactivation: another launch (or a macOS dock activation) asks the running
+  // instance to come forward.
+  // -------------------------------------------------------------------------
+  describe("reactivation", () => {
+    function createWindowManager() {
+      return {
+        create: vi.fn(),
+        maximizeAsync: vi.fn().mockResolvedValue(undefined),
+        focus: vi.fn(),
+        present: vi.fn(),
+      };
+    }
+
+    it("presents the window when another launch asks it to come forward", async () => {
+      const dispatcher = createMockDispatcher();
+      const viewManager = createMockViewManager();
+      const windowManager = createWindowManager();
+      const appLayer = createAppBoundaryMock();
+
+      dispatcher.registerOperation(
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
+          hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
+        })
+      );
+      dispatcher.registerModule(
+        createViewModule({
+          viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
+          logger: SILENT_LOGGER,
+          viewLayer: null,
+          windowLayer: null,
+          sessionLayer: null,
+          windowManager,
+          appLayer,
+        })
+      );
+
+      await dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} });
+
+      // present(), not focus(): the window is typically minimized or buried
+      // when a second launch arrives, and focus() alone would not surface it.
+      expect(windowManager.present).not.toHaveBeenCalled();
+      appLayer.$.triggerReactivate();
+      expect(windowManager.present).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a reactivation that arrives before the window exists", async () => {
+      // The lock is claimed in before-ready but the window is only created in
+      // init, so a launch landing in that gap has nothing to present.
+      const windowManager = createWindowManager();
+      const appLayer = createAppBoundaryMock();
+
+      createViewModule({
+        viewManager: createMockViewManager() as unknown as ViewModuleDeps["viewManager"],
+        logger: SILENT_LOGGER,
+        viewLayer: null,
+        windowLayer: null,
+        sessionLayer: null,
+        windowManager,
+        appLayer,
+      });
+
+      expect(() => {
+        appLayer.$.triggerReactivate();
+      }).not.toThrow();
+      expect(windowManager.present).not.toHaveBeenCalled();
+    });
+
+    it("stops presenting once the app has shut down", async () => {
+      const dispatcher = createMockDispatcher();
+      const viewManager = createMockViewManager();
+      const windowManager = createWindowManager();
+      const appLayer = createAppBoundaryMock();
+
+      dispatcher.registerOperation(
+        createMinimalOperation(APP_START_OPERATION_ID, INTENT_APP_START, "init", {
+          hookContext: (ctx) => ({ intent: ctx.intent, capabilities: { "app-ready": true } }),
+        })
+      );
+      dispatcher.registerOperation(new AppShutdownOperation());
+      dispatcher.registerModule(
+        createViewModule({
+          viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],
+          logger: SILENT_LOGGER,
+          viewLayer: null,
+          windowLayer: null,
+          sessionLayer: null,
+          windowManager,
+          appLayer,
+        })
+      );
+      dispatcher.registerModule({
+        name: "test",
+        hooks: { [APP_SHUTDOWN_OPERATION_ID]: { quit: { handler: async () => {} } } },
+      });
+
+      await dispatcher.dispatch<AppStartIntent>({ type: INTENT_APP_START, payload: {} });
+      await dispatcher.dispatch<AppShutdownIntent>({ type: INTENT_APP_SHUTDOWN, payload: {} });
+
+      appLayer.$.triggerReactivate();
+      expect(windowManager.present).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Test 17: app-start/init → creates window/views, maximizes, loads UI, focuses
   // -------------------------------------------------------------------------
   describe("app-start/init", () => {
@@ -351,6 +456,7 @@ describe("ViewModule Integration", () => {
         create: vi.fn(),
         maximizeAsync: vi.fn().mockResolvedValue(undefined),
         focus: vi.fn(),
+        present: vi.fn(),
       };
       const module = createViewModule({
         viewManager: viewManager as unknown as ViewModuleDeps["viewManager"],

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -23,6 +23,7 @@ import type { Logger } from "../boundaries/platform/logging";
 import type { ViewBoundary } from "../boundaries/shell/view";
 import type { WindowBoundary } from "../boundaries/shell/window";
 import type { SessionBoundary } from "../boundaries/shell/session";
+import type { AppBoundary } from "../boundaries/shell/app";
 import type { WebPreferences } from "../boundaries/shell/types";
 import { GLOBAL_SESSION_PARTITION } from "../boundaries/shell/ui-view-manager";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
@@ -59,7 +60,10 @@ export interface ViewModuleDeps {
     create(webPreferences?: WebPreferences): void;
     maximizeAsync(): Promise<void>;
     focus(): void;
+    present(): void;
   } | null;
+  /** App layer, for the "another launch wants us in front" subscription. */
+  readonly appLayer?: Pick<AppBoundary, "onReactivate"> | null;
   readonly uiHtmlPath?: string | null;
   /** Preload script for the UI page hosted directly by the window. */
   readonly uiPreloadPath?: string | null;
@@ -75,6 +79,9 @@ export interface ViewModuleDeps {
  */
 export function createViewModule(deps: ViewModuleDeps): IntentModule {
   const { viewManager } = deps;
+
+  /** Set once the window exists; released on shutdown. */
+  let unsubscribeReactivate: (() => void) | null = null;
 
   const module: IntentModule = {
     name: "view",
@@ -126,6 +133,18 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             // Focus UI
             viewManager.focus();
 
+            // A second launch (or a macOS dock activation) asks the running
+            // instance to come forward. Subscribed here, after the window
+            // exists — the lock is claimed in before-ready, so a launch landing
+            // in that gap finds no window to present and is simply dropped.
+            if (deps.appLayer && deps.windowManager) {
+              const windowManager = deps.windowManager;
+              unsubscribeReactivate = deps.appLayer.onReactivate(() => {
+                deps.logger.info("Another launch asked us to come forward");
+                windowManager.present();
+              });
+            }
+
             return { provides: { "ui-ready": true } };
           },
         },
@@ -176,6 +195,9 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
       [APP_SHUTDOWN_OPERATION_ID]: {
         stop: {
           handler: async () => {
+            unsubscribeReactivate?.();
+            unsubscribeReactivate = null;
+
             // Destroy the UI view before disposing layers (uses viewLayer internally)
             viewManager.destroy();
 


### PR DESCRIPTION
Launching CodeHydra a second time died with `Port 25448 is already in use` and a **Startup Failed** dialog, and sent a diagnostic report for what is not a fault. Reported twice ([019f84af](https://eu.posthog.com/project/119202/error_tracking/019f84af-7470-75f3-91ca-6fcf0369224a), [019f40b9](https://eu.posthog.com/project/119202/error_tracking/019f40b9-9c98-7250-8114-04c0281a95aa)) and seen ten times across two users.

- Claim Electron's single-instance lock in electron-lifecycle's `before-ready` hook; present the running window when a second launch asks us to come forward
- No lock scoping needed: electron-lifecycle already relocates `userData` to `<dataRoot>/electron/userData` and Electron keys `ProcessSingleton` on that directory, so the lock is per data root for free — a packaged install, an e2e run under `_CH_ROOT_DIR`, and each `pnpm dev` worktree all contend separately. Claimed strictly after the `setPath` loop for that reason, with a test asserting the call order
- The second process exits hard (`app.exit`, not `app.quit`): quit would fire `before-quit` → `app:shutdown`, whose stop hooks tear down state this process never set up — cli-module would withdraw the *running* instance's `plugin.port`/`plugin.token` from the shared `state.json` and break `ch` in every one of its workspaces. Exiting synchronously also means `before-ready` needs no abort mechanism
- `AppBoundary` gains `ensureSingleInstance()` and `onReactivate()`; the latter covers both `second-instance` and macOS `activate` so a platform cannot be wired while the other is forgotten
- `WindowBoundary`/`WindowManager` gain `present()` — un-minimize, show, focus — because `focus()` alone will not surface the minimized window a second launch typically finds

The port collision an orphaned vscodium leaves behind after a crash is a separate cause, not addressed here.

**Testing**: new e2e spec launches the app a second time from the driver's own recipe (new fixtures `launchCommand`, sharing `appFlags` and appctrl's `DRIVER_APP_ARGS` so it cannot drift), giving it a free `ide-server.port` of its own — nothing but the lock can stop it. Verified to fail when the lock is stubbed out. `waitForConnectionDetails` moves from `cli.e2e.ts` into fixtures, now shared by both specs.