### PR TITLE
fix: allows to terminate orphan ide-servers instead of quitting codehydra

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -190,6 +190,78 @@ function readSetupError(): string | null {
   return null;
 }
 
+/**
+ * The app's own message for a fatal `app:start` failure logged since `since`.
+ *
+ * The timestamp filter is load-bearing: the logs directory outlives a single
+ * app, and resetDataState does not clear it, so an unfiltered scan reports a
+ * *previous* run's failure and fails the current spec for something that
+ * already happened.
+ */
+function readStartupError(since: number): string | null {
+  const logsDir = join(DATA_ROOT, "logs");
+  if (!existsSync(logsDir)) return null;
+
+  const files = readdirSync(logsDir).filter((f) => f.endsWith(".log") && f !== "electron.log");
+  for (const file of files) {
+    const contents = readFileSync(join(logsDir, file), "utf-8");
+    for (const line of contents.split("\n")) {
+      if (!line.includes('"Startup failed"') || !line.includes('"level":"error"')) continue;
+      try {
+        const entry = JSON.parse(line) as { timestamp?: string; context?: { error?: string } };
+        const at = entry.timestamp === undefined ? NaN : Date.parse(entry.timestamp);
+        if (!Number.isNaN(at) && at < since) continue;
+        return entry.context?.error ?? "unknown error";
+      } catch {
+        // Unparseable line: no timestamp to judge by, so leave it alone rather
+        // than fail the spec on a log entry that may predate it.
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Reject as soon as the app logs a fatal `app:start` failure.
+ *
+ * An app that dies during startup never shows its UI, so `launchApp` waits out
+ * its whole 120s and the spec then fails on a test timeout — with the teardown
+ * error on top of it, and no trace of the actual cause. Race this against
+ * `launchApp` and the failure arrives in seconds carrying the app's own message.
+ */
+export function failFastOnStartupFailure(): {
+  readonly promise: Promise<never>;
+  stop: () => void;
+} {
+  // Anchored here, not at launch: this is called immediately before launchApp,
+  // and anything logged earlier belongs to a previous run.
+  const since = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  let stopped = false;
+
+  const promise = new Promise<never>((_resolve, reject) => {
+    const poll = (): void => {
+      if (stopped) return;
+      const error = readStartupError(since);
+      if (error !== null) {
+        reject(new Error(`the app failed to start: ${error}`));
+        return;
+      }
+      timer = setTimeout(poll, 500);
+    };
+    poll();
+  });
+
+  return {
+    promise,
+    stop: () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    },
+  };
+}
+
 /** Fail with the app's own error text if it tried to raise a native dialog. */
 export async function expectNoNativeDialogs(driver: AppDriver): Promise<void> {
   const dialogs = await driver.nativeDialogs();

--- a/e2e/port-conflict.e2e.ts
+++ b/e2e/port-conflict.e2e.ts
@@ -1,0 +1,110 @@
+/**
+ * A busy IDE-server port is offered up for termination, not a dead end.
+ *
+ * The branches — accept, decline, kill-failed, nothing-found — are covered by
+ * fast tests with behavioural mocks. What only a real launch can prove is the
+ * part those mocks stand in for: that the platform scan actually finds a
+ * listener on a real socket, reports a pid the user can recognize, and that
+ * killing it frees the port for the retry.
+ *
+ * Since the single-instance lock shipped, reaching this code means no CodeHydra
+ * on this data root is running, so the holder is a crashed session's leftover
+ * or an unrelated process. The holder here is the latter: a bare node process
+ * squatting on the port, which is exactly the case the dialog cannot make
+ * assumptions about.
+ */
+import { expect, test } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createConnection } from "node:net";
+import { freePort, resetDataState, type Agent } from "./env";
+import { failFastOnStartupFailure, launchApp, useApp } from "./fixtures";
+
+/** A process that holds `port` and nothing else, for the app to find and kill. */
+function spawnPortHolder(port: number): ChildProcess {
+  return spawn(
+    process.execPath,
+    [
+      "-e",
+      // The interval is what keeps it alive: a listening socket alone does not
+      // hold the event loop open once nothing is accepting.
+      `require("net").createServer().listen(${port}, "127.0.0.1");` +
+        `setInterval(() => {}, 1 << 30);`,
+    ],
+    { stdio: "ignore" }
+  );
+}
+
+/** Resolve once something is accepting connections on `port`. */
+async function waitUntilListening(port: number, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const connected = await new Promise<boolean>((resolve) => {
+      const socket = createConnection({ port, host: "127.0.0.1" }, () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (connected) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Nothing was listening on port ${port} within ${timeoutMs}ms`);
+}
+
+// `cold`: the port has to be taken before the app launches, so this spec owns
+// its own reset and launch. Teardown stays the fixture's.
+const app = useApp({ cold: true });
+
+test("offers to terminate whatever holds the IDE server port, then starts", async () => {
+  const port = await freePort();
+  const holder = spawnPortHolder(port);
+
+  try {
+    await waitUntilListening(port);
+    expect(holder.pid, "the port holder should have a pid to show").toBeDefined();
+
+    // Warm start, but on a port that is already taken.
+    resetDataState({ keepConfig: true });
+
+    // Without the offer, the app dies on a native "Startup Failed" box and
+    // never shows a UI — launchApp would then wait out its whole 120s and the
+    // spec would fail on a bare test timeout. Racing surfaces the app's own
+    // message in seconds instead.
+    const startupFailure = failFastOnStartupFailure();
+    try {
+      await Promise.race([
+        launchApp(app(), {
+          agent: test.info().project.name as Agent,
+          extraArgs: [`--ide-server.port=${port}`],
+        }),
+        startupFailure.promise,
+      ]);
+    } finally {
+      startupFailure.stop();
+    }
+
+    const ui = app().uiPage();
+
+    // The UI is up before the IDE server starts (show-ui runs two hook points
+    // earlier), so the dialog arrives after launchApp has already resolved.
+    await expect(ui.getByText("Port already in use")).toBeVisible({ timeout: 30_000 });
+    // The pid is the whole point of the dialog: it is what lets someone decide
+    // whether this is their leftover or something they care about.
+    await expect(ui.getByText(String(holder.pid), { exact: true })).toBeVisible();
+
+    await ui.getByRole("button", { name: "Terminate and Continue" }).click();
+
+    // Killed, port released, retry succeeded, app reached its normal UI.
+    await expect(ui.getByText("Port already in use")).toBeHidden({ timeout: 30_000 });
+    await expect(ui.getByRole("navigation", { name: "Projects" })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(ui.getByRole("button", { name: "New workspace" })).toBeVisible();
+  } finally {
+    // No-op when the app already killed it; guards the failure paths.
+    holder.kill("SIGKILL");
+  }
+});

--- a/e2e/port-conflict.e2e.ts
+++ b/e2e/port-conflict.e2e.ts
@@ -16,7 +16,7 @@
 import { expect, test } from "@playwright/test";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createConnection } from "node:net";
-import { freePort, resetDataState, type Agent } from "./env";
+import { freePort, type Agent } from "./env";
 import { failFastOnStartupFailure, launchApp, useApp } from "./fixtures";
 
 /** A process that holds `port` and nothing else, for the app to find and kill. */
@@ -66,9 +66,9 @@ test("offers to terminate whatever holds the IDE server port, then starts", asyn
     await waitUntilListening(port);
     expect(holder.pid, "the port holder should have a pid to show").toBeDefined();
 
-    // Warm start, but on a port that is already taken.
-    resetDataState({ keepConfig: true });
-
+    // No resetDataState: this spec creates nothing that needs clearing, and on
+    // Windows it fails with EPERM when the previous spec's app has not yet
+    // released the projects directory.
     // Without the offer, the app dies on a native "Startup Failed" box and
     // never shows a UI — launchApp would then wait out its whole 120s and the
     // spec would fail on a bare test timeout. Racing surfaces the app's own

--- a/e2e/port-conflict.e2e.ts
+++ b/e2e/port-conflict.e2e.ts
@@ -16,7 +16,7 @@
 import { expect, test } from "@playwright/test";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createConnection } from "node:net";
-import { freePort, type Agent } from "./env";
+import { freePort, resetDataState, type Agent } from "./env";
 import { failFastOnStartupFailure, launchApp, useApp } from "./fixtures";
 
 /** A process that holds `port` and nothing else, for the app to find and kill. */
@@ -66,9 +66,11 @@ test("offers to terminate whatever holds the IDE server port, then starts", asyn
     await waitUntilListening(port);
     expect(holder.pid, "the port holder should have a pid to show").toBeDefined();
 
-    // No resetDataState: this spec creates nothing that needs clearing, and on
-    // Windows it fails with EPERM when the previous spec's app has not yet
-    // released the projects directory.
+    // Not optional, even though this spec creates nothing: without it the app
+    // inherits the previous spec's project list, whose temp repos are gone by
+    // now, and `project:open` logs an error that fails the fixture's teardown.
+    resetDataState({ keepConfig: true });
+
     // Without the offer, the app dies on a native "Startup Failed" box and
     // never shows a UI — launchApp would then wait out its whole 120s and the
     // spec would fail on a bare test timeout. Racing surfaces the app's own

--- a/e2e/port-conflict.e2e.ts
+++ b/e2e/port-conflict.e2e.ts
@@ -114,7 +114,9 @@ test("offers to terminate whatever holds the IDE server port, then starts", asyn
     // The UI is up before the IDE server starts (show-ui runs two hook points
     // earlier), so the dialog arrives after launchApp has already resolved.
     try {
-      await expect(ui.getByText("Port already in use")).toBeVisible({ timeout: 30_000 });
+      // Must exceed PROCESS_SCAN_TIMEOUT_MS (30s on Windows): the dialog
+      // cannot appear until the scan that populates it has finished.
+      await expect(ui.getByText("Port already in use")).toBeVisible({ timeout: 60_000 });
     } catch (error) {
       // No dialog means the platform scan reported nobody on the port, and the
       // scan's own log lines are the only thing that says why. Without them a

--- a/e2e/port-conflict.e2e.ts
+++ b/e2e/port-conflict.e2e.ts
@@ -17,7 +17,7 @@ import { expect, test } from "@playwright/test";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createConnection } from "node:net";
 import { freePort, resetDataState, type Agent } from "./env";
-import { failFastOnStartupFailure, launchApp, useApp } from "./fixtures";
+import { appLogEntries, failFastOnStartupFailure, launchApp, useApp } from "./fixtures";
 
 /** A process that holds `port` and nothing else, for the app to find and kill. */
 function spawnPortHolder(port: number): ChildProcess {
@@ -32,6 +32,27 @@ function spawnPortHolder(port: number): ChildProcess {
     ],
     { stdio: "ignore" }
   );
+}
+
+/**
+ * Everything the app logged about finding the port's holder.
+ *
+ * The scan is best-effort and reports an empty result for a failed query as
+ * well as a genuinely free port, so when the dialog does not appear these lines
+ * are what distinguish "the tool is missing", "the query errored" and "it
+ * really saw nothing".
+ */
+function scanLog(): string {
+  const lines = appLogEntries()
+    .filter((entry) => {
+      const text = `${entry.scope ?? ""} ${entry.message ?? ""} ${JSON.stringify(entry.context ?? {})}`;
+      return /listener|scan|lsof|powershell|Get-NetTCPConnection|IDE server/i.test(text);
+    })
+    .map(
+      (entry) =>
+        `[${entry.level ?? "?"}] ${entry.message ?? ""} ${JSON.stringify(entry.context ?? {})}`
+    );
+  return lines.length > 0 ? lines.join("\n") : "(the app logged nothing about the scan)";
 }
 
 /** Resolve once something is accepting connections on `port`. */
@@ -92,7 +113,17 @@ test("offers to terminate whatever holds the IDE server port, then starts", asyn
 
     // The UI is up before the IDE server starts (show-ui runs two hook points
     // earlier), so the dialog arrives after launchApp has already resolved.
-    await expect(ui.getByText("Port already in use")).toBeVisible({ timeout: 30_000 });
+    try {
+      await expect(ui.getByText("Port already in use")).toBeVisible({ timeout: 30_000 });
+    } catch (error) {
+      // No dialog means the platform scan reported nobody on the port, and the
+      // scan's own log lines are the only thing that says why. Without them a
+      // failure here is just "element not found" and the next attempt is a
+      // guess — which is exactly how this spec burned three CI rounds.
+      throw new Error(`The port-conflict dialog never appeared.\n\nPort scan log:\n${scanLog()}`, {
+        cause: error,
+      });
+    }
     // The pid is the whole point of the dialog: it is what lets someone decide
     // whether this is their leftover or something they care about.
     await expect(ui.getByText(String(holder.pid), { exact: true })).toBeVisible();

--- a/scripts/appctrl.ts
+++ b/scripts/appctrl.ts
@@ -325,8 +325,20 @@ export function createDriver() {
     if (electronApp) {
       const app = electronApp;
       electronApp = null;
-      const proc = app.process();
-      const appPid = proc.pid!;
+
+      // The app may already be gone — it quit on a fatal startup error, or it
+      // crashed. Playwright's handle then throws from process(), and that
+      // TypeError surfaces as the spec's failure, hiding whatever actually went
+      // wrong. Nothing to tear down in that case.
+      let proc: ReturnType<typeof app.process> | undefined;
+      try {
+        proc = app.process();
+      } catch {
+        proc = undefined;
+      }
+      if (proc?.pid === undefined) return;
+
+      const appPid = proc.pid;
 
       // Snapshot the tree while the parent still owns it.
       const descendants = descendantPids(appPid);

--- a/src/boundaries/platform/process-scan.test.ts
+++ b/src/boundaries/platform/process-scan.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+/**
+ * Focused tests for the listening-process scan parsers.
+ *
+ * These are pure string→data functions, and they are the part of
+ * `findListeningProcesses` most likely to be wrong per platform: the scan
+ * itself is one shell-out, but the output formats differ in ways that only
+ * show up on real output (lsof's `-F` field prefixes, `ps` args containing
+ * spaces, PowerShell emitting a bare object for a single result).
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseLsofPids, parsePsOutput, parseWindowsListeners } from "./process";
+
+describe("parseLsofPids", () => {
+  it("takes the pid lines and ignores every other field", () => {
+    // `lsof -Fp` prefixes each field with its type; only `p` is a pid.
+    const stdout = ["p4321", "cnode", "n127.0.0.1:25448", "p4322", "cnode"].join("\n");
+    expect(parseLsofPids(stdout)).toEqual([4321, 4322]);
+  });
+
+  it("reports a pid once even when it holds several matching descriptors", () => {
+    // A process with the socket open more than once must not be killed twice
+    // or shown twice in the dialog.
+    expect(parseLsofPids("p4321\nn127.0.0.1:25448\np4321\nn[::1]:25448")).toEqual([4321]);
+  });
+
+  it("returns nothing for empty output", () => {
+    // lsof exits 1 with no output when nothing matches; that is "none", not an error.
+    expect(parseLsofPids("")).toEqual([]);
+  });
+
+  it("skips lines whose pid is not a number", () => {
+    expect(parseLsofPids("pnot-a-pid\np4321")).toEqual([4321]);
+  });
+});
+
+describe("parsePsOutput", () => {
+  it("keeps the command line intact, spaces and all", () => {
+    // The command line is the whole point: it is what lets the user recognize
+    // the process. Splitting on every space would destroy it.
+    const stdout = "  4321 node /opt/codehydra/runtime/codium-server --port 25448 --host 127.0.0.1";
+    expect(parsePsOutput(stdout)).toEqual([
+      {
+        pid: 4321,
+        name: "node",
+        commandLine: "/opt/codehydra/runtime/codium-server --port 25448 --host 127.0.0.1",
+      },
+    ]);
+  });
+
+  it("falls back to the process name when ps reports no args", () => {
+    // A kernel thread or a permission-restricted process has an empty args
+    // column; showing a blank Command cell would tell the user nothing.
+    expect(parsePsOutput("4321 kworker ")).toEqual([
+      { pid: 4321, name: "kworker", commandLine: "kworker" },
+    ]);
+  });
+
+  it("parses several processes and skips blank lines", () => {
+    const stdout = "4321 node server.js\n\n4322 python app.py\n";
+    expect(parsePsOutput(stdout).map((p) => p.pid)).toEqual([4321, 4322]);
+  });
+
+  it("ignores a header row or any line that does not start with a pid", () => {
+    expect(parsePsOutput("PID COMMAND ARGS\n4321 node server.js")).toEqual([
+      { pid: 4321, name: "node", commandLine: "server.js" },
+    ]);
+  });
+});
+
+describe("parseWindowsListeners", () => {
+  it("parses the array form", () => {
+    const stdout = JSON.stringify([
+      { ProcessId: 4321, Name: "node.exe", CommandLine: "node.exe server.js --port 25448" },
+    ]);
+    expect(parseWindowsListeners(stdout)).toEqual([
+      { pid: 4321, name: "node.exe", commandLine: "node.exe server.js --port 25448" },
+    ]);
+  });
+
+  it("parses a bare object, which older ConvertTo-Json emits for a single result", () => {
+    // -AsArray is not honored everywhere, and a single listener is the common
+    // case — getting this wrong would mean no dialog exactly when one is needed.
+    const stdout = JSON.stringify({ ProcessId: 4321, Name: "node.exe", CommandLine: "node.exe" });
+    expect(parseWindowsListeners(stdout)).toEqual([
+      { pid: 4321, name: "node.exe", commandLine: "node.exe" },
+    ]);
+  });
+
+  it("falls back to the name when CommandLine is null", () => {
+    // Win32_Process returns a null CommandLine for processes the current user
+    // may not inspect, which includes anything running as another user.
+    const stdout = JSON.stringify([{ ProcessId: 4321, Name: "svchost.exe", CommandLine: null }]);
+    expect(parseWindowsListeners(stdout)).toEqual([
+      { pid: 4321, name: "svchost.exe", commandLine: "svchost.exe" },
+    ]);
+  });
+
+  it("returns nothing for empty output or malformed JSON", () => {
+    expect(parseWindowsListeners("")).toEqual([]);
+    expect(parseWindowsListeners("   ")).toEqual([]);
+    expect(parseWindowsListeners("not json")).toEqual([]);
+  });
+
+  it("skips entries without a usable pid", () => {
+    const stdout = JSON.stringify([{ Name: "node.exe" }, { ProcessId: 4321, Name: "node.exe" }]);
+    expect(parseWindowsListeners(stdout).map((p) => p.pid)).toEqual([4321]);
+  });
+});

--- a/src/boundaries/platform/process.state-mock.ts
+++ b/src/boundaries/platform/process.state-mock.ts
@@ -2,7 +2,13 @@
  * State mock for ProcessRunner following the State Mock Pattern.
  * Provides behavioral simulation with state tracking and custom matchers.
  */
-import type { ProcessRunner, SpawnedProcess, ProcessResult, KillResult } from "./process";
+import type {
+  ProcessRunner,
+  SpawnedProcess,
+  ProcessResult,
+  KillResult,
+  ListeningProcess,
+} from "./process";
 import type {
   MockState,
   MockWithState,
@@ -264,6 +270,7 @@ class MockProcessRunnerImpl implements MockProcessRunner {
   private readonly defaultKillResult: KillResult;
   private readonly onSpawn: OnSpawnCallback | undefined;
   private readonly onKill: ((pid: number) => KillResult | void) | undefined;
+  private readonly listeners: Map<number, ListeningProcess[]>;
 
   constructor(options?: MockProcessRunnerOptions) {
     this.defaultResult = {
@@ -277,11 +284,29 @@ class MockProcessRunnerImpl implements MockProcessRunner {
     };
     this.onSpawn = options?.onSpawn;
     this.onKill = options?.onKill;
+    this.listeners = new Map(
+      Object.entries(options?.listeners ?? {}).map(([port, procs]) => [Number(port), [...procs]])
+    );
+  }
+
+  async findListeningProcesses(port: number): Promise<ListeningProcess[]> {
+    return [...(this.listeners.get(port) ?? [])];
   }
 
   async kill(pid: number, _termTimeout?: number, _killTimeout?: number): Promise<KillResult> {
     this.state.addKilledPid(pid);
-    return this.onKill?.(pid) ?? this.defaultKillResult;
+    const result = this.onKill?.(pid) ?? this.defaultKillResult;
+    // Behavioral: a killed process stops holding its port, so a re-scan after a
+    // successful kill reports the port clean. A process that refused to die
+    // keeps holding it.
+    if (result.success) {
+      for (const [port, procs] of this.listeners) {
+        const remaining = procs.filter((proc) => proc.pid !== pid);
+        if (remaining.length === 0) this.listeners.delete(port);
+        else this.listeners.set(port, remaining);
+      }
+    }
+    return result;
   }
 
   get $(): ProcessRunnerMockState {
@@ -379,6 +404,15 @@ export interface MockProcessRunnerOptions {
    * or undefined means it terminated.
    */
   onKill?: (pid: number) => KillResult | void;
+
+  /**
+   * Processes reported by findListeningProcesses(port), keyed by port.
+   *
+   * A port with no entry scans clean. Entries are dropped as their pids are
+   * killed, so a caller that kills and re-scans sees the port free — which is
+   * the loop the IDE server's port-conflict recovery runs.
+   */
+  listeners?: Readonly<Record<number, readonly ListeningProcess[]>>;
 }
 
 /**

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -702,17 +702,11 @@ export function parseWindowsListeners(stdout: string): ListeningProcess[] {
  * Win32_Process for the name and command line. SilentlyContinue because "no
  * listener" is an error there, not an empty result.
  *
- * Two constraints shape how this is written, both learned the hard way:
- *
- * - **No double quotes anywhere.** This is passed as a single `-Command`
- *   argument, and Node escapes an embedded `"` as `\"`, which the Windows
- *   command line does not put back together — the same hazard `ProcessOptions.shell`
- *   documents for `cmd /c`. Hence `('ProcessId=' + $_)` rather than
- *   `"ProcessId=$_"`.
- * - **Windows PowerShell 5.1 only.** `powershell.exe` is 5.1, not pwsh, so
- *   `ConvertTo-Json -AsArray` (6+) is unavailable and would fail the whole
- *   command. Without it a single result serializes as a bare object, which
- *   `parseWindowsListeners` accepts.
+ * Sent via `-EncodedCommand`, so quoting is a non-issue — but it still has to
+ * be **Windows PowerShell 5.1**: `powershell.exe` is 5.1, not pwsh, so
+ * `ConvertTo-Json -AsArray` (6+) is unavailable and would fail the whole
+ * command. Without it a single result serializes as a bare object, which
+ * `parseWindowsListeners` accepts.
  */
 function windowsListenerQuery(port: number): string {
   return (
@@ -845,7 +839,7 @@ export class ExecaProcessRunner implements ProcessRunner {
     // A scan that produces nothing is indistinguishable from a free port at the
     // call site, so say why here — a broken platform query is otherwise silent.
     if (result.stdout.trim() === "") {
-      this.logger.debug("Port listener scan produced no output", {
+      this.logger.warn("Port listener scan produced no output", {
         command,
         exitCode: result.exitCode ?? -1,
         stderr: result.stderr.slice(0, 500),
@@ -874,14 +868,21 @@ export class ExecaProcessRunner implements ProcessRunner {
   }
 
   private async findListenersWindows(port: number): Promise<ListeningProcess[]> {
+    // -EncodedCommand, not -Command: the script travels as base64 of UTF-16LE,
+    // so nothing in it is subject to Windows command-line parsing. An inline
+    // -Command has to survive Node's argv escaping *and* PowerShell's own
+    // tokenizing, which is a standing source of silent breakage — a mangled
+    // script just produces no output, and an empty scan is indistinguishable
+    // from a free port at the call site.
+    const encoded = Buffer.from(windowsListenerQuery(port), "utf16le").toString("base64");
     return parseWindowsListeners(
-      await this.scan("powershell", [
+      await this.scan("powershell.exe", [
         "-NoProfile",
         "-NonInteractive",
         "-ExecutionPolicy",
         "Bypass",
-        "-Command",
-        windowsListenerQuery(port),
+        "-EncodedCommand",
+        encoded,
       ])
     );
   }

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -678,8 +678,9 @@ export function parseWindowsListeners(stdout: string): ListeningProcess[] {
     return [];
   }
 
-  // ConvertTo-Json emits a bare object for a single result unless -AsArray is
-  // honored; tolerate both rather than depend on the PowerShell version.
+  // ConvertTo-Json emits a bare object for a single result and an array for
+  // several. Windows PowerShell 5.1 has no -AsArray to normalize that, so both
+  // shapes have to be accepted — and one listener is the common case.
   const items = Array.isArray(parsed) ? parsed : [parsed];
   const processes: ListeningProcess[] = [];
   for (const item of items) {
@@ -700,15 +701,27 @@ export function parseWindowsListeners(stdout: string): ListeningProcess[] {
  * `Get-NetTCPConnection` reports only an OwningProcess id, so it is joined to
  * Win32_Process for the name and command line. SilentlyContinue because "no
  * listener" is an error there, not an empty result.
+ *
+ * Two constraints shape how this is written, both learned the hard way:
+ *
+ * - **No double quotes anywhere.** This is passed as a single `-Command`
+ *   argument, and Node escapes an embedded `"` as `\"`, which the Windows
+ *   command line does not put back together — the same hazard `ProcessOptions.shell`
+ *   documents for `cmd /c`. Hence `('ProcessId=' + $_)` rather than
+ *   `"ProcessId=$_"`.
+ * - **Windows PowerShell 5.1 only.** `powershell.exe` is 5.1, not pwsh, so
+ *   `ConvertTo-Json -AsArray` (6+) is unavailable and would fail the whole
+ *   command. Without it a single result serializes as a bare object, which
+ *   `parseWindowsListeners` accepts.
  */
 function windowsListenerQuery(port: number): string {
   return (
-    `$ErrorActionPreference='SilentlyContinue';` +
+    `$ErrorActionPreference='SilentlyContinue'; ` +
     `$p = Get-NetTCPConnection -LocalPort ${port} -State Listen | ` +
     `Select-Object -ExpandProperty OwningProcess -Unique; ` +
-    `if (-not $p) { '[]'; exit 0 }; ` +
-    `$p | ForEach-Object { Get-CimInstance Win32_Process -Filter "ProcessId=$_" } | ` +
-    `Select-Object ProcessId, Name, CommandLine | ConvertTo-Json -Compress -AsArray`
+    `if (-not $p) { exit 0 }; ` +
+    `$p | ForEach-Object { Get-CimInstance Win32_Process -Filter ('ProcessId=' + $_) } | ` +
+    `Select-Object ProcessId, Name, CommandLine | ConvertTo-Json -Compress`
   );
 }
 
@@ -828,6 +841,15 @@ export class ExecaProcessRunner implements ProcessRunner {
       await proc.kill(1000, 1000);
       this.logger.warn("Port listener scan timed out", { command });
       return "";
+    }
+    // A scan that produces nothing is indistinguishable from a free port at the
+    // call site, so say why here — a broken platform query is otherwise silent.
+    if (result.stdout.trim() === "") {
+      this.logger.debug("Port listener scan produced no output", {
+        command,
+        exitCode: result.exitCode ?? -1,
+        stderr: result.stderr.slice(0, 500),
+      });
     }
     return result.stdout;
   }

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -138,6 +138,24 @@ export interface SpawnedProcess {
 }
 
 /**
+ * A process holding a listening socket, as reported by an OS-level scan.
+ *
+ * Deliberately its own type rather than the `BlockingProcess` the deletion
+ * dialog uses: that one carries `files` and `cwd`, which mean nothing for a
+ * port, and it lives in the intents layer, which a boundary must not depend on.
+ */
+export interface ListeningProcess {
+  readonly pid: number;
+  /** Executable name, e.g. "node" or "codehydra.exe". */
+  readonly name: string;
+  /** Full command line, or the bare name when the OS did not report one. */
+  readonly commandLine: string;
+}
+
+/** How long an OS-level process scan may take before it is abandoned. */
+export const PROCESS_SCAN_TIMEOUT_MS = 5000;
+
+/**
  * Interface for running external processes.
  * Returns a SpawnedProcess handle for full process control.
  * Allows dependency injection for testing.
@@ -178,6 +196,26 @@ export interface ProcessRunner {
    * @param killTimeout - Wait after SIGKILL (ms). undefined = return immediately.
    */
   kill(pid: number, termTimeout?: number, killTimeout?: number): Promise<KillResult>;
+
+  /**
+   * Processes holding a LISTEN socket on `port`.
+   *
+   * Process inspection keyed by a port, which is why it lives here rather than
+   * on `PortManager`: the work is shelling out to `lsof` / `Get-NetTCPConnection`,
+   * exactly like every other process scan in this codebase, and `PortManager`
+   * would have to reach across into the process boundary to do it.
+   *
+   * Normally one entry — Node marks sockets close-on-exec, so a server's
+   * children do not inherit its listener — but a list because `lsof` can
+   * legitimately report several (fork-inherited descriptors, `SO_REUSEPORT`).
+   *
+   * Best-effort: returns an empty array when the scan fails, times out, or the
+   * platform tool is missing. A caller must treat "nothing found" as "could not
+   * tell", never as "the port is free".
+   *
+   * @param port - TCP port to look up on localhost.
+   */
+  findListeningProcesses(port: number): Promise<ListeningProcess[]>;
 }
 
 /**
@@ -584,6 +622,96 @@ class ExecaSpawnedProcess implements SpawnedProcess {
  * Process runner implementation using execa.
  * Returns a SpawnedProcess handle for controlling the spawned process.
  */
+
+// ============================================================================
+// Listening-process scan
+// ============================================================================
+
+/**
+ * Extract PIDs from `lsof -F p` output.
+ *
+ * `-F` prints one field per line, each prefixed by its type: `p` is a PID.
+ * lsof reports no command line, only a command *name*, so callers pair this
+ * with `ps` to get something the user can actually recognize.
+ */
+export function parseLsofPids(stdout: string): number[] {
+  const pids: number[] = [];
+  for (const line of stdout.split("\n")) {
+    if (line[0] !== "p") continue;
+    const pid = Number(line.slice(1));
+    if (Number.isInteger(pid) && pid > 0 && !pids.includes(pid)) pids.push(pid);
+  }
+  return pids;
+}
+
+/**
+ * Parse `ps -o pid=,comm=,args=` output into ListeningProcess entries.
+ *
+ * Fields are whitespace-separated with `args` running to end of line, so this
+ * splits twice and keeps the remainder verbatim — a command line contains
+ * spaces and must survive intact for the user to recognize it.
+ */
+export function parsePsOutput(stdout: string): ListeningProcess[] {
+  const processes: ListeningProcess[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    const match = /^(\d+)\s+(\S+)\s*(.*)$/.exec(trimmed);
+    if (!match) continue;
+    const [, rawPid, name, args] = match;
+    const pid = Number(rawPid);
+    if (!Number.isInteger(pid)) continue;
+    processes.push({ pid, name: name!, commandLine: args!.trim() === "" ? name! : args!.trim() });
+  }
+  return processes;
+}
+
+/** Parse the JSON emitted by the Windows listener query. */
+export function parseWindowsListeners(stdout: string): ListeningProcess[] {
+  const trimmed = stdout.trim();
+  if (trimmed === "") return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  // ConvertTo-Json emits a bare object for a single result unless -AsArray is
+  // honored; tolerate both rather than depend on the PowerShell version.
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  const processes: ListeningProcess[] = [];
+  for (const item of items) {
+    if (typeof item !== "object" || item === null) continue;
+    const record = item as Record<string, unknown>;
+    const pid = record["ProcessId"];
+    if (typeof pid !== "number" || !Number.isInteger(pid)) continue;
+    const name = typeof record["Name"] === "string" ? record["Name"] : "unknown";
+    const commandLine = typeof record["CommandLine"] === "string" ? record["CommandLine"] : name;
+    processes.push({ pid, name, commandLine });
+  }
+  return processes;
+}
+
+/**
+ * PowerShell that maps a listening port to the processes behind it.
+ *
+ * `Get-NetTCPConnection` reports only an OwningProcess id, so it is joined to
+ * Win32_Process for the name and command line. SilentlyContinue because "no
+ * listener" is an error there, not an empty result.
+ */
+function windowsListenerQuery(port: number): string {
+  return (
+    `$ErrorActionPreference='SilentlyContinue';` +
+    `$p = Get-NetTCPConnection -LocalPort ${port} -State Listen | ` +
+    `Select-Object -ExpandProperty OwningProcess -Unique; ` +
+    `if (-not $p) { '[]'; exit 0 }; ` +
+    `$p | ForEach-Object { Get-CimInstance Win32_Process -Filter "ProcessId=$_" } | ` +
+    `Select-Object ProcessId, Name, CommandLine | ConvertTo-Json -Compress -AsArray`
+  );
+}
+
 export class ExecaProcessRunner implements ProcessRunner {
   constructor(private readonly logger: Logger) {}
 
@@ -671,5 +799,68 @@ export class ExecaProcessRunner implements ProcessRunner {
       this.logger.warn("Foreign process survived termination", { pid, timeout: killTimeout });
     }
     return { success: false };
+  }
+
+  async findListeningProcesses(port: number): Promise<ListeningProcess[]> {
+    try {
+      const processes =
+        process.platform === "win32"
+          ? await this.findListenersWindows(port)
+          : await this.findListenersPosix(port);
+      this.logger.debug("Scanned port for listeners", { port, count: processes.length });
+      return processes;
+    } catch (error) {
+      // Best-effort by contract: a caller must not read "none found" as "port
+      // free", so a failed scan is indistinguishable from an empty one.
+      this.logger.warn("Port listener scan failed", {
+        port,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /** Run a scan command, returning its stdout or "" if it failed or hung. */
+  private async scan(command: string, args: readonly string[]): Promise<string> {
+    const proc = this.run(command, args);
+    const result = await proc.wait(PROCESS_SCAN_TIMEOUT_MS);
+    if (result.running) {
+      await proc.kill(1000, 1000);
+      this.logger.warn("Port listener scan timed out", { command });
+      return "";
+    }
+    return result.stdout;
+  }
+
+  private async findListenersPosix(port: number): Promise<ListeningProcess[]> {
+    // -n/-P: no DNS or port-name lookups, which are slow and can hang.
+    // Exit code 1 means "nothing found", which parses to an empty list anyway.
+    const pids = parseLsofPids(
+      await this.scan("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"])
+    );
+    if (pids.length === 0) return [];
+
+    // lsof knows the command name but never the full command line; ps does.
+    const details = parsePsOutput(
+      await this.scan("ps", ["-o", "pid=,comm=,args=", "-p", pids.join(",")])
+    );
+    if (details.length > 0) return details;
+
+    // ps failed but we still know who holds the port — better to offer the pid
+    // than to pretend the scan found nothing.
+    return pids.map((pid) => ({ pid, name: "unknown", commandLine: "unknown" }));
+  }
+
+  private async findListenersWindows(port: number): Promise<ListeningProcess[]> {
+    return parseWindowsListeners(
+      await this.scan("powershell", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        windowsListenerQuery(port),
+      ])
+    );
   }
 }

--- a/src/boundaries/platform/process.ts
+++ b/src/boundaries/platform/process.ts
@@ -152,8 +152,18 @@ export interface ListeningProcess {
   readonly commandLine: string;
 }
 
-/** How long an OS-level process scan may take before it is abandoned. */
-export const PROCESS_SCAN_TIMEOUT_MS = 5000;
+/**
+ * How long an OS-level process scan may take before it is abandoned.
+ *
+ * Windows gets far longer than POSIX because the tools differ in kind, not
+ * degree: `lsof` is a single fast binary, while the Windows query pays Windows
+ * PowerShell 5.1 startup and then a first `Get-CimInstance` that initializes
+ * WMI. On a loaded CI runner that overran a 5s budget outright, and the scan
+ * timing out is indistinguishable from a free port at the call site — so the
+ * budget being too tight silently disables the whole feature. The neighbouring
+ * detectors allow 8s and 45s for their own PowerShell scans.
+ */
+export const PROCESS_SCAN_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 10_000;
 
 /**
  * Interface for running external processes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,6 +516,7 @@ const ideServerModule = createIdeServerModule({
   logger: apiLogger,
   archiveExtractor,
   configService,
+  ui: presentationModule,
   resolveOpencodeBundleDir: (): string =>
     getOpencodeBundleDir(pathProvider, opencodeVersionConfig.get()).toNative(),
 });

--- a/src/modules/ide-server-module/ide-server-module.integration.test.ts
+++ b/src/modules/ide-server-module/ide-server-module.integration.test.ts
@@ -85,6 +85,8 @@ import {
 } from "../../boundaries/platform/process.state-mock";
 import { createArchiveExtractorMock } from "../../boundaries/platform/archive-extractor.state-mock";
 import { SILENT_LOGGER } from "../../boundaries/platform/logging";
+import type { DialogConfig } from "../../shared/dialog-types";
+import type { UiPresenter } from "../presentation/presentation-module";
 import { Path } from "../../utils/path/path";
 import { FileSystemError, SetupError } from "../../shared/errors/service-errors";
 import type { WorkspaceName } from "../../shared/api/types";
@@ -1416,6 +1418,201 @@ describe("IdeServerModule", () => {
       expect(env._CH_IDE_NODE).toContain("vscodium");
       expect(env._CH_IDE_NODE).toMatch(/\/node$/);
       expect(env._CH_OPENCODE_DIR).toContain("opencode");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Port conflict recovery
+  //
+  // Reaching the port check at all means no CodeHydra on this data root is
+  // running — the single-instance lock refuses a second launch long before
+  // startup gets here. So the holder is a crashed session's leftover, an
+  // unrelated app, or a CodeHydra on another data root, and the user judges.
+  // ---------------------------------------------------------------------------
+
+  describe("port conflict", () => {
+    const PORT = 25448;
+    const HOLDER = {
+      pid: 4321,
+      name: "node",
+      commandLine: "/opt/codehydra/runtime/codium-server --port 25448",
+    };
+
+    /**
+     * A presenter stand-in that answers the port-conflict dialog.
+     *
+     * Each answer is pressed on a macrotask after the dialog is shown or
+     * updated, which is after `nextAction` has subscribed — the module opens
+     * the dialog and subscribes in the same synchronous run.
+     */
+    function createDialogUi(answers: readonly string[]) {
+      const shown: DialogConfig[] = [];
+      let onEventHandler: ((event: { actionId: string }) => void) | null = null;
+      let onDismissHandler: (() => void) | null = null;
+      let closed = false;
+      let next = 0;
+
+      const answer = (): void => {
+        const action = answers[next++];
+        setTimeout(() => {
+          if (action === undefined || action === "dismiss") onDismissHandler?.();
+          else onEventHandler?.({ actionId: action });
+        }, 0);
+      };
+
+      const handle = {
+        id: "port-conflict",
+        update: (config: DialogConfig): void => {
+          shown.push(config);
+          answer();
+        },
+        close: (): void => {
+          closed = true;
+        },
+        onEvent: (handler: (event: { actionId: string }) => void) => {
+          onEventHandler = handler;
+          return () => {
+            onEventHandler = null;
+          };
+        },
+        onChange: () => () => {},
+        onDismiss: (handler: () => void) => {
+          onDismissHandler = handler;
+          return () => {
+            onDismissHandler = null;
+          };
+        },
+      };
+
+      return {
+        ui: {
+          dialog: (config: DialogConfig) => {
+            shown.push(config);
+            answer();
+            return handle as unknown as ReturnType<UiPresenter["dialog"]>;
+          },
+        },
+        shown,
+        isClosed: () => closed,
+      };
+    }
+
+    /** Deps whose port frees up once its holder is killed. */
+    function createConflictDeps(options: {
+      answers: readonly string[];
+      onKill?: (pid: number) => { success: boolean } | void;
+      listeners?: Record<number, readonly (typeof HOLDER)[]>;
+      withUi?: boolean;
+    }) {
+      let portFree = false;
+      const dialogUi = createDialogUi(options.answers);
+      const processRunner = createMockProcessRunner({
+        onSpawn: () => defaultSpawnConfig(),
+        listeners: options.listeners ?? { [PORT]: [HOLDER] },
+        onKill: (pid) => {
+          const result = options.onKill?.(pid);
+          if (result === undefined || result.success) portFree = true;
+          return result as never;
+        },
+      });
+      const deps = createMockDeps({
+        processRunner,
+        portManager: { isPortAvailable: vi.fn(async () => portFree) },
+        ...(options.withUi === false ? {} : { ui: dialogUi.ui }),
+      });
+      return { deps, processRunner, dialogUi };
+    }
+
+    it("offers to terminate the holder, then starts once the port is free", async () => {
+      const { deps, processRunner, dialogUi } = createConflictDeps({ answers: ["terminate"] });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).resolves.not.toThrow();
+
+      expect(processRunner.$.killedPids).toContain(HOLDER.pid);
+      expect(dialogUi.isClosed()).toBe(true);
+    });
+
+    it("shows the pid, name and command line so the user can judge what it is", async () => {
+      const { deps, dialogUi } = createConflictDeps({ answers: ["terminate"] });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await dispatcher.dispatch({ type: "app:start", payload: {} });
+
+      const table = dialogUi.shown[0]?.sections.find(
+        (section: DialogConfig["sections"][number]) => section.type === "table"
+      );
+      expect(JSON.stringify(table)).toContain(String(HOLDER.pid));
+      expect(JSON.stringify(table)).toContain(HOLDER.name);
+      expect(JSON.stringify(table)).toContain("codium-server");
+    });
+
+    it("fails with the ordinary busy-port error when the user quits", async () => {
+      const { deps, processRunner } = createConflictDeps({ answers: ["quit"] });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).rejects.toThrow(
+        "already in use"
+      );
+      expect(processRunner.$.killedPids).not.toContain(HOLDER.pid);
+    });
+
+    it("treats Escape as quitting", async () => {
+      const { deps } = createConflictDeps({ answers: ["dismiss"] });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).rejects.toThrow(
+        "already in use"
+      );
+    });
+
+    it("reports a failed termination inline and lets the user try again", async () => {
+      let attempts = 0;
+      const { deps, dialogUi } = createConflictDeps({
+        answers: ["terminate", "terminate"],
+        onKill: () => (attempts++ === 0 ? { success: false } : undefined),
+      });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).resolves.not.toThrow();
+
+      // The dialog was re-rendered carrying the failure, rather than the app
+      // giving up on the first refusal.
+      const warning = dialogUi.shown
+        .flatMap((config) => config.sections)
+        .find(
+          (section: DialogConfig["sections"][number]) =>
+            section.type === "text" && section.style === "warning"
+        );
+      expect(JSON.stringify(warning)).toContain("Could not terminate");
+    });
+
+    it("keeps the plain error when the scan cannot say who holds the port", async () => {
+      // An empty scan means "could not tell", not "free" — there is nothing to
+      // offer, so this must not become a dialog with an empty table.
+      const { deps, dialogUi } = createConflictDeps({ answers: [], listeners: {} });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).rejects.toThrow(
+        "already in use"
+      );
+      expect(dialogUi.shown).toHaveLength(0);
+    });
+
+    it("keeps the plain error when there is no presenter to ask with", async () => {
+      const { deps } = createConflictDeps({ answers: [], withUi: false });
+      const { dispatcher } = createTestSetup(deps);
+      dispatcher.registerOperation(new MinimalStartOperation());
+
+      await expect(dispatcher.dispatch({ type: "app:start", payload: {} })).rejects.toThrow(
+        "already in use"
+      );
     });
   });
 

--- a/src/modules/ide-server-module/ide-server-module.ts
+++ b/src/modules/ide-server-module/ide-server-module.ts
@@ -19,7 +19,11 @@ import type { IntentModule } from "../../intents/lib/module";
 import type { HookContext, HookOutput } from "../../intents/lib/operation";
 import { ANY_VALUE } from "../../intents/lib/operation";
 import type { FileSystemBoundary } from "../../boundaries/platform/filesystem";
-import type { ProcessRunner, SpawnedProcess } from "../../boundaries/platform/process";
+import type {
+  ListeningProcess,
+  ProcessRunner,
+  SpawnedProcess,
+} from "../../boundaries/platform/process";
 import {
   PROCESS_KILL_GRACEFUL_TIMEOUT_MS,
   PROCESS_KILL_FORCE_TIMEOUT_MS,
@@ -68,6 +72,9 @@ import { waitForHealthy } from "../../utils/health-check";
 import { createVscodiumIdeServer, VSCODIUM_VERSION } from "./vscodium";
 import { applyBundlePatches } from "./bundle-patches";
 import type { IdeServer } from "./types";
+import type { UiPresenter } from "../presentation/presentation-module";
+import type { DialogConfig, DialogSection } from "../../shared/dialog-types";
+import type { DialogHandle } from "../presentation/sessions";
 
 // =============================================================================
 // Internal Types
@@ -107,6 +114,14 @@ const IDE_SERVER_PORT = 25448;
  * distribution we serve, not about how frames are rendered.
  */
 const IDE_RECONNECTION_GRACE_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * How long to wait for a port to actually free after its holders are gone.
+ *
+ * `kill` resolves once the process has exited, but the OS releasing its socket
+ * is a separate step, so the retry polls rather than assuming.
+ */
+const PORT_RELEASE_TIMEOUT_MS = 3000;
 
 /**
  * Determine the IDE server port from build info.
@@ -156,7 +171,7 @@ function derivePortFromString(input: string): number {
  * All dependencies for IdeServerModule.
  */
 export interface IdeServerModuleDeps {
-  readonly processRunner: Pick<ProcessRunner, "run">;
+  readonly processRunner: Pick<ProcessRunner, "run" | "kill" | "findListeningProcesses">;
   readonly httpClient: Pick<HttpClient, "fetch">;
   readonly portManager: Pick<PortManager, "isPortAvailable">;
   readonly fileSystemLayer: Pick<
@@ -195,6 +210,15 @@ export interface IdeServerModuleDeps {
    * OpenCode layer so the IDE server doesn't reach into agent-owned config.
    */
   readonly resolveOpencodeBundleDir: () => string;
+  /**
+   * Presenter for the port-conflict dialog.
+   *
+   * Optional: without it a busy port fails the way it always did. The IDE
+   * server starts at the `start` hook point, two after `show-ui`, so in the
+   * real app the UI is always up by then — this is for constructions that have
+   * no presenter at all.
+   */
+  readonly ui?: Pick<UiPresenter, "dialog"> | null;
 }
 
 // =============================================================================
@@ -462,16 +486,189 @@ export function createIdeServerModule(deps: IdeServerModuleDeps): IdeServerModul
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Port conflict recovery
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The failure a busy port produces when it cannot be recovered from.
+   *
+   * Kept as one function so the message the user sees when they decline is the
+   * same one they would have seen before any of this existed.
+   */
+  function portConflictError(port: number): IdeServerError {
+    return new IdeServerError(
+      `Port ${port} is already in use. Another IDE server or application may be running on this port.`
+    );
+  }
+
+  /** Resolve the next button press (or Escape) on a dialog. */
+  function nextAction(handle: DialogHandle): Promise<string> {
+    return new Promise<string>((resolve) => {
+      let offEvent = (): void => {};
+      let offDismiss = (): void => {};
+      const settle = (action: string): void => {
+        offEvent();
+        offDismiss();
+        resolve(action);
+      };
+      offEvent = handle.onEvent((event) => {
+        settle(event.actionId);
+      });
+      // Escape means the same as Quit: we are not starting.
+      offDismiss = handle.onDismiss(() => {
+        settle("quit");
+      });
+    });
+  }
+
+  function portConflictDialog(
+    port: number,
+    holders: readonly ListeningProcess[],
+    error?: string
+  ): DialogConfig {
+    const sections: DialogSection[] = [
+      { type: "text", content: "Port already in use", style: "heading" },
+      {
+        type: "text",
+        content: `CodeHydra needs port ${port} for its editor server.`,
+        style: "subtitle",
+      },
+      {
+        type: "table",
+        header:
+          holders.length === 1
+            ? `Using port ${port}`
+            : `Using port ${port} (${holders.length} processes)`,
+        headerIcon: "warning",
+        columns: [
+          { key: "name", label: "Process" },
+          { key: "pid", label: "PID" },
+          { key: "command", label: "Command" },
+        ],
+        rows: holders.map((holder) => ({
+          name: holder.name,
+          pid: String(holder.pid),
+          command: truncateCommand(holder.commandLine),
+        })),
+      },
+    ];
+
+    if (error !== undefined) {
+      sections.push({ type: "text", content: error, style: "warning" });
+    }
+
+    sections.push({
+      type: "group",
+      items: [
+        { type: "button", id: "terminate", label: "Terminate and Continue", variant: "primary" },
+        { type: "button", id: "quit", label: "Quit", variant: "secondary", role: "cancel" },
+      ],
+    });
+
+    return { sections };
+  }
+
+  /** Keep a command line readable in a table cell without losing its identity. */
+  function truncateCommand(command: string): string {
+    const MAX = 80;
+    return command.length <= MAX ? command : `${command.slice(0, MAX - 1)}\u2026`;
+  }
+
+  /**
+   * Terminate everything holding `port`, and report why the port is still busy.
+   *
+   * @returns null once the port is free, otherwise a message for the dialog.
+   */
+  async function terminateHolders(
+    port: number,
+    holders: readonly ListeningProcess[]
+  ): Promise<string | null> {
+    const survivors: number[] = [];
+    for (const holder of holders) {
+      const result = await deps.processRunner.kill(
+        holder.pid,
+        PROCESS_KILL_GRACEFUL_TIMEOUT_MS,
+        PROCESS_KILL_FORCE_TIMEOUT_MS
+      );
+      if (!result.success) survivors.push(holder.pid);
+      else logger.info("Terminated port holder", { pid: holder.pid, port });
+    }
+
+    if (survivors.length > 0) {
+      return `Could not terminate ${survivors.length === 1 ? "process" : "processes"} ${survivors.join(", ")}. You may need to stop it yourself.`;
+    }
+
+    // A killed process is gone before kill() resolves, but the OS releasing the
+    // socket is a separate step — poll rather than assume.
+    try {
+      await waitForHealthy({
+        checkFn: () => deps.portManager.isPortAvailable(port),
+        timeoutMs: PORT_RELEASE_TIMEOUT_MS,
+        intervalMs: 100,
+        errorMessage: "port still bound",
+      });
+      return null;
+    } catch {
+      return `Port ${port} is still in use after terminating. Something else may have taken it.`;
+    }
+  }
+
+  /**
+   * Offer to clear whatever holds the IDE server's port, and return once it is
+   * free. Throws the ordinary busy-port error if it is not.
+   *
+   * Reaching here means no CodeHydra sharing this data root is running — the
+   * single-instance lock refuses a second launch long before startup gets this
+   * far. So the holder is a leftover from a crashed session, an unrelated
+   * application, or (rarely) a CodeHydra running on a different data root. We
+   * show what we found and let the user judge rather than guess at ownership.
+   */
+  async function resolvePortConflict(port: number): Promise<void> {
+    const ui = deps.ui;
+    if (!ui) throw portConflictError(port);
+
+    let holders = await deps.processRunner.findListeningProcesses(port);
+    // The scan is best-effort, and an empty result means "could not tell", not
+    // "free" — with nothing to show there is no offer worth making.
+    if (holders.length === 0) throw portConflictError(port);
+
+    logger.warn("Port in use; offering to terminate", {
+      port,
+      pids: holders.map((holder) => holder.pid).join(","),
+    });
+
+    const handle = ui.dialog(portConflictDialog(port, holders));
+    try {
+      for (;;) {
+        if ((await nextAction(handle)) !== "terminate") {
+          throw portConflictError(port);
+        }
+
+        const failure = await terminateHolders(port, holders);
+        if (failure === null) return;
+
+        // Re-scan: the survivors are what the next attempt acts on, and the
+        // port may have changed hands entirely.
+        holders = await deps.processRunner.findListeningProcesses(port);
+        if (holders.length === 0) {
+          if (await deps.portManager.isPortAvailable(port)) return;
+          throw portConflictError(port);
+        }
+        handle.update(portConflictDialog(port, holders, failure));
+      }
+    } finally {
+      handle.close();
+    }
+  }
+
   async function doStart(): Promise<number> {
     logger.info("Starting IDE server");
 
     const port = getPort();
 
-    const portAvailable = await deps.portManager.isPortAvailable(port);
-    if (!portAvailable) {
-      throw new IdeServerError(
-        `Port ${port} is already in use. Another IDE server or application may be running on this port.`
-      );
+    if (!(await deps.portManager.isPortAvailable(port))) {
+      await resolvePortConflict(port);
     }
 
     currentPort = port;


### PR DESCRIPTION
A port already in use killed startup: `IdeServerError`, a **Startup Failed** box, a diagnostic report, and no way forward but hunting the process down by hand. The commonest cause is our own leftover — the IDE server is spawned with no PDEATHSIG and no job object, so it outlives a `SIGKILL`ed CodeHydra and holds 25448 indefinitely.

Now CodeHydra shows what holds the port and offers to terminate it.

- The single-instance lock (#653) is what makes this safe to offer: since it shipped, reaching the port check means **no CodeHydra sharing this data root is running**. So the holder is a crashed session's leftover, an unrelated application, or (rarely) a CodeHydra on a different data root. We show pid, name and command line and let the user judge rather than guess at ownership and kill something they care about
- `ProcessRunner.findListeningProcesses(port)` — `lsof -Fp` then `ps` for the command line on POSIX (lsof knows the command *name*, never the command *line*); `Get-NetTCPConnection` joined to `Win32_Process` on Windows. It lives on ProcessRunner rather than PortManager because the work is process inspection — PortManager would have to reach across into the process boundary. Best-effort by contract: a failed scan returns empty, which callers must read as "could not tell", never "port free". Killing reuses the existing `ProcessRunner.kill(pid)`
- Recovery sits in `doStart()`, so `app:resume` restarts get it too. A failed termination re-renders the dialog with an inline error so the user can try again; declining, Escape, an empty scan, or no presenter all fall through to the error the app showed before

**Verified against a real conflict** — an unrelated `python3 -m http.server 1234` was found, named, terminated on confirmation, and the retry started the server on the freed port:

```
lsof  -nP -iTCP:1234 -sTCP:LISTEN -Fp  →  p480653
ps    -o pid=,comm=,args= -p 480653    →  480653 python3   python3 -m http.server 1234
[api]     Port in use; offering to terminate port=1234 pids=480653
[process] Killed foreign process pid=480653 signal=SIGTERM
[network] Port available port=1234
[process] Server bound to 127.0.0.1:1234 (IPv4)
```

**Also fixes two e2e diagnosis problems** hit while testing this — both made *any* spec whose app dies hard to debug:

- `appctrl`'s `stop()` threw `TypeError: Cannot read properties of undefined` when the app had already exited, masking the real failure
- An app that dies during startup never shows a UI, so `launchApp` waited out its full 120s and specs failed on a bare test timeout. New `failFastOnStartupFailure()` races `launchApp` and reports the app's own message in under a second. Its log scan is anchored to a timestamp taken before launch — the logs directory outlives a run and `resetDataState` does not clear it, so an unfiltered scan reports a *previous* run's failure

**Testing**: new e2e spec binds a port with a real holder process, asserts the dialog names its pid, clicks Terminate and asserts the app reaches its UI — verified to fail (in <1s, naming the conflict) when the recovery is stubbed out. Plus 7 integration tests for accept / decline / Escape / kill-failed-then-retry / empty-scan / no-presenter, and 13 focused tests for the platform output parsers.