### PR TITLE
feat: tags can be emojis and have a tooltip

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -60,7 +60,7 @@ All methods operate on the **connected workspace**.
 | `getMetadata`        | `() => Promise<Record<string, string>>`                                                | Get all metadata (always includes `base` key)                         |
 | `setMetadata`        | `(key: string, value: string \| null) => Promise<void>`                                | Set or delete a metadata key                                          |
 | `getTags`            | `() => Promise<readonly WorkspaceTag[]>`                                               | Get all tags (metadata entries with the `tags.` prefix)               |
-| `setTag`             | `(name: string, options?: { color?: string }) => Promise<void>`                        | Set or update a tag                                                   |
+| `setTag`             | `(name: string, options?: TagOptions) => Promise<void>`                                | Set or update a tag (full replace — an omitted option is cleared)     |
 | `deleteTag`          | `(name: string) => Promise<void>`                                                      | Delete a tag                                                          |
 | `executeCommand`     | `(command: string, args?: readonly unknown[]) => Promise<unknown>`                     | Execute a VS Code command (10-second timeout)                         |
 | `create`             | `(name: string, base: string, options?: WorkspaceCreateOptions) => Promise<Workspace>` | Create a new workspace in the same project                            |
@@ -346,8 +346,15 @@ interface AgentSession {
 
 interface WorkspaceTag {
   readonly name: string;
+  /** Renders the tag as a pill; without one it is bare text. */
   readonly color?: string;
+  /** Shown instead of the name — any UTF-8, typically an emoji. */
+  readonly label?: string;
+  /** Sidebar hover text, shown instead of the name in the tooltip. */
+  readonly description?: string;
 }
+
+type TagOptions = { color?: string; label?: string; description?: string };
 
 interface WorkspaceApi {
   getStatus(options?: { refresh?: boolean }): Promise<WorkspaceStatus>;
@@ -356,7 +363,7 @@ interface WorkspaceApi {
   getMetadata(): Promise<Readonly<Record<string, string>>>;
   setMetadata(key: string, value: string | null): Promise<void>;
   getTags(): Promise<readonly WorkspaceTag[]>;
-  setTag(name: string, options?: { color?: string }): Promise<void>;
+  setTag(name: string, options?: TagOptions): Promise<void>;
   deleteTag(name: string): Promise<void>;
   executeCommand(command: string, args?: readonly unknown[]): Promise<unknown>;
   create(name: string, base: string, options?: WorkspaceCreateOptions): Promise<Workspace>;
@@ -473,7 +480,7 @@ All events use acknowledgment callbacks for request/response pattern.
 | `api:workspace:wake`               | None                                   | `PluginResult<Workspace>`                  |
 | `api:workspace:setTitle`           | `{ title: string \| null }`            | `PluginResult<void>`                       |
 | `api:workspace:listTags`           | None                                   | `PluginResult<WorkspaceTag[]>`             |
-| `api:workspace:setTag`             | `{ name: string; color?: string }`     | `PluginResult<void>`                       |
+| `api:workspace:setTag`             | `{ name: string } & TagOptions`        | `PluginResult<void>`                       |
 | `api:workspace:removeTag`          | `{ name: string }`                     | `PluginResult<void>`                       |
 | `api:workspace:openAgent`          | None                                   | `PluginResult<unknown>`                    |
 | `api:workspace:closeAgent`         | None                                   | `PluginResult<{ closed: boolean }>`        |

--- a/extensions/sidekick/api.d.ts
+++ b/extensions/sidekick/api.d.ts
@@ -210,10 +210,16 @@ export interface WorkspaceStatus {
 
 /**
  * A tag attached to a workspace.
+ *
+ * `name` is the identity. The rest is presentation: `label` is displayed in place
+ * of the name (any UTF-8, typically an emoji), `color` turns the bare label into a
+ * pill, and `description` is the sidebar hover text.
  */
 export interface WorkspaceTag {
   readonly name: string;
   readonly color?: string;
+  readonly label?: string;
+  readonly description?: string;
 }
 
 /**
@@ -334,8 +340,12 @@ export interface WorkspaceApi {
    * Set or update a tag on this workspace.
    * Tags are stored as metadata entries with the "tags." prefix.
    *
+   * Replaces the tag entirely: an option you omit is cleared, so re-pass the ones
+   * you want to keep. Without a color the tag renders as bare text rather than a
+   * pill; `label` is shown in place of the name, and `description` is its tooltip.
+   *
    * @param name - Tag name (letters, digits, hyphens, dots)
-   * @param options - Optional tag properties (e.g., color)
+   * @param options - Optional tag presentation (color, label, description)
    * @throws Error if not connected or request fails
    *
    * @example
@@ -343,11 +353,20 @@ export interface WorkspaceApi {
    * // Tag with color
    * await api.workspace.setTag('bugfix', { color: '#ff0000' });
    *
+   * // Emoji tag, explained on hover
+   * await api.workspace.setTag('review', {
+   *   label: '🔍',
+   *   description: 'waiting on review',
+   * });
+   *
    * // Tag without color
    * await api.workspace.setTag('wip');
    * ```
    */
-  setTag(name: string, options?: { color?: string }): Promise<void>;
+  setTag(
+    name: string,
+    options?: { color?: string; label?: string; description?: string }
+  ): Promise<void>;
 
   /**
    * Delete a tag from this workspace.

--- a/extensions/sidekick/src/extension.ts
+++ b/extensions/sidekick/src/extension.ts
@@ -27,44 +27,10 @@ import {
   reconstructVscodeObjects,
   type VscodeFactories,
 } from "../../../src/shared/vscode-serialization";
-import { isValidMetadataKey } from "../../../src/shared/api/types";
+import { extractTags, isValidMetadataKey } from "../../../src/shared/api/types";
+import type { WorkspaceTag } from "../../../src/shared/api/types";
 
-const TAGS_PREFIX = "tags.";
 const SYSTEM_METADATA_KEYS = new Set(["base"]);
-
-interface WorkspaceTag {
-  readonly name: string;
-  readonly color?: string;
-}
-
-function extractTagsFromMetadata(metadata: Record<string, string>): WorkspaceTag[] {
-  const tags: WorkspaceTag[] = [];
-  for (const [key, value] of Object.entries(metadata)) {
-    if (!key.startsWith(TAGS_PREFIX)) continue;
-    const name = key.slice(TAGS_PREFIX.length);
-    if (name.length === 0) continue;
-
-    let color: string | undefined;
-    try {
-      const parsed: unknown = JSON.parse(value);
-      if (typeof parsed === "object" && parsed !== null && "color" in parsed) {
-        const candidate = (parsed as { color: unknown }).color;
-        if (typeof candidate === "string") {
-          color = candidate;
-        }
-      }
-    } catch {
-      // Invalid JSON — tag with just name
-    }
-
-    if (color !== undefined) {
-      tags.push({ name, color });
-    } else {
-      tags.push({ name });
-    }
-  }
-  return tags;
-}
 
 function validateMetadataKeyInput(v: string): string | null {
   if (!v) return "Key is required";
@@ -427,11 +393,20 @@ const codehydraApi = {
 
     async getTags(): Promise<readonly WorkspaceTag[]> {
       const metadata = await emitApiCall<Record<string, string>>("api:workspace:getMetadata");
-      return extractTagsFromMetadata(metadata);
+      return extractTags(metadata);
     },
 
-    async setTag(name: string, options?: { color?: string }): Promise<void> {
-      const value = options?.color !== undefined ? JSON.stringify({ color: options.color }) : "{}";
+    async setTag(
+      name: string,
+      options?: { color?: string; label?: string; description?: string }
+    ): Promise<void> {
+      // Full replace, matching workspace.tag.set: the stored object is exactly the
+      // options this call passed, so an omitted field clears whatever was there.
+      const tag: { color?: string; label?: string; description?: string } = {};
+      if (options?.color !== undefined) tag.color = options.color;
+      if (options?.label !== undefined) tag.label = options.label.trim();
+      if (options?.description !== undefined) tag.description = options.description.trim();
+      const value = JSON.stringify(tag);
       await emitApiCall<void>("api:workspace:setMetadata", { key: `tags.${name}`, value });
     },
 
@@ -963,7 +938,7 @@ export function activate(context: vscode.ExtensionContext): { codehydra: typeof 
       "codehydra.getTags",
       async (): Promise<readonly { name: string; color?: string }[]> => {
         const metadata = (await codehydraApi.workspace.getMetadata()) as Record<string, string>;
-        const tags = extractTagsFromMetadata(metadata);
+        const tags = extractTags(metadata);
         if (tags.length === 0) {
           await vscode.window.showInformationMessage("No tags on this workspace");
         } else {
@@ -984,13 +959,24 @@ export function activate(context: vscode.ExtensionContext): { codehydra: typeof 
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "codehydra.setTag",
-      async (arg?: { name: string; color?: string }): Promise<void> => {
+      async (arg?: {
+        name: string;
+        color?: string;
+        label?: string;
+        description?: string;
+      }): Promise<void> => {
         let name: string;
         let color: string | undefined;
+        // Only the programmatic form carries these; the interactive flow prompts
+        // for name and color alone rather than growing two more steps.
+        let label: string | undefined;
+        let description: string | undefined;
 
         if (arg && typeof arg.name === "string") {
           name = arg.name;
           color = typeof arg.color === "string" ? arg.color : undefined;
+          label = typeof arg.label === "string" ? arg.label.trim() : undefined;
+          description = typeof arg.description === "string" ? arg.description.trim() : undefined;
         } else {
           const nameInput = await vscode.window.showInputBox({
             title: "Tag Name",
@@ -1019,8 +1005,11 @@ export function activate(context: vscode.ExtensionContext): { codehydra: typeof 
           }
         }
 
-        const value = color !== undefined ? JSON.stringify({ color }) : "{}";
-        await codehydraApi.workspace.setMetadata(`tags.${name}`, value);
+        const tag: { color?: string; label?: string; description?: string } = {};
+        if (color !== undefined) tag.color = color;
+        if (label !== undefined) tag.label = label;
+        if (description !== undefined) tag.description = description;
+        await codehydraApi.workspace.setMetadata(`tags.${name}`, JSON.stringify(tag));
       }
     )
   );
@@ -1033,7 +1022,7 @@ export function activate(context: vscode.ExtensionContext): { codehydra: typeof 
         name = arg;
       } else {
         const metadata = (await codehydraApi.workspace.getMetadata()) as Record<string, string>;
-        const tags = extractTagsFromMetadata(metadata);
+        const tags = extractTags(metadata);
         if (tags.length === 0) {
           await vscode.window.showInformationMessage("No tags to delete");
           return;

--- a/src/api/entries/metadata.ts
+++ b/src/api/entries/metadata.ts
@@ -129,18 +129,42 @@ export function metadataEntries(deps: EntryDeps): readonly AnyOperationEntry[] {
     name: "workspace.tag.set",
     kind: "command",
     description: "Add or update a tag on a workspace.",
+    instructions:
+      "Replaces the tag entirely — any field you omit is cleared, so re-pass the ones you " +
+      "want to keep.",
     input: z.object({
       workspacePath: targetWorkspace,
       name: z.string().min(1).describe("Tag name"),
-      color: z.string().min(1).optional().describe("Hex color, e.g. '#8b949e'"),
+      color: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Hex color, e.g. '#8b949e'. Without one the tag renders as bare text, not a pill"
+        ),
+      label: z
+        .string()
+        .optional()
+        .describe("Shown instead of the tag name — any UTF-8, e.g. an emoji. Trimmed"),
+      description: z
+        .string()
+        .optional()
+        .describe("Hover text, shown instead of the tag name in the tooltip. Trimmed"),
     }),
     requiresWorkspace: true,
-    handler: async (ctx, input) =>
-      write(
+    handler: async (ctx, input) => {
+      // Full replace: what is stored is exactly what this call passed. No
+      // read-before-write, so a tag is always exactly what its last setter said.
+      const tag: { color?: string; label?: string; description?: string } = {};
+      if (input.color !== undefined) tag.color = input.color;
+      if (input.label !== undefined) tag.label = input.label.trim();
+      if (input.description !== undefined) tag.description = input.description.trim();
+      return write(
         targetOf(ctx, input.workspacePath),
         `${TAG_PREFIX}${input.name}`,
-        JSON.stringify(input.color !== undefined ? { color: input.color } : {})
-      ),
+        JSON.stringify(tag)
+      );
+    },
   });
 
   const tagRemove = defineEntry({

--- a/src/boundaries/platform/git-worktree-provider.ts
+++ b/src/boundaries/platform/git-worktree-provider.ts
@@ -92,9 +92,16 @@ export const EXTERNAL_TAG_METADATA_KEY = `tags.${EXTERNAL_TAG_NAME}`;
 
 /**
  * Tag value: a neutral grey, quieter than CodeHydra's blue `new` tag — this marks a
- * permanent property of the workspace, not a call to action.
+ * permanent property of the workspace, not a call to action. The description is the
+ * sidebar tooltip, saying what "external" means without spending row width on it.
+ *
+ * Written once, at adoption. Worktrees adopted before a change here keep whatever
+ * value they were adopted with; nothing backfills them.
  */
-export const EXTERNAL_TAG_VALUE = JSON.stringify({ color: "#8b949e" });
+export const EXTERNAL_TAG_VALUE = JSON.stringify({
+  color: "#8b949e",
+  description: "Adopted worktree — created outside CodeHydra",
+});
 
 /**
  * Global provider managing git worktree operations across all projects.

--- a/src/modules/auto-workspace/template-defaults.ts
+++ b/src/modules/auto-workspace/template-defaults.ts
@@ -97,13 +97,16 @@ const METADATA = `=== METADATA ===
   metadata:
     title: "{{ summary }}"           sidebar display title
     tags:
-      review: { color: "#4b6de8" }   a colored tag named "review"
+      review: { color: "#4b6de8", label: "🔍" }
     <any-key>: "<any value>"         passed through as-is
 
 - title sets the sidebar display title; when unset the row falls back
   to the branch name (template.name).
-- each tags.<name> becomes a workspace tag; its { color } object is
-  JSON-encoded for the tag system. Omit color for an uncolored tag.
+- each tags.<name> becomes a workspace tag; its object is JSON-encoded
+  for the tag system. color, label and description are all optional:
+    color        renders the tag as a pill; without one it is bare text
+    label        shown instead of the name (any UTF-8, e.g. an emoji)
+    description  hover text, shown instead of the name in the tooltip
 
 Three different "names", easy to confuse:
   name (document)          the source id — unique, prefixes its state keys

--- a/src/modules/presentation/presentation-module.integration.test.ts
+++ b/src/modules/presentation/presentation-module.integration.test.ts
@@ -1026,6 +1026,36 @@ describe("PresentationModule - ui:state snapshots", () => {
     ]);
   });
 
+  it("carries a tag's label and description through the metadata patch path", async () => {
+    const deps = createDeps();
+    const module = await startModule(deps);
+    const workspace = makeWorkspace("feat");
+    await emit(module, EVENT_PROJECT_OPENED, { project: makeProject([workspace]) });
+
+    const change = (key: string, value: string | null): Promise<void> =>
+      emit(module, EVENT_METADATA_CHANGED, {
+        projectId: PROJECT_ID,
+        workspaceName: workspace.name,
+        workspacePath: workspace.path,
+        key,
+        value,
+      });
+
+    await change("tags.review", '{"color":"#4b6de8","label":"🔍","description":"waiting"}');
+    await flush();
+    expect(lastSnapshot(deps).sidebar.projects[0]!.workspaces[0]!.tags).toEqual([
+      { name: "review", color: "#4b6de8", label: "🔍", description: "waiting" },
+    ]);
+
+    // Overwriting the same key replaces the tag rather than appending a second one,
+    // and a full-replace write drops the fields it omits.
+    await change("tags.review", '{"label":"✅"}');
+    await flush();
+    expect(lastSnapshot(deps).sidebar.projects[0]!.workspaces[0]!.tags).toEqual([
+      { name: "review", label: "✅" },
+    ]);
+  });
+
   it("reads the title metadata into the row, and clears it when emptied", async () => {
     const deps = createDeps();
     const module = await startModule(deps);

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -463,8 +463,13 @@
                               <span class="ws-branch">{workspace.name}</span>
                             {/if}
                             {#each workspace.tags as tag (tag.name)}
-                              <span class="ws-tag" style:--tag-color={tag.color ?? null}
-                                >{tag.name}</span
+                              {@const shown = tag.label ?? tag.name}
+                              {@const tip = tag.description ?? tag.name}
+                              <span
+                                class="ws-tag"
+                                class:colored={tag.color !== undefined}
+                                style:--tag-color={tag.color ?? null}
+                                title={tip === shown ? undefined : tip}>{shown}</span
                               >
                             {/each}
                           </ScrollingLabel>
@@ -983,19 +988,25 @@
     opacity: 0.6;
   }
 
-  /* Inline tag pill on the row's second line (branch + tags scroll together). */
+  /* Inline tag on the row's second line (branch + tags scroll together).
+     Bare by default so a label that is just an emoji wears no chrome; the branch
+     beside it is dimmed to 0.6, and that contrast is what separates them. */
   .ws-tag {
-    --_color: var(--tag-color, var(--ch-foreground));
     display: inline-block;
     font-size: 10px;
     line-height: 1;
+    color: var(--ch-foreground);
+    white-space: nowrap;
+    font-weight: 500;
+  }
+
+  /* A color is what makes a tag a pill. */
+  .ws-tag.colored {
+    --_color: var(--tag-color, var(--ch-foreground));
     padding: 2px 6px;
     border-radius: 8px;
     border: 1px solid var(--_color);
     background: color-mix(in srgb, var(--_color) 50%, transparent);
-    color: var(--ch-foreground);
-    white-space: nowrap;
-    font-weight: 500;
   }
 
   .status-cell {

--- a/src/renderer/lib/components/Sidebar.test.ts
+++ b/src/renderer/lib/components/Sidebar.test.ts
@@ -1138,6 +1138,56 @@ describe("Sidebar component", () => {
       expect(container.querySelector(".ws-secondary-line")).not.toBeInTheDocument();
       expect(container.querySelector(".ws-tag")).not.toBeInTheDocument();
     });
+
+    it("shows a tag's label in place of its name", () => {
+      const ws = makeUiWorkspaceRow("ws1", {
+        tags: [{ name: "review", label: "🔍" }],
+      });
+
+      const { container } = render(Sidebar, {
+        props: { ...defaultProps, projects: [makeUiProjectRow([ws])] },
+      });
+
+      const tag = container.querySelector(".ws-tag");
+      expect(tag?.textContent?.trim()).toBe("🔍");
+      expect(tag?.textContent).not.toContain("review");
+    });
+
+    it("wears pill chrome only when the tag has a color", () => {
+      const ws = makeUiWorkspaceRow("ws1", {
+        tags: [{ name: "wip" }, { name: "bugfix", color: "#ff0" }],
+      });
+
+      const { container } = render(Sidebar, {
+        props: { ...defaultProps, projects: [makeUiProjectRow([ws])] },
+      });
+
+      const [bare, pill] = Array.from(container.querySelectorAll(".ws-tag"));
+      expect(bare).not.toHaveClass("colored");
+      expect(pill).toHaveClass("colored");
+    });
+
+    it("titles a tag only when the tooltip adds something the pill does not show", () => {
+      const ws = makeUiWorkspaceRow("ws1", {
+        tags: [
+          // Nothing to add: displayed text already is the name.
+          { name: "wip" },
+          // An emoji hides the name, so the name becomes the tooltip.
+          { name: "review", label: "🔍" },
+          // An explicit description wins over the name.
+          { name: "blocked", label: "🚧", description: "waiting on CI" },
+        ],
+      });
+
+      const { container } = render(Sidebar, {
+        props: { ...defaultProps, projects: [makeUiProjectRow([ws])] },
+      });
+
+      const [plain, emoji, described] = Array.from(container.querySelectorAll(".ws-tag"));
+      expect(plain).not.toHaveAttribute("title");
+      expect(emoji).toHaveAttribute("title", "review");
+      expect(described).toHaveAttribute("title", "waiting on CI");
+    });
   });
 
   describe("workspace title", () => {

--- a/src/shared/api/types.test.ts
+++ b/src/shared/api/types.test.ts
@@ -246,4 +246,42 @@ describe("extractTags", () => {
     const metadata = { "tags.": "{}" };
     expect(extractTags(metadata)).toEqual([]);
   });
+
+  it("should extract label and description alongside color", () => {
+    const metadata = {
+      "tags.review": '{"color":"#4b6de8","label":"\u{1F50D}","description":"waiting on review"}',
+    };
+    expect(extractTags(metadata)).toEqual([
+      {
+        name: "review",
+        color: "#4b6de8",
+        label: "\u{1F50D}",
+        description: "waiting on review",
+      },
+    ]);
+  });
+
+  it("should extract a label with no color (a bare emoji tag)", () => {
+    const metadata = { "tags.review": '{"label":"\u{1F50D}"}' };
+    expect(extractTags(metadata)).toEqual([{ name: "review", label: "\u{1F50D}" }]);
+  });
+
+  it("should keep an empty-string label rather than dropping it", () => {
+    // A blank label is stored, not normalized away — the tag then renders as
+    // nothing (a bare color chip when colored). Deliberately unlike `title`.
+    const metadata = { "tags.chip": '{"color":"#4b6de8","label":""}' };
+    expect(extractTags(metadata)).toEqual([{ name: "chip", color: "#4b6de8", label: "" }]);
+  });
+
+  it("should ignore non-string label and description values", () => {
+    const metadata = {
+      "tags.bad": '{"color":"#f00","label":123,"description":null}',
+    };
+    expect(extractTags(metadata)).toEqual([{ name: "bad", color: "#f00" }]);
+  });
+
+  it("should cost only the malformed field, never the whole tag", () => {
+    const metadata = { "tags.mixed": '{"color":123,"label":"ok"}' };
+    expect(extractTags(metadata)).toEqual([{ name: "mixed", label: "ok" }]);
+  });
 });

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -102,16 +102,35 @@ export const TAGS_METADATA_KEY_PREFIX = "tags.";
 
 /**
  * A tag attached to a workspace.
+ *
+ * `name` is the identity — it is the metadata key's suffix, so it obeys
+ * `isValidMetadataKey`. The rest is presentation and carries no identity:
+ * `label` is displayed in place of the name (any UTF-8, typically an emoji),
+ * `color` turns the bare label into a pill, and `description` is the hover text.
  */
 export interface WorkspaceTag {
   readonly name: string;
   readonly color?: string;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+/**
+ * Read one string field out of a parsed tag object.
+ *
+ * Anything that is not a string is ignored rather than coerced: a tag written by
+ * hand into git config should cost the one field it got wrong, never the tag.
+ */
+function readTagField(parsed: unknown, field: string): string | undefined {
+  if (typeof parsed !== "object" || parsed === null || !(field in parsed)) return undefined;
+  const candidate = (parsed as Record<string, unknown>)[field];
+  return typeof candidate === "string" ? candidate : undefined;
 }
 
 /**
  * Extract tags from a metadata record by filtering keys with "tags." prefix.
- * Parses JSON values and extracts optional color field.
- * Invalid JSON values produce tags with just the name (no color).
+ * Parses JSON values and extracts the optional color, label and description fields.
+ * Invalid JSON values produce tags with just the name.
  *
  * @param metadata Metadata record from workspace
  * @returns Array of workspace tags
@@ -123,24 +142,24 @@ export function extractTags(metadata: Readonly<Record<string, string>>): Workspa
     const name = key.slice(TAGS_METADATA_KEY_PREFIX.length);
     if (name.length === 0) continue;
 
-    let color: string | undefined;
+    let parsed: unknown;
     try {
-      const parsed: unknown = JSON.parse(value);
-      if (typeof parsed === "object" && parsed !== null && "color" in parsed) {
-        const candidate = (parsed as { color: unknown }).color;
-        if (typeof candidate === "string") {
-          color = candidate;
-        }
-      }
+      parsed = JSON.parse(value);
     } catch {
       // Invalid JSON — tag with just name
+      parsed = undefined;
     }
 
-    if (color !== undefined) {
-      tags.push({ name, color });
-    } else {
-      tags.push({ name });
-    }
+    const color = readTagField(parsed, "color");
+    const label = readTagField(parsed, "label");
+    const description = readTagField(parsed, "description");
+
+    tags.push({
+      name,
+      ...(color !== undefined ? { color } : {}),
+      ...(label !== undefined ? { label } : {}),
+      ...(description !== undefined ? { description } : {}),
+    });
   }
   return tags;
 }


### PR DESCRIPTION
- A workspace tag gains two optional fields beside `color`: `label`, shown in place of the tag name (any UTF-8, typically an emoji), and `description`, its sidebar tooltip. `name` stays the identity — it is the metadata key's suffix.
- Pill chrome now keys off `color` rather than being unconditional, so a tag that is just an emoji wears no border. This restyles tags created without a color; both built-ins are colored, so neither changes appearance.
- `external` gains a description explaining what it means. Written at adopt time like its color, so nothing backfills worktrees adopted earlier.
- The tooltip is set only when it would say something the pill does not already show, so a plain text tag gets none.
- `workspace.tag.set` gains `--label` / `--description` and keeps full-replace semantics: an omitted field is cleared. CLI help and the MCP tool schema pick the new fields up from the zod describes.
- The sidekick's duplicate tag parser is dropped in favour of the shared `extractTags`; `api-drift-guard` type-asserts the two `WorkspaceTag` shapes match, so they could not diverge anyway.
- Tests: `extractTags` parse table (label/description, empty-string label kept, non-string fields ignored per field), sidebar rendering (label over name, `.colored` only with a color, conditional `title`), and the presentation metadata-patch path.