### PR TITLE
fix: after deleting workspace in background active workspace did change

### DIFF
--- a/src/boundaries/shell/ui-view-manager.ts
+++ b/src/boundaries/shell/ui-view-manager.ts
@@ -42,6 +42,20 @@ export const GLOBAL_SESSION_PARTITION = "persist:codehydra-global";
  * re-focuses it whenever the iframe's window receives focus (which the
  * renderer triggers via `iframe.contentWindow.focus()` when showing).
  *
+ * It also reports a blur that took focus out of the frame entirely, so the
+ * host can put it back. A hidden workspace frame is not rendered, so nothing
+ * inside it can be focused — but `window.focus()` is a *frame*-level call that
+ * Chromium honours regardless of layout, and VS Code's webview bootstrap makes
+ * exactly that call. The focused frame then moves into a subtree where no
+ * element can hold the caret, every frame reports `document.hasFocus() ===
+ * false`, and the user's keystrokes go nowhere while the host still believes
+ * the visible frame has focus (PostHog issue 019fc47f). Nothing can deny a
+ * same-origin child that call — `inert` does not reach into a frame's
+ * document, and the `focus-without-user-activation` permissions policy is
+ * unshipped and, because activation propagates across same-origin siblings,
+ * would not cover a user who is actively typing. So the frame that lost focus
+ * says so, and WorkspaceFrames restores it.
+ *
  * Runs inside the iframe's same-origin page context — bypasses cross-origin
  * focus restrictions that would block any host-side equivalent.
  */
@@ -55,6 +69,20 @@ const CHILD_FRAME_FOCUS_TRACKER = `
       if (last && document.contains(last)) {
         try { last.focus(); } catch(e) {}
       }
+    });
+    // Only direct children of the UI page report: a nested webview's parent is
+    // the workspace frame, which cannot act on it.
+    if (window.parent === window || window.parent !== window.top) return;
+    window.addEventListener('blur', function(){
+      // Settle first: activeElement is only meaningful once focus has landed.
+      setTimeout(function(){
+        // Focus moved deeper into this frame's own tree (into a webview, say).
+        // The frame still owns it, so this is not a loss.
+        if (document.hasFocus()) return;
+        var active = document.activeElement;
+        if (active && active.tagName === 'IFRAME') return;
+        try { window.parent.postMessage({ __chBlurred: true }, '*'); } catch(e) {}
+      }, 0);
     });
   })();
 `;

--- a/src/intents/delete-workspace.integration.test.ts
+++ b/src/intents/delete-workspace.integration.test.ts
@@ -432,23 +432,18 @@ function createTestHarness(options?: {
       [DELETE_WORKSPACE_OPERATION_ID]: {
         shutdown: {
           handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
-            const { workspacePath, active: isActive } = ctx as DeletePipelineHookInput;
+            const { workspacePath } = ctx as DeletePipelineHookInput;
             const { payload } = ctx.intent as DeleteWorkspaceIntent;
 
             try {
               await viewManager.destroyWorkspaceView(workspacePath);
-              return { result: { ...(isActive && { wasActive: true }) } };
+              return { result: {} };
             } catch (error) {
               if (payload.force) {
                 logger.warn("ViewModule: error in force mode (ignored)", {
                   error: getErrorMessage(error),
                 });
-                return {
-                  result: {
-                    ...(isActive && { wasActive: true }),
-                    error: getErrorMessage(error),
-                  },
-                };
+                return { result: { error: getErrorMessage(error) } };
               }
               throw error;
             }
@@ -1329,7 +1324,7 @@ describe("DeleteWorkspaceOperation.workspaceSwitching", () => {
     });
 
     // Simulate user navigating to workspace A during the delete hook
-    // (after the initial shutdown switch-away already ran, finding wasActive=false)
+    // (after the pre-shutdown active check already found it inactive)
     harness.gitWorktreeProviderMock.gitWorktreeProvider.removeWorkspace = vi
       .fn()
       .mockImplementation(async () => {
@@ -1342,6 +1337,91 @@ describe("DeleteWorkspaceOperation.workspaceSwitching", () => {
 
     // autoSwitchIfBecameActive should have detected the change and switched back to B
     expect(harness.activeWorkspace.path).toBe(WORKSPACE_PATH_B);
+  });
+
+  it("leaves the user on the workspace they moved to while the delete was running", async () => {
+    // The active workspace is read at the start of the operation, but the
+    // switch decision happens after the interactive confirm (a dialog the user
+    // sits in front of) and the teardown. A user who moves away in that window
+    // has said where they want to be (PostHog issue 019fb79f).
+    const WORKSPACE_PATH_C = wsPath("/test/project/workspaces/feature-c");
+    const harness = createTestHarness({
+      activeWorkspacePath: WORKSPACE_PATH,
+      initialProjects: [
+        {
+          path: PROJECT_PATH,
+          name: "test-project",
+          workspaces: [
+            { path: WORKSPACE_PATH, branch: "feature-a", metadata: { base: "main" } },
+            { path: WORKSPACE_PATH_B, branch: "feature-b", metadata: { base: "main" } },
+            { path: WORKSPACE_PATH_C, branch: "feature-c", metadata: { base: "main" } },
+          ],
+        },
+      ],
+    });
+
+    // The user switches to C before the teardown starts. Auto-select would pick
+    // B (the nearest candidate to the deleted A), so the two outcomes differ.
+    harness.dispatcher.registerModule({
+      name: "test-user-moves-away",
+      hooks: {
+        [DELETE_WORKSPACE_OPERATION_ID]: {
+          preflight: {
+            handler: async (): Promise<HookOutput<PreflightHookResult>> => {
+              harness.activeWorkspace.path = WORKSPACE_PATH_C;
+              return { result: {} };
+            },
+          },
+        },
+      },
+    });
+
+    await harness.dispatcher.dispatch(buildDeleteIntent());
+
+    expect(harness.activeWorkspace.path).toBe(WORKSPACE_PATH_C);
+  });
+
+  it("leaves the user on the workspace they moved to during the teardown", async () => {
+    // The teardown between the active read and the switch decision takes
+    // seconds — killing terminals and stopping servers — and the user can
+    // switch inside it. Deleting test-0 and moving to test-2 mid-teardown used
+    // to land the user on test-1 two seconds later (reported against 718304f0).
+    const WORKSPACE_PATH_C = wsPath("/test/project/workspaces/feature-c");
+    const harness = createTestHarness({
+      activeWorkspacePath: WORKSPACE_PATH,
+      initialProjects: [
+        {
+          path: PROJECT_PATH,
+          name: "test-project",
+          workspaces: [
+            { path: WORKSPACE_PATH, branch: "feature-a", metadata: { base: "main" } },
+            { path: WORKSPACE_PATH_B, branch: "feature-b", metadata: { base: "main" } },
+            { path: WORKSPACE_PATH_C, branch: "feature-c", metadata: { base: "main" } },
+          ],
+        },
+      ],
+    });
+
+    // The switch lands during shutdown — after the active workspace was read,
+    // before the switch decision. Auto-select would pick B, so the two
+    // outcomes differ.
+    harness.dispatcher.registerModule({
+      name: "test-user-switches-mid-teardown",
+      hooks: {
+        [DELETE_WORKSPACE_OPERATION_ID]: {
+          shutdown: {
+            handler: async (): Promise<HookOutput<ShutdownHookResult>> => {
+              harness.activeWorkspace.path = WORKSPACE_PATH_C;
+              return { result: {} };
+            },
+          },
+        },
+      },
+    });
+
+    await harness.dispatcher.dispatch(buildDeleteIntent());
+
+    expect(harness.activeWorkspace.path).toBe(WORKSPACE_PATH_C);
   });
 
   it("test 14: deleting last workspace sets active to null", async () => {
@@ -1628,7 +1708,7 @@ describe("DeleteWorkspaceOperation.safetyNet", () => {
       hooks: {
         async collect(hookPointId: string) {
           if (hookPointId === "shutdown") {
-            return { results: [{ wasActive: false }], errors: [] };
+            return { results: [{}], errors: [] };
           }
           if (hookPointId === "release") {
             // Simulate unexpected infrastructure-level failure

--- a/src/intents/delete-workspace.ts
+++ b/src/intents/delete-workspace.ts
@@ -132,11 +132,14 @@ export const preflightResultSchema = z
 
 /**
  * Per-handler result for the "shutdown" hook point.
- * ViewModule provides wasActive; AgentModule may provide error.
+ * AgentModule may provide serverName and error.
+ *
+ * Whether the deleted workspace is the active one is deliberately NOT reported
+ * here. It is read by the operation immediately before this hook point — see
+ * runPipelineBody.
  */
 export const shutdownResultSchema = z
   .object({
-    wasActive: z.boolean().optional(),
     serverName: z.string().optional(),
     error: z.string().optional(),
   })
@@ -276,7 +279,6 @@ export type FlushHookInput = HookContext & z.infer<typeof flushEnrichmentSchema>
 // =============================================================================
 
 interface MergedShutdown {
-  readonly wasActive: boolean;
   readonly serverName: string | undefined;
   readonly errors: readonly string[];
 }
@@ -311,13 +313,11 @@ function mergeShutdown(
   results: readonly ShutdownHookResult[],
   collectErrors: readonly Error[]
 ): MergedShutdown {
-  let wasActive = false;
   let serverName: string | undefined;
   for (const r of results) {
-    if (r.wasActive) wasActive = true;
     if (r.serverName && !serverName) serverName = r.serverName;
   }
-  return { wasActive, serverName, errors: errorMessages(results, collectErrors) };
+  return { serverName, errors: errorMessages(results, collectErrors) };
 }
 
 function mergeErrors(
@@ -561,9 +561,26 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
       "cleanup-workspace"
     );
 
-    // Dispatch workspace:switch(auto) if deleted workspace was the active one.
-    // Auto-select mode finds the best candidate via find-candidates hook.
-    if (shutdown.wasActive && !payload.skipSwitch) {
+    // Dispatch workspace:switch(auto) if the deleted workspace is the one on
+    // screen. Auto-select mode finds the best candidate via find-candidates.
+    //
+    // Asked here, where it is acted on, and not a step earlier. Everything
+    // before this point is slow and user-facing — the interactive confirm hook
+    // is a dialog the user sits in front of (12s in PostHog issue 019fb79f),
+    // and the shutdown hooks kill terminals and stop servers for seconds after
+    // it — and a user who switches during any of that has said where they want
+    // to be. An answer sampled earlier is only a claim about the past: reading
+    // it before the shutdown hooks still overruled a user who switched two
+    // seconds later.
+    //
+    // `get-active-workspace` reports what is on screen, which is the question
+    // being asked. It survives the teardown: only a workspace:switched event
+    // moves it, so with nobody switching it still names the workspace being
+    // deleted. (The `active` flag on workspace:resolve is a different field,
+    // and that one is cleared during shutdown.)
+    const activeNow = await this.activeWorkspacePath(ctx);
+
+    if (activeNow === payload.workspacePath && !payload.skipSwitch) {
       try {
         const switchIntent: SwitchWorkspaceIntent = {
           type: INTENT_SWITCH_WORKSPACE,
@@ -693,6 +710,26 @@ export class DeleteWorkspaceOperation implements Operation<typeof schemas> {
    * If the user navigated to the workspace after the initial switch-away,
    * we must switch again before emitting workspace:deleted.
    */
+  /**
+   * The workspace currently on screen, or null when none is. Best-effort: a
+   * failure answers null, which reads as "nothing claimed the surface" — the
+   * same answer as an ordinary teardown, so a lookup failure never moves a
+   * user who had gone somewhere else.
+   */
+  private async activeWorkspacePath(
+    ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>
+  ): Promise<WorkspacePath | null> {
+    try {
+      const activeRef = await ctx.dispatch<GetActiveWorkspaceIntent>({
+        type: INTENT_GET_ACTIVE_WORKSPACE,
+        payload: {},
+      });
+      return activeRef?.path ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private async autoSwitchIfBecameActive(
     ctx: OperationContext<DeleteWorkspaceIntent, typeof schemas>,
     workspacePath: WorkspacePath

--- a/src/modules/view-module.integration.test.ts
+++ b/src/modules/view-module.integration.test.ts
@@ -34,16 +34,6 @@ import type { AppShutdownIntent } from "../intents/app-shutdown";
 import { EVENT_IDE_SERVER_RESTARTED, EVENT_IDE_SERVER_SESSIONS_STALE } from "../intents/app-resume";
 import type { IdeServerRestartedEvent, IdeServerSessionsStaleEvent } from "../intents/app-resume";
 import {
-  INTENT_DELETE_WORKSPACE,
-  DELETE_WORKSPACE_OPERATION_ID,
-  shutdownResultSchema,
-} from "../intents/delete-workspace";
-import type {
-  DeleteWorkspaceIntent,
-  DeletePipelineHookInput,
-  ShutdownHookResult,
-} from "../intents/delete-workspace";
-import {
   INTENT_OPEN_PROJECT,
   OPEN_PROJECT_OPERATION_ID,
   selectFolderHookResultSchema,
@@ -52,8 +42,7 @@ import type { SelectFolderHookResult } from "../intents/open-project";
 import { SILENT_LOGGER } from "../boundaries/platform/logging";
 import { createMockViewManager } from "../boundaries/shell/view-manager.test-utils";
 import { createViewModule, type ViewModuleDeps } from "./view-module";
-import type { WorkspaceName } from "../shared/api/types";
-import { wsPath, projPath, testPath } from "../shared/test-fixtures";
+import { testPath } from "../shared/test-fixtures";
 import type { ProjectPath } from "../intents/contract";
 
 // =============================================================================
@@ -74,40 +63,6 @@ function createMockShellLayers() {
 // =============================================================================
 // Minimal Test Operations
 // =============================================================================
-
-const deleteOpSchemas = {
-  type: INTENT_DELETE_WORKSPACE,
-  payload: z.unknown(),
-  result: z.custom<ShutdownHookResult>(),
-  hooks: { shutdown: { result: shutdownResultSchema } },
-} satisfies OperationSchemas;
-
-/** Runs "shutdown" hook point only. */
-class MinimalDeleteOperation implements Operation<typeof deleteOpSchemas> {
-  readonly id = DELETE_WORKSPACE_OPERATION_ID;
-  readonly schemas = deleteOpSchemas;
-  constructor(private readonly active: boolean = false) {}
-  async execute(
-    ctx: OperationContext<IntentOf<typeof deleteOpSchemas>, typeof deleteOpSchemas>
-  ): Promise<ShutdownHookResult> {
-    const payload = ctx.intent.payload as DeleteWorkspaceIntent["payload"];
-    const hookCtx: DeletePipelineHookInput = {
-      intent: ctx.intent,
-      projectPath: projPath("/projects/test"),
-      workspacePath: payload.workspacePath,
-      workspaceName: "test-workspace" as WorkspaceName,
-      active: this.active,
-    };
-    const { results, errors } = await ctx.hooks.collect("shutdown", hookCtx);
-    if (errors.length > 0) throw errors[0]!;
-    const merged: ShutdownHookResult = {};
-    for (const r of results) {
-      if (r.wasActive !== undefined) (merged as Record<string, unknown>).wasActive = r.wasActive;
-      if (r.error !== undefined) (merged as Record<string, unknown>).error = r.error;
-    }
-    return merged;
-  }
-}
 
 const selectFolderOpSchemas = {
   type: INTENT_OPEN_PROJECT,
@@ -222,30 +177,6 @@ describe("ViewModule Integration", () => {
       await module.events![EVENT_IDE_SERVER_SESSIONS_STALE]!.handler(event);
 
       expect(viewManager.reloadFrames).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // delete-workspace/shutdown → clears active surface, returns wasActive
-  // -------------------------------------------------------------------------
-  describe("delete-workspace/shutdown", () => {
-    it("returns wasActive when the deleted workspace was active", async () => {
-      const { dispatcher } = createTestSetup({
-        intentType: INTENT_DELETE_WORKSPACE,
-        operation: new MinimalDeleteOperation(true),
-      });
-
-      const result = await dispatcher.dispatch<DeleteWorkspaceIntent>({
-        type: INTENT_DELETE_WORKSPACE,
-        payload: {
-          workspacePath: wsPath("/workspaces/ws1"),
-          keepBranch: false,
-          force: false,
-          removeWorktree: true,
-        },
-      });
-
-      expect(result).toEqual(expect.objectContaining({ wasActive: true }));
     });
   });
 

--- a/src/modules/view-module.ts
+++ b/src/modules/view-module.ts
@@ -9,7 +9,6 @@
  * bookkeeping moved to workspace-lifecycle-module, which owns the transient
  * per-workspace facts contributed to workspace:resolve. What remains here:
  * - app-start `init` hook (window + UI view creation, HTML load, focus)
- * - delete-workspace `shutdown` (reports wasActive, driving the auto-switch)
  * - open-project `select-folder` (native folder picker)
  * - app-shutdown/stop (UI view + layer disposal)
  *
@@ -17,7 +16,7 @@
 
 import type { DialogBoundary } from "../boundaries/shell/dialog";
 import type { IntentModule } from "../intents/lib/module";
-import type { HookContext, HookOutput } from "../intents/lib/operation";
+import type { HookOutput } from "../intents/lib/operation";
 import type { IViewManager } from "../boundaries/shell/view-manager.interface";
 import type { Logger } from "../boundaries/platform/logging";
 import type { ViewBoundary } from "../boundaries/shell/view";
@@ -27,11 +26,9 @@ import type { AppBoundary } from "../boundaries/shell/app";
 import type { WebPreferences } from "../boundaries/shell/types";
 import { GLOBAL_SESSION_PARTITION } from "../boundaries/shell/ui-view-manager";
 import { APP_START_OPERATION_ID } from "../intents/app-start";
-import type { ShutdownHookResult, DeletePipelineHookInput } from "../intents/delete-workspace";
 import type { SelectFolderHookResult } from "../intents/open-project";
 import { OPEN_PROJECT_OPERATION_ID } from "../intents/open-project";
 import { APP_SHUTDOWN_OPERATION_ID } from "../intents/app-shutdown";
-import { DELETE_WORKSPACE_OPERATION_ID } from "../intents/delete-workspace";
 import { EVENT_IDE_SERVER_RESTARTED, EVENT_IDE_SERVER_SESSIONS_STALE } from "../intents/app-resume";
 import { projectPathSchema } from "../intents/contract";
 
@@ -146,21 +143,6 @@ export function createViewModule(deps: ViewModuleDeps): IntentModule {
             }
 
             return { provides: { "ui-ready": true } };
-          },
-        },
-      },
-
-      // -------------------------------------------------------------------
-      // delete-workspace → shutdown: report whether the deleted workspace was
-      // the active one, which drives the post-delete auto-switch. The active
-      // bookkeeping itself belongs to workspace-lifecycle-module; the iframe
-      // unmounts in the renderer off the presenter snapshot.
-      // -------------------------------------------------------------------
-      [DELETE_WORKSPACE_OPERATION_ID]: {
-        shutdown: {
-          handler: async (ctx: HookContext): Promise<HookOutput<ShutdownHookResult>> => {
-            const { active } = ctx as DeletePipelineHookInput;
-            return { result: { ...(active && { wasActive: true }) } };
           },
         },
       },

--- a/src/renderer/lib/components/WorkspaceFrames.svelte
+++ b/src/renderer/lib/components/WorkspaceFrames.svelte
@@ -23,6 +23,15 @@
   are only focused while in "workspace" mode; entering shortcut mode blurs
   the frame so navigation keys don't reach VS Code.
 
+  Focus repair: a hidden frame can still take focus away from the visible one
+  (`window.focus()` is frame-level, so Chromium honours it even for a
+  display:none iframe — VS Code's webview bootstrap makes that call). Focus
+  then sits in a subtree where nothing is focusable and keystrokes vanish. The
+  frame that lost it says so (`__chBlurred`, from the injected tracker) and the
+  active frame is focused again. Unlike the mode routing above this runs in
+  "hover" too: hovering the sidebar is a mouse position, not a decision to give
+  up the caret.
+
   Liveness: showing a frame pings it, and it answers via the probe responder
   the UiViewManager injects alongside the focus tracker. All workspace iframes
   are same-origin, so Chromium hosts them in one shared renderer process; when
@@ -178,13 +187,52 @@
     return undefined;
   }
 
+  /**
+   * Modes in which a frame losing focus is a defect rather than the point.
+   * "shortcut" blurs the frame deliberately (below) and "dialog" hands focus
+   * to a modal, so neither is repaired. "hover" is — the sidebar being under
+   * the pointer says nothing about where the user is typing.
+   */
+  function repairableMode(current: UIMode): boolean {
+    return current === "workspace" || current === "hover";
+  }
+
+  /**
+   * Restore focus to the active frame after another frame took it. Bounded, so
+   * a frame that steals in a loop cannot start a focus fight the user is caught
+   * in the middle of: past the budget the caret is left where it is.
+   */
+  const REPAIR_WINDOW_MS = 2000;
+  const REPAIR_LIMIT = 3;
+  let repairTimes: number[] = [];
+
+  function repairFocus(blurredKey: string): void {
+    if (blurredKey !== activeKey) return;
+    if (!repairableMode(mode)) return;
+    // The whole window lost focus (alt-tab, another app): not ours to reclaim.
+    if (!document.hasFocus()) return;
+
+    const now = Date.now();
+    repairTimes = repairTimes.filter((at) => now - at < REPAIR_WINDOW_MS);
+    if (repairTimes.length >= REPAIR_LIMIT) {
+      logger.warn("Active frame keeps losing focus; leaving it alone", { key: blurredKey });
+      return;
+    }
+    repairTimes.push(now);
+    focusActiveFrame();
+  }
+
   function handleFrameMessage(event: MessageEvent): void {
     const data: unknown = event.data;
-    const alive =
-      typeof data === "object" &&
-      data !== null &&
-      (data as { __chAlive?: unknown }).__chAlive === true;
-    if (!alive) return;
+    if (typeof data !== "object" || data === null) return;
+
+    if ((data as { __chBlurred?: unknown }).__chBlurred === true) {
+      const blurredKey = keyForSource(event.source);
+      if (blurredKey !== undefined) repairFocus(blurredKey);
+      return;
+    }
+
+    if ((data as { __chAlive?: unknown }).__chAlive !== true) return;
     const key = keyForSource(event.source);
     if (key === undefined) return;
     everAnswered.add(key);

--- a/src/renderer/lib/components/WorkspaceFrames.test.ts
+++ b/src/renderer/lib/components/WorkspaceFrames.test.ts
@@ -130,6 +130,123 @@ describe("WorkspaceFrames", () => {
   });
 
   // ===========================================================================
+  // Focus repair
+  //
+  // A hidden frame can still take focus from the visible one: window.focus()
+  // is frame-level, so Chromium honours it even for a display:none iframe, and
+  // VS Code's webview bootstrap makes that call. Focus then sits where nothing
+  // is focusable and keystrokes vanish (PostHog issue 019fc47f). The frame that
+  // lost it reports __chBlurred and the active frame is focused again.
+  // ===========================================================================
+
+  describe("focus repair", () => {
+    /** happy-dom leaves contentWindow null, so give each frame a spyable one. */
+    function giveWindows(container: HTMLElement): Map<string, { focus: ReturnType<typeof vi.fn> }> {
+      const windows = new Map<string, { focus: ReturnType<typeof vi.fn> }>();
+      for (const el of frames(container)) {
+        const win = { focus: vi.fn(), postMessage: vi.fn() };
+        Object.defineProperty(el, "contentWindow", { configurable: true, value: win });
+        windows.set(el.dataset.key!, win);
+      }
+      return windows;
+    }
+
+    /** Report, as `source`, that focus left that frame. */
+    function reportBlur(source: object): void {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { __chBlurred: true },
+          source: source as MessageEventSource,
+        })
+      );
+      vi.advanceTimersByTime(50);
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      window.api = createMockApi();
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    /** Render with the active frame settled, so only repairs are observed. */
+    function setup(mode: "workspace" | "hover" | "shortcut" | "dialog" = "workspace") {
+      const rendered = render(WorkspaceFrames, {
+        props: { frames: FRAMES, activeKey: FRAMES[0]!.key, mode },
+      });
+      const windows = giveWindows(rendered.container);
+      vi.advanceTimersByTime(50);
+      for (const win of windows.values()) win.focus.mockClear();
+      return { ...rendered, windows };
+    }
+
+    it("focuses the active frame again after another frame takes focus", () => {
+      const { windows } = setup();
+
+      reportBlur(windows.get(FRAMES[0]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).toHaveBeenCalled();
+    });
+
+    it("ignores a blur reported by a frame that is not the active one", () => {
+      const { windows } = setup();
+
+      reportBlur(windows.get(FRAMES[1]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).not.toHaveBeenCalled();
+    });
+
+    it("repairs while the sidebar is hovered", () => {
+      // The pointer resting over the sidebar says nothing about where the user
+      // is typing, so hover must not switch the protection off.
+      const { windows } = setup("hover");
+
+      reportBlur(windows.get(FRAMES[0]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).toHaveBeenCalled();
+    });
+
+    it("leaves focus alone in shortcut mode, which blurs the frame on purpose", () => {
+      const { windows } = setup("shortcut");
+
+      reportBlur(windows.get(FRAMES[0]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).not.toHaveBeenCalled();
+    });
+
+    it("leaves focus alone while a dialog owns it", () => {
+      const { windows } = setup("dialog");
+
+      reportBlur(windows.get(FRAMES[0]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).not.toHaveBeenCalled();
+    });
+
+    it("does not reclaim focus the whole window has lost", () => {
+      const { windows } = setup();
+      vi.mocked(document.hasFocus).mockReturnValue(false);
+
+      reportBlur(windows.get(FRAMES[0]!.key)!);
+
+      expect(windows.get(FRAMES[0]!.key)!.focus).not.toHaveBeenCalled();
+    });
+
+    it("gives up on a frame that keeps stealing, rather than fighting it", () => {
+      const { windows } = setup();
+      const active = windows.get(FRAMES[0]!.key)!;
+
+      for (let i = 0; i < 6; i++) reportBlur(active);
+
+      // Bounded: the caret is left where it is rather than ping-ponging.
+      expect(active.focus.mock.calls.length).toBeLessThan(6);
+    });
+  });
+
+  // ===========================================================================
   // Liveness
   //
   // Showing a frame pings it; a frame that does not answer is logged, and


### PR DESCRIPTION
Two focus-related bug reports from PostHog error tracking.

**Deleting a workspace moved the user even when it was no longer on screen** (PostHog `019fb79f`)

- Delete `test-0`, switch to `test-2` while the teardown runs, and the auto-switch lands you on `test-1` seconds later.
- Whether the deleted workspace was active was sampled at the top of the operation and carried to the switch decision, with the interactive confirm dialog and the shutdown hooks in between — seconds of user-facing time.
- Now asked at the point it is acted on, via `get-active-workspace` (which reports what is on screen and survives the teardown). `wasActive` leaves the shutdown hook contract, and view-module's delete hook goes with it.

**Keyboard focus lost when a workspace is created in the background** (PostHog `019fc47f`)

- `window.focus()` is frame-level, so Chromium honours it for a `display:none` iframe; VS Code's webview bootstrap makes that call when a webview comes up in a background workbench. Focus lands where nothing is focusable and keystrokes vanish, while the host still believes the visible frame has it.
- The frame that lost focus now reports it and the active frame is focused again. Runs in `hover` as well as `workspace` — the pointer resting over the sidebar says nothing about where the user is typing — while `shortcut` and `dialog` blur the frame deliberately and are left alone. Bounded per interval so a frame that steals in a loop cannot start a focus fight.