### PR TITLE
test(agent): drive real agents against a mock model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,18 @@ jobs:
         shell: bash
         run: echo "_CH_ROOT_DIR=${{ runner.temp }}/ch-e2e" >> "$GITHUB_ENV"
 
+      # agent-turn.e2e.ts launches Claude for real. CodeHydra never downloads it
+      # (version.claude defaults to null, so resolveBinary() returns null) and the
+      # wrapper resolves `claude` on PATH alone — the same system install the
+      # postinstall script tells a developer to make. No login is needed: the spec
+      # points it at a local mock.
+      #
+      # Deliberately unpinned. The fixtures gate on the request Claude sends, so a
+      # release that changes it should turn CI red here rather than go unnoticed.
+      - name: Install the Claude CLI
+        shell: bash
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Download packaged artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,22 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      # wrapper.boundary.test.ts executes dist/bin/*.cjs and throws without it.
+      # wrapper.boundary.test.ts executes dist/bin/*.cjs and throws without it,
+      # and server-manager.boundary.test.ts runs the hook handler built there.
       # Binaries are downloaded by the root postinstall during `pnpm install`.
       - run: pnpm build:wrappers
+
+      # server-manager.boundary.test.ts launches Claude for real, against a local
+      # mock model — no login, no key, no network. It throws rather than skipping
+      # when `claude` is absent, so a missing install fails the job instead of
+      # silently dropping the coverage.
+      #
+      # Deliberately unpinned, like the e2e job: a release that changes which
+      # hooks Claude emits should turn CI red here rather than go unnoticed.
+      - name: Install the Claude CLI
+        shell: bash
+        run: npm install -g @anthropic-ai/claude-code
+
       - run: pnpm check
       - run: pnpm test
       - run: git diff --exit-code
@@ -70,6 +83,13 @@ jobs:
       - uses: ./.github/actions/setup
 
       - run: pnpm build:wrappers
+
+      # Same requirement as the `validate` job: the Claude boundary tests throw
+      # without a real `claude` on PATH.
+      - name: Install the Claude CLI
+        shell: bash
+        run: npm install -g @anthropic-ai/claude-code
+
       - run: pnpm test:canary
 
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,13 +266,14 @@ cd /path/to/main && git merge --ff-only <branch>  # Fast-forward only
 
 ### Testing
 
-| Code Change           | Required Tests                       |
-| --------------------- | ------------------------------------ |
-| New feature/module    | Integration tests (behavioral mocks) |
-| Pure utility function | Focused tests (input/output)         |
-| External interface    | Boundary tests                       |
-| Bug fix               | Test covering the fix                |
-| Packaging / startup   | e2e spec (`e2e/*.e2e.ts`)            |
+| Code Change           | Required Tests                                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| New feature/module    | Integration tests (behavioral mocks)                                                                                        |
+| Pure utility function | Focused tests (input/output)                                                                                                |
+| External interface    | Boundary tests                                                                                                              |
+| Bug fix               | Test covering the fix                                                                                                       |
+| Packaging / startup   | e2e spec (`e2e/*.e2e.ts`)                                                                                                   |
+| Agent launch / MCP    | `e2e/agent-turn.e2e.ts` — a real agent, a mock model (`useAgentMock()`, `@copilotkit/aimock`). No login, no key, no network |
 
 **Note**: Unit tests deprecated. Use integration tests with behavioral mocks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,14 +266,15 @@ cd /path/to/main && git merge --ff-only <branch>  # Fast-forward only
 
 ### Testing
 
-| Code Change           | Required Tests                                                                                                              |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| New feature/module    | Integration tests (behavioral mocks)                                                                                        |
-| Pure utility function | Focused tests (input/output)                                                                                                |
-| External interface    | Boundary tests                                                                                                              |
-| Bug fix               | Test covering the fix                                                                                                       |
-| Packaging / startup   | e2e spec (`e2e/*.e2e.ts`)                                                                                                   |
-| Agent launch / MCP    | `e2e/agent-turn.e2e.ts` — a real agent, a mock model (`useAgentMock()`, `@copilotkit/aimock`). No login, no key, no network |
+| Code Change           | Required Tests                                                                                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New feature/module    | Integration tests (behavioral mocks)                                                                                                                                                                              |
+| Pure utility function | Focused tests (input/output)                                                                                                                                                                                      |
+| External interface    | Boundary tests                                                                                                                                                                                                    |
+| Bug fix               | Test covering the fix                                                                                                                                                                                             |
+| Packaging / startup   | e2e spec (`e2e/*.e2e.ts`)                                                                                                                                                                                         |
+| Agent launch / MCP    | `e2e/agent-turn.e2e.ts` — a real agent, a mock model (`useAgentMock()`, `@copilotkit/aimock`). No login, no key, no network                                                                                       |
+| Claude hook contract  | `claude/server-manager.boundary.test.ts` — a real `claude` against a mock model, asserting the `AgentStatus` the shipped hook chain derives. Needs `claude` on PATH + `pnpm build:wrappers` (throws, never skips) |
 
 **Note**: Unit tests deprecated. Use integration tests with behavioral mocks.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -721,6 +721,7 @@ it from an ordinary shell.
 ```console
 $ ch ws status                       # the workspace containing the current directory
 $ ch ws create feature-x main --prompt "add the export button"
+$ ch ws create review-x --agent claude --permission-mode plan --agent-name reviewer
 $ ch ws switch feature-x             # by name, from anywhere
 $ ch ws delete --keep-branch
 $ ch project open .                  # a path, or a git URL to clone

--- a/docs/INTENTS.md
+++ b/docs/INTENTS.md
@@ -490,7 +490,9 @@ The `open-workspace` operation uses these hook modules:
 
 - **create**: WorktreeModule (creates git worktree, or populates context from `existingWorkspace` data when activating discovered workspaces)
 - **setup**: KeepFilesModule (copies .keepfiles), AgentModule (starts agent server) -- both best-effort with internal try/catch
-- **finalize**: IdeServerModule (creates .code-workspace file)
+- **finalize**: IdeServerModule (creates .code-workspace file), WorktreeModule (re-reads the workspace's `codehydra.*` metadata)
+
+The metadata a `workspace:open` reports is the `create` snapshot plus whatever setup and finalize handlers **return in their results** -- so it can only be as complete as its reporters. An agent acting on its own workspace during creation writes through `workspace:set-metadata`, which is not a hook result: its `metadata:changed` event lands on a row the presenter is about to overwrite with that snapshot, and the change is lost until a restart re-reads git config. (OpenCode hits this readily -- it sends its initial prompt from the setup hook, one MCP call away from `workspace_set_title`.) WorktreeModule's finalize handler re-reads the metadata and contributes it; because finalize results fold in last and last write wins, that read supersedes the snapshot, and `workspace:created` and the returned `Workspace` both carry what git config actually holds. It is best-effort -- an unreadable workspace still opens with the snapshot it had. Covered end to end by `e2e/agent-turn.e2e.ts`.
 
 The `delete-workspace` operation uses these hook modules:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -286,6 +286,34 @@ true so the wizard stays away). `workers: 1`, `retries: 0`.
   branch config and relaunches, which is the same state startup discovery reads.
 - `extraArgs` accepts a thunk, resolved at launch. A spec whose flags name temp paths needs
   it: `useApp()` is called at module scope, before its own `beforeAll` has created them.
+  `env` is the same shape, for the same reason.
+
+**Driving a real agent turn (`agent-turn.e2e.ts`).** The agent is real; only the model is
+mocked. No login, no API key, no network:
+
+- `useAgentMock()` starts an `@copilotkit/aimock` server and returns the environment that
+  points this project's agent at it. **Call it before `useApp()`** — both register
+  `beforeAll`, Playwright runs them in registration order, and the launch environment is
+  built from the mock's port.
+- Nothing in the app knows about this. It hands `{...process.env}` to the IDE server (whose
+  terminals run `ch claude`) and to the OpenCode server it spawns, so `ANTHROPIC_BASE_URL`
+  reaches Claude and `OPENCODE_CONFIG` reaches OpenCode by inheritance alone. OpenCode's
+  config survives because the app's `OPENCODE_CONFIG_CONTENT` — which wins over everything
+  — sets only `instructions` and `mcp`.
+- **The fixtures are half the assertion.** Each one in `e2e/aimock/<agent>.json` matches
+  only when the request carries CodeHydra's system prompt _and_ advertises its MCP tool,
+  and the server runs with `strict: true`. A launch that stopped injecting either matches
+  nothing, gets a 503, and fails the turn — so there is deliberately **no catch-all**. An
+  unanticipated call is a finding: read it out of `server.getRequests()` and give it a
+  narrow fixture of its own.
+- Grant the agent permission, or it parks on a prompt nobody answers — and `PermissionRequest`
+  maps to _idle_, so the workspace would look finished. Claude takes
+  `--permission-mode bypassPermissions` on `ch ws create`; OpenCode has no such flag, so its
+  grant is `permission: { "*": "allow" }` in the config the mock writes.
+- Claude gets `ANTHROPIC_AUTH_TOKEN`, not `ANTHROPIC_API_KEY`: an API key makes it ask the
+  user to approve it once. Plus its own `CLAUDE_CONFIG_DIR` (seeded past onboarding, so the
+  run never touches `~/.claude`) and `DISABLE_NON_ESSENTIAL_MODEL_CALLS`, which keeps the
+  background haiku calls out of the mock's journal.
 
 ### Unit Tests (\*.test.ts) - DEPRECATED
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -315,6 +315,42 @@ mocked. No login, no API key, no network:
   run never touches `~/.claude`) and `DISABLE_NON_ESSENTIAL_MODEL_CALLS`, which keeps the
   background haiku calls out of the mock's journal.
 
+**Pinning Claude's hook contract (`claude/server-manager.boundary.test.ts`).** The same
+trick, one layer down and without Electron: a real `claude` against a mock model, driving
+the shipped chain into a real `ClaudeCodeServerManager`.
+
+- **Why it exists.** `server-manager.integration.test.ts` covers how the manager reacts to
+  hook payloads — with payloads we write ourselves. The premise underneath them (that Claude
+  still emits those hooks, with those shapes) was a pile of empirical findings that no test
+  touched, so a Claude release could invalidate it with the suite green.
+- **It asserts `AgentStatus`, never hook names or payload fields.** That is enough: rename
+  `background_tasks` and the running-shell `Stop` stops being suppressed, so "stays busy"
+  fails. The status is the drift detector, and a hook Claude adds that changes nothing
+  passes silently, as it should.
+- **Additive.** Nothing synthetic was retired. A synthetic failure says _our logic_ broke; a
+  failure here says _Claude_ changed, and you want to be told which.
+- **Requires a real `claude` on PATH and `pnpm build:wrappers`** (the shipped hook handler).
+  Both throw rather than skipping, so the coverage cannot be lost by accident. CI installs
+  the CLI, unpinned, in the `validate` and `canary` jobs.
+- One `describe` per scenario, one `claude` per `describe`, ~8s for the file. A recording tap
+  in front of the bridge is what correlates each hook with the status it produced — the
+  manager exposes status only through `onStatusChange`, and only the URL carries the name.
+- **Traps worth knowing**, all of them paid for once already:
+  - aimock's `ToolCall.arguments` is a JSON **string**. An object is not rejected; it reaches
+    Claude with no parameters and returns `InputValidationError`, which reads like Claude
+    misbehaving.
+  - `StopFailure` comes from `finishReason: "max_tokens"`. HTTP errors are _not_ a trigger —
+    429, 401, 500 and 529 are all retried silently, well past any sane timeout.
+  - The prompt goes in as a stream-json message on an **open stdin**. With `-p "prompt"`
+    Claude tears down the moment the turn ends and its hook subprocesses lose the race —
+    `StopFailure` is spawned, handed its payload, and killed mid-POST.
+  - The `ch-bg` scenario puts `resources/bin` on the agent's PATH. Without it the shell dies
+    instantly, `background_tasks` is empty, and the test goes idle _for the wrong reason_
+    while still passing.
+  - A background task finishing makes Claude re-invoke the agent with a fresh
+    `UserPromptSubmit`. A fixture that answers that with another background shell loops
+    forever, so the one-shot fixture in `bgcomplete` is load-bearing.
+
 ### Unit Tests (\*.test.ts) - DEPRECATED
 
 **Status**: Existing unit tests remain until migrated per-module.

--- a/e2e/agent-mock.ts
+++ b/e2e/agent-mock.ts
@@ -1,0 +1,309 @@
+/**
+ * A mock LLM the agent under test talks to, so an e2e run can drive a real
+ * agent turn without a login, an API key, or the network.
+ *
+ * Neither agent needs the app's help to be redirected: the app hands
+ * `{...process.env}` to the IDE server (whose terminals run `ch claude`) and to
+ * the OpenCode server it spawns, so pointing an agent at this server is a matter
+ * of the environment `launchApp` is given. Claude takes `ANTHROPIC_BASE_URL`;
+ * OpenCode takes a config file naming a provider, via `OPENCODE_CONFIG` — which
+ * survives because the app's own `OPENCODE_CONFIG_CONTENT` (which wins over
+ * everything) only sets `instructions` and `mcp`.
+ *
+ * The fixtures assert as much as they answer. Each one matches only when the
+ * request carries CodeHydra's system prompt AND advertises CodeHydra's MCP tool,
+ * and the server runs in strict mode — so a launch that stopped injecting either
+ * one produces no match, the turn fails, and the spec fails with the mock's own
+ * diagnostic. There is deliberately no catch-all: an unanticipated call is a
+ * finding, and gets a fixture of its own once we know what it is.
+ */
+import { getTextContent, LLMock, type ChatCompletionRequest } from "@copilotkit/aimock";
+import { test } from "@playwright/test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Agent } from "./env.ts";
+
+/** The title the fixtures tell the agent to set. Asserted on in the spec. */
+export const AGENT_SET_TITLE = "renamed by agent";
+
+/**
+ * The prompt the spec sends. The fixtures match a substring of it, so it has to
+ * survive whatever the agent wraps around a user message.
+ */
+export const AGENT_PROMPT = `rename this workspace to '${AGENT_SET_TITLE}'`;
+
+/**
+ * CodeHydra's MCP tool for the title, as each agent namespaces it.
+ *
+ * Claude Code prefixes `mcp__<server>__`; OpenCode joins with a single
+ * underscore. The fixture gates on the name, so a wrong one here reads as "the
+ * MCP server never reached the agent" — which is exactly what it would mean.
+ */
+const SET_TITLE_TOOL: Record<Agent, string> = {
+  claude: "mcp__codehydra__workspace_set_title",
+  opencode: "codehydra_workspace_set_title",
+};
+
+/** A phrase from `resources/prompts/shared.md`, present for either agent. */
+const SYSTEM_PROMPT_MARKER = "You are running inside CodeHydra.";
+
+/** What every request carried, for the three things the fixtures gate on. */
+export interface SeenRequest {
+  readonly systemHasMarker: boolean;
+  readonly system: string;
+  readonly userMessage: string;
+  readonly tools: readonly string[];
+  readonly hasToolResult: boolean;
+  /** What the last tool returned — for an MCP call, CodeHydra's own answer. */
+  readonly toolResult: string;
+}
+
+export interface AgentMock {
+  /** Base URL of the running mock. */
+  readonly url: string;
+  /** Environment for `launchApp`, pointing this run's agent at the mock. */
+  readonly env: Record<string, string>;
+  /** The server itself — `getRequests()` is the first stop when a spec fails. */
+  readonly server: LLMock;
+  /**
+   * Pre-accept Claude's folder-trust dialog for `workspacePath`.
+   *
+   * Claude asks "is this a project you trust?" before it will do anything, and
+   * in an agent terminal nobody is there to answer — it just sits on the prompt
+   * until the workspace is torn down. The acceptance is keyed by **exact**
+   * directory (a parent entry does not cover its children) and lives in
+   * `.claude.json`, so the path has to be known before the agent launches.
+   *
+   * A no-op for OpenCode, which has no such dialog.
+   */
+  trustWorkspace(workspacePath: string): void;
+  /**
+   * Every request the mock was asked to serve, summarised.
+   *
+   * NOT read from the journal: that truncates a body over 64KB, and an agent's
+   * main turn — system prompt plus every tool schema — is well past that, so the
+   * one request a failure is usually about is the one the journal cannot show.
+   * This comes from a match predicate instead, which sees the whole request.
+   */
+  seenRequests(): readonly SeenRequest[];
+}
+
+export interface AgentMockHandle {
+  (): AgentMock;
+}
+
+/**
+ * Start a mock LLM for the agent this Playwright project exercises.
+ *
+ * Call this BEFORE `useApp()`: both register `beforeAll` hooks, Playwright runs
+ * them in registration order, and `launchApp` needs the mock's port.
+ */
+export function useAgentMock(): AgentMockHandle {
+  let handle: AgentMock;
+  let server: LLMock;
+  let configDir: string;
+  let seen: SeenRequest[] = [];
+
+  test.beforeAll(async () => {
+    const agent = test.info().project.name as Agent;
+    configDir = mkdtempSync(join(tmpdir(), "ch-e2e-agent-"));
+
+    // port 0: the suite already picks a free port for the IDE server rather than
+    // colliding with a developer's running instance, and a mock is no different.
+    server = new LLMock({ port: 0, strict: true });
+    server.loadFixtureFile(join(import.meta.dirname, "aimock", `${agent}.json`));
+
+    // A recorder, not a fixture: its predicate always returns false, so matching
+    // carries on to the real fixtures and behaviour is unchanged. Prepended so
+    // it sees every request, including ones a later fixture will serve.
+    seen = [];
+    server.prependFixture({
+      match: {
+        predicate: (request) => {
+          seen.push(summarize(request));
+          return false;
+        },
+      },
+      response: { content: "" },
+    });
+    const url = await server.start();
+
+    const dir = configDir;
+    handle = {
+      url,
+      env: agentEnv(agent, url, dir),
+      server,
+      trustWorkspace: (workspacePath) => {
+        if (agent !== "claude") return;
+        writeClaudeConfig(dir, pathSpellings(workspacePath));
+      },
+      seenRequests: () => seen,
+    };
+  });
+
+  // A failing turn is otherwise mute: the assertions can see the sidebar and the
+  // app's log, but not the conversation. Print what the mock was actually asked
+  // for, field by field, so a miss names the gate it failed.
+  test.afterEach(() => {
+    if (test.info().status === test.info().expectedStatus) return;
+    if (seen.length === 0) {
+      console.log("[agent-mock] the agent never called the mock at all");
+      return;
+    }
+    for (const [index, request] of seen.entries()) {
+      console.log(
+        `[agent-mock] request ${index}: systemMarker=${request.systemHasMarker} ` +
+          `hasToolResult=${request.hasToolResult} tools=${request.tools.length}`
+      );
+      console.log(`[agent-mock]   user: ${JSON.stringify(request.userMessage.slice(0, 160))}`);
+      console.log(
+        `[agent-mock]   last tool result: ${JSON.stringify(request.toolResult.slice(0, 300))}`
+      );
+      console.log(`[agent-mock]   system: ${JSON.stringify(request.system.slice(0, 160))}`);
+      console.log(
+        `[agent-mock]   codehydra tools: ${JSON.stringify(
+          request.tools.filter((name) => name.includes("codehydra"))
+        )}`
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    await server?.stop().catch(() => {});
+    if (!configDir) return;
+    try {
+      // Retried, like every other rm in the suite: on Windows the agent has only
+      // just exited and still holds its config dir, so the first attempt sees
+      // ENOTEMPTY. Tolerated if it still fails — this is an OS temp directory
+      // that existed to configure a process which has now gone, and a leftover
+      // must not fail a turn that passed.
+      rmSync(configDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch {
+      // Left for the OS to reap.
+    }
+  });
+
+  return () => handle;
+}
+
+/** Reduce a request to the fields the fixtures gate on. */
+function summarize(request: ChatCompletionRequest): SeenRequest {
+  const messages = request.messages ?? [];
+  const system = messages
+    .filter((message) => message.role === "system")
+    .map((message) => getTextContent(message.content) ?? "")
+    .join(" ");
+  const lastUser = messages.filter((message) => message.role === "user").at(-1);
+  const lastUserIndex = messages.findLastIndex((message) => message.role === "user");
+  return {
+    systemHasMarker: system.includes(SYSTEM_PROMPT_MARKER),
+    system,
+    userMessage: getTextContent(lastUser?.content ?? null) ?? "",
+    tools: (request.tools ?? []).map((tool) => tool.function.name),
+    // aimock's own `hasToolResult` scoping: a tool message after the last user
+    // message.
+    hasToolResult: messages.slice(lastUserIndex + 1).some((message) => message.role === "tool"),
+    toolResult:
+      getTextContent(
+        messages.filter((message) => message.role === "tool").at(-1)?.content ?? null
+      ) ?? "",
+  };
+}
+
+/** Everything the agent needs to run offline against `url`. */
+function agentEnv(agent: Agent, url: string, configDir: string): Record<string, string> {
+  if (agent === "opencode") {
+    // OpenCode resolves config as: global -> OPENCODE_CONFIG -> project file ->
+    // .opencode -> OPENCODE_CONFIG_CONTENT (the app's, which wins). The app sets
+    // only `instructions` and `mcp`, so everything below survives the merge.
+    const configPath = join(configDir, "opencode.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        provider: {
+          mock: {
+            npm: "@ai-sdk/openai-compatible",
+            options: { baseURL: `${url}/v1` },
+            models: { test: { name: "Mock Model" } },
+          },
+        },
+        model: "mock/test",
+        // OpenCode has no permission mode on its AgentSpec — the grant has to
+        // come from config, or the agent parks on a prompt no one will answer.
+        // Keys are wildcard patterns over tool names, and an MCP tool is named
+        // `<server>_<tool>`, so `*` is what `bypassPermissions` is for Claude.
+        permission: { "*": "allow" },
+      })
+    );
+    return { OPENCODE_CONFIG: configPath };
+  }
+
+  // Trust is added per workspace by `trustWorkspace`, once its path is known.
+  writeClaudeConfig(configDir, []);
+
+  return {
+    ANTHROPIC_BASE_URL: url,
+    // A Bearer token rather than ANTHROPIC_API_KEY: an API key makes Claude ask
+    // the user to approve it once, and nobody is there to answer.
+    ANTHROPIC_AUTH_TOKEN: "codehydra-e2e",
+    ANTHROPIC_MODEL: "claude-sonnet-4-5",
+    // A config dir of our own, so the run neither reads nor writes the
+    // developer's ~/.claude, and starts past onboarding.
+    CLAUDE_CONFIG_DIR: configDir,
+    // Keep the mock's journal to the turn under test, and keep a version check
+    // or a crash report from reaching the network mid-run.
+    DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1",
+    DISABLE_AUTOUPDATER: "1",
+    DISABLE_TELEMETRY: "1",
+    DISABLE_ERROR_REPORTING: "1",
+  };
+}
+
+/**
+ * Every spelling of `path` the trust key might be written under.
+ *
+ * Trust is keyed by the directory as Claude sees it, matched exactly, and on
+ * Windows the same directory has several spellings: CodeHydra normalizes paths
+ * to forward slashes and case-folds them (`d:/a/_temp/...`), while `join()` here
+ * produces the native `D:\a\_temp\...`. Seeding one spelling left the agent
+ * parked on the dialog in CI with no one to answer it. Cheap to cover them all;
+ * a key that matches nothing costs nothing.
+ */
+function pathSpellings(path: string): readonly string[] {
+  // Only Windows has more than one spelling of a path. Elsewhere both transforms
+  // are identity, and a backslash form would just be a key matching nothing.
+  if (process.platform !== "win32") return [path];
+  const separators = [path, path.replace(/\\/g, "/")];
+  return [...new Set(separators.flatMap((form) => [form, form.toLowerCase()]))];
+}
+
+/**
+ * Write the Claude config for this run: past first-run onboarding, past the
+ * bypass-permissions warning, and trusting exactly `trusted`.
+ */
+function writeClaudeConfig(configDir: string, trusted: readonly string[]): void {
+  writeFileSync(
+    join(configDir, ".claude.json"),
+    JSON.stringify({
+      hasCompletedOnboarding: true,
+      theme: "dark",
+      // `--permission-mode bypassPermissions` otherwise stops on a one-time
+      // warning screen of its own.
+      bypassPermissionsModeAccepted: true,
+      projects: Object.fromEntries(
+        trusted.map((path) => [
+          path,
+          { hasTrustDialogAccepted: true, allowedTools: [], history: [] },
+        ])
+      ),
+    })
+  );
+}
+
+/** The tool name the fixtures for `agent` expect the agent to advertise. */
+export function setTitleTool(agent: Agent): string {
+  return SET_TITLE_TOOL[agent];
+}
+
+export { SYSTEM_PROMPT_MARKER };

--- a/e2e/agent-turn.e2e.ts
+++ b/e2e/agent-turn.e2e.ts
@@ -1,0 +1,196 @@
+/**
+ * A real agent, taking a real turn, calling back into CodeHydra over MCP.
+ *
+ * Every other spec stops at the wiring: a workspace is created, an agent
+ * terminal opens, and the sidebar reports a status derived from the terminal's
+ * own open/close. Nothing checks the part CodeHydra exists for — that what it
+ * hands the agent (a system prompt, an MCP server, an initial prompt) arrives,
+ * that the agent can act on it, and that acting on it lands back in the UI.
+ *
+ * The agent is real; only the model is not. `useAgentMock` points it at a local
+ * mock whose fixtures match ONLY when CodeHydra's system prompt and its MCP tool
+ * are both present in the request, with the server in strict mode — so the
+ * assertions below are not the whole test. A launch that stopped injecting
+ * either one matches no fixture, gets a 503, and fails the turn.
+ *
+ * Runs once per warm Playwright project, so both agents are held to the same
+ * behaviour through their two very different launch paths.
+ */
+import { expect, test } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { createTestGitRepo } from "../src/utils/testing/test-utils";
+import { AGENT_PROMPT, AGENT_SET_TITLE, setTitleTool, useAgentMock } from "./agent-mock.ts";
+import { chAsync, json } from "./ch.ts";
+import { useApp, waitForConnectionDetails, workspaceRow, workspacesDir } from "./fixtures";
+import type { Agent } from "./env.ts";
+
+const WORKSPACE_NAME = "agent-turn";
+
+/** A whole turn: worktree, IDE server, agent boot, two round trips to the mock. */
+const TURN_TIMEOUT_MS = 240_000;
+
+test.describe.configure({ timeout: TURN_TIMEOUT_MS + 120_000 });
+
+let repo: { path: string; cleanup: () => Promise<void> };
+
+test.beforeAll(async () => {
+  repo = await createTestGitRepo();
+});
+
+test.afterAll(async () => {
+  await repo?.cleanup();
+});
+
+// Order matters: both register `beforeAll`, Playwright runs them in registration
+// order, and the app's launch environment is built from the mock's port.
+const mock = useAgentMock();
+const app = useApp({ env: () => mock().env });
+
+/**
+ * The workspace's title as CodeHydra stores it: `codehydra.title` on the
+ * workspace's branch, in the project repository's git config.
+ */
+function readWorkspaceTitle(): string {
+  const run = spawnSync(
+    "git",
+    ["-C", repo.path, "config", "--get", `branch.${WORKSPACE_NAME}.codehydra.title`],
+    { encoding: "utf-8" }
+  );
+  return (run.stdout ?? "").trim();
+}
+
+/** The agent this Playwright project exercises. */
+function currentAgent(): Agent {
+  return test.info().project.name as Agent;
+}
+
+/**
+ * `<dataRoot>/projects/<id>/workspaces`, once opening the project has created it.
+ *
+ * `workspacesDir()` throws until exactly one project directory exists, and the
+ * app writes it a moment after `ch project open` returns.
+ */
+async function resolvedWorkspacesDir(): Promise<string> {
+  let dir = "";
+  await expect
+    .poll(
+      () => {
+        try {
+          dir = workspacesDir();
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 60_000 }
+    )
+    .toBe(true);
+  return dir;
+}
+
+test("an agent takes a turn and renames its own workspace over MCP", async () => {
+  const agent = currentAgent();
+  const ui = app().uiPage();
+
+  // launchApp returns at the `show-ui` hook point, two before the plugin server
+  // binds and publishes its port — so `ch` would otherwise race startup and
+  // report the app as not running.
+  await waitForConnectionDetails();
+
+  // Open the project first, for one reason: Claude refuses to work in a folder
+  // it has not been told to trust, and the acceptance is keyed by the exact
+  // workspace directory — which only exists once the project does. Creating the
+  // workspace in the same breath would launch the agent onto a trust prompt
+  // nobody is there to answer.
+  expect(json(await chAsync(["project", "open", repo.path]))).toBeTruthy();
+  const workspacePath = join(await resolvedWorkspacesDir(), WORKSPACE_NAME);
+  mock().trustWorkspace(workspacePath);
+
+  // Created through the CLI rather than the panel: that is the path a caller
+  // (or another agent) actually uses to hand a new workspace a prompt, and it
+  // exercises the initial-prompt file the wrapper consumes at launch.
+  //
+  // `chAsync`, never the synchronous `ch`: the mock LLM lives in this process,
+  // and OpenCode's server comes up and sends its first prompt DURING creation.
+  // A blocking spawn here would stop the mock answering it, and the agent would
+  // hang on a socket nobody is reading.
+  const created = await chAsync([
+    "ws",
+    "create",
+    WORKSPACE_NAME,
+    "--project",
+    repo.path,
+    "--prompt",
+    AGENT_PROMPT,
+    "--agent",
+    agent,
+    // Claude would otherwise stop on a permission prompt for the MCP tool, and
+    // `PermissionRequest` maps to *idle* — the workspace would look finished.
+    // OpenCode has no such flag; its grant is in the config the mock wrote.
+    ...(agent === "claude" ? ["--permission-mode", "bypassPermissions"] : []),
+  ]);
+  expect(created.status, `ch ws create failed: ${created.stderr}`).toBe(0);
+
+  // Two separate facts, asserted separately so a failure says which one broke.
+  //
+  // First: the agent's MCP call reached CodeHydra and took effect. Read straight
+  // out of git config, where workspace metadata lives — no app connection, so a
+  // transport problem cannot be mistaken for the agent not having acted.
+  await expect
+    .poll(() => readWorkspaceTitle(), {
+      timeout: TURN_TIMEOUT_MS,
+      message:
+        "the agent never set the title — its MCP call to CodeHydra did not land " +
+        "(the mock's per-request diagnostic above says how far the conversation got)",
+    })
+    .toBe(AGENT_SET_TITLE);
+
+  // Second: it reached the UI. On the row's TEXT, not its accessible name: the
+  // aria-label is built from `workspace.name` (Sidebar.svelte), while the title
+  // is what the row renders (`primaryLabel = workspace.title ?? workspace.name`).
+  //
+  // No need to expand the sidebar: it is overflow-clipped but its rows still
+  // have a box, which is why `createWorkspace()` asserts on them the same way.
+  await expect(workspaceRow(ui, WORKSPACE_NAME)).toBeVisible({ timeout: TURN_TIMEOUT_MS });
+  const row = ui
+    .getByRole("listitem")
+    .filter({ has: workspaceRow(ui, WORKSPACE_NAME) })
+    .last();
+  await expect(row).toContainText(AGENT_SET_TITLE, { timeout: TURN_TIMEOUT_MS });
+
+  // Idle, and idle because the agent finished: with permissions granted there is
+  // no PermissionRequest to park on, and a turn that ended any other way leaves
+  // the workspace busy.
+  await expect(
+    ui.getByRole("button", { name: new RegExp(`^${WORKSPACE_NAME} in .* - 1 agent idle$`) })
+  ).toBeVisible({ timeout: TURN_TIMEOUT_MS });
+
+  // The mock's own account of the conversation. Two turns: the tool call, then
+  // the reply to its result.
+  const requests = mock().server.getRequests();
+  const unmatched = requests.filter((entry) => entry.response.fixture === null);
+  expect(
+    unmatched.map((entry) => `${entry.path} -> ${entry.response.status}`),
+    "the agent made a call no fixture anticipated — read it in the journal and give it one, " +
+      "rather than adding a catch-all"
+  ).toEqual([]);
+  expect(requests.length, "expected a tool-call turn and a follow-up turn").toBeGreaterThanOrEqual(
+    2
+  );
+
+  // That the injections arrived is asserted by WHICH fixture served the turn:
+  // the tool-call fixture matches only when CodeHydra's system prompt and its
+  // MCP tool are both in the request. Asserted through the fixture rather than
+  // by re-reading the request, because the journal truncates a body over 64KB
+  // and Claude's main turn — system prompt plus every tool schema — is ~130KB.
+  const gatedTurn = mock()
+    .server.getFixtures()
+    .find((fixture) => "toolCalls" in fixture.response);
+  expect(gatedTurn, "the tool-call fixture is missing from the fixture file").toBeDefined();
+  expect(
+    requests.some((entry) => entry.response.fixture === gatedTurn),
+    `nothing was served by the gated fixture — the agent never sent a request carrying both ` +
+      `CodeHydra's system prompt and ${setTitleTool(agent)}`
+  ).toBe(true);
+});

--- a/e2e/aimock/claude.json
+++ b/e2e/aimock/claude.json
@@ -1,0 +1,59 @@
+{
+  "fixtures": [
+    {
+      "_comment": "Claude names the session before it does anything else, in a separate call carrying neither CodeHydra's system prompt nor any tools. DISABLE_NON_ESSENTIAL_MODEL_CALLS does not suppress it (checked on 2.1.250). Strict mode would 503 it and kill the turn, so it gets a fixture of its own \u2014 gated on the titling agent's own system prompt so it cannot absorb the real turn.",
+      "match": {
+        "systemMessage": "You are naming a coding session"
+      },
+      "response": {
+        "content": "Rename workspace"
+      }
+    },
+    {
+      "_comment": "Turn 3. The set-title result is back, so the turn ends. Matched on the id this file gave the call, which is the only thing that separates it from turn 2 \u2014 both carry the tool AND a tool result (turn 2's is WaitForMcpServers'). Must precede turn 2: first match wins.",
+      "match": {
+        "systemMessage": "You are running inside CodeHydra.",
+        "toolCallId": "call_ch_set_title"
+      },
+      "response": {
+        "content": "Renamed the workspace."
+      }
+    },
+    {
+      "_comment": "Turn 2. CodeHydra's MCP tool is now advertised, so call it. Gating on the tool name is the assertion: it is in this list only because `ch mcp` started, authenticated with the plugin token, and served its tool list.",
+      "match": {
+        "systemMessage": "You are running inside CodeHydra.",
+        "toolName": "mcp__codehydra__workspace_set_title"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_ch_set_title",
+            "name": "mcp__codehydra__workspace_set_title",
+            "arguments": {
+              "title": "renamed by agent"
+            }
+          }
+        ],
+        "reasoning": "Renaming the workspace through CodeHydra's MCP server."
+      },
+      "_thinking": "Claude Code runs with extended thinking on, and Anthropic rejects a tool-loop continuation whose assistant turn does not begin with a thinking block. aimock replays `reasoning` as exactly that block, so every tool-call fixture needs one."
+    },
+    {
+      "_comment": "Turn 1. Claude submits the initial prompt before its MCP servers have finished connecting, so this first request carries only built-ins \u2014 no mcp__* at all \u2014 plus WaitForMcpServers for exactly this situation. Answering with it is what makes the MCP tool appear on the next request. Last, so it only catches requests the tool-bearing fixtures above did not.",
+      "match": {
+        "systemMessage": "You are running inside CodeHydra."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "WaitForMcpServers",
+            "arguments": {}
+          }
+        ],
+        "reasoning": "Waiting for the MCP servers to finish connecting."
+      },
+      "_thinking": "Claude Code runs with extended thinking on, and Anthropic rejects a tool-loop continuation whose assistant turn does not begin with a thinking block. aimock replays `reasoning` as exactly that block, so every tool-call fixture needs one."
+    }
+  ]
+}

--- a/e2e/aimock/opencode.json
+++ b/e2e/aimock/opencode.json
@@ -1,0 +1,31 @@
+{
+  "fixtures": [
+    {
+      "_comment": "OpenCode titles the session in a separate call carrying neither CodeHydra's system prompt nor any tools, and repeats it. Strict mode would 503 it, so it gets a fixture of its own — gated on the title generator's own system prompt so it cannot absorb the real turn. (The pre-aimock mock guarded the same agent by checking for an empty tools list.)",
+      "match": { "systemMessage": "You are a title generator" },
+      "response": { "content": "Rename workspace" }
+    },
+    {
+      "_comment": "Turn 2. The set-title result is back, so the turn ends.",
+      "match": { "systemMessage": "You are running inside CodeHydra.", "hasToolResult": true },
+      "response": { "content": "Renamed the workspace." }
+    },
+    {
+      "_comment": "Turn 1. Gating on the tool name is the assertion: it is in this list only because `ch mcp` started, authenticated with the plugin token, and served its tool list. OpenCode namespaces MCP tools as <server>_<tool>, and configures them at server start — so unlike Claude there is no wait-for-servers step.",
+      "match": {
+        "systemMessage": "You are running inside CodeHydra.",
+        "toolName": "codehydra_workspace_set_title",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_ch_set_title",
+            "name": "codehydra_workspace_set_title",
+            "arguments": { "title": "renamed by agent" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/ch.ts
+++ b/e2e/ch.ts
@@ -1,0 +1,88 @@
+/**
+ * Running the `ch` CLI from a spec.
+ *
+ * Deliberately invoked the way a user or a script would — by absolute path, with
+ * none of CodeHydra's environment — because that is the case with no other
+ * coverage. Inside a workspace terminal `ch` inherits `_CH_IDE_NODE` and its
+ * cwd; here it must resolve both on its own.
+ */
+import { expect } from "@playwright/test";
+import { spawn, spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { DATA_ROOT } from "./env.ts";
+
+const isWindows = process.platform === "win32";
+
+export const BIN_DIR = join(DATA_ROOT, "bin");
+export const CH = join(BIN_DIR, isWindows ? "ch.cmd" : "ch");
+
+export interface Run {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number;
+  /** Set when the process could not be spawned at all, e.g. a missing cwd. */
+  readonly error?: string;
+}
+
+/** Run `ch` with a deliberately bare environment. */
+export function ch(args: readonly string[], cwd: string = DATA_ROOT): Run {
+  // PATH is kept because the shell needs one; every `_CH_*` variable is dropped
+  // so the CLI has to find its instance and its interpreter the way it would
+  // from a terminal CodeHydra never touched.
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith("_CH_")) env[key] = value;
+  }
+
+  const result = isWindows
+    ? spawnSync("cmd", ["/c", CH, ...args], { cwd, env, encoding: "utf-8" })
+    : spawnSync(CH, [...args], { cwd, env, encoding: "utf-8" });
+
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? -1,
+    ...(result.error && { error: result.error.message }),
+  };
+}
+
+/**
+ * Run `ch` WITHOUT blocking this process's event loop.
+ *
+ * `ch()` is synchronous, which is fine for a spec that only talks to the app.
+ * It is not fine for one that also *serves* the agent: a mock LLM running in
+ * this process cannot answer a request while `spawnSync` holds the loop, so the
+ * agent hangs on a socket nobody is reading until the CLI's own timeout fires.
+ * Any spec with an in-process server the agent depends on must use this.
+ */
+export async function chAsync(args: readonly string[], cwd: string = DATA_ROOT): Promise<Run> {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith("_CH_")) env[key] = value;
+  }
+
+  const child = isWindows
+    ? spawn("cmd", ["/c", CH, ...args], { cwd, env })
+    : spawn(CH, [...args], { cwd, env });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf-8");
+  child.stderr.setEncoding("utf-8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  child.stderr.on("data", (chunk: string) => (stderr += chunk));
+
+  return new Promise<Run>((resolve) => {
+    child.on("error", (error) => resolve({ stdout, stderr, status: -1, error: error.message }));
+    child.on("close", (code) => resolve({ stdout, stderr, status: code ?? -1 }));
+  });
+}
+
+/** Parse a JSON result. stdout is JSON because spawnSync gives no TTY. */
+export function json(run: Run): unknown {
+  expect(
+    run.status,
+    `expected success.\n  spawn error: ${run.error ?? "none"}\n  stderr: ${run.stderr}\n  stdout: ${run.stdout}`
+  ).toBe(0);
+  return JSON.parse(run.stdout) as unknown;
+}

--- a/e2e/cli.e2e.ts
+++ b/e2e/cli.e2e.ts
@@ -8,16 +8,16 @@
  * connection details a separate process can find, and that a real socket
  * connection authenticates and answers.
  *
- * Deliberately invoked the way a user or a script would — by absolute path, with
- * none of CodeHydra's environment — because that is the case with no other
- * coverage. Inside a workspace terminal `ch` inherits `_CH_IDE_NODE` and its
- * cwd; here it must resolve both on its own.
+ * `e2e/ch.ts` runs the CLI the way a user or a script would — by absolute path,
+ * with none of CodeHydra's environment — which is the case with no other
+ * coverage.
  */
 import { expect, test } from "@playwright/test";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createTestGitRepo } from "../src/utils/testing/test-utils";
+import { BIN_DIR, CH, ch, json } from "./ch.ts";
 import {
   DATA_ROOT,
   createWorkspace,
@@ -28,50 +28,6 @@ import {
 } from "./fixtures";
 
 const isWindows = process.platform === "win32";
-const BIN_DIR = join(DATA_ROOT, "bin");
-const CH = join(BIN_DIR, isWindows ? "ch.cmd" : "ch");
-
-interface Run {
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly status: number;
-  /** Set when the process could not be spawned at all, e.g. a missing cwd. */
-  readonly error?: string;
-}
-
-/**
- * Run `ch` with a deliberately bare environment.
- *
- * PATH is kept because the shell needs one; every `_CH_*` variable is dropped so
- * the CLI has to find its instance and its interpreter the way it would from a
- * terminal CodeHydra never touched.
- */
-function ch(args: readonly string[], cwd: string = DATA_ROOT): Run {
-  const env: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (!key.startsWith("_CH_")) env[key] = value;
-  }
-
-  const result = isWindows
-    ? spawnSync("cmd", ["/c", CH, ...args], { cwd, env, encoding: "utf-8" })
-    : spawnSync(CH, [...args], { cwd, env, encoding: "utf-8" });
-
-  return {
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-    status: result.status ?? -1,
-    ...(result.error && { error: result.error.message }),
-  };
-}
-
-/** Parse a JSON result. stdout is JSON because spawnSync gives no TTY. */
-function json(run: Run): unknown {
-  expect(
-    run.status,
-    `expected success.\n  spawn error: ${run.error ?? "none"}\n  stderr: ${run.stderr}\n  stdout: ${run.stdout}`
-  ).toBe(0);
-  return JSON.parse(run.stdout) as unknown;
-}
 
 let repo: { path: string; cleanup: () => Promise<void> };
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -38,6 +38,20 @@ export interface LaunchAppOptions {
    * and the paths only exist once its own `beforeAll` has run.
    */
   extraArgs?: readonly string[] | (() => readonly string[]);
+  /**
+   * Extra environment for the app process, merged over `process.env`.
+   *
+   * This is how a spec reaches the *agent*: the app hands `{...process.env}` to
+   * the IDE server (ide-server-module.ts), which hands it to every terminal,
+   * which is where `ch claude` runs — and it hands the same to the OpenCode
+   * server it spawns. So an `ANTHROPIC_BASE_URL` set here lands on the agent
+   * without the app knowing anything about it.
+   *
+   * A thunk for the same reason `extraArgs` is one: `useApp` is called at module
+   * scope, and a value that depends on a mock server's port only exists once
+   * that server's own `beforeAll` has run.
+   */
+  env?: Record<string, string> | (() => Record<string, string>);
 }
 
 /** Build the app flags. Every one is `--key=value` or a bare `--flag`; never a loose token. */
@@ -117,7 +131,11 @@ export async function launchApp(driver: AppDriver, options: LaunchAppOptions = {
     cwd: REPO_ROOT,
     args,
     // _CH_ROOT_DIR moves dataRoot and bundlesRoot together, whatever the build flavor.
-    env: { ...process.env, _CH_ROOT_DIR: ROOT_DIR },
+    env: {
+      ...process.env,
+      _CH_ROOT_DIR: ROOT_DIR,
+      ...(typeof options.env === "function" ? options.env() : (options.env ?? {})),
+    },
     timeout: 120_000,
     actionTimeout: 15_000,
   });

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@copilotkit/aimock": "^1.39.0",
     "@eslint/compat": "^2.0.3",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@copilotkit/aimock':
+        specifier: ^1.39.0
+        version: 1.39.0(vitest@4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@eslint/compat':
         specifier: ^2.0.3
         version: 2.0.3(eslint@10.0.3(jiti@2.6.1))
@@ -408,6 +411,19 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@copilotkit/aimock@1.39.0':
+    resolution: {integrity: sha512-AWw4vmW2hBchHoggh0G4McWGmGZD6wtXAehL6K5ncWF5lVIjlv++bPmxmRwrpQCi/K4/xK10N9Zp9srJYipEJw==}
+    engines: {node: '>=20.15.0'}
+    hasBin: true
+    peerDependencies:
+      jest: '>=29'
+      vitest: '>=3'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+      vitest:
+        optional: true
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -2699,6 +2715,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5442,6 +5459,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@copilotkit/aimock@1.39.0(vitest@4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    optionalDependencies:
+      vitest: 4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@csstools/color-helpers@6.0.2': {}
 

--- a/src/api/entries/index.integration.test.ts
+++ b/src/api/entries/index.integration.test.ts
@@ -13,16 +13,57 @@ import { SILENT_LOGGER } from "../../boundaries/platform/logging.test-utils";
 import { createRegistry } from "./index";
 import { OPERATION_NAMES } from "../names";
 import type { AnyOperationEntry } from "../types";
+import { schemas as openWorkspaceSchemas } from "../../intents/open-workspace";
+import { workspaceSchema, type AgentSpec } from "../../intents/contract";
+import type { Dispatcher } from "../../intents/lib/dispatcher";
 
-function registry() {
+function registry(dispatcher: Dispatcher = createMockDispatcher()) {
   return createRegistry(
     {
-      dispatcher: createMockDispatcher(),
+      dispatcher,
       appLayer: { openPath: async () => undefined },
       awaitDeletion: () => ({ outcome: new Promise(() => {}), release: () => {} }),
     },
     SILENT_LOGGER
   );
+}
+
+/**
+ * Run `workspace.create` far enough to see the AgentSpec it builds.
+ *
+ * The projection from flat input onto the contract's discriminated union is the
+ * behaviour under test, and it is only observable in the dispatched payload —
+ * so stand in a recording operation for `workspace:open` and read it back.
+ */
+async function createdAgentSpec(
+  input: Record<string, unknown>
+): Promise<AgentSpec | undefined | "not-dispatched"> {
+  const dispatcher = createMockDispatcher();
+  let seen: AgentSpec | undefined | "not-dispatched" = "not-dispatched";
+  dispatcher.registerOperation({
+    id: "recording-open-workspace",
+    schemas: openWorkspaceSchemas,
+    execute: async (ctx) => {
+      seen = ctx.intent.payload.agent;
+      // The dispatcher validates the result, so it has to be a real Workspace —
+      // parsed rather than cast, so the branded fields are branded.
+      return workspaceSchema.parse({
+        projectId: "p",
+        name: "w",
+        branch: "w",
+        metadata: {},
+        path: "/p/w",
+      });
+    },
+  });
+  const create = registry(dispatcher).get("workspace.create");
+  // `project` explicitly, so the handler skips resolving one from the caller.
+  await create.handler(
+    { workspacePath: null, cwd: null },
+    // The entry's own schema is what an adapter feeds the handler.
+    create.input.parse({ name: "w", project: "/p", ...input })
+  );
+  return seen;
 }
 
 const entries = (): readonly AnyOperationEntry[] => registry().all();
@@ -81,6 +122,83 @@ describe("registry contents", () => {
         model: "opus",
       });
       expect(parsed.success).toBe(true);
+    });
+  });
+
+  /**
+   * The creation panel emits a backend-specific AgentSpec arm; every other
+   * surface goes through this entry, so the two must offer the same options.
+   */
+  describe("create builds the same AgentSpec the creation panel does", () => {
+    it("carries every claude option onto the claude arm", async () => {
+      await expect(
+        createdAgentSpec({
+          prompt: "go",
+          agent: "claude",
+          model: "anthropic/claude-sonnet-4-5",
+          permissionMode: "bypassPermissions",
+          agentName: "reviewer",
+        })
+      ).resolves.toEqual({
+        type: "claude",
+        prompt: "go",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+        permissionMode: "bypassPermissions",
+        agentName: "reviewer",
+      });
+    });
+
+    it("carries the opencode options onto the opencode arm", async () => {
+      await expect(
+        createdAgentSpec({ prompt: "go", agent: "opencode", model: "mock/test" })
+      ).resolves.toEqual({
+        type: "opencode",
+        prompt: "go",
+        model: { providerID: "mock", modelID: "test" },
+      });
+    });
+
+    it("takes a bare model id for claude, which reads only the id", async () => {
+      await expect(createdAgentSpec({ agent: "claude", model: "opus" })).resolves.toEqual({
+        type: "claude",
+        model: { providerID: "anthropic", modelID: "opus" },
+      });
+    });
+
+    it("still emits the option-less default arm for a bare prompt", async () => {
+      await expect(createdAgentSpec({ prompt: "go" })).resolves.toEqual({
+        type: "default",
+        prompt: "go",
+      });
+    });
+
+    it("dispatches no agent at all when nothing about one was asked for", async () => {
+      await expect(createdAgentSpec({})).resolves.toBeUndefined();
+    });
+
+    it("rejects an option that needs a backend when none was named", async () => {
+      // Silently dropping these is what made the CLI poorer than the panel.
+      await expect(createdAgentSpec({ permissionMode: "plan" })).rejects.toThrow(
+        /needs an agent backend/
+      );
+    });
+
+    it("rejects a claude-only option on opencode", async () => {
+      await expect(createdAgentSpec({ agent: "opencode", permissionMode: "plan" })).rejects.toThrow(
+        /Claude option/
+      );
+    });
+
+    it("rejects an unknown backend rather than falling back to default", async () => {
+      await expect(createdAgentSpec({ agent: "claud", prompt: "go" })).rejects.toThrow(
+        /Unknown agent "claud"/
+      );
+    });
+
+    it("rejects a provider-less model for opencode, which cannot guess one", async () => {
+      await expect(createdAgentSpec({ agent: "opencode", model: "test" })).rejects.toThrow(
+        /provider\/model/
+      );
     });
 
     it("lets app-global entries run without a workspace", () => {

--- a/src/api/entries/workspace.ts
+++ b/src/api/entries/workspace.ts
@@ -12,7 +12,12 @@ import { ApiError } from "../errors";
 import { defineEntry } from "../types";
 import type { AnyOperationEntry, OperationContext } from "../types";
 import type { EntryDeps } from "./deps";
-import { workspacePathSchema, type WorkspacePath } from "../../intents/contract";
+import {
+  workspacePathSchema,
+  type AgentSpec,
+  type PromptModel,
+  type WorkspacePath,
+} from "../../intents/contract";
 import type { DeletionProgress, Workspace } from "../../shared/api/types";
 
 import { INTENT_GET_WORKSPACE_STATUS } from "../../intents/get-workspace-status";
@@ -49,6 +54,93 @@ function targetOf(ctx: OperationContext, explicit: WorkspacePath | undefined): W
     throw new ApiError("no-workspace", "No workspace to act on.");
   }
   return target;
+}
+
+/** The agent options `workspace.create` accepts, as the caller typed them. */
+interface AgentInput {
+  readonly prompt?: string | undefined;
+  readonly agent?: string | undefined;
+  readonly model?: string | undefined;
+  readonly permissionMode?: string | undefined;
+  readonly agentName?: string | undefined;
+}
+
+/**
+ * Split a `provider/model` reference into the contract's `PromptModel`.
+ *
+ * The command line wants one token, the contract wants two fields. Split on the
+ * FIRST slash so a model id that contains slashes (`anthropic/claude-x/beta`)
+ * keeps them. Claude reads only `modelID` (server-manager projects the spec onto
+ * `--model`), so a bare id is accepted there and the provider is a placeholder;
+ * OpenCode addresses models as `provider/model` and cannot guess one.
+ */
+function parseModel(model: string, backend: "claude" | "opencode"): PromptModel {
+  const slash = model.indexOf("/");
+  if (slash > 0 && slash < model.length - 1) {
+    return { providerID: model.slice(0, slash), modelID: model.slice(slash + 1) };
+  }
+  if (backend === "opencode") {
+    throw new ApiError(
+      "usage",
+      `Invalid model "${model}" for opencode: use 'provider/model', e.g. 'anthropic/claude-sonnet-4-5'.`
+    );
+  }
+  return { providerID: "anthropic", modelID: model };
+}
+
+/**
+ * Build the typed AgentSpec arm from the create input.
+ *
+ * The creation panel emits a backend-specific arm carrying prompt, model,
+ * permission mode and named agent; this is the same projection for callers that
+ * come in through the CLI, MCP or the plugin, so the two surfaces offer the same
+ * options. Only with no backend named at all do we fall back to the option-less
+ * "default" arm — which is why an option that needs a backend is a usage error
+ * rather than a silent drop.
+ */
+function buildAgentSpec(input: AgentInput): AgentSpec | undefined {
+  const { prompt, agent, model, permissionMode, agentName } = input;
+
+  if (agent === undefined) {
+    const needsBackend = [
+      ["model", model],
+      ["permissionMode", permissionMode],
+      ["agentName", agentName],
+    ].find(([, value]) => value !== undefined);
+    if (needsBackend) {
+      throw new ApiError(
+        "usage",
+        `${needsBackend[0]} needs an agent backend — pass agent=claude or agent=opencode.`
+      );
+    }
+    return prompt === undefined ? undefined : { type: "default", prompt };
+  }
+
+  if (agent !== "claude" && agent !== "opencode") {
+    throw new ApiError("usage", `Unknown agent "${agent}", expected "claude" or "opencode".`);
+  }
+
+  const parsed = model === undefined ? undefined : parseModel(model, agent);
+
+  if (agent === "opencode") {
+    if (permissionMode !== undefined) {
+      throw new ApiError("usage", "permissionMode is a Claude option; opencode does not take one.");
+    }
+    return {
+      type: "opencode",
+      ...(prompt !== undefined && { prompt }),
+      ...(parsed !== undefined && { model: parsed }),
+      ...(agentName !== undefined && { agentName }),
+    };
+  }
+
+  return {
+    type: "claude",
+    ...(prompt !== undefined && { prompt }),
+    ...(parsed !== undefined && { model: parsed }),
+    ...(permissionMode !== undefined && { permissionMode }),
+    ...(agentName !== undefined && { agentName }),
+  };
 }
 
 /** Build a human-readable failure from a terminal deletion-progress event. */
@@ -192,8 +284,25 @@ export function workspaceEntries(deps: EntryDeps): readonly AnyOperationEntry[] 
         .describe("Remote branch to check out, e.g. 'origin/feature-login'."),
       prompt: z.string().min(1).optional().describe("Initial prompt to send once created."),
       // Divergence 5: the rich shape is the definition; MCP now sees it too.
-      agent: z.string().min(1).optional().describe("Agent backend to launch."),
-      model: z.string().min(1).optional().describe("Model for the initial prompt."),
+      agent: z.string().min(1).optional().describe("Agent backend to launch: claude or opencode."),
+      model: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Model for the initial prompt: 'provider/model' (opencode requires the provider; " +
+            "claude accepts a bare model id)."
+        ),
+      permissionMode: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Claude permission mode to start in, e.g. 'plan'. Requires agent=claude."),
+      agentName: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Named agent (persona) to launch. Requires an agent backend."),
       stealFocus: z.boolean().optional().default(false).describe("Switch to the new workspace."),
     }),
     requiresWorkspace: false,
@@ -218,13 +327,7 @@ export function workspaceEntries(deps: EntryDeps): readonly AnyOperationEntry[] 
         project = resolved.projectPath;
       }
 
-      const agentSpec =
-        input.prompt !== undefined || input.agent !== undefined || input.model !== undefined
-          ? {
-              type: "default" as const,
-              ...(input.prompt !== undefined && { prompt: input.prompt }),
-            }
-          : undefined;
+      const agentSpec = buildAgentSpec(input);
 
       const intent: OpenWorkspaceIntent = {
         type: INTENT_OPEN_WORKSPACE,

--- a/src/modules/agent-module/claude/boundary-test-utils.ts
+++ b/src/modules/agent-module/claude/boundary-test-utils.ts
@@ -29,7 +29,7 @@
  * and without that its hooks lose a race against its own teardown.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { existsSync, writeFileSync } from "node:fs";
 import { delimiter, join, resolve } from "node:path";
@@ -458,11 +458,58 @@ interface SpawnAgentOptions {
   readonly pathPrefix: readonly string[];
 }
 
+/**
+ * Quote an argument for cmd.exe, the way `wrapper.ts` does.
+ *
+ * Node's `shell: true` joins the file and args with single spaces and wraps the
+ * whole line in ONE outer pair of quotes — it does not quote them individually,
+ * so any arg containing a space (every temp path here) is re-split by cmd.exe.
+ */
+function quoteForCmd(arg: string): string {
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+/**
+ * How `claude` has to be spawned here.
+ *
+ * A global npm install puts `claude.cmd` on PATH on Windows, and Node has
+ * refused to execute a `.cmd` directly since CVE-2024-27980 — it needs a shell,
+ * and therefore the hand-quoting above. Mirrors `findSystemClaude()` in
+ * `wrapper.ts`, which resolves the very same binary in production.
+ */
+function resolveClaudeCommand(): { command: string; useShell: boolean } {
+  const candidates =
+    process.platform === "win32"
+      ? [
+          { command: "claude.exe", useShell: false },
+          { command: "claude.cmd", useShell: true },
+        ]
+      : [{ command: "claude", useShell: false }];
+
+  for (const candidate of candidates) {
+    try {
+      execFileSync(candidate.command, ["--version"], {
+        stdio: "ignore",
+        shell: candidate.useShell,
+      });
+      return candidate;
+    } catch {
+      // Try the next spelling.
+    }
+  }
+  throw new Error(
+    `No working \`claude\` on PATH (tried ${candidates.map((c) => c.command).join(", ")}).\n` +
+      `These tests drive the real CLI: \`npm install -g @anthropic-ai/claude-code\`.`
+  );
+}
+
 /** Spawn the real `claude`, pointed at the mock and at the recording tap. */
 function spawnAgent(options: SpawnAgentOptions): ChildProcess {
   const path = [...options.pathPrefix, process.env.PATH ?? ""].join(delimiter);
+  const { command, useShell } = resolveClaudeCommand();
+  const quote = (value: string): string => (useShell ? quoteForCmd(value) : value);
   return spawn(
-    "claude",
+    quote(command),
     [
       "-p",
       // The prompt arrives on stdin, not argv — see `--input-format` below.
@@ -477,9 +524,10 @@ function spawnAgent(options: SpawnAgentOptions): ChildProcess {
       // nobody a way to answer.
       "--permission-mode",
       "bypassPermissions",
-    ],
+    ].map(quote),
     {
       cwd: options.cwd,
+      shell: useShell,
       env: {
         ...process.env,
         PATH: path,
@@ -524,8 +572,20 @@ async function waitForRecording(
   let exited = false;
   child.on("exit", () => (exited = true));
 
+  // Without this a failed spawn is invisible: no "exit" fires, so the loop below
+  // would sit out the full timeout and report "timed out" for what is really
+  // "the binary could not be started".
+  let spawnError: Error | undefined;
+  child.on("error", (error: Error) => {
+    spawnError = error;
+    exited = true;
+  });
+
   while (Date.now() < deadline) {
     if (until(records)) return;
+    if (spawnError !== undefined) {
+      throw new Error(`could not start claude: ${spawnError.message}`);
+    }
     if (exited) {
       // A hook is a separate process Claude spawns, so the last few can still be
       // in flight — or not yet started — when Claude itself has gone. `Stop` and

--- a/src/modules/agent-module/claude/boundary-test-utils.ts
+++ b/src/modules/agent-module/claude/boundary-test-utils.ts
@@ -1,0 +1,596 @@
+/**
+ * Harness for the Claude hook-contract boundary tests.
+ *
+ * Runs a REAL `claude` against a mock LLM and drives the whole shipped chain:
+ *
+ *     claude -p (a stream-json session on stdin)
+ *       -> the settings file `buildSettingsFile()` really writes
+ *         -> dist/bin/claude-code-hook-handler.cjs (the shipped handler)
+ *           -> a recording tap
+ *             -> a real ClaudeCodeServerManager bridge
+ *               -> AgentStatus
+ *
+ * Only the model is fake. Everything the hooks travel through is the code that
+ * ships, so a Claude release that changes what it emits shows up here as a
+ * wrong `AgentStatus` rather than as a silent regression in production.
+ *
+ * `claude` runs headless rather than in the interactive TUI CodeHydra actually
+ * launches. The hook payloads are built by the same code either way, and a
+ * headless scenario costs under a second against a TUI that would have to be
+ * driven through a PTY. What headless cannot reach stays covered by the
+ * synthetic tests in `server-manager.integration.test.ts`: `PermissionRequest`
+ * never fires, `AskUserQuestion` is refused outright ("disabled for this
+ * session, in subagents as well as here"), there is no idle prompt for
+ * `idle_prompt` to follow, and `!cmd` is a TUI input mode with no headless
+ * equivalent.
+ *
+ * It is a **stream-json session on stdin**, not a one-shot `-p "prompt"`. See
+ * {@link sendPrompt}: an open stdin keeps Claude alive past the end of a turn,
+ * and without that its hooks lose a race against its own teardown.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { existsSync, writeFileSync } from "node:fs";
+import { delimiter, join, resolve } from "node:path";
+import { LLMock } from "@copilotkit/aimock";
+import { DefaultFileSystemBoundary } from "../../../boundaries/platform/filesystem";
+import { DefaultNetworkLayer } from "../../../boundaries/platform/network";
+import { SILENT_LOGGER } from "../../../boundaries/platform/logging";
+import { DefaultPathProvider } from "../../../boundaries/platform/path-provider";
+import { NodePlatformInfo } from "../../../boundaries/platform/node-platform-info";
+import { createMockBuildInfo } from "../../../boundaries/platform/build-info.test-utils";
+import { createTempDir, createTestGitRepo } from "../../../utils/testing/test-utils";
+import { ClaudeCodeServerManager } from "./server-manager";
+import { isValidHookName, type ClaudeCodeHookName } from "./types";
+import type { AgentStatus } from "../types";
+
+/** The shipped hook handler. Built by `pnpm build:wrappers`. */
+const HOOK_HANDLER_PATH = resolve(__dirname, "../../../../dist/bin/claude-code-hook-handler.cjs");
+
+/** Ships `ch-bg`, which a background shell uses to opt out of keeping the workspace busy. */
+const RESOURCES_BIN = resolve(__dirname, "../../../../resources/bin");
+
+/** One hook, and what it did to the workspace's status. */
+export interface HookRecord {
+  readonly hook: ClaudeCodeHookName;
+  /** Status immediately before the bridge handled this hook. */
+  readonly before: AgentStatus;
+  /** Status immediately after — the bridge handles a hook before it responds. */
+  readonly after: AgentStatus;
+}
+
+/** The recording one `claude` run produced. */
+export interface ScenarioRun {
+  /** Every hook the bridge handled, in arrival order. */
+  readonly records: readonly HookRecord[];
+  /** Status after the `index`-th (default: first) occurrence of `hook`. */
+  statusAfter(hook: ClaudeCodeHookName, index?: number): AgentStatus;
+  /** Status either side of the `index`-th (default: first) occurrence of `hook`. */
+  statusAcross(
+    hook: ClaudeCodeHookName,
+    index?: number
+  ): { before: AgentStatus; after: AgentStatus };
+  /** How many times `hook` arrived. */
+  count(hook: ClaudeCodeHookName): number;
+  /** Status after the last hook of the run. */
+  readonly finalStatus: AgentStatus;
+}
+
+/** What a scenario waits for before it kills `claude`. */
+export interface ScenarioOptions {
+  /**
+   * Stop as soon as the recording satisfies this.
+   *
+   * The tests only care about hooks, never about a clean exit, so a scenario
+   * whose point is a still-running background shell need not wait out Claude's
+   * ~5s grace period before it gives up on one.
+   */
+  readonly until: (records: readonly HookRecord[]) => boolean;
+  /** Extra PATH entries for the spawned agent (the `ch-bg` scenario needs one). */
+  readonly pathPrefix?: readonly string[];
+  /**
+   * After `until` is met, close stdin and wait for the session to end.
+   *
+   * The only way to observe `SessionEnd`: while stdin is open Claude stays
+   * available for another turn, so the session never ends on its own.
+   */
+  readonly thenEndSession?: boolean;
+}
+
+/** Every scenario the boundary tests drive, and the fixtures that produce it. */
+export type ScenarioName = "plain" | "tool" | "bgcomplete" | "chbg" | "subagent" | "maxtokens";
+
+/** The prompt every scenario sends. Content is irrelevant — fixtures match on the system prompt. */
+const PROMPT = "do the thing";
+
+/**
+ * Feed the prompt as a stream-json message and leave stdin OPEN.
+ *
+ * That open stdin is the whole point. With the prompt on argv, Claude treats the
+ * turn as the entire session and tears the process down the moment it ends — and
+ * a hook is a separate process it does not wait for. `StopFailure` loses that
+ * race every time: the handler is spawned, is handed its payload, and is killed
+ * partway through the POST. (A handler that only wrote a local file would win
+ * it, which is exactly how this went unnoticed while probing.)
+ *
+ * Reading stdin, Claude stays alive after the turn, so every hook completes.
+ * The scenario ends when the recording says so and we kill the agent ourselves.
+ */
+function sendPrompt(child: ChildProcess): void {
+  child.stdin?.write(
+    JSON.stringify({
+      type: "user",
+      message: { role: "user", content: PROMPT },
+      parent_tool_use_id: null,
+      session_id: "codehydra-boundary-test",
+    }) + "\n"
+  );
+}
+
+/**
+ * Claude names the session before it does anything else, in a separate call
+ * carrying its own system prompt. `DISABLE_NON_ESSENTIAL_MODEL_CALLS` does not
+ * suppress it (checked on 2.1.250), and strict mode would 503 it and kill the
+ * run, so it gets a fixture of its own — gated on the titling agent's own
+ * system prompt so it cannot absorb the turn under test.
+ */
+const NAMING_FIXTURE = {
+  match: { systemMessage: "You are naming a coding session" },
+  response: { content: "Boundary probe" },
+} as const;
+
+/**
+ * A `Bash` tool call.
+ *
+ * `arguments` is a JSON **string**: aimock's `ToolCall` type says so, and an
+ * object is not rejected — it arrives at Claude with no parameters at all and
+ * comes back as `InputValidationError: The required parameter 'command' is
+ * missing`, which reads like Claude misbehaving rather than a fixture bug.
+ *
+ * `reasoning` is required on every tool-call fixture: Claude Code runs with
+ * extended thinking on, and Anthropic rejects a tool-loop continuation whose
+ * assistant turn does not open with a thinking block. aimock replays
+ * `reasoning` as exactly that block.
+ */
+function bashCall(command: string, description: string, background: boolean) {
+  return {
+    reasoning: `Running ${description}.`,
+    toolCalls: [
+      {
+        id: "call_bash",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command,
+          description,
+          ...(background && { run_in_background: true }),
+        }),
+      },
+    ],
+  };
+}
+
+/**
+ * Install the fixtures for one scenario. First match wins, so order is meaning.
+ *
+ * Every scenario answers a follow-up turn with plain text. A fixture that
+ * answers with another tool call instead loops forever: when a background task
+ * finishes, Claude re-invokes the agent with a fresh `UserPromptSubmit`, and a
+ * fixture that starts another background task never lets the run end.
+ */
+function installFixtures(mock: LLMock, scenario: ScenarioName): void {
+  mock.addFixture(NAMING_FIXTURE);
+
+  if (scenario === "maxtokens") {
+    // The only headless route to StopFailure. HTTP errors are NOT one: 429, 401,
+    // 500 and 529 are all retried, silently, well past any sane test timeout.
+    mock.addFixture({
+      match: {},
+      response: { content: "truncated reply", finishReason: "max_tokens" },
+    });
+    return;
+  }
+
+  if (scenario === "subagent") {
+    // The sub-agent talks to the same mock, under its own system prompt.
+    mock.addFixture({
+      match: { systemMessage: "You are an agent" },
+      response: { content: "Sub-agent done." },
+    });
+  }
+
+  // The follow-up turn, and (for `subagent`) the parent's turn after the Agent
+  // tool returns. Matched first so it beats the tool-call fixture below.
+  mock.addFixture({ match: { hasToolResult: true }, response: { content: "Done." } });
+
+  switch (scenario) {
+    case "plain":
+      mock.addFixture({ match: {}, response: { content: "Nothing to do." } });
+      break;
+    case "tool":
+      mock.addFixture({ match: {}, response: bashCall("echo probe", "echo", false) });
+      break;
+    case "bgcomplete": {
+      // Short enough to finish inside the run, so one scenario covers
+      // busyForBackgroundTasks being set AND cleared.
+      //
+      // One-shot, and that is load-bearing: when the shell exits Claude
+      // re-invokes the agent, and the re-invoked turn carries no tool result,
+      // so a plain `match: {}` would serve it another background shell and the
+      // run would never end. Only the first turn gets one.
+      let served = 0;
+      mock.addFixture({
+        match: { predicate: () => served++ === 0 },
+        response: bashCall("sleep 2", "short sleep", true),
+      });
+      mock.addFixture({ match: {}, response: { content: "The shell has finished." } });
+      break;
+    }
+    case "chbg":
+      // Long enough to still be running at Stop, so `taskKeepsBusy` really sees
+      // a running shell and opts it out on the marker rather than on an empty
+      // background_tasks — which would pass for the wrong reason.
+      mock.addFixture({ match: {}, response: bashCall("ch-bg sleep 30", "opted-out sleep", true) });
+      break;
+    case "subagent":
+      mock.addFixture({
+        match: {},
+        response: {
+          reasoning: "Delegating to a sub-agent.",
+          toolCalls: [
+            {
+              id: "call_agent",
+              name: "Task",
+              arguments: JSON.stringify({
+                subagent_type: "general-purpose",
+                description: "probe",
+                prompt: "say hello and stop",
+              }),
+            },
+          ],
+        },
+      });
+      break;
+  }
+}
+
+/** Refuse to run, loudly, rather than skip and lose the coverage silently. */
+function requirePrerequisites(): void {
+  if (!existsSync(HOOK_HANDLER_PATH)) {
+    throw new Error(
+      `The shipped hook handler is missing: ${HOOK_HANDLER_PATH}\n` +
+        `Run \`pnpm build:wrappers\` before \`pnpm test\`.`
+    );
+  }
+}
+
+/** Everything one scenario allocated, torn down in reverse. */
+interface Disposables {
+  readonly cleanups: (() => Promise<void> | void)[];
+}
+
+async function disposeAll(disposables: Disposables): Promise<void> {
+  for (const cleanup of disposables.cleanups.reverse()) {
+    try {
+      await cleanup();
+    } catch {
+      // Best effort: a leftover temp dir must not fail a run that passed.
+    }
+  }
+}
+
+/**
+ * Run one scenario end to end and return what the bridge saw.
+ *
+ * @throws if `claude` is not on PATH, or the shipped hook handler is missing.
+ */
+export async function runScenario(
+  scenario: ScenarioName,
+  options: ScenarioOptions
+): Promise<ScenarioRun> {
+  requirePrerequisites();
+
+  const disposables: Disposables = { cleanups: [] };
+  try {
+    return await runScenarioInner(scenario, options, disposables);
+  } finally {
+    await disposeAll(disposables);
+  }
+}
+
+async function runScenarioInner(
+  scenario: ScenarioName,
+  options: ScenarioOptions,
+  disposables: Disposables
+): Promise<ScenarioRun> {
+  // Claude refuses to work outside a directory it trusts, and print mode keys
+  // that off the cwd — so the workspace has to be a real repo of its own.
+  const repo = await createTestGitRepo();
+  disposables.cleanups.push(repo.cleanup);
+
+  const agentConfig = await createTempDir();
+  disposables.cleanups.push(agentConfig.cleanup);
+
+  const dataRoot = await createTempDir();
+  disposables.cleanups.push(dataRoot.cleanup);
+
+  // The mock the agent talks to instead of Anthropic.
+  const mock = new LLMock({ port: 0, strict: true });
+  installFixtures(mock, scenario);
+  const mockUrl = await mock.start();
+  disposables.cleanups.push(() => mock.stop());
+
+  // The real bridge, with real boundaries. `_CH_ROOT_DIR` relocates the data
+  // root so the generated config files land in this run's temp dir rather than
+  // in the developer's ./app-data next to a running dev instance.
+  const previousRoot = process.env._CH_ROOT_DIR;
+  process.env._CH_ROOT_DIR = dataRoot.path;
+  const pathProvider = new DefaultPathProvider(
+    createMockBuildInfo({ isDevelopment: true, appPath: process.cwd() }),
+    new NodePlatformInfo()
+  );
+  if (previousRoot === undefined) {
+    delete process.env._CH_ROOT_DIR;
+  } else {
+    process.env._CH_ROOT_DIR = previousRoot;
+  }
+
+  const manager = new ClaudeCodeServerManager({
+    portManager: new DefaultNetworkLayer(SILENT_LOGGER),
+    pathProvider,
+    fileSystem: new DefaultFileSystemBoundary(SILENT_LOGGER),
+    logger: SILENT_LOGGER,
+    config: { hookHandlerPath: HOOK_HANDLER_PATH },
+  });
+  disposables.cleanups.push(() => manager.dispose());
+
+  // Registers the workspace AND writes the real settings file Claude is given.
+  const bridgePort = await manager.startServer(repo.path);
+  const settingsPath = manager.getHooksConfigPath(repo.path).toNative();
+
+  // Track the status the bridge reports, so the tap can sample it either side
+  // of each hook.
+  let status: AgentStatus = "none";
+  manager.onStatusChange(repo.path, (next) => {
+    status = next;
+  });
+
+  const records: HookRecord[] = [];
+  const tap = await startRecordingTap(bridgePort, records, () => status);
+  disposables.cleanups.push(() => tap.close());
+
+  writeAgentConfig(agentConfig.path);
+
+  const child = spawnAgent({
+    cwd: repo.path,
+    settingsPath,
+    bridgePort: tap.port,
+    mockUrl,
+    configDir: agentConfig.path,
+    pathPrefix: options.pathPrefix ?? [],
+  });
+  disposables.cleanups.push(() => killAgent(child));
+  sendPrompt(child);
+
+  await waitForRecording(records, options.until, child);
+
+  if (options.thenEndSession === true) {
+    child.stdin?.end();
+    await waitForRecording(records, (entries) => seen(entries, "SessionEnd"), child);
+  }
+
+  return buildRun(records);
+}
+
+/**
+ * A recording proxy in front of the bridge.
+ *
+ * The bridge exposes status only through `onStatusChange`, so correlating a
+ * status with the hook that caused it needs the hook name — which only the URL
+ * carries. Sampling either side of the forwarded request is exact because the
+ * bridge handles a hook synchronously, before it responds.
+ */
+async function startRecordingTap(
+  bridgePort: number,
+  records: HookRecord[],
+  readStatus: () => AgentStatus
+): Promise<{ readonly port: number; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+    req.on("end", () => {
+      void (async () => {
+        const hook = /^\/hook\/([^/]+)$/.exec(req.url ?? "")?.[1];
+        const before = readStatus();
+        let upstream: Response | undefined;
+        try {
+          upstream = await fetch(`http://127.0.0.1:${bridgePort}${req.url ?? "/"}`, {
+            method: req.method ?? "POST",
+            headers: { "Content-Type": "application/json" },
+            body,
+          });
+        } catch {
+          // The bridge is already down (teardown raced a trailing hook).
+        }
+        if (hook !== undefined && isValidHookName(hook)) {
+          records.push({ hook, before, after: readStatus() });
+        }
+        res.writeHead(upstream?.status ?? 502, { "Content-Type": "application/json" });
+        res.end(upstream === undefined ? "{}" : await upstream.text());
+      })();
+    });
+  });
+
+  await new Promise<void>((done) => server.listen(0, "127.0.0.1", done));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Recording tap did not bind a TCP port");
+  }
+  return {
+    port: address.port,
+    close: () => new Promise<void>((done) => server.close(() => done())),
+  };
+}
+
+/**
+ * Claude's own config for this run: past onboarding, past the
+ * bypass-permissions warning, and isolated from the developer's ~/.claude.
+ */
+function writeAgentConfig(configDir: string): void {
+  writeFileSync(
+    join(configDir, ".claude.json"),
+    JSON.stringify({
+      hasCompletedOnboarding: true,
+      theme: "dark",
+      // `--permission-mode bypassPermissions` otherwise stops on a one-time
+      // warning screen, which in print mode means it stops for good.
+      bypassPermissionsModeAccepted: true,
+    })
+  );
+}
+
+interface SpawnAgentOptions {
+  readonly cwd: string;
+  readonly settingsPath: string;
+  readonly bridgePort: number;
+  readonly mockUrl: string;
+  readonly configDir: string;
+  readonly pathPrefix: readonly string[];
+}
+
+/** Spawn the real `claude`, pointed at the mock and at the recording tap. */
+function spawnAgent(options: SpawnAgentOptions): ChildProcess {
+  const path = [...options.pathPrefix, process.env.PATH ?? ""].join(delimiter);
+  return spawn(
+    "claude",
+    [
+      "-p",
+      // The prompt arrives on stdin, not argv — see `--input-format` below.
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--settings",
+      options.settingsPath,
+      // Without this Claude parks on a permission prompt that print mode gives
+      // nobody a way to answer.
+      "--permission-mode",
+      "bypassPermissions",
+    ],
+    {
+      cwd: options.cwd,
+      env: {
+        ...process.env,
+        PATH: path,
+        // Read by the shipped hook handler; the two together are what make it
+        // POST anything at all.
+        _CH_BRIDGE_PORT: String(options.bridgePort),
+        _CH_WORKSPACE_PATH: options.cwd,
+        ANTHROPIC_BASE_URL: options.mockUrl,
+        // A bearer token rather than ANTHROPIC_API_KEY: an API key makes Claude
+        // ask the user to approve it once, and nobody is there to answer.
+        ANTHROPIC_AUTH_TOKEN: "codehydra-boundary-test",
+        ANTHROPIC_MODEL: "claude-sonnet-4-5",
+        CLAUDE_CONFIG_DIR: options.configDir,
+        // Keep the run to the turn under test, and keep a version check or a
+        // crash report from reaching the network mid-test.
+        DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1",
+        DISABLE_AUTOUPDATER: "1",
+        DISABLE_TELEMETRY: "1",
+        DISABLE_ERROR_REPORTING: "1",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    }
+  );
+}
+
+/** How long one scenario may take before it is called a failure. */
+const SCENARIO_TIMEOUT_MS = 60_000;
+
+/** How long trailing hooks may keep arriving after `claude` has exited. */
+const POST_EXIT_GRACE_MS = 3_000;
+
+/** Poll until the recording satisfies `until`, or the agent dies, or time runs out. */
+async function waitForRecording(
+  records: readonly HookRecord[],
+  until: (records: readonly HookRecord[]) => boolean,
+  child: ChildProcess
+): Promise<void> {
+  const deadline = Date.now() + SCENARIO_TIMEOUT_MS;
+  let stderr = "";
+  child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+
+  let exited = false;
+  child.on("exit", () => (exited = true));
+
+  while (Date.now() < deadline) {
+    if (until(records)) return;
+    if (exited) {
+      // A hook is a separate process Claude spawns, so the last few can still be
+      // in flight — or not yet started — when Claude itself has gone. `Stop` and
+      // `SessionEnd` routinely land after exit. Give them room before calling it
+      // a failure.
+      await new Promise((done) => setTimeout(done, POST_EXIT_GRACE_MS));
+      if (until(records)) return;
+      throw new Error(
+        `claude exited before the scenario completed.\n` +
+          `hooks seen: ${records.map((entry) => entry.hook).join(", ") || "(none)"}\n` +
+          `stderr: ${stderr.slice(-800)}`
+      );
+    }
+    await new Promise((done) => setTimeout(done, 50));
+  }
+  throw new Error(
+    `scenario timed out after ${SCENARIO_TIMEOUT_MS}ms.\n` +
+      `hooks seen: ${records.map((entry) => entry.hook).join(", ") || "(none)"}\n` +
+      `stderr: ${stderr.slice(-800)}`
+  );
+}
+
+/** Stop the agent. Scenarios never need a clean exit — only the hooks it already sent. */
+function killAgent(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise<void>((done) => {
+    child.once("exit", () => done());
+    child.kill("SIGKILL");
+    // A process that refuses to die must not hang the suite.
+    setTimeout(done, 2_000).unref?.();
+  });
+}
+
+/** Wrap the raw records in the lookups the assertions use. */
+function buildRun(records: readonly HookRecord[]): ScenarioRun {
+  const pick = (hook: ClaudeCodeHookName, index: number): HookRecord => {
+    const matches = records.filter((entry) => entry.hook === hook);
+    const match = matches[index];
+    if (match === undefined) {
+      throw new Error(
+        `no ${hook}[${index}] in this run — hooks seen: ` +
+          `${records.map((entry) => entry.hook).join(", ") || "(none)"}`
+      );
+    }
+    return match;
+  };
+
+  return {
+    records,
+    statusAfter: (hook, index = 0) => pick(hook, index).after,
+    statusAcross: (hook, index = 0) => {
+      const { before, after } = pick(hook, index);
+      return { before, after };
+    },
+    count: (hook) => records.filter((entry) => entry.hook === hook).length,
+    finalStatus: records.at(-1)?.after ?? "none",
+  };
+}
+
+/** `resources/bin`, for the scenario whose shell must really find `ch-bg`. */
+export function chBgPathEntry(): string {
+  return RESOURCES_BIN;
+}
+
+/** Convenience: has `hook` arrived at least `count` times? */
+export function seen(records: readonly HookRecord[], hook: ClaudeCodeHookName, count = 1): boolean {
+  return records.filter((entry) => entry.hook === hook).length >= count;
+}

--- a/src/modules/agent-module/claude/server-manager.boundary.test.ts
+++ b/src/modules/agent-module/claude/server-manager.boundary.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+/**
+ * Boundary tests for ClaudeCodeServerManager against a REAL `claude`.
+ *
+ * `server-manager.integration.test.ts` covers how the manager REACTS to hook
+ * payloads — thoroughly, and with payloads we hand it ourselves. What nothing
+ * covered until now is the premise underneath all of it: that Claude Code still
+ * emits those hooks, with those payloads, in that order. That premise is a pile
+ * of empirical findings ("verified against Claude Code 2.1.202") which a Claude
+ * release can invalidate without a single test going red.
+ *
+ * So these tests spawn the real binary against a mock model and assert the
+ * `AgentStatus` that comes out the far end of the shipped chain. They are
+ * additive: nothing in the synthetic suite is retired, because a synthetic
+ * failure says *our logic* broke while a failure here says *Claude* changed.
+ *
+ * **They assert status, never hook names or payload fields.** That is
+ * deliberate, and it is still enough: rename `background_tasks` and the
+ * running-shell `Stop` stops being suppressed, so "stays busy" fails. The
+ * status is the drift detector, and a hook Claude adds that changes nothing
+ * passes silently, as it should.
+ *
+ * Requires a real `claude` on PATH and `pnpm build:wrappers` — both fail loudly
+ * rather than skipping, so the coverage cannot be lost by accident.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { chBgPathEntry, runScenario, seen, type ScenarioRun } from "./boundary-test-utils";
+
+/** A whole scenario is ~0.7s; the slowest (a background shell's full life) ~3s. */
+const SCENARIO_TIMEOUT_MS = 90_000;
+
+describe("a plain turn", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    run = await runScenario("plain", {
+      until: (r) => seen(r, "Stop"),
+      thenEndSession: true,
+    });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("SessionStart leaves the workspace idle", () => {
+    expect(run.statusAfter("SessionStart")).toBe("idle");
+  });
+
+  it("UserPromptSubmit makes it busy", () => {
+    expect(run.statusAfter("UserPromptSubmit")).toBe("busy");
+  });
+
+  it("Stop returns it to idle", () => {
+    expect(run.statusAfter("Stop")).toBe("idle");
+  });
+
+  it("SessionEnd leaves no agent", () => {
+    expect(run.statusAfter("SessionEnd")).toBe("none");
+  });
+});
+
+describe("a turn that uses a tool", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    run = await runScenario("tool", { until: (r) => seen(r, "Stop") });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("PreToolUse mid-turn does not change the status", () => {
+    // The "PreToolUse while idle -> busy" rule exists for turns we never saw
+    // start; a tool inside a turn already known to be running must be a no-op.
+    expect(run.statusAcross("PreToolUse")).toEqual({ before: "busy", after: "busy" });
+  });
+
+  it("PostToolUse keeps it busy", () => {
+    expect(run.statusAfter("PostToolUse")).toBe("busy");
+  });
+
+  it("the turn still ends idle", () => {
+    expect(run.statusAfter("Stop")).toBe("idle");
+  });
+});
+
+describe("a background shell, over its whole life", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    // Two Stops: the one suppressed while the shell runs, and the one after it
+    // exits. The second only exists because Claude re-invokes the agent when a
+    // background task finishes.
+    run = await runScenario("bgcomplete", { until: (r) => seen(r, "Stop", 2) });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("the Stop that lands while the shell is running stays busy", () => {
+    expect(run.statusAcross("Stop", 0)).toEqual({ before: "busy", after: "busy" });
+  });
+
+  it("Claude re-invokes the agent once the shell exits", () => {
+    // The re-invoke is a real UserPromptSubmit, and it is what clears the
+    // suppression stash so the next Stop can decide from fresh ground truth.
+    expect(run.count("UserPromptSubmit")).toBeGreaterThanOrEqual(2);
+    expect(run.statusAfter("UserPromptSubmit", 1)).toBe("busy");
+  });
+
+  it("the Stop after the shell has exited goes idle", () => {
+    expect(run.statusAfter("Stop", 1)).toBe("idle");
+  });
+});
+
+describe("a background shell wrapped in ch-bg", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    // `resources/bin` on PATH so the shell genuinely starts and is reported as
+    // running. Without it the shell dies instantly, background_tasks is empty,
+    // and this would go idle for the wrong reason and still pass.
+    run = await runScenario("chbg", {
+      until: (r) => seen(r, "Stop"),
+      pathPrefix: [chBgPathEntry()],
+    });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("goes idle even though the shell is still running", () => {
+    expect(run.statusAfter("Stop")).toBe("idle");
+  });
+});
+
+describe("a turn that spawns a sub-agent", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    run = await runScenario("subagent", { until: (r) => seen(r, "Stop") });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("SubagentStart does not drive the workspace status", () => {
+    const { before, after } = run.statusAcross("SubagentStart");
+    expect(after).toBe(before);
+  });
+
+  it("SubagentStop does not drive the workspace status", () => {
+    // Ignored because HOOK_SPEC maps SubagentStop to no status change — NOT by
+    // the `agent_id` guard on Stop/StopFailure. Real Claude ends a sub-agent's
+    // turn with SubagentStop, never with a Stop carrying an agent_id, so that
+    // guard is unreachable from here and stays covered synthetically.
+    const { before, after } = run.statusAcross("SubagentStop");
+    expect(after).toBe(before);
+  });
+
+  it("the main Stop stays busy while the sub-agent is still running", () => {
+    expect(run.statusAcross("Stop", 0)).toEqual({ before: "busy", after: "busy" });
+  });
+});
+
+describe("a turn that dies on max_tokens", () => {
+  let run: ScenarioRun;
+  beforeAll(async () => {
+    run = await runScenario("maxtokens", { until: (r) => seen(r, "StopFailure") });
+  }, SCENARIO_TIMEOUT_MS);
+
+  it("StopFailure surfaces the stuck agent as idle", () => {
+    expect(run.statusAfter("StopFailure")).toBe("idle");
+  });
+});

--- a/src/modules/git-worktree-workspace-module.integration.test.ts
+++ b/src/modules/git-worktree-workspace-module.integration.test.ts
@@ -32,7 +32,7 @@ import type { DiscoverHookResult } from "../intents/open-project";
 import { CLOSE_PROJECT_OPERATION_ID, INTENT_CLOSE_PROJECT } from "../intents/close-project";
 import { OPEN_WORKSPACE_OPERATION_ID, INTENT_OPEN_WORKSPACE } from "../intents/open-workspace";
 import type { OpenWorkspaceIntent } from "../intents/open-workspace";
-import type { CreateHookResult } from "../intents/open-workspace";
+import type { CreateHookResult, FinalizeHookResult } from "../intents/open-workspace";
 import {
   GET_PROJECT_BASES_OPERATION_ID,
   INTENT_GET_PROJECT_BASES,
@@ -99,6 +99,7 @@ function createMockGitWorktreeProvider() {
     ensureWorkspaceRegistered: vi.fn(),
     listUnmanagedWorktrees: vi.fn().mockResolvedValue([]),
     adoptWorktree: vi.fn().mockResolvedValue(undefined),
+    getMetadata: vi.fn().mockResolvedValue({}),
   };
 }
 
@@ -140,6 +141,26 @@ const openWorkspaceOperation = createMinimalOperation<CreateHookResult>(
       intent: ctx.intent,
       projectPath: (ctx.intent.payload as { projectPath?: ProjectPath }).projectPath ?? "",
     }),
+  }
+);
+
+/**
+ * Runs open-workspace's `finalize` hook point. Registered on a dispatcher of its
+ * own: only one operation may claim an intent type, and `openWorkspaceOperation`
+ * already claims this one for `create`.
+ */
+const openWorkspaceFinalizeOperation = createMinimalOperation<FinalizeHookResult>(
+  OPEN_WORKSPACE_OPERATION_ID,
+  INTENT_OPEN_WORKSPACE,
+  "finalize",
+  {
+    hookContext: (ctx) => ({
+      intent: ctx.intent,
+      workspacePath: (ctx.intent.payload as { workspacePath: WorkspacePath }).workspacePath,
+      envVars: {},
+      agentType: null,
+    }),
+    defaultResult: {},
   }
 );
 
@@ -1208,6 +1229,68 @@ describe("GitWorktreeWorkspaceModule Integration", () => {
   // ---------------------------------------------------------------------------
   // get-project-bases -> list
   // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // open-workspace -> finalize
+  // ---------------------------------------------------------------------------
+
+  describe("open-workspace -> finalize", () => {
+    /**
+     * A dispatcher whose `workspace:open` operation runs the finalize hook.
+     * `createTestSetup` wires the same intent to the create hook, and an intent
+     * type admits only one operation.
+     */
+    function finalizeSetup() {
+      const provider = createMockGitWorktreeProvider();
+      const pathProvider = createMockPathProvider({
+        getProjectWorkspacesDir: () => new Path("/workspaces"),
+      });
+      const dispatcher = createMockDispatcher();
+      dispatcher.registerOperation(openWorkspaceFinalizeOperation);
+      const { ui } = createMockUi();
+      dispatcher.registerModule(
+        createGitWorktreeWorkspaceModule(
+          provider as unknown as GitWorktreeProvider,
+          pathProvider,
+          SILENT_LOGGER,
+          ui
+        )
+      );
+      return { dispatcher, provider };
+    }
+
+    const finalize = async (dispatcher: Dispatcher, workspacePath: string) =>
+      (await dispatcher.dispatch({
+        type: INTENT_OPEN_WORKSPACE,
+        payload: { workspacePath },
+      } as unknown as Intent)) as FinalizeHookResult;
+
+    it("re-reads metadata so a write made during creation is not lost", async () => {
+      // What an agent acting on its own workspace mid-creation produces: the
+      // title is in git config, but it was never a hook result, so the `create`
+      // snapshot the operation is holding knows nothing about it.
+      const { dispatcher, provider } = finalizeSetup();
+      provider.getMetadata.mockResolvedValue({ base: "main", title: "renamed by agent" });
+
+      const result = await finalize(dispatcher, "/workspaces/new-feature");
+
+      expect(provider.getMetadata).toHaveBeenCalledWith(new Path("/workspaces/new-feature"));
+      // Folded last by open-workspace, so this supersedes the stale snapshot and
+      // reaches both workspace:created and the returned Workspace.
+      expect(result.metadata).toEqual({ base: "main", title: "renamed by agent" });
+    });
+
+    it("still opens the workspace when the metadata cannot be read", async () => {
+      const { dispatcher, provider } = finalizeSetup();
+      provider.getMetadata.mockRejectedValue(new Error("not a git directory"));
+
+      const result = await finalize(dispatcher, "/workspaces/new-feature");
+
+      // Best-effort: no metadata contributed, and no thrown error to fail the
+      // creation over a label.
+      expect(result.metadata).toBeUndefined();
+    });
+  });
 
   describe("get-project-bases -> list", () => {
     it("returns bases and defaultBaseBranch from provider", async () => {

--- a/src/modules/git-worktree-workspace-module.ts
+++ b/src/modules/git-worktree-workspace-module.ts
@@ -29,6 +29,8 @@ import type {
   OpenWorkspaceIntent,
   CreateHookInput,
   CreateHookResult,
+  FinalizeHookInput,
+  FinalizeHookResult,
 } from "../intents/open-workspace";
 import { OPEN_WORKSPACE_OPERATION_ID } from "../intents/open-workspace";
 import type {
@@ -664,6 +666,45 @@ export function createGitWorktreeWorkspaceModule(
                 resolvedBase: base,
               },
             };
+          },
+        },
+
+        finalize: {
+          /**
+           * Re-read the workspace's metadata so `workspace:created` (and the
+           * Workspace this operation returns) carry what git config actually
+           * holds when creation completes.
+           *
+           * The `create` snapshot plus the metadata hook handlers *report* is
+           * only as complete as its reporters. An agent that acts on its own
+           * workspace during creation — OpenCode sends its initial prompt from
+           * the setup hook, and `codehydra_workspace_set_title` is one MCP call
+           * away — writes through `workspace:set-metadata`, which is not a hook
+           * result and so is invisible to that fold. Its `metadata:changed`
+           * event then lands on a row the presenter is about to overwrite with
+           * the stale snapshot, and the change vanishes until a restart re-reads
+           * git config.
+           *
+           * Reading here fixes it for every writer rather than for the ones that
+           * remember to report, and keeps the presenter's "install the
+           * authoritative snapshot" semantics correct by making it authoritative.
+           * Merged last (open-workspace.ts folds finalize results after setup's),
+           * so it supersedes both.
+           */
+          handler: async (ctx: HookContext): Promise<HookOutput<FinalizeHookResult>> => {
+            const { workspacePath } = ctx as FinalizeHookInput;
+            try {
+              const metadata = await gitWorktreeProvider.getMetadata(new Path(workspacePath));
+              return { result: { metadata } };
+            } catch (error: unknown) {
+              // Best-effort: a workspace whose metadata cannot be read still
+              // opens, carrying the snapshot it already had.
+              logger.warn("Failed to re-read workspace metadata on finalize", {
+                workspacePath,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              return { result: {} };
+            }
           },
         },
       },

--- a/src/test/fixtures/mock-llm-server.test.ts
+++ b/src/test/fixtures/mock-llm-server.test.ts
@@ -1,15 +1,26 @@
 /**
  * Tests for mock LLM server.
+ *
+ * The wire format is aimock's problem now; what is ours is the fixture set
+ * behind each mode. A typo in one of those would otherwise surface only as a
+ * confusing failure in a slow opencode boundary test, so assert them here over
+ * real HTTP — the same way opencode reaches the server.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import {
-  createMockLlmServer,
-  type MockLlmServer,
-  createInstantCompletion,
-  createToolCallCompletion,
-  createRateLimitResponse,
-} from "./mock-llm-server";
+import { createMockLlmServer, type MockLlmServer } from "./mock-llm-server";
+
+interface Completion {
+  readonly choices: readonly {
+    readonly message: {
+      readonly content: string | null;
+      readonly tool_calls?: readonly {
+        readonly function: { readonly name: string; readonly arguments: string };
+      }[];
+    };
+    readonly finish_reason: string;
+  }[];
+}
 
 describe("createMockLlmServer", () => {
   let server: MockLlmServer;
@@ -23,199 +34,107 @@ describe("createMockLlmServer", () => {
     await server.stop();
   });
 
+  /** POST a chat completion the way the openai-compatible provider would. */
+  async function complete(
+    body: Record<string, unknown>
+  ): Promise<{ status: number; json: Completion }> {
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "test", ...body }),
+    });
+    const json = response.status === 200 ? ((await response.json()) as Completion) : ({} as never);
+    return { status: response.status, json };
+  }
+
   it("returns instant completion in instant mode", async () => {
     server.setMode("instant");
 
-    const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: "test",
-        messages: [{ role: "user", content: "Hello" }],
-      }),
-    });
+    const { status, json } = await complete({ messages: [{ role: "user", content: "Hello" }] });
 
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as {
-      id: string;
-      choices: { message: { content: string } }[];
-    };
-    expect(data.id).toMatch(/^chatcmpl-/);
-    expect(data.choices).toHaveLength(1);
-    expect(data.choices[0]!.message.content).toBe("Done.");
+    expect(status).toBe(200);
+    expect(json.choices[0]?.message.content).toBe("Done.");
+    expect(json.choices[0]?.finish_reason).toBe("stop");
   });
 
-  it("returns tool call in tool-call mode", async () => {
+  it("returns a bash tool call in tool-call mode", async () => {
     server.setMode("tool-call");
 
-    const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: "test",
-        messages: [{ role: "user", content: "Run echo hello" }],
-        tools: [{ type: "function", function: { name: "bash" } }],
-      }),
+    const { json } = await complete({
+      messages: [{ role: "user", content: "Run something" }],
+      tools: [{ type: "function", function: { name: "bash" } }],
     });
 
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as {
-      choices: {
-        message: { tool_calls: { function: { name: string } }[] };
-        finish_reason: string;
-      }[];
-    };
-    expect(data.choices).toHaveLength(1);
-    const choice = data.choices[0]!;
-    expect(choice.message.tool_calls).toBeDefined();
-    expect(choice.message.tool_calls[0]!.function.name).toBe("bash");
-    expect(choice.finish_reason).toBe("tool_calls");
+    const call = json.choices[0]?.message.tool_calls?.[0];
+    expect(call?.function.name).toBe("bash");
+    // opencode's bash schema requires both; a call missing `description` is
+    // rejected before any permission event is emitted.
+    expect(JSON.parse(call?.function.arguments ?? "{}")).toEqual({
+      command: "echo hello",
+      description: "Prints hello to stdout",
+    });
   });
 
-  it("returns 429 in rate-limit mode", async () => {
+  it("does not spend the tool-call slot on a request that carries no tools", async () => {
+    server.setMode("tool-call");
+
+    // opencode's title-generation agent prompts without tools.
+    const titling = await complete({ messages: [{ role: "user", content: "Title this" }] });
+    expect(titling.json.choices[0]?.message.content).toBe("ok");
+
+    const build = await complete({
+      messages: [{ role: "user", content: "Run something" }],
+      tools: [{ type: "function", function: { name: "bash" } }],
+    });
+    expect(build.json.choices[0]?.message.tool_calls?.[0]?.function.name).toBe("bash");
+  });
+
+  it("answers with text once the tool result comes back", async () => {
+    server.setMode("tool-call");
+
+    const { json } = await complete({
+      messages: [
+        { role: "user", content: "Run something" },
+        { role: "assistant", content: null, tool_calls: [] },
+        { role: "tool", tool_call_id: "call_1", content: "hello" },
+      ],
+      tools: [{ type: "function", function: { name: "bash" } }],
+    });
+
+    expect(json.choices[0]?.message.content).toBe("Tool executed successfully.");
+  });
+
+  it("returns 429 once in rate-limit mode, then recovers", async () => {
     server.setMode("rate-limit");
 
-    const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: "test",
-        messages: [{ role: "user", content: "Hello" }],
-      }),
-    });
+    const first = await complete({ messages: [{ role: "user", content: "Hi" }] });
+    expect(first.status).toBe(429);
 
-    expect(response.status).toBe(429);
-    expect(response.headers.get("Retry-After")).toBe("5");
-    const data = (await response.json()) as { error: { message: string } };
-    expect(data.error.message).toBe("Rate limit exceeded");
+    const retry = await complete({ messages: [{ role: "user", content: "Hi" }] });
+    expect(retry.status).toBe(200);
+    expect(retry.json.choices[0]?.message.content).toBe("Recovered from rate limit.");
   });
 
-  it("returns task tool call in sub-agent mode", async () => {
-    server.setMode("sub-agent");
-
-    const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: "test",
-        messages: [{ role: "user", content: "Search files" }],
-        tools: [{ type: "function", function: { name: "task" } }],
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as {
-      choices: {
-        message: { tool_calls: { function: { name: string; arguments: string } }[] };
-        finish_reason: string;
-      }[];
-    };
-    expect(data.choices).toHaveLength(1);
-    const choice = data.choices[0]!;
-    expect(choice.message.tool_calls).toBeDefined();
-    expect(choice.message.tool_calls[0]!.function.name).toBe("task");
-    expect(choice.finish_reason).toBe("tool_calls");
-
-    // Verify task tool arguments contain description and prompt
-    const args = JSON.parse(choice.message.tool_calls[0]!.function.arguments) as {
-      description: string;
-      prompt: string;
-    };
-    expect(args.description).toBeDefined();
-    expect(args.prompt).toBeDefined();
-  });
-
-  it("streams response with delays in slow-stream mode", async () => {
+  it("streams slowly enough to observe a busy window in slow-stream mode", async () => {
     server.setMode("slow-stream");
 
-    const startTime = Date.now();
+    const started = Date.now();
     const response = await fetch(`http://127.0.0.1:${server.port}/v1/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         model: "test",
-        messages: [{ role: "user", content: "Hello" }],
         stream: true,
+        messages: [{ role: "user", content: "Stream this slowly" }],
       }),
     });
+    const body = await response.text();
+    const elapsed = Date.now() - started;
 
-    expect(response.status).toBe(200);
-
-    // Read the stream
-    const reader = response.body!.getReader();
-    const chunks: string[] = [];
-    let done = false;
-
-    while (!done) {
-      const { value, done: readerDone } = await reader.read();
-      done = readerDone;
-      if (value) {
-        chunks.push(new TextDecoder().decode(value));
-      }
-    }
-
-    const elapsed = Date.now() - startTime;
-
-    // Should have multiple chunks with delays
-    expect(chunks.length).toBeGreaterThan(1);
-    // Should take at least some time due to streaming delays
-    expect(elapsed).toBeGreaterThan(50);
-  });
-});
-
-describe("response builders", () => {
-  it("createInstantCompletion creates valid response", () => {
-    const completion = createInstantCompletion("Test content");
-    const choice = completion.choices[0];
-
-    expect(completion.id).toMatch(/^chatcmpl-/);
-    expect(completion.object).toBe("chat.completion");
-    expect(choice?.message.content).toBe("Test content");
-    expect(choice?.finish_reason).toBe("stop");
-  });
-
-  it("createToolCallCompletion creates valid tool call", () => {
-    // Note: For bash tool, OpenCode requires both 'command' and 'description' parameters
-    const completion = createToolCallCompletion("bash", {
-      command: "echo hello",
-      description: "Prints hello",
-    });
-    const choice = completion.choices[0];
-    const toolCall = choice?.message.tool_calls?.[0];
-
-    expect(choice?.message.content).toBeNull();
-    expect(choice?.message.tool_calls).toHaveLength(1);
-    expect(toolCall?.function.name).toBe("bash");
-    expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toEqual({
-      command: "echo hello",
-      description: "Prints hello",
-    });
-    expect(choice?.finish_reason).toBe("tool_calls");
-  });
-
-  it("createToolCallCompletion creates task tool call for sub-agents", () => {
-    const completion = createToolCallCompletion("task", {
-      description: "Search for files",
-      prompt: "Find all TypeScript files",
-    });
-    const choice = completion.choices[0];
-    const toolCall = choice?.message.tool_calls?.[0];
-
-    expect(choice?.message.content).toBeNull();
-    expect(choice?.message.tool_calls).toHaveLength(1);
-    expect(toolCall?.function.name).toBe("task");
-    expect(JSON.parse(toolCall?.function.arguments ?? "{}")).toEqual({
-      description: "Search for files",
-      prompt: "Find all TypeScript files",
-    });
-    expect(choice?.finish_reason).toBe("tool_calls");
-  });
-
-  it("createRateLimitResponse creates 429 response", () => {
-    const response = createRateLimitResponse();
-
-    expect(response.status).toBe(429);
-    expect(response.headers["Retry-After"]).toBe("5");
-    expect(JSON.parse(response.body).error.type).toBe("rate_limit_error");
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(body).toContain("data: ");
+    // The point of the mode: the stream is still open long enough for a status
+    // read taken during it to see "busy".
+    expect(elapsed).toBeGreaterThan(300);
   });
 });

--- a/src/test/fixtures/mock-llm-server.ts
+++ b/src/test/fixtures/mock-llm-server.ts
@@ -1,8 +1,14 @@
 /**
  * Mock LLM Server for OpenCode boundary tests.
  *
- * Provides an OpenAI-compatible API endpoint that can be configured
- * to return different response types for testing various scenarios.
+ * A thin `MockLlmMode` façade over `@copilotkit/aimock`, which serves the actual
+ * OpenAI-compatible endpoints. It used to hand-roll the wire format; aimock
+ * speaks it (and the Anthropic one the e2e suite needs), keeps up with the real
+ * APIs through its own drift-detection CI, and is what `e2e/agent-mock.ts` uses
+ * — so there is one mock in the repo rather than two.
+ *
+ * The modes stay, because they are how the boundary tests name the scenario
+ * under test. Each one is a fixture set, swapped in on `setMode()`.
  *
  * @example
  * ```ts
@@ -17,7 +23,7 @@
  * ```
  */
 
-import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http";
+import { LLMock } from "@copilotkit/aimock";
 
 // ============================================================================
 // Types
@@ -29,50 +35,11 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
  * | Mode          | Response Behavior                   | Triggers                 |
  * | ------------- | ----------------------------------- | ------------------------ |
  * | `instant`     | Return completion immediately       | idle → busy → idle       |
- * | `slow-stream` | Stream with 100ms delays            | Extended busy state      |
+ * | `slow-stream` | Stream slowly enough to observe     | Extended busy state      |
  * | `tool-call`   | Return `bash` tool_call             | permission.updated event |
  * | `rate-limit`  | Return HTTP 429 with `Retry-After`  | retry status             |
- * | `sub-agent`   | Return `task` tool_call             | Child session creation   |
  */
-export type MockLlmMode = "instant" | "slow-stream" | "tool-call" | "rate-limit" | "sub-agent";
-
-/**
- * Chat completion response structure (OpenAI format).
- */
-export interface ChatCompletion {
-  id: string;
-  object: "chat.completion";
-  choices: Array<{
-    index: number;
-    message: {
-      role: "assistant";
-      content: string | null;
-      tool_calls?: ToolCall[];
-    };
-    finish_reason: "stop" | "tool_calls";
-  }>;
-}
-
-/**
- * Tool call structure.
- */
-export interface ToolCall {
-  id: string;
-  type: "function";
-  function: {
-    name: string;
-    arguments: string;
-  };
-}
-
-/**
- * Rate limit error response.
- */
-export interface RateLimitResponse {
-  status: 429;
-  headers: Record<string, string>;
-  body: string;
-}
+export type MockLlmMode = "instant" | "slow-stream" | "tool-call" | "rate-limit";
 
 /**
  * Mock LLM server handle.
@@ -89,219 +56,65 @@ export interface MockLlmServer {
 }
 
 // ============================================================================
-// Response Builders
+// Fixture sets
 // ============================================================================
 
 /**
- * Generate a random ID for completions.
+ * Install the fixtures for one mode. First match wins, so the order within each
+ * mode is part of its meaning.
  */
-function randomId(): string {
-  return Math.random().toString(36).substring(2, 15);
-}
+function applyMode(mock: LLMock, mode: MockLlmMode): void {
+  mock.clearFixtures();
 
-/**
- * Creates instant completion response.
- *
- * @param content - Text content to return
- * @returns ChatCompletion with the content
- */
-export function createInstantCompletion(content: string): ChatCompletion {
-  return {
-    id: `chatcmpl-${randomId()}`,
-    object: "chat.completion",
-    choices: [
-      {
-        index: 0,
-        message: { role: "assistant", content },
-        finish_reason: "stop",
-      },
-    ],
-  };
-}
+  switch (mode) {
+    case "slow-stream":
+      // Slow enough that a status read taken shortly after the prompt starts
+      // still lands mid-stream.
+      mock.on(
+        {},
+        { content: "This is a slow streamed response." },
+        {
+          streamingProfile: { ttft: 300, tps: 5 },
+        }
+      );
+      return;
 
-/**
- * Creates tool call completion (triggers permission request).
- *
- * IMPORTANT: For bash tool, args must include `command` AND `description`.
- * The description parameter is required by OpenCode's bash tool schema.
- *
- * @param toolName - Name of the tool to call
- * @param args - Arguments for the tool (e.g., { command: "ls", description: "List files" })
- * @returns ChatCompletion with tool_calls
- */
-export function createToolCallCompletion(
-  toolName: string,
-  args: Record<string, unknown>
-): ChatCompletion {
-  return {
-    id: `chatcmpl-${randomId()}`,
-    object: "chat.completion",
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: "assistant",
-          content: null,
-          tool_calls: [
+    case "tool-call":
+      // Requests that advertise no tools (opencode's title-generation agent)
+      // must not consume the tool-call slot: they would leave the build agent
+      // with a plain completion and no permission flow.
+      mock.on({ predicate: (req) => (req.tools?.length ?? 0) === 0 }, { content: "ok" });
+      // The result of the bash call comes back on the same conversation.
+      mock.on({ hasToolResult: true }, { content: "Tool executed successfully." });
+      // The bash tool's schema requires `description` alongside `command`.
+      mock.on(
+        {},
+        {
+          toolCalls: [
             {
-              id: `call_${randomId()}`,
-              type: "function",
-              function: {
-                name: toolName,
-                arguments: JSON.stringify(args),
-              },
+              name: "bash",
+              arguments: { command: "echo hello", description: "Prints hello to stdout" },
             },
           ],
-        },
-        finish_reason: "tool_calls",
-      },
-    ],
-  };
-}
+        }
+      );
+      return;
 
-/**
- * Creates rate limit error response.
- *
- * @returns Rate limit response object with status, headers, and body
- */
-export function createRateLimitResponse(): RateLimitResponse {
-  return {
-    status: 429,
-    headers: {
-      "Retry-After": "5",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      error: {
-        message: "Rate limit exceeded",
-        type: "rate_limit_error",
-      },
-    }),
-  };
-}
+    case "rate-limit":
+      // Only the first request in this group is rate limited; the retry then
+      // falls through to the completion below.
+      mock.on(
+        { sequenceIndex: 0 },
+        { error: { message: "Rate limit exceeded", type: "rate_limit_error" }, status: 429 }
+      );
+      mock.on({}, { content: "Recovered from rate limit." });
+      return;
 
-// ============================================================================
-// Streaming Helpers
-// ============================================================================
-
-/**
- * Delay for streaming chunks in slow-stream mode.
- */
-const STREAM_CHUNK_DELAY_MS = 50;
-
-/**
- * Creates SSE stream chunks for a completion.
- */
-function createStreamChunks(content: string): string[] {
-  const words = content.split(" ");
-  const chunks: string[] = [];
-  const completionId = `chatcmpl-${randomId()}`;
-
-  for (const word of words) {
-    const chunk = {
-      id: completionId,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: { content: word + " " },
-        },
-      ],
-    };
-    chunks.push(`data: ${JSON.stringify(chunk)}\n\n`);
+    case "instant":
+    default:
+      mock.on({}, { content: "Done." });
+      return;
   }
-
-  // Add final chunk with finish_reason to signal completion
-  const finalChunk = {
-    id: completionId,
-    object: "chat.completion.chunk",
-    choices: [
-      {
-        index: 0,
-        delta: {},
-        finish_reason: "stop",
-      },
-    ],
-  };
-  chunks.push(`data: ${JSON.stringify(finalChunk)}\n\n`);
-
-  // Add done signal
-  chunks.push("data: [DONE]\n\n");
-  return chunks;
-}
-
-/**
- * Creates SSE stream chunks for a tool call.
- * Streaming tool calls have a specific format with incremental arguments.
- */
-function createToolCallStreamChunks(toolName: string, args: Record<string, unknown>): string[] {
-  const chunks: string[] = [];
-  const callId = `call_${randomId()}`;
-  const argsString = JSON.stringify(args);
-
-  // First chunk: tool call start with function name
-  chunks.push(
-    `data: ${JSON.stringify({
-      id: `chatcmpl-${randomId()}`,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: {
-            role: "assistant",
-            tool_calls: [
-              {
-                index: 0,
-                id: callId,
-                type: "function",
-                function: { name: toolName, arguments: "" },
-              },
-            ],
-          },
-        },
-      ],
-    })}\n\n`
-  );
-
-  // Second chunk: arguments
-  chunks.push(
-    `data: ${JSON.stringify({
-      id: `chatcmpl-${randomId()}`,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: {
-            tool_calls: [
-              {
-                index: 0,
-                function: { arguments: argsString },
-              },
-            ],
-          },
-        },
-      ],
-    })}\n\n`
-  );
-
-  // Final chunk: finish_reason
-  chunks.push(
-    `data: ${JSON.stringify({
-      id: `chatcmpl-${randomId()}`,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: {},
-          finish_reason: "tool_calls",
-        },
-      ],
-    })}\n\n`
-  );
-
-  // Done signal
-  chunks.push("data: [DONE]\n\n");
-  return chunks;
 }
 
 // ============================================================================
@@ -318,309 +131,37 @@ function createToolCallStreamChunks(toolName: string, args: Record<string, unkno
  * @returns MockLlmServer handle
  */
 export function createMockLlmServer(port = 0): MockLlmServer {
-  let server: Server | null = null;
-  let serverPort = port;
-  let currentMode: MockLlmMode = "instant";
-  let rateLimitRequestCount = 0; // Track requests to allow recovery after first rate limit
-  let toolCallRequestCount = 0; // Track requests to return completion after tool execution
-  let subAgentRequestCount = 0; // Track requests for sub-agent task tool flow
-
-  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
-    // Handle various OpenAI-compatible endpoints
-    // GET /v1/models - list available models
-    if (req.method === "GET" && (req.url === "/v1/models" || req.url === "/path")) {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          object: "list",
-          data: [{ id: "test", object: "model", created: Date.now(), owned_by: "mock" }],
-        })
-      );
-      return;
-    }
-
-    // Only handle POST /v1/chat/completions
-    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
-      res.writeHead(404);
-      res.end(JSON.stringify({ error: "Not found" }));
-      return;
-    }
-
-    // Parse request body
-    const body = await new Promise<string>((resolve) => {
-      let data = "";
-      req.on("data", (chunk: Buffer) => (data += chunk.toString()));
-      req.on("end", () => resolve(data));
-    });
-
-    const request = JSON.parse(body) as { stream?: boolean; tools?: unknown[] };
-    const isStreaming = request.stream === true;
-    // Tool-driven modes (tool-call, sub-agent) must only fire on requests that
-    // actually advertise tools. Opencode's title-generation agent calls the LLM
-    // without tools and would otherwise consume the first response slot, leaving
-    // the build agent with a plain completion and no permission flow.
-    const hasTools = Array.isArray(request.tools) && request.tools.length > 0;
-
-    // Handle based on mode
-    switch (currentMode) {
-      case "rate-limit": {
-        // Return 429 only on first request, then recover with instant response
-        rateLimitRequestCount++;
-        if (rateLimitRequestCount === 1) {
-          const response = createRateLimitResponse();
-          res.writeHead(response.status, response.headers);
-          res.end(response.body);
-        } else {
-          // After first rate limit, return normal response
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-            const chunks = createStreamChunks("Recovered from rate limit.");
-            for (const chunk of chunks) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            const completion = createInstantCompletion("Recovered from rate limit.");
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(completion));
-          }
-        }
-        break;
-      }
-
-      case "slow-stream": {
-        // Force streaming mode for slow-stream
-        res.writeHead(200, {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        });
-
-        const chunks = createStreamChunks("This is a slow streamed response.");
-        for (const chunk of chunks) {
-          res.write(chunk);
-          await new Promise((resolve) => setTimeout(resolve, STREAM_CHUNK_DELAY_MS));
-        }
-        res.end();
-        break;
-      }
-
-      case "tool-call": {
-        // Return tool call only on first tool-bearing request, then return completion.
-        // Requests without tools (e.g. opencode's title-generation agent) get a
-        // plain completion and do not consume the tool-call slot.
-        if (!hasTools) {
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-            for (const chunk of createStreamChunks("ok")) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(createInstantCompletion("ok")));
-          }
-          break;
-        }
-        toolCallRequestCount++;
-        if (toolCallRequestCount === 1) {
-          if (isStreaming) {
-            // Stream tool call in SSE format
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-
-            const chunks = createToolCallStreamChunks("bash", {
-              command: "echo hello",
-              description: "Prints hello to stdout",
-            });
-            for (const chunk of chunks) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            const completion = createToolCallCompletion("bash", {
-              command: "echo hello",
-              description: "Prints hello to stdout",
-            });
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(completion));
-          }
-        } else {
-          // After tool execution, return a normal completion
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-            const chunks = createStreamChunks("Tool executed successfully.");
-            for (const chunk of chunks) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            const completion = createInstantCompletion("Tool executed successfully.");
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(completion));
-          }
-        }
-        break;
-      }
-
-      case "sub-agent": {
-        // Sub-agents are triggered via the `task` tool call, which creates a child session.
-        // Skip non-tool requests (e.g. title generation) so they don't consume the slot.
-        if (!hasTools) {
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-            for (const chunk of createStreamChunks("ok")) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(createInstantCompletion("ok")));
-          }
-          break;
-        }
-        subAgentRequestCount++;
-        if (subAgentRequestCount === 1) {
-          // First call: Return task tool call to create child session
-          const taskArgs = {
-            description: "Search TypeScript files",
-            prompt: "Please search for all TypeScript files in the project",
-          };
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-
-            const chunks = createToolCallStreamChunks("task", taskArgs);
-            for (const chunk of chunks) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            const completion = createToolCallCompletion("task", taskArgs);
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(completion));
-          }
-        } else {
-          // Subsequent calls: Child session or parent follow-up - return completion
-          if (isStreaming) {
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            });
-            const chunks = createStreamChunks("Task completed.");
-            for (const chunk of chunks) {
-              res.write(chunk);
-            }
-            res.end();
-          } else {
-            const completion = createInstantCompletion("Task completed.");
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(completion));
-          }
-        }
-        break;
-      }
-
-      case "instant":
-      default: {
-        if (isStreaming) {
-          // Stream even for instant mode if requested
-          res.writeHead(200, {
-            "Content-Type": "text/event-stream",
-            "Cache-Control": "no-cache",
-            Connection: "keep-alive",
-          });
-
-          const chunks = createStreamChunks("Done.");
-          for (const chunk of chunks) {
-            res.write(chunk);
-          }
-          res.end();
-        } else {
-          const completion = createInstantCompletion("Done.");
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(completion));
-        }
-        break;
-      }
-    }
-  };
+  // Deliberately NOT strict: these fixtures are catch-alls by design, and a
+  // boundary test's subject is opencode's behaviour, not the request shape.
+  const mock = new LLMock({ port, host: "127.0.0.1" });
+  applyMode(mock, "instant");
+  let started = false;
 
   return {
     get port(): number {
-      if (serverPort === 0) {
+      if (!started) {
         throw new Error("Server not started yet - port not assigned");
       }
-      return serverPort;
+      return mock.port;
     },
 
     async start(): Promise<void> {
-      if (server) return;
-
-      server = createServer((req, res) => {
-        handleRequest(req, res).catch((error) => {
-          console.error("Mock LLM server error:", error);
-          res.writeHead(500);
-          res.end(JSON.stringify({ error: "Internal server error" }));
-        });
-      });
-
-      await new Promise<void>((resolve, reject) => {
-        // Bind to 127.0.0.1 explicitly (not "localhost") to avoid IPv4/IPv6 resolution
-        // issues on Windows where localhost might resolve to ::1 while URLs use 127.0.0.1
-        server!.listen(serverPort, "127.0.0.1", () => {
-          const addr = server!.address();
-          if (addr && typeof addr === "object") {
-            serverPort = addr.port;
-            resolve();
-          } else {
-            reject(new Error("Failed to get server address"));
-          }
-        });
-        server!.on("error", reject);
-      });
+      if (started) return;
+      await mock.start();
+      started = true;
     },
 
     async stop(): Promise<void> {
-      if (!server) return;
-
-      await new Promise<void>((resolve) => {
-        server!.close(() => {
-          server = null;
-          resolve();
-        });
-      });
+      if (!started) return;
+      await mock.stop();
+      started = false;
     },
 
     setMode(mode: MockLlmMode): void {
-      currentMode = mode;
-      // Reset request counters when switching modes
-      rateLimitRequestCount = 0;
-      toolCallRequestCount = 0;
-      subAgentRequestCount = 0;
+      applyMode(mock, mode);
+      // Sequence counts are per fixture group; a mode swap must not inherit the
+      // previous mode's counter.
+      mock.resetMatchCounts();
     },
   };
 }


### PR DESCRIPTION
Makes the agent integration testable without a login, an API key, or the network — a real agent, a mock model — and then uses that to pin the parts of the Claude integration that were resting on unverified assumptions.

- **e2e**: `agent-turn.e2e.ts` drives a real agent through a whole turn (system prompt, MCP server, initial prompt) and asserts it lands back in the UI. Runs once per agent, so Claude and OpenCode are held to the same behaviour through their two very different launch paths.
- **Mock LLM**: `mock-llm-server.ts` is now a thin façade over `@copilotkit/aimock` rather than a hand-rolled wire format, so there is one mock in the repo instead of two.
- **Claude hook contract**: new `claude/server-manager.boundary.test.ts` runs a real `claude` against a mock model through the shipped chain — the settings file `buildSettingsFile()` writes, the shipped hook handler, a real `ClaudeCodeServerManager` — and asserts the `AgentStatus` that comes out.
  - Asserts status, never hook names or payload fields. Rename `background_tasks` and the running-shell `Stop` stops being suppressed, so "stays busy" fails; the status is the drift detector.
  - Additive: nothing synthetic retired. A synthetic failure says our logic broke, this one says Claude changed.
  - 6 scenarios, ~8s. Verified by mutation: breaking `background_tasks` reading or the `ch-bg` marker turns it red.
  - Requires `claude` on PATH and `pnpm build:wrappers`; both throw rather than skip, so coverage cannot be lost silently. CI installs the CLI, unpinned, in `validate` and `canary`.
- **API**: `ws create` gained the options the creation panel already offered, and workspace metadata is re-read when creation finalizes.